### PR TITLE
Fix the pod antiaffinity spec under affinity

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -298,15 +298,16 @@ presubmits:
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:


### PR DESCRIPTION
https://github.com/kubevirt/project-infra/pull/138 added a job for sriov ci but the pod antiaffinity section is wrong, so multiple pods are running at the same time causing tests to fail.