### PR TITLE
Filter test results before start of report

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ba3ccca1d326309eb424b552ee83e167069fc6aaa15558c763ea386493c1dd07
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:8cb3b403beaddcf2a19c459deeec6de81bc087a2f2c379f4449e8773bcab5105
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ba3ccca1d326309eb424b552ee83e167069fc6aaa15558c763ea386493c1dd07
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:8cb3b403beaddcf2a19c459deeec6de81bc087a2f2c379f4449e8773bcab5105
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ba3ccca1d326309eb424b552ee83e167069fc6aaa15558c763ea386493c1dd07
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:8cb3b403beaddcf2a19c459deeec6de81bc087a2f2c379f4449e8773bcab5105
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/downloader.go
+++ b/robots/flakefinder/downloader.go
@@ -85,13 +85,13 @@ func readGcsObject(ctx context.Context, client *storage.Client, bucket, object s
 func readGcsObjectAttrs(ctx context.Context, client *storage.Client, bucket, object string) (attrs *storage.ObjectAttrs, err error) {
 	logrus.Infof("Trying to read gcs object attrs '%s' in bucket '%s'\n", object, bucket)
 	attrs, err = client.Bucket(bucket).Object(object).Attrs(ctx)
-	if err == nil {
-		return
-	}
 	if err == storage.ErrObjectNotExist {
 		return nil, err
 	}
-	return nil, fmt.Errorf("Cannot read attrs from %s in bucket '%s'", object, bucket)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot read attrs from %s in bucket '%s'", object, bucket)
+	}
+	return
 }
 
 func FindUnitTestFiles(ctx context.Context, client *storage.Client, bucket, repo string, pr *github.PullRequest, startOfReport time.Time) ([]*Result, error) {

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -152,7 +152,7 @@ func main() {
 	}
 	reports := []*Result{}
 	for _, pr := range prs {
-		r, err := FindUnitTestFiles(ctx, client, BucketName, "kubevirt/kubevirt", pr)
+		r, err := FindUnitTestFiles(ctx, client, BucketName, "kubevirt/kubevirt", pr, startOfReport)
 		if err != nil {
 			log.Printf("failed to load JUnit file for %v: %v", pr.Number, err)
 		}


### PR DESCRIPTION
Checks file creation date of `finished.json` to be after report start date, if that's not the case, test results are skipped.

/cc @fedepaol @rmohr 