### PR TITLE
Add commenter bot token

### DIFF
--- a/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
@@ -37,7 +37,7 @@ periodics:
     volumes:
     - name: token
       secret:
-        secretName:  oauth-token
+        secretName:  commenter-oauth-token
 - name: periodic-test-infra-close
   interval: 1h
   decorate: true

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -94,6 +94,18 @@
       type: Opaque
       data:
         oauth: "{{ githubToken | b64encode }}"
+- name: Create OAuth commenter secret in prow jobs namespace
+  k8s:
+    state: present
+    namespace: "{{ prowJobsNamespace }}"
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: commenter-oauth-token
+      type: Opaque
+      data:
+        oauth: "{{ githubCommenterToken | b64encode }}"
 - name: Create OAuth Config
   k8s:
     state: present


### PR DESCRIPTION
Prow ignores `/retest` from itself. Therefore we need an extra commenter bot account.