### PR TITLE
Run Prow services on the CI zone

### DIFF
--- a/github/ci/prometheus/templates/grafana.yaml
+++ b/github/ci/prometheus/templates/grafana.yaml
@@ -23,12 +23,13 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       containers:
         - name: grafana
           image: "grafana/grafana:5.2.1"
           imagePullPolicy: "IfNotPresent"
           command:
-            - grafana-server 
+            - grafana-server
             - --homepath=/usr/share/grafana
             - --config=/etc/grafana/grafana.ini
             - cfg:default.log.mode=console

--- a/github/ci/prometheus/templates/prometheus.yaml
+++ b/github/ci/prometheus/templates/prometheus.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       priorityClassName: system-cluster-critical
       containers:
         - name: prometheus-server-configmap-reload

--- a/github/ci/prometheus/templates/token-counter.yaml
+++ b/github/ci/prometheus/templates/token-counter.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       containers:
       - name: token-counter
         args:

--- a/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
@@ -5,6 +5,7 @@ periodics:
   spec:
     nodeSelector:
       type: vm
+      zone: ci
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
       command:
@@ -39,6 +40,7 @@ periodics:
   spec:
     nodeSelector:
       type: vm
+      zone: ci
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
       command:
@@ -76,6 +78,7 @@ periodics:
   spec:
     nodeSelector:
       type: vm
+      zone: ci
     containers:
     - image: gcr.io/k8s-testimages/commenter:v20170808-abf66782
       command:

--- a/github/ci/prow/files/jobs/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20190213-2748736
         args:

--- a/github/ci/prow/templates/hook.yaml
+++ b/github/ci/prow/templates/hook.yaml
@@ -18,6 +18,7 @@ spec:
     spec:
       nodeSelector:
         type: vm
+        zone: ci
       serviceAccountName: hook
       terminationGracePeriodSeconds: 180
       containers:


### PR DESCRIPTION
The infra zone consist of VMs that can migrate, thus we use
it for running Jenkins instances in order to achieve high availability
(we can't run replicas of Jenkins because they can't share the same
storage).

We prefer not to have other services on the nodes that runs the Jenkins
instances, in order to make it more stable.

Signed-off-by: gbenhaim <galbh2@gmail.com>