### PR TITLE
kubevirt-presubmits: create shared-iso mount type if needed

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -89,7 +89,7 @@ presets:
   - name: shared-iso
     hostPath:
       path: /var/lib/stdci/shared/kubevirt-images/
-      type: Directory
+      type: DirectoryOrCreate
   volumeMounts:
   - name: shared-iso
     mountPath: /var/lib/stdci/shared/kubevirt-images/


### PR DESCRIPTION
Modified it to `DirectoryOrCreate` instead of `Directory`.