### PR TITLE
Skip new archived repos in label-sync

### DIFF
--- a/github/ci/prow/templates/label-sync.yaml
+++ b/github/ci/prow/templates/label-sync.yaml
@@ -29,12 +29,11 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-testimages/label_sync:v20180806-e93188ccb
+              image: index.docker.io/kubevirtci/label_sync:v20181214-258f6ce10-dirty
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               - --orgs=kubevirt
-              - --skip=kubevirt/blog,kubevirt/vadvisor,kubevirt/v2v-job,kubevirt/cockpit-demo
               - --token=/etc/github/oauth
               volumeMounts:
               - name: oauth


### PR DESCRIPTION
The label sync binary does not like archived repos. Use a forked build until a rebuild with kubernetes/test-infra#10407 included happens.