### PR TITLE
Sort report data descending by severity

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1678849bd1bfd921e4429895d62f5fe864192596445d4735b8924da3104b69d3
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1678849bd1bfd921e4429895d62f5fe864192596445d4735b8924da3104b69d3
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1678849bd1bfd921e4429895d62f5fe864192596445d4735b8924da3104b69d3
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:26ea456d87ec11ef579af5ff49cbd0a865f574515c567e5d4005b1f3517543ea
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1678849bd1bfd921e4429895d62f5fe864192596445d4735b8924da3104b69d3
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:26ea456d87ec11ef579af5ff49cbd0a865f574515c567e5d4005b1f3517543ea
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1678849bd1bfd921e4429895d62f5fe864192596445d4735b8924da3104b69d3
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:26ea456d87ec11ef579af5ff49cbd0a865f574515c567e5d4005b1f3517543ea
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1678849bd1bfd921e4429895d62f5fe864192596445d4735b8924da3104b69d3
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/index.go
+++ b/robots/flakefinder/index.go
@@ -100,7 +100,7 @@ func CreateReportIndex(ctx context.Context, client *storage.Client) (err error) 
 }
 
 func CreateOutputWriter(client *storage.Client, ctx context.Context) io.WriteCloser {
-	reportIndexObject := client.Bucket(BucketName).Object(path.Join(ReportsPath, "index.html"))
+	reportIndexObject := client.Bucket(BucketName).Object(path.Join(ReportOutputPath, "index.html"))
 	log.Printf("Report index page will be written to gs://%s/%s", BucketName, reportIndexObject.ObjectName())
 	reportIndexObjectWriter := reportIndexObject.NewWriter(ctx)
 	return reportIndexObjectWriter
@@ -168,7 +168,7 @@ func PrepareDataForTemplate(reportDirGcsObjects []string) IndexParams {
 func getReportItemsFromBucketDirectory(client *storage.Client, ctx context.Context) ([]string, error) {
 	var reportDirGcsObjects []string
 	it := client.Bucket(BucketName).Objects(ctx, &storage.Query{
-		Prefix:    ReportsPath + "/",
+		Prefix:    ReportOutputPath + "/",
 		Delimiter: "/",
 	})
 	for {


### PR DESCRIPTION
Sort tests descending by severity, so that worst (red) test cells are shown at the top of the report.

Furthermore add `--preview` flag to not meddle with existing reports, i.e. old reports are not overwritten any more if flag is used, if flag is used reports are written to `.../preview` subdirectory instead.

[Report preview available here.](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/flakefinder-2019-09-05-024h.html)

**Note: this is a quick shot, sorting is not really descending, it rather is grouped as not the number of failed tests has been used but the severity instead. However, the effect is good...**

/cc @fedepaol 
/cc @fabiand 

Closes #186