### PR TITLE
Separate namespace

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -29,8 +29,8 @@ sinker:
   max_prowjob_age: 48h
   max_pod_age: 30m
 
-prowjob_namespace: kubevirt-prow
-pod_namespace: kubevirt-prow
+prowjob_namespace: kubevirt-prow-jobs
+pod_namespace: kubevirt-prow-jobs
 log_level: debug
 
 tide:

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -5,17 +5,34 @@
     definition:
       kind: Project
       metadata:
+        name: '{{ prowJobsNamespace }}'
+      display_name: ProwJobs
+      description: Job namespace for Prow for KubeVirt
+- name: Create project
+  k8s:
+    state: present
+    definition:
+      kind: Project
+      metadata:
         name: '{{ prowNamespace }}'
       display_name: Prow
       description: Prow for KubeVirt
-- name: Add admins to the project
+- name: Add admins to the prow namespace
   command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/admin-rbac.yaml')}}"
+- name: Add admins to the pow job namespace
+  command: "oc -n {{prowJobsNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/admin-rbac.yaml')}}"
 - name: Create Prow Routes
   command: "oc -n {{prowNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/routes.yaml')}}"
+- name: Create Service Accounts
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/accounts.yaml')}}"
 - name: Create Docker-kubevirtbot secret
   k8s:
     state: present
@@ -119,7 +136,7 @@
   vars:
     prowLabelsConfig: "{{ lookup('file', '{{ role_path }}/files/labels.yaml') }}"
 - name: Deploy prow-hook-rbac
-  command: "oc -n {{prowNamespace}} apply -f -"
+  command: "oc -n {{prowJobsNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/hook-rbac.yaml')}}"
 - name: Deploy prow-hook
@@ -133,7 +150,7 @@
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/hook-service.yaml') | from_yaml }}"
 - name: Deploy horologium-rbac
-  command: "oc -n {{ prowNamespace }} apply -f -"
+  command: "oc -n {{ prowJobsNamespace }} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/horologium-rbac.yaml')}}"
 - name: Deploy horologium
@@ -142,7 +159,7 @@
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/horologium-deployment.yaml') | from_yaml }}"
 - name: Deploy plank-rbac
-  command: "oc -n {{ prowNamespace }} apply -f -"
+  command: "oc -n {{ prowJobsNamespace }} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/plank-rbac.yaml')}}"
 - name: Deploy plank
@@ -151,7 +168,7 @@
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/plank-deployment.yaml') | from_yaml }}"
 - name: Deploy sinker-rbac
-  command: "oc -n {{ prowNamespace }} apply -f -"
+  command: "oc -n {{ prowJobsNamespace }} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/sinker-rbac.yaml')}}"
 - name: Deploy sinker
@@ -185,7 +202,7 @@
     namespace: "{{ prowNamespace }}"
     definition: "{{ lookup('template', '{{ role_path }}/templates/cherrypicker_service.yaml') | from_yaml }}"
 - name: Deploy prow-deck-rbac
-  command: "oc -n {{prowNamespace}} apply -f -"
+  command: "oc -n {{prowJobsNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/deck-rbac.yaml')}}"
 - name: Deploy prow-deck-service
@@ -197,7 +214,7 @@
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/deck-deployment.yaml')}}"
 - name: Deploy prow-tide-rbac
-  command: "oc -n {{prowNamespace}} apply -f -"
+  command: "oc -n {{prowJobsNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/tide-rbac.yaml')}}"
 - name: Deploy prow-tide-service
@@ -209,7 +226,7 @@
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/tide-deployment.yaml')}}"
 - name: Deploy prow-statusreconciler-rbac
-  command: "oc -n {{prowNamespace}} apply -f -"
+  command: "oc -n {{prowJobsNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/statusreconciler-rbac.yaml')}}"
 - name: Deploy prow-statusreconciler-deployment

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -110,6 +110,11 @@
   command: "oc -n {{prowNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('file', '{{ role_path }}/templates/memory-defaults.yaml') }}"
+- name: Deploy job limit range
+  command: "oc -n {{prowJobsNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('file', '{{ role_path }}/templates/memory-job-defaults.yaml') }}"
+
 - name: Deploy the pushgateway
   command: "oc -n {{prowNamespace}} apply -f -"
   args:

--- a/github/ci/prow/templates/accounts.yaml
+++ b/github/ci/prow/templates/accounts.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "deck"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "hook"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "horologium"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "plank"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "sinker"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "statusreconciler"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "tide"
+---

--- a/github/ci/prow/templates/deck-rbac.yaml
+++ b/github/ci/prow/templates/deck-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "deck"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -33,4 +28,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "deck"
+  namespace: "{{prowJobsNamespace}}"
 ---

--- a/github/ci/prow/templates/hook-rbac.yaml
+++ b/github/ci/prow/templates/hook-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "hook"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -36,3 +31,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "hook"
+  namespace: "{{prowJobsNamespace}}"

--- a/github/ci/prow/templates/horologium-rbac.yaml
+++ b/github/ci/prow/templates/horologium-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "horologium"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -27,3 +22,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "horologium"
+  namespace: "{{prowJobsNamespace}}"

--- a/github/ci/prow/templates/memory-job-defaults.yaml
+++ b/github/ci/prow/templates/memory-job-defaults.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+spec:
+  limits:
+  - defaultRequest:
+      memory: 1Gi
+    type: Container

--- a/github/ci/prow/templates/plank-rbac.yaml
+++ b/github/ci/prow/templates/plank-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "plank"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -36,3 +31,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "plank"
+  namespace: "{{prowJobsNamespace}}"

--- a/github/ci/prow/templates/sinker-rbac.yaml
+++ b/github/ci/prow/templates/sinker-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "sinker"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -34,3 +29,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "sinker"
+  namespace: "{{prowJobsNamespace}}"

--- a/github/ci/prow/templates/statusreconciler-rbac.yaml
+++ b/github/ci/prow/templates/statusreconciler-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "statusreconciler"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -26,3 +21,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "statusreconciler"
+  namespace: "{{prowJobsNamespace}}"

--- a/github/ci/prow/templates/tide-rbac.yaml
+++ b/github/ci/prow/templates/tide-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: "tide"
----
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -27,3 +22,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "tide"
+  namespace: "{{prowJobsNamespace}}"


### PR DESCRIPTION
Move Jobs and Pods into a separate namespace, so that jobs are isolated from the prow components and that we can have for instance distinct memory limits.