### PR TITLE
Add cherrypicker

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -37,3 +37,4 @@ external_plugins:
   - name: needs-rebase
     events:
       - pull_request
+  - name: cherrypicker

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -146,3 +146,14 @@
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/needs-rebase_service.yaml') | from_yaml }}"
   state: present
+- name: Deploy cherrypicker
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/cherrypicker_deployment.yaml') | from_yaml }}"
+- name: Deploy cherrypicker-service
+  openshift_raw:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/cherrypicker_service.yaml') | from_yaml }}"
+  state: present

--- a/github/ci/prow/templates/cherrypicker_deployment.yaml
+++ b/github/ci/prow/templates/cherrypicker_deployment.yaml
@@ -1,0 +1,59 @@
+# Copyright 2016 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: cherrypicker
+  labels:
+    app: cherrypicker
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cherrypicker
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: cherrypicker
+        image: gcr.io/k8s-prow/cherrypicker:v20181208-bb1d41d
+        imagePullPolicy: Always
+        args:
+        - --dry-run=false
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: plugins
+        configMap:
+          name: plugins

--- a/github/ci/prow/templates/cherrypicker_service.yaml
+++ b/github/ci/prow/templates/cherrypicker_service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors All rights reserved.
+# Copyright 2018 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: hook
+  name: cherrypicker
 spec:
   selector:
-    app: hook
+    app: cherrypicker
   ports:
-  - port: 8888
+  - port: 80
+    targetPort: 8888

--- a/github/ci/prow/templates/needs-rebase_service.yaml
+++ b/github/ci/prow/templates/needs-rebase_service.yaml
@@ -22,4 +22,3 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
-  type: NodePort


### PR DESCRIPTION
Enable the cherrypicker plugin to simplify backporting very simple patches.