### PR TITLE
testing new hosts

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -103,3 +103,8 @@ presets:
   volumeMounts:
   - name: shared-iso
     mountPath: /var/lib/stdci/shared/kubevirt-images/
+- labels:
+    preset-bazel-cache: "true"
+  env:
+  - name: BAZEL_CACHE
+    value: "http://bazel-cache-external.kubevirt-prow.svc.cluster.local:8080/kubevirt.io/kubevirt"

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -84,6 +84,16 @@ presets:
     mountPath: /etc/default
     readOnly: true
 - labels:
+    preset-docker-mtu: "true"
+  volumes:
+  - name: docker-config
+    configMap:
+      name: docker-daemon-mtu-config
+  volumeMounts:
+  - name: docker-config
+    mountPath: /etc/default
+    readOnly: true
+- labels:
     preset-shared-images: "true"
   volumes:
   - name: shared-iso

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
@@ -1,0 +1,263 @@
+presubmits:
+  kubevirt/kubevirt:
+  - name: pull-kubevirt-e2e-k8s-1.11.0
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-1.11.0 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-kubevirt-e2e-k8s-genie-1.11.1
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-genie-1.11.1 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-kubevirt-e2e-k8s-1.13.3
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-kubevirt-e2e-k8s-multus-1.13.3
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-kubevirt-e2e-os-3.11.0-crio
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=os-3.11.0-crio && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "16Gi"
+  - name: pull-kubevirt-e2e-os-3.11.0-multus
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=os-3.11.0-multus && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "16Gi"
+  - name: pull-kubevirt-e2e-os-3.11.0
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=os-3.11.0 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "16Gi"
+  - name: pull-kubevirt-e2e-okd-4.1.0-rc.0
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 8
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=okd-4.1.0-rc.0 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "19Gi"
+  - name: pull-kubevirt-e2e-windows2016
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        model: r430
+        type: bare-metal
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=windows2016 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
@@ -11,6 +11,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-shared-images: "true"
+      preset-docker-mtu: "true"
     spec:
       nodeSelector:
         kubernetes.io/hostname: 139.178.69.73.nip.io
@@ -36,6 +37,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -63,6 +65,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -90,6 +93,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -117,6 +121,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -144,6 +149,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -171,6 +177,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -198,6 +205,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 8
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:
@@ -225,6 +233,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
@@ -4,11 +4,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
       preset-docker-mtu: "true"
@@ -32,11 +34,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -60,11 +64,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -88,11 +94,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -116,11 +124,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -144,11 +154,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -172,11 +184,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -200,11 +214,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 8
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"
@@ -228,11 +244,13 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 5
     labels:
+      preset-bazel-cache: "true"
       preset-docker-mtu: "true"
       preset-dind-enabled: "true"
       preset-shared-images: "true"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
@@ -90,7 +90,530 @@ presubmits:
         resources:
           requests:
             memory: "12Gi"
-  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-7
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-8
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-9
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-10
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-11
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-12
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-13
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-14
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-15
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-16
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-17
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-18
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-1
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-2
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-3
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-4
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-5
+    always_run: true
+    optional: true
+    decorate: true
+    skip_report: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 5
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mtu: "true"
+      preset-dind-enabled: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "12Gi"
+
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3-6
     always_run: true
     optional: true
     decorate: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-packer-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubevirt/kubevirt:
-  - name: pull-kubevirt-e2e-k8s-1.11.0
+  - name: pull-packer-kubevirt-e2e-k8s-1.11.0
     always_run: true
     optional: true
     decorate: true
@@ -10,12 +10,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -29,7 +27,7 @@ presubmits:
         resources:
           requests:
             memory: "12Gi"
-  - name: pull-kubevirt-e2e-k8s-genie-1.11.1
+  - name: pull-packer-kubevirt-e2e-k8s-genie-1.11.1
     always_run: true
     optional: true
     decorate: true
@@ -39,12 +37,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -58,7 +54,7 @@ presubmits:
         resources:
           requests:
             memory: "12Gi"
-  - name: pull-kubevirt-e2e-k8s-1.13.3
+  - name: pull-packer-kubevirt-e2e-k8s-1.13.3
     always_run: true
     optional: true
     decorate: true
@@ -68,12 +64,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -87,7 +81,7 @@ presubmits:
         resources:
           requests:
             memory: "12Gi"
-  - name: pull-kubevirt-e2e-k8s-multus-1.13.3
+  - name: pull-packer-kubevirt-e2e-k8s-multus-1.13.3
     always_run: true
     optional: true
     decorate: true
@@ -97,12 +91,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -116,7 +108,7 @@ presubmits:
         resources:
           requests:
             memory: "12Gi"
-  - name: pull-kubevirt-e2e-os-3.11.0-crio
+  - name: pull-packer-kubevirt-e2e-os-3.11.0-crio
     always_run: true
     optional: true
     decorate: true
@@ -126,12 +118,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -145,7 +135,7 @@ presubmits:
         resources:
           requests:
             memory: "16Gi"
-  - name: pull-kubevirt-e2e-os-3.11.0-multus
+  - name: pull-packer-kubevirt-e2e-os-3.11.0-multus
     always_run: true
     optional: true
     decorate: true
