### PR TITLE
Added build-change label

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -260,6 +260,12 @@ repos:
         target: prs
         prowPlugin: trigger
         addedBy: prow
+      - color: e11d21
+        description: Categorizes PRs as related to changing build files of virt-* components
+        name: kind/build-change
+        target: prs
+        prowPlugin: label
+        addedBy: anyone
   kubevirt/project-infra:
     labels:
       - color: 15dd18


### PR DESCRIPTION
Will be used via OWNER file in kubevirt/kubevirt repo in order to raise awareness for build changes