### PR TITLE
Improve flakefinder test sorting

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:630d4d05c2a6bf810f6cc0dab6cdc2d7dce68f375a8870dfd2c6c4593ea5f68c
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ba3ccca1d326309eb424b552ee83e167069fc6aaa15558c763ea386493c1dd07
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:630d4d05c2a6bf810f6cc0dab6cdc2d7dce68f375a8870dfd2c6c4593ea5f68c
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ba3ccca1d326309eb424b552ee83e167069fc6aaa15558c763ea386493c1dd07
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:630d4d05c2a6bf810f6cc0dab6cdc2d7dce68f375a8870dfd2c6c4593ea5f68c
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ba3ccca1d326309eb424b552ee83e167069fc6aaa15558c763ea386493c1dd07
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:630d4d05c2a6bf810f6cc0dab6cdc2d7dce68f375a8870dfd2c6c4593ea5f68c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:630d4d05c2a6bf810f6cc0dab6cdc2d7dce68f375a8870dfd2c6c4593ea5f68c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:59d9a15c2efe2dd300326397875c64762625dadddaf72c78d38940cb5ea66ecb
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:630d4d05c2a6bf810f6cc0dab6cdc2d7dce68f375a8870dfd2c6c4593ea5f68c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/BUILD.bazel
+++ b/robots/flakefinder/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     deps = [
         "//vendor/github.com/google/go-github/v28/github:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/robots/flakefinder/index_test.go
+++ b/robots/flakefinder/index_test.go
@@ -71,7 +71,7 @@ var _ = Describe("index.go", func() {
 		buffer := bytes.Buffer{}
 		WriteReportIndexPage(reportDataFiles, &buffer)
 		htmlIndex := buffer.String()
-		logger.Printf(htmlIndex)
+		logger.Printf("")
 
 		It("uses all report items", func() {
 			Expect(htmlIndex).To(ContainSubstring("flakefinder-2019-08-24-672h.html"))

--- a/robots/flakefinder/index_test.go
+++ b/robots/flakefinder/index_test.go
@@ -66,12 +66,16 @@ var _ = Describe("index.go", func() {
 
 	When("writing the index page", func() {
 
+		printLogOutput := false
+
 		logger := log.New(os.Stdout, "index.go:", log.Flags())
 
 		buffer := bytes.Buffer{}
 		WriteReportIndexPage(reportDataFiles, &buffer)
 		htmlIndex := buffer.String()
-		logger.Printf("")
+		if printLogOutput {
+			logger.Printf(htmlIndex)
+		}
 
 		It("uses all report items", func() {
 			Expect(htmlIndex).To(ContainSubstring("flakefinder-2019-08-24-672h.html"))

--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -313,23 +313,7 @@ func Report(results []*Result, reportOutputWriter *storage.Writer) error {
 
 				entry := data[test.Name][result.Job]
 
-				var ratio float32 = 1.0
-				if entry.Succeeded > 0 {
-					ratio = float32(entry.Failed) / float32(entry.Succeeded)
-				}
-
-				entry.Severity = Fine
-				if entry.Succeeded == 0 && entry.Failed == 0 {
-					entry.Severity = Unimportant
-				} else if ratio > 0.5 {
-					entry.Severity = HeavilyFlaky
-				} else if ratio > 0.2 {
-					entry.Severity = MostlyFlaky
-				} else if ratio > 0.1 {
-					entry.Severity = ModeratelyFlaky
-				} else if ratio > 0 {
-					entry.Severity = MildlyFlaky
-				}
+				SetSeverity(entry)
 			}
 		}
 	}
@@ -347,6 +331,28 @@ func Report(results []*Result, reportOutputWriter *storage.Writer) error {
 	}
 
 	return nil
+}
+
+// SetSeverity sets the field Severity on the passed details according to the ratio of failed vs succeeded tests,
+// where test results are the more severe the more test failures they contain in relation to succeeded tests.
+func SetSeverity(entry *Details) {
+	var ratio float32 = 1.0
+	if entry.Succeeded > 0 {
+		ratio = float32(entry.Failed) / float32(entry.Succeeded)
+	}
+
+	entry.Severity = Fine
+	if entry.Succeeded == 0 && entry.Failed == 0 {
+		entry.Severity = Unimportant
+	} else if ratio > 0.5 {
+		entry.Severity = HeavilyFlaky
+	} else if ratio > 0.2 {
+		entry.Severity = MostlyFlaky
+	} else if ratio > 0.1 {
+		entry.Severity = ModeratelyFlaky
+	} else if ratio > 0 {
+		entry.Severity = MildlyFlaky
+	}
 }
 
 // SortTestsByRelevance sorts given tests according to the severity from the test data, where tests with a higher

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -2,11 +2,13 @@ package main_test
 
 import (
 	"bytes"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"log"
 	"os"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
 
 	. "kubevirt.io/project-infra/robots/flakefinder"
 )
@@ -121,5 +123,18 @@ var _ = Describe("report.go", func() {
 		})
 
 	})
+
+	DescribeTable("When calculating severity",
+		func(details *Details, expected string) {
+			SetSeverity(details)
+			Expect(details.Severity).To(BeEquivalentTo(expected))
+		},
+		Entry("results having no failed tests but successful tests is fine", &Details{Failed: 0, Succeeded: 1, Skipped: 2, Jobs: []*Job{}}, Fine),
+		Entry("results having no successful tests is heavily flaky", &Details{Failed: 1, Succeeded: 0, Skipped: 2, Jobs: []*Job{}}, HeavilyFlaky),
+		Entry("results being HeavilyFlaky", &Details{Failed: 1, Succeeded: 1, Skipped: 2, Jobs: []*Job{}}, HeavilyFlaky),
+		Entry("results being MostlyFlaky", &Details{Failed: 1, Succeeded: 2, Skipped: 2, Jobs: []*Job{}}, MostlyFlaky),
+		Entry("results being ModeratelyFlaky", &Details{Failed: 1, Succeeded: 5, Skipped: 2, Jobs: []*Job{}}, ModeratelyFlaky),
+		Entry("results being MildlyFlaky", &Details{Failed: 1, Succeeded: 10, Skipped: 2, Jobs: []*Job{}}, MildlyFlaky),
+	)
 
 })

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -20,6 +20,8 @@ var _ = Describe("report.go", func() {
 	reportTime, e := time.Parse("2006-01-02", "2019-08-23")
 	Expect(e).ToNot(HaveOccurred())
 
+	printLogOutput := false
+
 	When("creates filename with date and merged as hours", func() {
 
 		It("creates a filename for week", func() {
@@ -43,7 +45,9 @@ var _ = Describe("report.go", func() {
 		WriteReportToOutput(&buffer, parameters)
 
 		logger := log.New(os.Stdout, "report.go:", log.Flags())
-		logger.Printf("")
+		if printLogOutput {
+			logger.Printf(buffer.String())
+		}
 
 		It("outputs something", func() {
 			Expect(buffer.String()).ToNot(BeEmpty())

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -75,16 +75,6 @@ var _ = Describe("report.go", func() {
 	When("sorting test data", func() {
 		tests := []string{"t1", "t2", "t3"}
 
-		It("returns tests in correct order", func() {
-			data := map[string]map[string]*Details{
-				"t1": {"a": &Details{Failed: 3, Succeeded: 1, Skipped: 2, Severity: MostlyFlaky, Jobs: []*Job{}}},
-				"t2": {"a": &Details{Failed: 2, Succeeded: 1, Skipped: 2, Severity: MildlyFlaky, Jobs: []*Job{}}},
-				"t3": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}},
-			}
-
-			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
-		})
-
 		It("returns all tests", func() {
 			data := map[string]map[string]*Details{
 				"t3": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}},
@@ -120,6 +110,50 @@ var _ = Describe("report.go", func() {
 			}
 
 			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
+		})
+
+		It("returns tests sorted descending by severity", func() {
+			data := map[string]map[string]*Details{
+				"t1": {"a": &Details{Failed: 3, Succeeded: 1, Skipped: 2, Severity: MostlyFlaky, Jobs: []*Job{}}},
+				"t2": {"a": &Details{Failed: 2, Succeeded: 1, Skipped: 2, Severity: MildlyFlaky, Jobs: []*Job{}}},
+				"t3": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}},
+			}
+
+			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
+		})
+
+		It("returns tests of same severity sorted descending by number of severity points", func() {
+			data := map[string]map[string]*Details{
+				"t1": {"a": &Details{Failed: 3, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}, "b": &Details{Failed: 3, Succeeded: 1, Skipped: 2, Severity: MostlyFlaky, Jobs: []*Job{}}},
+				"t2": {"a": &Details{Failed: 2, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}, "b": &Details{Failed: 2, Succeeded: 1, Skipped: 2, Severity: MildlyFlaky, Jobs: []*Job{}}},
+				"t3": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}, "b": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}},
+			}
+
+			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
+		})
+
+	})
+
+	When("sorting test via severity", func() {
+
+		It("returns tests of same severity sorted descending by number of severity points", func() {
+			tests := map[string][]string{HeavilyFlaky: {"t1", "t2", "t3"}}
+
+			Expect(BuildUpSortedTestsBySeverity(tests, map[string]map[string]int{
+				"t1": {HeavilyFlaky: 2},
+				"t2": {HeavilyFlaky: 1},
+				"t3": {HeavilyFlaky: 3},
+			})).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
+		})
+
+		It("returns tests of same severity and same number of severity points sorted lexically", func() {
+			tests := map[string][]string{HeavilyFlaky: {"tc", "tb", "ta"}}
+
+			Expect(BuildUpSortedTestsBySeverity(tests, map[string]map[string]int{
+				"tb": {HeavilyFlaky: 2},
+				"tc": {HeavilyFlaky: 2},
+				"ta": {HeavilyFlaky: 2},
+			})).To(BeEquivalentTo([]string{"ta", "tb", "tc"}))
 		})
 
 	})

--- a/vendor/github.com/onsi/ginkgo/extensions/table/BUILD.bazel
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "table.go",
+        "table_entry.go",
+    ],
+    importmap = "kubevirt.io/project-infra/vendor/github.com/onsi/ginkgo/extensions/table",
+    importpath = "github.com/onsi/ginkgo/extensions/table",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/onsi/ginkgo:go_default_library"],
+)

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,81 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := []reflect.Value{}
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -105,6 +105,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/onsi/ginkgo v1.7.0
 github.com/onsi/ginkgo
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
 github.com/onsi/ginkgo/internal/failer


### PR DESCRIPTION
Test sorting has been revised so that the sorting of tests now accurately reflects the total test severity over all lanes. If severity of test lanes are equal they are sorted lexically.

![Screenshot from 2019-09-19 14-51-18](https://user-images.githubusercontent.com/809335/65246332-99dd4e80-daee-11e9-857e-c67721bb1403.png)

Previews:
- [4 weekly](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/flakefinder-2019-09-19-672h.html)
- [weekly](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/flakefinder-2019-09-19-168h.html)
- [daily](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/flakefinder-2019-09-19-024h.html)