### PR TITLE
Enable verify-owners and owners-label plugin for kubevirt

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -65,6 +65,12 @@ default:
       target: both
       addedBy: anyone
       prowPlugin: label
+    - color: e11d21
+      description: Categorizes issue or PR as related to adding, removing, or otherwise changing an API
+      name: kind/api-change
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - name: size/L
       color: ee9900
       target: both

--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -17,12 +17,14 @@ plugins:
   - assign
   - blunderbuss
   - lifecycle
+  - verify-owners
 
   kubevirt/project-infra:
   - config-updater
 
   kubevirt/kubevirt:
   - release-note
+  - owners-label
 
   kubevirt/containerized-data-importer:
   - release-note


### PR DESCRIPTION
* owner-label sets labels specified in OWNERS files if specific files
  have changed
* verify-owners ensures that changed OWNERS files are valid