### PR TITLE
Add prow role which provides useful github bots

### DIFF
--- a/github/ci/README.md
+++ b/github/ci/README.md
@@ -31,10 +31,12 @@ for changes will always work.
    `public_repo` permission.
 2. register the Prow callback URL in your github project
 
- * Fill in your callback URL (e.g. `http://prow.myopenshift.com/hook/`)
+ * Fill in your callback URL (e.g. `https://prow.myopenshift.com/hook/`)
  * Content-type should be `application/json`
  * Create a secret with `openssl rand -hex 20` and set it on the webhook
  * Enable all notifications
+
+Note that the included route for prow hooks will be exposed via `https`.
 
 ## Prepare your Ansible Variables
 

--- a/github/ci/README.md
+++ b/github/ci/README.md
@@ -4,7 +4,7 @@ Ansible based description of the KubeVirt CI environment for functional tests.
 The Ansible roles here allow to re-crate and scale the Jenkins CI environment
 used.
 
-## Prepare your Github Project
+## Prepare your Github Project for Jenkins
 
 The following steps **1** and **2** give your Jenkins server the permissions to
 add comments to your Pull Request and to change the build status. Step **3**
@@ -25,6 +25,17 @@ for changes will always work.
  * Add a secret
  * Enable `Push`, `Pull request`, `Issue comment` notifications
 
+## Prepare your Github Project for Prow
+
+1. create an access token or use the one you created above. Prow needs the
+   `public_repo` permission.
+2. register the Prow callback URL in your github project
+
+ * Fill in your callback URL (e.g. `http://prow.myopenshift.com/hook/`)
+ * Content-type should be `application/json`
+ * Create a secret with `openssl rand -hex 20` and set it on the webhook
+ * Enable all notifications
+
 ## Prepare your Ansible Variables
 
 Create a file `group_vars/all/main.yml` based on
@@ -43,6 +54,9 @@ storeSshUser: "fas-user"
 storeSshUrl: "fedoraproject.org"
 storeSshRemoteDir: "public_html/jenkins"
 storeReportUrl: "https://fas-user.fedorapeople.org/jenkins"
+prowUrl: "deck-prow.e8ca.engint.openshiftapps.com" # without the /hook subpath
+prowNamespace: "prow"
+prowHmac: "e4a61a12b5cae91dca3b8c1a576c735fe971110f" # the webhook secret generated
 ```
 
 There you can fill in you token, your secret and the Jenkins callback URL.
@@ -63,6 +77,9 @@ master ansible_host=my.jenkins.com ansible_user=root
 [jenkins-slaves]
 slave0 ansible_host=slave0.my.jenkins.com ansible_user=root labels="windows test1"
 slave1 ansible_host=slave1.my.jenkins.com ansible_user=root
+
+[prow]
+localhost ansible_connection=local
 ```
 
 The master itself has no executors. It will not run any jobs. If you want to

--- a/github/ci/README.md
+++ b/github/ci/README.md
@@ -82,12 +82,13 @@ slave1 ansible_host=slave1.my.jenkins.com ansible_user=root
 localhost ansible_connection=local
 ```
 
-The master itself has no executors. It will not run any jobs. If you want to
+The `[jenkins-master]` itself has no executors. It will not run any jobs. If you want to
 build also on master, it is possible to add the master to the
 `[jenkins-slaves]` section. Then the swarm plugin will register the master node
 as a slave too. Optionally it is possible to use the `labels` variable to
 assign labels to jenkins nodes. In the example above slave0 would get the
-labels `windows` and `test1` attached.
+labels `windows` and `test1` attached. `[prow]` will use your local openshift
+credentials and deploy prow on the configured cluster.
 
 Provision your machines:
 
@@ -135,6 +136,16 @@ fedorapeople server to your hosts file:
 [store]
 store0 ansible_host=fedorapeople.org ansible_user=fas-user
 ```
+
+### Prow Role
+
+It deploys the main prow components and related configs. In the case of prow,
+we don't config templates per repo. Instead we have fully configs inside
+`prow/files`:
+
+ * `config.yaml`: Contains all prow jobs (not used right now)
+ * `plugins.yaml`: Contains all enabled github bots per repo (again, not templatized, instead the full kubevirt-org config)
+ * `labels.yaml`: Labels which are used in `kubevirt/kubevirt`. They will be synchronized twice a day with `kubevirt/kubevirt`
 
 ## Testing the CI infrastructure
 

