### PR TITLE
Automatically update configs if the are merged to master

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -1,8 +1,21 @@
+config_updater:
+  maps:
+    github/ci/prow/files/config.yaml:
+      name: config
+    github/ci/prow/files/plugins.yaml:
+      name: plugins
+    github/ci/prow/files/labels.yaml:
+      name: label-config
+
 plugins:
   kubevirt/kubevirt:
   - size
-  - assign
-  - hold
-  - release-note
   - label
+  - hold
+  - assign
+  - release-note
   - blunderbuss
+
+  kubevirt/project-infra:
+  - config-updater
+

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -60,6 +60,20 @@
   state: present
   vars:
     prowLabelsConfig: "{{ lookup('file', '{{ role_path }}/files/labels.yaml') }}"
+- name: Deploy prow-hook-role
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/hook-rbac.yaml')}}"
+- name: Deploy prow-hook-service-account
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/hook-service-account.yaml') | from_yaml }}"
+  state: present
+- name: Deploy prow-hook-rbac-role-binding
+  command: "oc -n {{ prowNamespace }} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/hook-rbac-role-binding.yaml')}}"
 - name: Deploy prow-hook
   openshift_raw:
     state: present

--- a/github/ci/prow/templates/hook-rbac-role-binding.yaml
+++ b/github/ci/prow/templates/hook-rbac-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: hook-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hook
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: system:serviceaccount:{{ prowNamespace }}:hook

--- a/github/ci/prow/templates/hook-rbac.yaml
+++ b/github/ci/prow/templates/hook-rbac.yaml
@@ -1,0 +1,8 @@
+kind: Role
+apiVersion: v1 
+metadata:
+  name: hook
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["update", "get", "create", "delete"]

--- a/github/ci/prow/templates/hook-service-account.yaml
+++ b/github/ci/prow/templates/hook-service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hook

--- a/github/ci/prow/templates/hook.yaml
+++ b/github/ci/prow/templates/hook.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: hook
     spec:
+      serviceAccountName: hook
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook


### PR DESCRIPTION
Instead of running ansible everytime when prow configs change, let's run
the config-updater plugin which will update the configs whenever a PR
gets merged which changes these files. In order to achieve this, this PR contains the following:

- enable config-updater plugin for kubevirt/project-infra
- add a service account for hook which allows it to modify the configs
- `openshift_raw` has some issues with some resource types (fixed in ansible 2.6) which required to run oc directly.