### PR TITLE
Allow jobs which run always to run more often

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
     decoration_config:
       timeout: 5h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 10
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -91,7 +91,7 @@ presubmits:
     decoration_config:
       timeout: 5h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 10
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -119,7 +119,7 @@ presubmits:
     decoration_config:
       timeout: 5h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 10
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"


### PR DESCRIPTION
Now we only run a subset of jobs when PRs are opened. They can now run
more often, since the other tests don't run by default that often
anymore. They only run when the PR is in the mergepool or if they are
manually triggered. This should help to bring PR faster into the merge
pool.