--- a/github/ci/ci.yaml
+++ b/github/ci/ci.yaml
@@ -1,5 +1,5 @@
 ---
-- hosts: "!store"
+- hosts: "!store:!prow"
   become: true
   become_user: root
   gather_facts: False
@@ -27,5 +27,6 @@
   roles:
     - store
 - hosts: prow
+  gather_facts: False
   roles:
     - prow

--- a/github/ci/ci.yaml
+++ b/github/ci/ci.yaml
@@ -26,3 +26,6 @@
 - hosts: store
   roles:
     - store
+- hosts: prow
+  roles:
+    - prow

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -1,0 +1,8 @@
+periodics:
+- interval: 10m
+  agent: kubernetes
+  name: echo-test
+  spec:
+    containers:
+    - image: alpine
+      command: ["/bin/date"]

--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -1,0 +1,161 @@
+---
+labels:
+- name: area/api-server
+  color: bfd4f2
+  target: both
+- name: area/controller
+  color: bfd4f2
+  target: both
+- name: area/handler
+  color: bfd4f2
+  target: both
+- name: area/launcher
+  color: bfd4f2
+  target: both
+- name: area/virtctl
+  color: bfd4f2
+  target: both
+- name: distro/kuberenetes
+  color: fcb3ad
+  target: both
+- name: distro/openshift
+  color: fcb3ad
+  target: both
+- color: e11d21
+  description: Indicates that a PR should not merge because it's missing one of the release note labels.
+  name: do-not-merge/release-note-label-needed
+  previously:
+    - name: needs/release-note
+      color: d4c5f9
+  target: prs
+- name: duplicate
+  color: cccccc
+  target: both
+- name: for/developers
+  color: fef2c0
+  target: both
+- name: for/users
+  color: fef2c0
+  target: both
+- name: good first issue
+  color: 128A0C
+  target: issues
+- name: help wanted
+  color: 128A0C
+  target: issues
+- name: kind/blocker
+  color: b60205
+  target: both
+- name: kind/bug
+  color: ee0701
+  target: both
+- name: kind/enhancement
+  color: bfd4f2
+  target: both
+- name: kind/proposal
+  color: bfd4f2
+  target: both
+- name: kind/question
+  color: cc317c
+  target: both
+- name: kind/tracker
+  color: bc19c1
+  target: both
+- name: needs/documentation
+  color: d4c5f9
+  target: both
+- name: priority/backlog
+  color: fbca04
+  target: both
+- name: priority/critical-urgent
+  color: d93f0b
+  target: both
+- color: c2e0c6
+  name: release-note
+  target: prs
+  description: Denotes a PR that will be considered when it comes time to generate release notes.
+- color: c2e0c6
+  description: Denotes a PR that doesn't merit a release note. # will be ignored when it comes time to generate release notes.
+  name: release-note-none
+  target: prs
+- name: research-needed
+  color: fef2c0
+  target: both
+- name: size/L
+  color: ee9900
+  target: both
+  previously:
+  - name: size-L
+    color: f9d0c4
+- name: size/M
+  color: eebb00
+  target: both
+  previously:
+  - name: size-M
+    color: f9d0c4
+- name: size/S
+  color: 77bb00
+  target: both
+  previously:
+  - name: size-S
+    color: f9d0c4
+- name: size/XL
+  color: ee5500
+  target: both
+  previously:
+  - name: size-XL
+    color: f9d0c4
+- color: "009900"
+  name: size/XS
+  target: both
+- color: ee0000
+  name: size/XXL
+  target: both
+- name: topic/api
+  color: c5def5
+  target: both
+- name: topic/build
+  color: c5def5
+  target: both
+- name: topic/ci
+  color: c5def5
+  target: both
+- name: topic/client
+  color: c5def5
+  target: both
+- name: topic/community
+  color: c5def5
+  target: both
+- name: topic/documentation
+  color: c5def5
+  target: both
+- name: topic/infrastructure
+  color: c5def5
+  target: both
+- name: topic/integration
+  color: c5def5
+  target: both
+- name: topic/network
+  color: c5def5
+  target: both
+- name: topic/packaging
+  color: c5def5
+  target: both
+- name: topic/scheduling
+  color: c5def5
+  target: both
+- name: topic/security
+  color: c5def5
+  target: both
+- name: topic/storage
+  color: c5def5
+  target: both
+- name: topic/testing
+  color: c5def5
+  target: both
+- name: topic/virtualization
+  color: c5def5
+  target: both
+- name: wontfix
+  color: ffffff
+  target: both

