### PR TITLE
Add ghproxy

### DIFF
--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -215,4 +215,7 @@
   command: "oc -n {{prowNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/greenhouse-service.yaml')}}"
-
+- name: Deploy ghproxy
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/ghproxy.yaml')}}"

--- a/github/ci/prow/templates/ghproxy.yaml
+++ b/github/ci/prow/templates/ghproxy.yaml
@@ -1,0 +1,71 @@
+# Copyright 2018 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+  volumeName: "storage02-pv9-32g"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: ghproxy
+  labels:
+    app: ghproxy
+spec:
+  replicas: 1 
+  template:
+    metadata:
+      labels:
+        app: ghproxy
+    spec:
+      containers:
+      - name: ghproxy
+        image: gcr.io/k8s-testimages/ghproxy:latest # TODO(fejta): tagged
+        imagePullPolicy: Always
+        args:
+        - --cache-dir=/cache
+        - --cache-sizeGB=29
+        ports:
+        - containerPort: 8888
+        volumeMounts:
+        - name: cache
+          mountPath: /cache
+      volumes:
+      - name: cache
+        persistentVolumeClaim:
+          claimName: ghproxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: ghproxy


### PR DESCRIPTION
ghproxy is needed to not waste API token requests on github.

/hold

need a PV first.