### PR TITLE
Always run kubevirt e2e with prow instead of stdci

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -1,42 +1,13 @@
 presubmits:
   kubevirt/kubevirt:
-  - name: pull-kubevirt-e2e-k8s-1.10.11
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 14400000000000 # 4h
-      grace_period: 500000000000 # 5m
-    max_concurrency: 8
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        model: r430
-        type: bare-metal
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "export TARGET=k8s-1.10.11 && automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "12Gi"
   - name: pull-kubevirt-e2e-k8s-1.11.0
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 14400000000000 # 4h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -59,13 +30,13 @@ presubmits:
           requests:
             memory: "12Gi"
   - name: pull-kubevirt-e2e-k8s-genie-1.11.1
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 14400000000000 # 4h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -88,13 +59,13 @@ presubmits:
           requests:
             memory: "12Gi"
   - name: pull-kubevirt-e2e-k8s-multus-1.13.3
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 14400000000000 # 4h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -117,13 +88,13 @@ presubmits:
           requests:
             memory: "12Gi"
   - name: pull-kubevirt-e2e-os-3.11.0-crio
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 18000000000000 # 5h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -146,13 +117,13 @@ presubmits:
           requests:
             memory: "16Gi"
   - name: pull-kubevirt-e2e-os-3.11.0-multus
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 18000000000000 # 5h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -175,13 +146,13 @@ presubmits:
           requests:
             memory: "16Gi"
   - name: pull-kubevirt-e2e-os-3.11.0
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 18000000000000 # 5h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -233,13 +204,13 @@ presubmits:
           requests:
             memory: "19Gi"
   - name: pull-kubevirt-e2e-windows2016
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
       timeout: 14400000000000 # 4h
       grace_period: 500000000000 # 5m
-    max_concurrency: 8
+    max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"


### PR DESCRIPTION
/hold

Can only be merged after the following preconditions:
 * #91 needs to be merged
 * https://github.com/kubevirt/kubevirt/pull/2199 needs to be merged
 * The stdci webhook needs to be disabled for kubevirt/kubevirt

In case something goes wrong, the tests can be disabled again and the stdci webhook re-enabled.
This does not enable `tide`. It only let's the prow jobs run.