### PR TITLE
Feat: Adding Kubevirt-Tutorial to Prow config allowing repo management

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -39,6 +39,7 @@ tide:
     kubevirt/kubevirtci: squash
     kubevirt/kubevirt.github.io: squash
     kubevirt/cloud-image-builder: squash
+    kubevirt/kubevirt-tutorial: squash
 
   queries:
   - repos:
@@ -46,6 +47,7 @@ tide:
     - kubevirt/kubevirtci
     - kubevirt/kubevirt.github.io
     - kubevirt/cloud-image-builder
+    - kubevirt/kubevirt-tutorial
     labels:
     - lgtm
     - approved

--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -326,3 +326,23 @@ repos:
         target: both
         addedBy: anyone
         prowPlugin: label
+  kubevirt/kubevirt-tutorial:
+    labels:
+      - color: 80e591
+        description: Label for new Labs included
+        name: kind/new-lab
+        target: prs
+        addedBy: anyone
+        prowPlugin: label
+      - color: 064d70
+        description: Label for Lab deployment inclusion
+        name: kind/lab-deployment
+        target: prs
+        addedBy: anyone
+        prowPlugin: label
+      - name: kind/lab-updates
+        description: Label for Labs updates
+        color: bfd4f2
+        target: pr
+        addedBy: anyone
+        prowPlugin: label

--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -57,6 +57,12 @@ plugins:
   - owners-label
   - trigger
 
+  kubevirt/kubevirt-tutorial:
+  - approve
+  - lgtm
+  - owners-label
+  - trigger
+
   kubevirt/cloud-image-builder:
   - approve
   - lgtm
@@ -82,6 +88,7 @@ triggers:
   - kubevirt/kubevirt
   - kubevirt/kubevirt.github.io
   - kubevirt/cloud-image-builder
+  - kubevirt/kubevirt-tutorial
   trusted_org: kubevirt
 
 approve:
@@ -91,6 +98,7 @@ approve:
   - kubevirt/kubevirt.github.io
   - kubevirt/cloud-image-builder
   - kubevirt/community
+  - kubevirt/kubevirt-tutorial
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -102,4 +110,5 @@ lgtm:
   - kubevirt/kubevirt.github.io
   - kubevirt/cloud-image-builder
   - kubevirt/community
+  - kubevirt/kubevirt-tutorial
   review_acts_as_lgtm: true


### PR DESCRIPTION
**Added Kubevirt-Tutorial repo to Prow CI/CD**

- Added Config to manage AutoMerges on Kubevirt-Tutorial repo
- Added Plugins:
  - approve
  - lgtm
  - owners-label
  - config-updater
  - skip
  - override
  - trigger

- Added Labels for this concrete repo:
  - kind/lab-updates
  - kind/lab-deployment
  - kind/new-lab