### PR TITLE
Let tests w/o success be unmportant

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1305d0299ab75d1b7c5c9585ecc91e87738cb153c1bd6f9c1ab332c953f8a2c1
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1305d0299ab75d1b7c5c9585ecc91e87738cb153c1bd6f9c1ab332c953f8a2c1
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1305d0299ab75d1b7c5c9585ecc91e87738cb153c1bd6f9c1ab332c953f8a2c1
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/BUILD.bazel
+++ b/robots/flakefinder/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     deps = [
         "//vendor/github.com/google/go-github/v28/github:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -2,11 +2,13 @@ package main_test
 
 import (
 	"bytes"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"log"
 	"os"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 
 	. "kubevirt.io/project-infra/robots/flakefinder"
 )
@@ -121,5 +123,18 @@ var _ = Describe("report.go", func() {
 		})
 
 	})
+
+	DescribeTable("When calculating severity",
+		func(details *Details, expected string) {
+			SetSeverity(details)
+			Expect(details.Severity).To(BeEquivalentTo(expected))
+		},
+		Entry("no failed tests but successful tests is fine", &Details{Failed: 0, Succeeded: 1, Skipped: 2, Jobs: []*Job{}}, Fine),
+		Entry("test that never succeed is unimportant", &Details{Failed: 1, Succeeded: 0, Skipped: 2, Jobs: []*Job{}}, Unimportant),
+		Entry("HeavilyFlaky", &Details{Failed: 1, Succeeded: 1, Skipped: 2, Jobs: []*Job{}}, HeavilyFlaky),
+		Entry("MostlyFlaky", &Details{Failed: 1, Succeeded: 2, Skipped: 2, Jobs: []*Job{}}, MostlyFlaky),
+		Entry("ModeratelyFlaky", &Details{Failed: 1, Succeeded: 5, Skipped: 2, Jobs: []*Job{}}, ModeratelyFlaky),
+		Entry("MildlyFlaky", &Details{Failed: 1, Succeeded: 10, Skipped: 2, Jobs: []*Job{}}, MildlyFlaky),
+	)
 
 })

--- a/vendor/github.com/onsi/ginkgo/extensions/table/BUILD.bazel
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "table.go",
+        "table_entry.go",
+    ],
+    importmap = "kubevirt.io/project-infra/vendor/github.com/onsi/ginkgo/extensions/table",
+    importpath = "github.com/onsi/ginkgo/extensions/table",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/onsi/ginkgo:go_default_library"],
+)

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,81 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := []reflect.Value{}
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,6 +105,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/onsi/ginkgo v1.7.0
 github.com/onsi/ginkgo
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
 github.com/onsi/ginkgo/internal/failer


### PR DESCRIPTION
A test is flaky if it succeeds **and** fails. [This report](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/flakefinder-2019-09-12-672h.html) shows tests having these numbers

1/0/66

where the first number is the number of failed tests and the second number is the number of succeeded tests. Obviously this test has never succeeded and therefore should not be regarded as flaky.

This PR fixes this by setting priority of tests without successful test runs as unimportant.