### PR TITLE
Add dco-signoff:no to missingLabels for tide

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -68,6 +68,7 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - needs-rebase
+    - "dco-signoff: no"
   - repos:
     - kubevirt/kubevirt
     labels:
@@ -80,6 +81,7 @@ tide:
     - do-not-merge/work-in-progress
     - do-not-merge/release-note-label-needed
     - needs-rebase
+    - "dco-signoff: no"
   pr_status_base_url: https://prow.apps.ovirt.org/pr
   context_options:
     orgs:

--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -32,6 +32,7 @@ plugins:
   - pony
   - dog
   - cat
+  - dco
 
   kubevirt/kubevirt:
   - trigger
@@ -39,7 +40,6 @@ plugins:
   - owners-label
   - lgtm
   - approve
-  - dco
 
   kubevirt/machine-remediation-operator:
   - trigger
@@ -62,7 +62,6 @@ plugins:
   - trigger
   - lgtm
   - approve
-  - dco
 
   kubevirt/kubevirt.github.io:
   - approve


### PR DESCRIPTION
In order to avoid tide automatically merging PRs having this label
we later on can enable the dco plugin per repo or for the whole org
to enforce commit signoff.
We might think about making the dco check mandatory by branch-protection
to avoid being able to manually merge PRs failing the dco check.

/cc @rmohr 