### PR TITLE
The config-updater needs read permissions for config maps

### DIFF
--- a/github/ci/prow/templates/hook-rbac.yaml
+++ b/github/ci/prow/templates/hook-rbac.yaml
@@ -22,6 +22,8 @@ rules:
     verbs:
       - create
       - update
+      - get
+      - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
The automatic config-updater needs read permissions for config-maps. Saw in the `hook` logs that it failed accessing them because of our rbac rules. The change is already rolled out and worked for #72.