### PR TITLE
Remove all untracked content after git checkout

### DIFF
--- a/github/ci/jenkins-master/templates/04-jobs.groovy
+++ b/github/ci/jenkins-master/templates/04-jobs.groovy
@@ -42,6 +42,7 @@ job('kubevirt-functional-tests') {
             branch('${sha1}')
             extensions {
                 relativeTargetDirectory('go/src/kubevirt.io/kubevirt')
+                cleanAfterCheckout()
             }
         }
     }


### PR DESCRIPTION
Especially to avoid re-deploying non-tracked manifests, make sure that
we only have the git content in the repo.

Signed-off-by: Roman Mohr <rmohr@redhat.com>