### PR TITLE
virtblocks: Set VIRTBLOCKS_LANGUAGE=golang

### DIFF
--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
@@ -10,6 +10,8 @@ presubmits:
             - "make"
             - "build"
           env:
+            - name: VIRTBLOCKS_LANGUAGE
+              value: "golang"
             - name: GO111MODULE
               value: "on"
             - name: XDG_CACHE_HOME
@@ -24,6 +26,8 @@ presubmits:
             - "make"
             - "vet"
           env:
+            - name: VIRTBLOCKS_LANGUAGE
+              value: "golang"
             - name: GO111MODULE
               value: "on"
             - name: XDG_CACHE_HOME
@@ -38,6 +42,8 @@ presubmits:
             - "make"
             - "verify-fmt"
           env:
+            - name: VIRTBLOCKS_LANGUAGE
+              value: "golang"
             - name: GO111MODULE
               value: "on"
             - name: XDG_CACHE_HOME


### PR DESCRIPTION
This is necessary as of https://github.com/virtblocks/virtblocks/commit/42b2615357c41780abcc973cd2224e945da9f528.