### PR TITLE
Allow setting normal and exclusive mode for swarm plugin

### DIFF
--- a/github/ci/jenkins-slave/defaults/main.yml
+++ b/github/ci/jenkins-slave/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 swarmRootDir: "/var/lib/swarm"
+mode: "normal"
 slaveSlots: 2
 labels: ""

--- a/github/ci/jenkins-slave/templates/swarm.service
+++ b/github/ci/jenkins-slave/templates/swarm.service
@@ -4,7 +4,7 @@ Description=Jenkins Swarm client
 [Service]
 Type=simple
 User=jenkins
-ExecStart=/usr/bin/java -jar /opt/swarm-client.jar -master {{ master }} -username {{ jenkinsUser }} -password @/opt/.pwd -executors {{ slaveSlots }} -deleteExistingClients -fsroot {{ swarmRootDir }} -labelsFile {{ swarmRootDir }}/labels -disableSslVerification
+ExecStart=/usr/bin/java -jar /opt/swarm-client.jar -master {{ master }} -username {{ jenkinsUser }} -password @/opt/.pwd -executors {{ slaveSlots }} -deleteExistingClients -fsroot {{ swarmRootDir }} -labelsFile {{ swarmRootDir }}/labels -disableSslVerification -mode {{ mode }}
 Restart=always
 
 [Install]


### PR DESCRIPTION
Allow setting "exclusive" for labeled nodes to improve build speed. Use "normal" as default.