### PR TITLE
Pushgateway

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -58,6 +58,9 @@ tide:
     # Treat unknown contexts as optional
     skip-unknown-contexts: true
 
+push_gateway:
+  endpoint: pushgateway
+
 presets:
 - labels:
     preset-dind-enabled: "true"

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -76,7 +76,10 @@
       type: Opaque
       data:
         service-account.json: "{{ gcsServiceAccount | b64encode }}"
-
+- name: Deploy the pushgateway
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/pushgateway.yaml')}}"
 - name: Update prow config
   k8s:
     state: present

--- a/github/ci/prow/templates/ghproxy.yaml
+++ b/github/ci/prow/templates/ghproxy.yaml
@@ -46,6 +46,7 @@ spec:
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=29
+        - --push-gateway=pushgateway
         ports:
         - containerPort: 8888
         volumeMounts:

--- a/github/ci/prow/templates/greenhouse-service.yaml
+++ b/github/ci/prow/templates/greenhouse-service.yaml
@@ -24,3 +24,18 @@ spec:
     protocol: TCP
   selector:
     app: greenhouse
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazel-cache-metrics
+  labels:
+    metrics: "true"
+spec:
+  selector:
+    app: greenhouse
+  ports:
+  - name: default
+    protocol: TCP
+    port: 80
+    targetPort: 9090

--- a/github/ci/prow/templates/pushgateway.yaml
+++ b/github/ci/prow/templates/pushgateway.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: pushgateway
+    spec:
+      containers:
+      - name: pushgateway
+        image: prom/pushgateway:v0.7.0
+        ports:
+          - name: http
+            containerPort: 9091
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pushgateway
+  labels:
+    app: pushgateway
+    metrics: "true"
+spec:
+  ports:
+  - name: pushgateway
+    port: 80
+    targetPort: http
+  selector:
+    app: pushgateway


### PR DESCRIPTION
Add the pushgateway and configure all prow components to push metrics to it. Greenhouse is the only component which wants to be scraped (under `/prometheus`) and does not want to push metrics.

This PR does not include prometheus itself or a graphana dashboard. It only prepares the ground.