### PR TITLE
Use same container image for all Virt Blocks jobs

### DIFF
--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
@@ -19,7 +19,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.12.5
+        - image: kubevirt/golang-libtool:1.12.5-r1
           command:
             - "make"
             - "vet"
@@ -33,7 +33,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: golang:1.12.5
+        - image: kubevirt/golang-libtool:1.12.5-r1
           command:
             - "make"
             - "verify-fmt"


### PR DESCRIPTION
While technically the `pull-virtblocks-vet` and `pull-virtblocks-fmt` jobs don't need `libtool` to run, it makes sense that all jobs for the projects would use the same container image.