### PR TITLE
Add job for sriov ci

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -313,7 +313,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "automation/check-patch.k8s-1.14.2-kind-sriov.sh"
+        - "apt update && apt install pciutils -y && automation/check-patch.k8s-1.14.2-kind-sriov.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -329,16 +329,16 @@ presubmits:
             mountPath: /sys/fs/cgroup
           - name: vfio
             mountPath: /dev/vfio/
-        volumes:
-          - name: modules
-            hostPath:
-              path: /lib/modules
-              type: Directory
-          - name: cgroup
-            hostPath:
-              path: /sys/fs/cgroup
-              type: Directory
-          - name: vfio
-            hostPath:
-              path: /dev/vfio/
-              type: Directory
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio/
+            type: Directory

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -302,7 +302,7 @@ presubmits:
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
-              - key: sriovpod
+              - key: sriov-pod
                 operator: In
                 values:
                 - "true"
@@ -319,7 +319,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "24Gi"
+            memory: "29Gi"
         volumeMounts:
           #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
           - name: modules   

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -313,7 +313,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "automation/check-patch.k8s-1.13.6-kind-sriov.sh"
+        - "automation/check-patch.k8s-1.14.2-kind-sriov.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -280,3 +280,65 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
+  - name: pull-kubevirt-e2e-k8s-sriov-kind-1.13.6
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 10
+    annotations:
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+      sriov-pod: "true"
+    spec:
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: sriovpod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "automation/check-patch.k8s-1.13.6-kind-sriov.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "24Gi"
+        volumeMounts:
+          #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+          - name: modules   
+            mountPath: /lib/modules
+            readOnly: true
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: vfio
+            mountPath: /dev/vfio/
+        volumes:
+          - name: modules
+            hostPath:
+              path: /lib/modules
+              type: Directory
+          - name: cgroup
+            hostPath:
+              path: /sys/fs/cgroup
+              type: Directory
+          - name: vfio
+            hostPath:
+              path: /dev/vfio/
+              type: Directory

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -280,7 +280,7 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-sriov-kind-1.13.6
+  - name: pull-kubevirt-e2e-kind-k8s-sriov-1.14.2
     always_run: true
     optional: false
     decorate: true
@@ -313,7 +313,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "apt update && apt install pciutils -y && automation/check-patch.k8s-1.14.2-kind-sriov.sh"
+        - "apt update && apt install pciutils -y && export TARGET=kind-k8s-sriov-1.14.2 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR configures a new job for running kubevirt tests that need a sriov device.
