### PR TITLE
Reduce max_concurrency of presubmits to 3

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decoration_config:
       timeout: 4h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -36,7 +36,7 @@ presubmits:
     decoration_config:
       timeout: 4h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -65,7 +65,7 @@ presubmits:
     decoration_config:
       timeout: 4h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -94,7 +94,7 @@ presubmits:
     decoration_config:
       timeout: 4h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -123,7 +123,7 @@ presubmits:
     decoration_config:
       timeout: 5h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -152,7 +152,7 @@ presubmits:
     decoration_config:
       timeout: 5h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -181,7 +181,7 @@ presubmits:
     decoration_config:
       timeout: 5h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -210,7 +210,7 @@ presubmits:
     decoration_config:
       timeout: 4h
       grace_period: 5m
-    max_concurrency: 8
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -239,7 +239,7 @@ presubmits:
     decoration_config:
       timeout: 4h
       grace_period: 5m
-    max_concurrency: 5
+    max_concurrency: 3
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"


### PR DESCRIPTION
With max_concurrency set to 5, we're taking
all the available resources of the cluster
and other projects end up waiting for too
long time before they get a some compute
resources.