### PR TITLE
Give plank "get" access to prowjobs

### DIFF
--- a/github/ci/prow/templates/plank-rbac.yaml
+++ b/github/ci/prow/templates/plank-rbac.yaml
@@ -18,6 +18,7 @@ rules:
     verbs:
       - create
       - list
+      - get
       - update
 ---
 kind: RoleBinding


### PR DESCRIPTION
"get" was missing and led to situations where plank can not properly
update prowjobs.