### PR TITLE
Set correct config-map namepspace for config-updater

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -2,12 +2,16 @@ config_updater:
   maps:
     github/ci/prow/files/config.yaml:
       name: config
+      namespace: kubevirt-prow
     github/ci/prow/files/jobs/**/*.yaml:
       name: job-config
+      namespace: kubevirt-prow
     github/ci/prow/files/plugins.yaml:
       name: plugins
+      namespace: kubevirt-prow
     github/ci/prow/files/labels.yaml:
       name: label-config
+      namespace: kubevirt-prow
 
 plugins:
   kubevirt:


### PR DESCRIPTION
The config updater looks by default into the namespace of the prowjobs.
We have the prowjobs now in a different namespace than the prow
components. Setting the namespace therefore now explicitly for all
config maps. Fixes #88 