### PR TITLE
Set DCO required for org members explicitly

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,3 @@
+---
+require:
+  members: true 


### PR DESCRIPTION
This is just a test for the Prow DCO plugin. I added an unsigned commit to see how it looks.

/hold
/cc @rmohr