### PR TITLE
Feat: Added Kubevirt-Tutorial related jobs for lab testing

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
@@ -1,0 +1,27 @@
+periodics:
+  - interval: 96h
+    name: periodic-kubevirt-tutorial-lab-testing
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+    extra_refs:
+      - org: kubevirt
+        repo: kubevirt-tutorial
+        base_ref: master
+        path_alias: kubevirt-tutorial
+    spec:
+      nodeSelector:
+        region: primary
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.13.3 && make tests"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "10Gi"

--- a/github/ci/prow/files/jobs/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
@@ -1,0 +1,25 @@
+presubmits:
+  kubevirt/kubevirt-tutorial:
+    - name: kubevirt-tutorial-presubmit-lab-testing-k8s-1.13.3
+      always_run: true
+      skip_report: false
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+      spec:
+        nodeSelector:
+          region: primary
+        containers:
+          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.13.3 && make tests"
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "10Gi"

--- a/github/ci/prow/files/jobs/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -2,6 +2,11 @@ periodics:
   - interval: 24h
     name: kubevirt-io-periodic-link-checker
     decorate: true
+    extra_refs:
+      - org: kubevirt
+        repo: kubevirt.github.io
+        base_ref: master
+        path_alias: kubevirt.github.io
     spec:
       nodeSelector:
         region: primary
@@ -11,4 +16,4 @@ periodics:
             - name: NOKOGIRI_USE_SYSTEM_LIBRARIES
               value: "true"
           command: ["/bin/sh", "-c"]
-          args: ["git clone https://github.com/kubevirt/kubevirt.github.io.git && cd kubevirt.github.io && /usr/local/bin/bundle install && bundle exec rake"]
+          args: ["/usr/local/bin/bundle install && bundle exec rake"]


### PR DESCRIPTION
- Added Periodic job to test laboratories every 96h
- Added Presubmit job to test labs on every PR
- Both, periodics and presubmits jobs uploads log files for every lab tested, also the log from the Job (more info at https://github.com/kubevirt/kubevirt-tutorial/pull/105 PR)
- Refactored kubevirt.io link-checker job using extra-refs instead of a raw git clone

WIP: Still waiting on https://github.com/kubevirt/kubevirt-tutorial/pull/105 to be merged before continue with this one.