### PR TITLE
Fix two outdated entries in ansible

### DIFF
--- a/github/ci/jenkins-master/templates/04-jobs.groovy
+++ b/github/ci/jenkins-master/templates/04-jobs.groovy
@@ -1,6 +1,6 @@
 {% for target in targets %}
 job('kubevirt-functional-tests-{{ target }}') {
-    {% if target == "windows" %}
+    {% if target == "windows2016" %}
        label('windows')
     {% endif %}
     throttleConcurrentBuilds {

--- a/github/ci/jenkins-slave/defaults/main.yml
+++ b/github/ci/jenkins-slave/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-swarmRootDir: "/var/lib/jenkins"
+swarmRootDir: "/var/lib/swarm"
 slaveSlots: 2
 labels: ""


### PR DESCRIPTION
 * Windows Job is now called "windows2016". We did not update the labeling regarding to that
 * The preferred workdir for clients is "/var/lib/warm" and not "/var/lib/jenkins" anymore. That is already reflected on the host but the change is not merged in the repo