--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -1,0 +1,8 @@
+plugins:
+  rmohr/kubevirt:
+  - size
+  - assign
+  - hold
+  - release-note
+  - label
+  - blunderbuss

--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -1,5 +1,5 @@
 plugins:
-  rmohr/kubevirt:
+  kubevirt/kubevirt:
   - size
   - assign
   - hold

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -36,18 +36,30 @@
       type: Opaque
       data:
         oauth: "{{ githubToken | b64encode }}"
-- name: Update plugin config-map
+- name: Update prow plugins config 
   openshift_raw:
     state: present
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/plugins.yaml') | from_yaml }}"
   state: present
-- name: Update config config-map
+  vars:
+    prowPluginsConfig: "{{ lookup('file', '{{ role_path }}/files/plugins.yaml') }}"
+- name: Update prow job config
   openshift_raw:
     state: present
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/config.yaml') | from_yaml }}"
   state: present
+  vars:
+    prowConfig: "{{ lookup('file', '{{ role_path }}/files/config.yaml') }}"
+- name: Update prow label-sync config
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/labels.yaml') | from_yaml }}"
+  state: present
+  vars:
+    prowLabelsConfig: "{{ lookup('file', '{{ role_path }}/files/labels.yaml') }}"
 - name: Deploy prow-hook
   openshift_raw:
     state: present
@@ -59,4 +71,10 @@
     state: present
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/hook-service.yaml') | from_yaml }}"
+  state: present
+- name: Deploy label-sync cron job
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/label-sync.yaml') | from_yaml }}"
   state: present

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Create project
+  openshift_raw:
+    state: present
+    kind: Project
+    name: '{{ prowNamespace }}'
+    display_name: Prow
+    description: Prow for KubeVirt
+- name: Create Prow Hook Route
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/route-hook.yaml') | from_yaml }}"
+  state: present
+- name: Create HMAC secret
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: hmac-token
+      type: Opaque            
+      data:
+        hmac: "{{ prowHmac | b64encode }}"
+- name: Create OAuth secret
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: oauth-token
+      type: Opaque
+      data:
+        oauth: "{{ githubToken | b64encode }}"
+- name: Update plugin config-map
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/plugins.yaml') | from_yaml }}"
+  state: present
+- name: Update config config-map
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/config.yaml') | from_yaml }}"
+  state: present
+- name: Deploy prow-hook
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/hook.yaml') | from_yaml }}"
+  state: present
+- name: Deploy prow-hook-service
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/hook-service.yaml') | from_yaml }}"
+  state: present

--- a/github/ci/prow/templates/config.yaml
+++ b/github/ci/prow/templates/config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+data:
+  config.yaml: |
+    periodics:
+    - interval: 10m
+      agent: kubernetes
+      name: echo-test
+      spec:
+        containers:
+        - image: alpine
+          command: ["/bin/date"]

--- a/github/ci/prow/templates/config.yaml
+++ b/github/ci/prow/templates/config.yaml
@@ -4,11 +4,4 @@ metadata:
   name: config
 data:
   config.yaml: |
-    periodics:
-    - interval: 10m
-      agent: kubernetes
-      name: echo-test
-      spec:
-        containers:
-        - image: alpine
-          command: ["/bin/date"]
+{{ prowConfig | indent(width=4, indentfirst=True) }}

--- a/github/ci/prow/templates/hook-service.yaml
+++ b/github/ci/prow/templates/hook-service.yaml
@@ -1,0 +1,24 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: hook
+spec:
+  selector:
+    app: hook
+  ports:
+  - port: 8888
+  type: NodePort

--- a/github/ci/prow/templates/hook.yaml
+++ b/github/ci/prow/templates/hook.yaml
@@ -1,0 +1,54 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hook
+  labels:
+    app: hook
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: hook
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: hook
+        image: gcr.io/k8s-prow/hook:v20180615-0824a2979
+        imagePullPolicy: Always
+        args:
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: config
+        configMap:
+          name: config
+      - name: plugins
+        configMap:
+          name: plugins

