### PR TITLE
We now decorate periodic jobs, specify the command explicitly

### DIFF
--- a/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
@@ -7,6 +7,8 @@ periodics:
       type: vm
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      command:
+      - /commenter
       args:
       - |-
         --query=org:kubevirt
@@ -39,6 +41,8 @@ periodics:
       type: vm
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      command:
+      - /commenter
       args:
       - |-
         --query=org:kubevirt
@@ -74,6 +78,8 @@ periodics:
       type: vm
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
+      command:
+      - /commenter
       args:
       - |-
         --query=org:kubevirt


### PR DESCRIPTION
We now decorate periodic jobs, like we should, but that also means that
the command must be explicitly specified, since the decorators override
the entrypoint.