### PR TITLE
Prepare matrix build for release testing

### DIFF
--- a/github/ci/README.md
+++ b/github/ci/README.md
@@ -132,6 +132,9 @@ storeSshUser: "vagrant"
 storeSshUrl: "192.168.201.4"
 storeSshRemoteDir: "public_html/jenkins"
 storeReportUrl: "http://192.168.201.4/jenkins"
+targets:
+  - vagrant-dev
+  - vagrant-release
 EOL
 vagrant up
 ```

--- a/github/ci/jenkins-master/templates/04-jobs.groovy
+++ b/github/ci/jenkins-master/templates/04-jobs.groovy
@@ -1,4 +1,5 @@
-job('kubevirt-functional-tests') {
+{% for target in targets %}
+job('kubevirt-functional-tests-{{ target }}') {
     throttleConcurrentBuilds {
         maxTotal(0)
         maxPerNode(1)
@@ -19,7 +20,7 @@ job('kubevirt-functional-tests') {
                             transfers {
                                 'jenkins.plugins.publish__over__ssh.BapSshTransfer' {
                              remoteDirectory('$BUILD_NUMBER')
-                              sourceFiles('console.log')
+                              sourceFiles('{{ target }}-console.log')
                                 }
                             }
                         }
@@ -53,10 +54,10 @@ job('kubevirt-functional-tests') {
             allowMembersOfWhitelistedOrgsAsAdmin()
             extensions {
                 commitStatus {
-                    context('kubevirt-functional-tests/jenkins/pr')
-                    triggeredStatus('kubevirt-functional-tests/jenkins/pr')
-                    startedStatus('kubevirt-functional-tests/jenkins/pr')
-                    statusUrl('{{ storeReportUrl }}/$BUILD_NUMBER/console.log')
+                    context('kubevirt-functional-tests/jenkins/pr/{{ target }}')
+                    triggeredStatus('kubevirt-functional-tests/jenkins/pr {{ target }}')
+                    startedStatus('kubevirt-functional-tests/jenkins/pr {{ target }}')
+                    statusUrl('{{ storeReportUrl }}/$BUILD_NUMBER/{{ target }}-console.log')
                     completedStatus('SUCCESS', 'All is well')
                     completedStatus('FAILURE', 'Something went wrong. Investigate!')
                     completedStatus('PENDING', 'still in progress...')
@@ -68,6 +69,8 @@ job('kubevirt-functional-tests') {
     steps {
         shell('''#!/bin/bash
 set -o pipefail
-cd go/src/kubevirt.io/kubevirt && bash automation/test.sh 2>&1 | tee ${WORKSPACE}/console.log''')
+export TARGET={{ target }}
+cd go/src/kubevirt.io/kubevirt && bash automation/test.sh 2>&1 | tee ${WORKSPACE}/{{ target }}-console.log''')
     }
 }
+{% endfor %}

--- a/github/ci/jenkins-master/templates/04-jobs.groovy
+++ b/github/ci/jenkins-master/templates/04-jobs.groovy
@@ -7,7 +7,7 @@ job('kubevirt-functional-tests-{{ target }}') {
     concurrentBuild()
     wrappers {
         timeout {
-          absolute(minutes = 120)
+          absolute(minutes = 180)
         }
         configure { node ->
             node / 'buildWrappers'  << 'jenkins.plugins.publish__over__ssh.BapSshPostBuildWrapper' {

--- a/github/ci/jenkins-master/templates/05-github.groovy
+++ b/github/ci/jenkins-master/templates/05-github.groovy
@@ -26,4 +26,9 @@ githubAuth = new ArrayList<GhprbGitHubAuth>(1)
 githubAuth.add(new GhprbGitHubAuth(serverUri.toString(), "{{ githubCallbackUrl }}", githubCredentials , "kubevirt-bot", "aebe0886-5ead-47cd-9a13-18490b7a2831" , new Secret("{{ githubSecret }}")))
 auth.set(descriptor, githubAuth)
 
+// Disable request for testing phrase
+Field requestPhrase = descriptor.class.getDeclaredField("requestForTestingPhrase")
+requestPhrase.setAccessible(true)
+requestPhrase.set(descriptor, "")
+
 descriptor.save()


### PR DESCRIPTION
Add matrix build support. The automation script can check the $TARGET environment variable to determine what it should deploy and test.

Signed-off-by: Roman Mohr <rmohr@redhat.com>