### PR TITLE
Release 0.17 jobs

### DIFF
--- a/github/ci/README.md
+++ b/github/ci/README.md
@@ -115,3 +115,15 @@ go get k8s.io/test-infra/prow/cmd/mkpj
 mkpj --pull-number <pr-number> -job <job-name>  -job-config-path github/ci/prow/files/jobs/ --config-path github/ci/prow/files/config.yaml > job.yaml
 oc create -f job.yaml -n kubevirt-prow-jobs
 ```
+
+### Forking kubevirt/kubevirt jobs on release
+
+Run
+
+```
+git clone git@github.com:kubernetes/test-infra.git
+cd test-infra
+bazel run //experiment/config-forker -- --job-config ~/project-infra/jobs/kubevirt/kubevirt-presubmits.yaml   --version ${RELEASE_VERSION} --output ~/project-infra/jobs/kubevirt/kubevirt-presubmits-${RELEASE_VERSION}.yaml
+```
+
+For more details see https://github.com/kubernetes/test-infra/blob/master/experiment/config-forker/README.md

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.17.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.17.yaml
@@ -71,35 +71,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    max_concurrency: 6
-    name: pull-kubevirt-e2e-k8s-1.13.3
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - export TARGET=k8s-1.13.3 && automation/test.sh
-        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    branches:
-    - release-0.17
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 6h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-k8s-multus-1.13.3
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.17.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.17.yaml
@@ -1,0 +1,296 @@
+periodics: null
+postsubmits: {}
+presubmits:
+  kubevirt/kubevirt:
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-k8s-1.11.0
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=k8s-1.11.0 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-k8s-genie-1.11.1
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=k8s-genie-1.11.1 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-k8s-1.13.3
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=k8s-1.13.3 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 10
+    name: pull-kubevirt-e2e-k8s-multus-1.13.3
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=k8s-multus-1.13.3 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-os-3.11.0-crio
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=os-3.11.0-crio && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-os-3.11.0-multus
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=os-3.11.0-multus && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-os-3.11.0
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=os-3.11.0 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-okd-4.1.0
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=okd-4.1.0 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-okd-4.1.2
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=okd-4.1.2 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.17
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    name: pull-kubevirt-e2e-windows2016
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=windows2016 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -1,6 +1,10 @@
 presubmits:
   kubevirt/kubevirt:
   - name: pull-kubevirt-e2e-k8s-1.11.0
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -29,6 +33,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-k8s-genie-1.11.1
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -57,6 +65,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-k8s-1.13.3
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -85,6 +97,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-k8s-multus-1.13.3
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -113,6 +129,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-os-3.11.0-crio
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -141,6 +161,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-os-3.11.0-multus
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -169,6 +193,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-os-3.11.0
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -197,6 +225,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-okd-4.1.0
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: false
     optional: true
     decorate: true
@@ -225,6 +257,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-okd-4.1.2
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: false
     optional: true
     decorate: true
@@ -253,6 +289,10 @@ presubmits:
             requests:
               memory: "29Gi"
   - name: pull-kubevirt-e2e-windows2016
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true
@@ -281,6 +321,10 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-kubevirt-e2e-kind-k8s-sriov-1.14.2
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
     always_run: true
     optional: false
     decorate: true


### PR DESCRIPTION
* Lock master jobs to non-release branches 
* Ensure that we have a sane and locked set of CI jobs for 0.17 release.

The jobs were generated with the config-forker from test-infra. Related to #121. We are still at a very dark spot for our longterm 0.13 release branch.