### PR TITLE
Virt Blocks update

### DIFF
--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: kubevirt/golang-libtool:1.12.5-r1
+        - image: quay.io/virtblocks/buildenv:1.0.0
           command:
             - "make"
             - "build"
@@ -21,7 +21,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: kubevirt/golang-libtool:1.12.5-r1
+        - image: quay.io/virtblocks/buildenv:1.0.0
           command:
             - "make"
             - "vet"
@@ -37,7 +37,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: kubevirt/golang-libtool:1.12.5-r1
+        - image: quay.io/virtblocks/buildenv:1.0.0
           command:
             - "make"
             - "verify-fmt"

--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
@@ -14,6 +14,34 @@ presubmits:
               value: "on"
             - name: XDG_CACHE_HOME
               value: "/tmp/.cache"
+  - name: pull-virtblocks-test
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: quay.io/virtblocks/buildenv:1.0.0
+          command:
+            - "make"
+            - "test"
+          env:
+            - name: GO111MODULE
+              value: "on"
+            - name: XDG_CACHE_HOME
+              value: "/tmp/.cache"
+  - name: pull-virtblocks-run-examples
+    decorate: true
+    always_run: true
+    spec:
+      containers:
+        - image: quay.io/virtblocks/buildenv:1.0.0
+          command:
+            - "make"
+            - "run-examples"
+          env:
+            - name: GO111MODULE
+              value: "on"
+            - name: XDG_CACHE_HOME
+              value: "/tmp/.cache"
   - name: pull-virtblocks-vet
     decorate: true
     always_run: true

--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-periodics.yaml
@@ -10,8 +10,6 @@ presubmits:
             - "make"
             - "build"
           env:
-            - name: VIRTBLOCKS_LANGUAGE
-              value: "golang"
             - name: GO111MODULE
               value: "on"
             - name: XDG_CACHE_HOME
@@ -26,8 +24,6 @@ presubmits:
             - "make"
             - "vet"
           env:
-            - name: VIRTBLOCKS_LANGUAGE
-              value: "golang"
             - name: GO111MODULE
               value: "on"
             - name: XDG_CACHE_HOME
@@ -42,8 +38,6 @@ presubmits:
             - "make"
             - "verify-fmt"
           env:
-            - name: VIRTBLOCKS_LANGUAGE
-              value: "golang"
             - name: GO111MODULE
               value: "on"
             - name: XDG_CACHE_HOME


### PR DESCRIPTION
Build the Rust code along with the Go code; in addition to building, run the test suite and the example programs too.

Doing this requires using a custom container image that includes a Rust compiler.