### PR TITLE
Add memory limits to Prow deployment

### DIFF
--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -89,6 +89,10 @@
       type: Opaque
       data:
         service-account.json: "{{ gcsServiceAccount | b64encode }}"
+- name: Deploy limit range
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('file', '{{ role_path }}/templates/memory-defaults.yaml') }}"
 - name: Deploy the pushgateway
   command: "oc -n {{prowNamespace}} apply -f -"
   args:

--- a/github/ci/prow/templates/cherrypicker_deployment.yaml
+++ b/github/ci/prow/templates/cherrypicker_deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker

--- a/github/ci/prow/templates/deck-deployment.yaml
+++ b/github/ci/prow/templates/deck-deployment.yaml
@@ -32,6 +32,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: "deck" # Uncomment for use with RBAC
       terminationGracePeriodSeconds: 30
       containers:
@@ -64,6 +65,11 @@ spec:
         - name: gcs
           mountPath: /etc/gcs
           readOnly: true
+        resources:
+          requests:
+            memory: 2Gi
+          limits:
+            memory: 2Gi
       volumes:
       - name: oauth-config
         secret:
@@ -80,3 +86,12 @@ spec:
       - name: gcs
         secret:
           secretName: gcs
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values: ["deck"]
+              topologyKey: "kubernetes.io/hostname"

--- a/github/ci/prow/templates/ghproxy.yaml
+++ b/github/ci/prow/templates/ghproxy.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       containers:
       - name: ghproxy
         image: gcr.io/k8s-testimages/ghproxy:latest # TODO(fejta): tagged

--- a/github/ci/prow/templates/greenhouse-deployment.yaml
+++ b/github/ci/prow/templates/greenhouse-deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       containers:
       - name: greenhouse
         image: gcr.io/k8s-testimages/greenhouse@sha256:ab1a3421cc3c072a813d8543735f218ca6caa811011391a0e5b00104700e6e7b
@@ -42,6 +43,11 @@ spec:
         volumeMounts:
         - name: cache
           mountPath: /data
+        resources:
+          requests:
+            memory: 3Gi
+          limits:
+            memory: 3Gi
       volumes:
       - name: cache
         persistentVolumeClaim:

--- a/github/ci/prow/templates/hook.yaml
+++ b/github/ci/prow/templates/hook.yaml
@@ -62,3 +62,12 @@ spec:
       - name: job-config
         configMap:
           name: job-config
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values: ["hook"]
+              topologyKey: "kubernetes.io/hostname"

--- a/github/ci/prow/templates/horologium-deployment.yaml
+++ b/github/ci/prow/templates/horologium-deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: "horologium"
       terminationGracePeriodSeconds: 30
       containers:

--- a/github/ci/prow/templates/label-sync.yaml
+++ b/github/ci/prow/templates/label-sync.yaml
@@ -29,6 +29,7 @@ spec:
         spec:
           nodeSelector:
             type: vm
+            zone: ci
           containers:
             - name: label-sync
               image: index.docker.io/kubevirtci/label_sync:v20181214-258f6ce10-dirty

--- a/github/ci/prow/templates/memory-defaults.yaml
+++ b/github/ci/prow/templates/memory-defaults.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+spec:
+  limits:
+  - default:
+      memory: 512Mi
+    defaultRequest:
+      memory: 512Mi
+    type: Container

--- a/github/ci/prow/templates/needs-rebase_deployment.yaml
+++ b/github/ci/prow/templates/needs-rebase_deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase

--- a/github/ci/prow/templates/plank-deployment.yaml
+++ b/github/ci/prow/templates/plank-deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: "plank"
       containers:
       - name: plank

--- a/github/ci/prow/templates/pushgateway.yaml
+++ b/github/ci/prow/templates/pushgateway.yaml
@@ -13,6 +13,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       containers:
       - name: pushgateway
         image: prom/pushgateway:v0.7.0

--- a/github/ci/prow/templates/sinker-deployment.yaml
+++ b/github/ci/prow/templates/sinker-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: "sinker"
       containers:
       - name: sinker

--- a/github/ci/prow/templates/statusreconciler-deployment.yaml
+++ b/github/ci/prow/templates/statusreconciler-deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: "statusreconciler" # Uncomment for use with RBAC
       terminationGracePeriodSeconds: 180
       containers:

--- a/github/ci/prow/templates/tide-deployment.yaml
+++ b/github/ci/prow/templates/tide-deployment.yaml
@@ -29,6 +29,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: "tide" # Uncomment for use with RBAC
       containers:
       - name: tide


### PR DESCRIPTION
To ensure that different components are not being evicted at runtime, we
should have memory requests and limits set on every deployed container.
Currently, added default req and lim for all the containers and set it
to 510Mi. For components that are expected to consume more memory
(currently greenhouse and deck), we overwrite the defaults.
Also, added pod anti-affinity rules for components with more than one
replica.