### PR TITLE
Prepare for docker-only usage

### DIFF
--- a/github/ci/beaker/tasks/main.yaml
+++ b/github/ci/beaker/tasks/main.yaml
@@ -1,20 +1,19 @@
 ---
-- lvol:
-    vg: fedora
-    lv: data
-    size: +100%FREE
-- filesystem:
-    fstype: ext4
-    dev: /dev/mapper/fedora-data
-- name: Mount data volume
-  mount:
-    path: /var/lib/libvirt/images/
-    src: /dev/mapper/fedora-data
-    fstype: ext4
-    state: present
-- name: Mount data volume
-  mount:
-    path: /var/lib/libvirt/images/
-    src: /dev/mapper/fedora-data
-    fstype: ext4
-    state: mounted
+- stat: path=/var/lib/docker
+  register: links
+- debug: msg="link does not exists"
+  when: links.stat.islnk is undefined or not links.stat.islnk
+- name: Remove docker directory if it is not a symlink
+  file:
+    state: absent
+    path: /var/lib/docker
+  when: links.stat.islnk is undefined or not links.stat.islnk
+- name: Create docker directory in /home/
+  file:
+    state: directory
+    path: /home/docker
+- name: Link
+  file: path=/var/lib/docker
+        src=/home/docker
+        state=link 
+        force=yes

--- a/github/ci/ci.yaml
+++ b/github/ci/ci.yaml
@@ -5,7 +5,7 @@
   gather_facts: False
   tasks:
   - name: install python 2
-    raw: dnf install -y python2 libselinux-python
+    raw: yum install -y python2 libselinux-python
 - hosts: beaker
   become: true
   become_user: root

--- a/github/ci/jenkins-deps/tasks/main.yml
+++ b/github/ci/jenkins-deps/tasks/main.yml
@@ -43,11 +43,15 @@
   shell: 'cat /sys/module/kvm_amd/parameters/nested'
   register: kvm_amd
   ignore_errors: True
+- name: Check if nesting is enabled
+  shell: '(cat /sys/module/kvm_intel/parameters/nested || cat /sys/module/kvm_amd/parameters/nested) | egrep "[nN0]"'
+  register: nesting_disabled
+  ignore_errors: True
 - name: Remove virtualization module to allow enabling it with nesting
   modprobe:
     name: "kvm_intel"
     state: absent
-  when: kvm_intel.rc == 0
+  when: kvm_intel.rc == 0 and nesting_disabled.rc == 0
 - name: Enable module with nesting
   modprobe:
     name: "kvm_intel"
@@ -58,7 +62,7 @@
   modprobe:
     name: "kvm_amd"
     state: absent
-  when: kvm_amd.rc == 0
+  when: kvm_amd.rc == 0 and nesting_disabled.rc == 0
 - name: Enable module with nesting
   modprobe:
     name: "kvm_amd"

--- a/github/ci/jenkins-deps/tasks/main.yml
+++ b/github/ci/jenkins-deps/tasks/main.yml
@@ -1,46 +1,67 @@
 ---
 - name: Install build dependencies
-  dnf:
+  yum:
     name: '{{ item }}'
     state: latest
   with_items:
     - python-firewall
-    - vagrant
-    - vagrant-libvirt
     - git
-    - mercurial
-    - golang
+    - make
     - rsync
-    - libvirt-client
-    - libvirt-devel
     - docker
 - name: Add docker group for the jenkins user
   group:
     name: docker
     state: present
-- name: Add jenkins user to libvirt and docker group
+- name: Add jenkins user to docker group
   user:
     name: jenkins
-    groups: libvirt,docker
+    groups: docker
     append: yes
-- name: Enable Libvirt and Docker
+- name: Enable Docker
   systemd:
     name: '{{ item }}'
     enabled: yes
   with_items:
-    - virtlogd
-    - libvirtd
     - docker
-- name: Start Libvirt and Docker
+- name: Start Docker
   systemd:
     name: '{{ item }}'
     state: restarted
     daemon_reload: yes
   with_items:
-    - virtlogd
-    - libvirtd
     - docker
 - name: Disable selinux, to not block rsync via SSH in Jenkins
   selinux:
     policy: targeted
     state: permissive
+- name: Check if we are on intel
+  shell: 'cat /sys/module/kvm_intel/parameters/nested'
+  register: kvm_intel
+  ignore_errors: True
+- name: Check if we are on amd
+  shell: 'cat /sys/module/kvm_amd/parameters/nested'
+  register: kvm_amd
+  ignore_errors: True
+- name: Remove virtualization module to allow enabling it with nesting
+  modprobe:
+    name: "kvm_intel"
+    state: absent
+  when: kvm_intel.rc == 0
+- name: Enable module with nesting
+  modprobe:
+    name: "kvm_intel"
+    state: present
+    params: "nested=1"
+  when: kvm_intel.rc == 0
+- name: Remove virtualization module to allow enabling it with nesting
+  modprobe:
+    name: "kvm_amd"
+    state: absent
+  when: kvm_amd.rc == 0
+- name: Enable module with nesting
+  modprobe:
+    name: "kvm_amd"
+    state: present
+    params: "nested=1"
+  when: kvm_amd.rc == 0

--- a/github/ci/jenkins-master/tasks/main.yml
+++ b/github/ci/jenkins-master/tasks/main.yml
@@ -8,7 +8,7 @@
     state: present
     key: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
 - name: Install jenkins
-  dnf:
+  yum:
     name: '{{ item }}'
     state: latest
   with_items:

--- a/github/ci/jenkins-master/tasks/main.yml
+++ b/github/ci/jenkins-master/tasks/main.yml
@@ -74,6 +74,11 @@
     state: enabled
 - firewalld:
     zone: public
+    port: 37947/tcp
+    permanent: true
+    state: enabled
+- firewalld:
+    zone: public
     service: http
     permanent: true
     state: enabled

--- a/github/ci/jenkins-slave/tasks/main.yml
+++ b/github/ci/jenkins-slave/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install the latest version of Java
-  dnf:
+  yum:
     name: java
     state: latest
 - user:


### PR DESCRIPTION
* Assume Centos 7.4 as slave base, now that we only need docker
* Make sure that nested virtualization is enabled
* Make sure that the docker store is located at /home/docker where most
  free space is available

Signed-off-by: Roman Mohr <rmohr@redhat.com>