### PR TITLE
Fixed label config of area/virtctl

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -203,6 +203,8 @@ repos:
         color: bfd4f2
         target: both
       - name: area/virtctl
+        color: bfd4f2
+        target: both
       - name: topic/api
         color: c5def5
         target: both


### PR DESCRIPTION
added missing color and target for area/virtctl