### PR TITLE
Tide for kubevirt/kubevirt

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -40,6 +40,7 @@ log_level: debug
 
 tide:
   merge_method:
+    kubevirt/kubevirt: merge
     kubevirt/project-infra: squash
     kubevirt/kubevirtci: squash
     kubevirt/kubevirt.github.io: squash
@@ -64,12 +65,39 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
+  - repos:
+    - kubevirt/kubevirt
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - needs-rebase
   pr_status_base_url: https://prow.apps.ovirt.org/pr
   context_options:
-    # Use branch protection options to define required and optional contexts
-    from-branch-protection: false
-    # Treat unknown contexts as optional
-    skip-unknown-contexts: true
+    orgs:
+     kubevirt:
+      repos:
+        dashboard:
+          skip-unknown-contexts: true
+          from-branch-protection: true
+
+# we don't enable the branch protector itself yet, but want to
+# let tide know that travis-ci is needed
+branch-protection:
+  orgs:
+    kubevirt:
+      repos:
+        kubevirt:
+          protect: true
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci
+            - coverage/coveralls
 
 push_gateway:
   endpoint: pushgateway

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -1,8 +1,8 @@
 presubmits:
   kubevirt/kubevirt:
   - name: pull-kubevirt-e2e-k8s-1.11.0
-    always_run: true
-    optional: true
+    always_run: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -29,8 +29,8 @@ presubmits:
           requests:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-k8s-genie-1.11.1
-    always_run: true
-    optional: true
+    always_run: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -58,7 +58,7 @@ presubmits:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-k8s-1.13.3
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -86,7 +86,7 @@ presubmits:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-k8s-multus-1.13.3
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -114,7 +114,7 @@ presubmits:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-os-3.11.0-crio
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -141,8 +141,8 @@ presubmits:
           requests:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-os-3.11.0-multus
-    always_run: true
-    optional: true
+    always_run: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -169,8 +169,8 @@ presubmits:
           requests:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-os-3.11.0
-    always_run: true
-    optional: true
+    always_run: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h
@@ -225,8 +225,8 @@ presubmits:
           requests:
             memory: "24Gi"
   - name: pull-kubevirt-e2e-windows2016
-    always_run: true
-    optional: true
+    always_run: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
Tide is now enabled for kubevirt and will treat travis and coveralls as external required tests.

Further the test-run configuration looks now like this:

All e2e test are required, but don't run all of them until the PR is
approved.

The following tests will always run:

 * pull-kubevirt-e2e-k8s-1.13.3
 * pull-kubevirt-e2e-k8s-multus-1.13.3
 * pull-kubevirt-e2e-os-3.11.0-crio

The following tests will only be run when a PR is in the merge pool:

 * pull-kubevirt-e2e-k8s-1.11.0
 * pull-kubevirt-e2e-k8s-genie-1.11.1
 * pull-kubevirt-e2e-os-3.11.0-multus
 * pull-kubevirt-e2e-windows2016

Tests which by default only run in the merge-pool can still be triggered
via `/test <name>` or `/test all` and will be rerun if `/retest` is done
afterwards.
 