### PR TITLE
Remove pci-utils, install gettext in for sriov lane (switch to sriov-operator)

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -358,7 +358,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "apt update && apt install pciutils -y && export TARGET=kind-k8s-sriov-1.14.2 && automation/test.sh"
+        - "apt update && apt install gettext-base -y && export TARGET=kind-k8s-sriov-1.14.2 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Once https://github.com/kubevirt/kubevirtci/pull/134 and https://github.com/kubevirt/kubevirt/pull/2628 are merged, the dependency with pciutils is not needed anymore since the setup is done via the openshift sriov operator, but the operator needs envsubst in order to work so we are installing it before running the tests.