### PR TITLE
Add timeout of 120 minutes to builds

### DIFF
--- a/github/ci/jenkins-master/templates/01-plugins.groovy
+++ b/github/ci/jenkins-master/templates/01-plugins.groovy
@@ -5,7 +5,7 @@ def logger = Logger.getLogger("")
 def installed = false
 def initialized = false
 
-def pluginParameter="ghprb job-dsl github-oauth swarm throttle-concurrents publish-over-ssh"
+def pluginParameter="ghprb job-dsl github-oauth swarm throttle-concurrents publish-over-ssh build-timeout"
 def plugins = pluginParameter.split()
 logger.info("" + plugins)
 def instance = Jenkins.getInstance()

--- a/github/ci/jenkins-master/templates/04-jobs.groovy
+++ b/github/ci/jenkins-master/templates/04-jobs.groovy
@@ -5,6 +5,9 @@ job('kubevirt-functional-tests') {
     }
     concurrentBuild()
     wrappers {
+        timeout {
+          absolute(minutes = 120)
+        }
         configure { node ->
             node / 'buildWrappers'  << 'jenkins.plugins.publish__over__ssh.BapSshPostBuildWrapper' {
                 postBuild {


### PR DESCRIPTION
In the last two weeks we had repeatedly broken code, which caused some
pods to never start succeeding. To avoid hanging jobs, set a timeout of
120 minutes.

Signed-off-by: Roman Mohr <rmohr@redhat.com>