--- a/github/ci/prow/templates/label-sync.yaml
+++ b/github/ci/prow/templates/label-sync.yaml
@@ -32,9 +32,9 @@ spec:
               image: gcr.io/k8s-testimages/label_sync:v20180531-20dbd7ab8
               args:
               - --config=/etc/config/labels.yaml
-              - --confirm=false
-              - --orgs=rmohr
-              - --only=rmohr/kubevirt
+              - --confirm=true
+              - --orgs=kubevirt
+              - --only=kubevirt/kubevirt
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth

--- a/github/ci/prow/templates/label-sync.yaml
+++ b/github/ci/prow/templates/label-sync.yaml
@@ -1,0 +1,53 @@
+
+# Copyright 2017 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: label-sync
+spec:
+  schedule: "17 23 * * *"    # Every day 23:17 / 11:17PM
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        app: label-sync
+    spec:
+      template:
+        spec:
+          containers:
+            - name: label-sync
+              image: gcr.io/k8s-testimages/label_sync:v20180531-20dbd7ab8
+              args:
+              - --config=/etc/config/labels.yaml
+              - --confirm=false
+              - --orgs=rmohr
+              - --only=rmohr/kubevirt
+              - --token=/etc/github/oauth
+              volumeMounts:
+              - name: oauth
+                mountPath: /etc/github
+                readOnly: true
+              - name: config
+                mountPath: /etc/config
+                readOnly: true
+          restartPolicy: Never
+          volumes:
+          - name: oauth
+            secret:
+              secretName: oauth-token
+          - name: config
+            configMap:
+              name: label-config

--- a/github/ci/prow/templates/labels.yaml
+++ b/github/ci/prow/templates/labels.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  labels.yaml: |
+{{ prowLabelsConfig | indent(width=4, indentfirst=True) }}
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: label-config
+

--- a/github/ci/prow/templates/plugins.yaml
+++ b/github/ci/prow/templates/plugins.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+data:
+  plugins.yaml: |
+    plugins:
+      kubevirt/kubevirt:
+      - size
+      - assign
+      - hold
+      - release-note
+      - label
+      - blunderbuss
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: plugins
+

--- a/github/ci/prow/templates/plugins.yaml
+++ b/github/ci/prow/templates/plugins.yaml
@@ -1,16 +1,9 @@
+#jinja2: lstrip_blocks: "False", trim_blocks: "False"
 apiVersion: v1
 data:
   plugins.yaml: |
-    plugins:
-      kubevirt/kubevirt:
-      - size
-      - assign
-      - hold
-      - release-note
-      - label
-      - blunderbuss
+{{ prowPluginsConfig | indent(width=4, indentfirst=True) }}
 kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: plugins
-

--- a/github/ci/prow/templates/route-hook.yaml
+++ b/github/ci/prow/templates/route-hook.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: hook
+spec:
+  host: "{{ prowUrl }}"
+  path: /hook
+  to:
+    kind: Service
+    name: hook
+    weight: 100
+  wildcardPolicy: None

--- a/github/ci/prow/templates/route-hook.yaml
+++ b/github/ci/prow/templates/route-hook.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   host: "{{ prowUrl }}"
   path: /hook
+  tls:
+    termination: edge
   to:
     kind: Service
     name: hook


### PR DESCRIPTION
* Only deploy the minimum prow setup which allows using github bots
* plugins.yaml will at the end contain the plugins for all repos which want to use prow-bots

Plugins which would be enabled:

* assigner (allows people to self-assign tasks: /assign)
* size (estimate PR size and add labels)
* labels (/king bug|improvment, /area virtctl, ...)
* releasenote needs to be specified or `NONE` needs to be give in a `release-note` codeblock. Labels are managed according to that
* blunderbuss (assign reviewers and approvers automatically based on the file  history out of an OWNER file)
* Adds a label configmap which can synchronize github labels, including renames, color changes, setting descriptions, ...

TODO:

* Give maintainers access to prow (can be done via role binding in os/ansible)
* Improve documentation
* Add OWNERS file to kubevirt/kubevirt (needed for automatically assigning reviewers and approvers)