@@ -155,12 +145,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -174,7 +162,7 @@ presubmits:
         resources:
           requests:
             memory: "16Gi"
-  - name: pull-kubevirt-e2e-os-3.11.0
+  - name: pull-packer-kubevirt-e2e-os-3.11.0
     always_run: true
     optional: true
     decorate: true
@@ -184,12 +172,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -203,8 +189,8 @@ presubmits:
         resources:
           requests:
             memory: "16Gi"
-  - name: pull-kubevirt-e2e-okd-4.1.0-rc.0
-    always_run: false
+  - name: pull-packer-kubevirt-e2e-okd-4.1.0-rc.0
+    always_run: true
     optional: true
     decorate: true
     decoration_config:
@@ -213,12 +199,10 @@ presubmits:
     max_concurrency: 8
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
@@ -232,7 +216,7 @@ presubmits:
         resources:
           requests:
             memory: "19Gi"
-  - name: pull-kubevirt-e2e-windows2016
+  - name: pull-packer-kubevirt-e2e-windows2016
     always_run: true
     optional: true
     decorate: true
@@ -242,12 +226,10 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
-        model: r430
-        type: bare-metal
+        kubernetes.io/hostname: 139.178.69.73.nip.io
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:

--- a/github/ci/prow/templates/config.yaml
+++ b/github/ci/prow/templates/config.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
+data:
+  docker: |
+    DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"
+    DOCKER_OPTS="${DOCKER_OPTS} --mtu=1450"
 kind: ConfigMap
 metadata:
-  name: config
-data:
-  config.yaml: |
-{{ prowConfig | indent(width=4, indentfirst=True) }}
+  name: docker-daemon-mtu-config
+  namespace: kubevirt-prow-jobs

--- a/github/ci/prow/templates/config.yaml
+++ b/github/ci/prow/templates/config.yaml
@@ -1,9 +1,113 @@
+---
 apiVersion: v1
 data:
   docker: |
     DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"
     DOCKER_OPTS="${DOCKER_OPTS} --mtu=1450"
+    DOCKER_OPTS="${DOCKER_OPTS} --registry-mirror=http://docker-mirror-external.kubevirt-prow.svc:5000 --insecure-registry=http://docker-mirror-external.kubevirt-prow.svc:5000"
 kind: ConfigMap
 metadata:
   name: docker-daemon-mtu-config
   namespace: kubevirt-prow-jobs
+---  
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: greenhouse-external
+  namespace: kubevirt-prow
+  labels:
+    app: greenhouse-external
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: greenhouse-external
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - name: greenhouse
+        image: gcr.io/k8s-testimages/greenhouse@sha256:ab1a3421cc3c072a813d8543735f218ca6caa811011391a0e5b00104700e6e7b
+        imagePullPolicy: Always
+        ports:
+        - name: cache
+          containerPort: 8080
+        - name: metrics
+          containerPort: 9090
+        args:
+        - --dir=/data
+        - --min-percent-blocks-free=3
+        volumeMounts:
+        - name: cache
+          mountPath: /data
+        resources:
+          requests:
+            memory: 3Gi
+          limits:
+            memory: 3Gi
+      volumes:
+      - name: cache
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bazel-cache-external
+  namespace: kubevirt-prow
+  labels:
+    run: bazel-cache-external
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: greenhouse-external
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-mirror-external
+  namespace: kubevirt-prow
+spec:
+  selector:
+    matchLabels:
+      app: docker-mirror-external
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: docker-mirror-external
+    spec:
+      terminationGracePeriodSeconds: 180
+      nodeSelector:
+        kubernetes.io/hostname: 139.178.69.73.nip.io
+      containers:
+      - name: mirror
+        image: registry:2.7.1
+        volumeMounts:
+        - name: config
+          mountPath: /etc/docker/registry/
+          readOnly: true
+        - name: storage
+          mountPath: /var/lib/registry
+        ports:
+          - name: http
+            containerPort: 5000
+      volumes:
+      - name: config
+        configMap:
+          name: mirror-config
+      - name: storage
+        emptyDir: {}
+---  
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-mirror-external
+  namespace: kubevirt-prow
+spec:
+  selector:
+    app: docker-mirror-external
+  ports:
+  - port: 5000

--- a/github/ci/prow/templates/routes.yaml
+++ b/github/ci/prow/templates/routes.yaml
@@ -31,3 +31,22 @@ spec:
     name: deck
     weight: 100
   wildcardPolicy: None
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: deck-legacy
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  host: "deck-kubevirt-prow.apps.ovirt.org"
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: deck
+    weight: 100
+  wildcardPolicy: None
+
+
+  


### PR DESCRIPTION
/hold

```
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-os-3.11.0-crio  -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-k8s-1.11.0 -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-k8s-genie-1.11.1 -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-k8s-1.13.3 -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-k8s-multus-1.13.3 -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-os-3.11.0-crio -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-os-3.11.0-multus -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-os-3.11.0 -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
mkpj --pull-number 2338 -job pull-packer-kubevirt-e2e-windows2016 -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
oc create -f job.yaml -n kubevirt-prow-jobs
```


 * Disable docker cache
 * Schedule on new nodes only