### PR TITLE
Give caches their own serviceaccount

### DIFF
--- a/github/ci/prow/templates/accounts.yaml
+++ b/github/ci/prow/templates/accounts.yaml
@@ -21,6 +21,11 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: "caches"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
   name: "sinker"
 ---
 apiVersion: v1

--- a/github/ci/prow/templates/greenhouse-deployment.yaml
+++ b/github/ci/prow/templates/greenhouse-deployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         app: greenhouse
     spec:
+      serviceAccountName: "caches"
       nodeSelector:
         type: bare-metal-external
         zone: ci

--- a/github/ci/prow/templates/mirror.yaml
+++ b/github/ci/prow/templates/mirror.yaml
@@ -13,6 +13,7 @@ spec:
         app: docker-mirror
     spec:
       terminationGracePeriodSeconds: 180
+      serviceAccountName: "caches"
       nodeSelector:
         type: bare-metal-external
       containers:


### PR DESCRIPTION
The caches write to hostPaths, give them their own service account which
is allowed to use hostPaths.

@slintes already rolled out. Was necessary to let the containers start.