### PR TITLE
Use newer boostrap image with newer docker

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -46,7 +46,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -75,7 +75,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -104,7 +104,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -133,7 +133,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -162,7 +162,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -191,7 +191,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -220,7 +220,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -249,7 +249,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"

--- a/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -38,7 +38,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -63,7 +63,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -89,7 +89,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -114,7 +114,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -140,7 +140,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -166,7 +166,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -193,7 +193,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -218,7 +218,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -244,7 +244,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -269,7 +269,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -295,7 +295,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -320,7 +320,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -346,7 +346,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -371,7 +371,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -397,7 +397,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -422,7 +422,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -448,7 +448,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -473,7 +473,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -499,7 +499,7 @@ presubmits:
         model: r430
         type: bare-metal
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190211-fab6034b4
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/12655 is merged which brings a newer docker version. This docker version is not affected by https://github.com/moby/moby/issues/37581. This allows us to prepare containerized clusters which create containers bigger than 8GB.