### PR TITLE
Deploy gcsweb viewer

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -19,6 +19,7 @@ plank:
 deck:
   spyglass:
     size_limit: 500000000 # 500MB
+    gcs_browser_prefix: https://gcsweb.apps.ovirt.org/gcs/
     viewers:
       "started.json|finished.json":
       - "metadata"

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -289,6 +289,14 @@
   command: "oc -n {{prowNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/deck-deployment.yaml')}}"
+- name: Deploy gcsweb-service
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/gcsweb-service.yaml')}}"
+- name: Deploy gcsweb-deployment
+  command: "oc -n {{prowNamespace}} apply -f -"
+  args:
+    stdin: "{{ lookup('template', '{{ role_path }}/templates/gcsweb-deployment.yaml')}}"
 - name: Deploy prow-tide-rbac
   command: "oc -n {{prowJobsNamespace}} apply -f -"
   args:

--- a/github/ci/prow/templates/gcsweb-deployment.yaml
+++ b/github/ci/prow/templates/gcsweb-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  replicas: 2
+  # selector defaults from template labels
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: gcsweb
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: gcsweb
+          image: k8s.gcr.io/gcsweb:v1.1.0
+          args:
+            - -upgrade-proxied-http-to-https
+            - -b=kubevirt-prow
+            - -p=8080
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 0.1
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2

--- a/github/ci/prow/templates/gcsweb-service.yaml
+++ b/github/ci/prow/templates/gcsweb-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+spec:
+  selector:
+    app: gcsweb
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/github/ci/prow/templates/routes.yaml
+++ b/github/ci/prow/templates/routes.yaml
@@ -31,3 +31,19 @@ spec:
     name: deck
     weight: 100
   wildcardPolicy: None
+---
+apiVersion: v1
+kind: Route
+metadata:
+  name: gcsweb
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  host: "{{ gcswebUrl }}"
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: gcsweb
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
Add a gcsweb viewer which allows browsing test artifacts.  With this
config, an `Artifacts` button is visible in spyglass which points to all
artifacts uploaded by the job into gcs.