### PR TITLE
Filter PRs on base branch, add output path config

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:8cb3b403beaddcf2a19c459deeec6de81bc087a2f2c379f4449e8773bcab5105
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:c3eaa8f8979ee58c8f4f16d13d54f252bc7921bf7c314e32da4be96ab15059a8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:8cb3b403beaddcf2a19c459deeec6de81bc087a2f2c379f4449e8773bcab5105
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:c3eaa8f8979ee58c8f4f16d13d54f252bc7921bf7c314e32da4be96ab15059a8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:8cb3b403beaddcf2a19c459deeec6de81bc087a2f2c379f4449e8773bcab5105
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:c3eaa8f8979ee58c8f4f16d13d54f252bc7921bf7c314e32da4be96ab15059a8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:601781ed13f473ecb3711ffa7794ad4991fd2e8559dba1ea177dcc932834d798
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:c16e906eafd7f3065a9b6481f10641fbb26f555302e4f802557e32c67d42cace
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:601781ed13f473ecb3711ffa7794ad4991fd2e8559dba1ea177dcc932834d798
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:c16e906eafd7f3065a9b6481f10641fbb26f555302e4f802557e32c67d42cace
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:601781ed13f473ecb3711ffa7794ad4991fd2e8559dba1ea177dcc932834d798
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:c16e906eafd7f3065a9b6481f10641fbb26f555302e4f802557e32c67d42cace
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:c3eaa8f8979ee58c8f4f16d13d54f252bc7921bf7c314e32da4be96ab15059a8
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:601781ed13f473ecb3711ffa7794ad4991fd2e8559dba1ea177dcc932834d798
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:c3eaa8f8979ee58c8f4f16d13d54f252bc7921bf7c314e32da4be96ab15059a8
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:601781ed13f473ecb3711ffa7794ad4991fd2e8559dba1ea177dcc932834d798
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:c3eaa8f8979ee58c8f4f16d13d54f252bc7921bf7c314e32da4be96ab15059a8
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:601781ed13f473ecb3711ffa7794ad4991fd2e8559dba1ea177dcc932834d798
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/BUILD.bazel
+++ b/robots/flakefinder/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "downloader_test.go",
         "flakefinder_suite_test.go",
         "index_test.go",
+        "main_test.go",
         "report_test.go",
     ],
     embed = [":go_default_library"],

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"strings"
+	"path/filepath"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -60,11 +60,6 @@ type Options struct {
 	IsPreview             bool
 	PRBaseBranch          string
 	ReportOutputChildPath string
-}
-
-type client interface {
-	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
-	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
 }
 
 const BucketName = "kubevirt-prow"
@@ -181,12 +176,10 @@ func main() {
 }
 
 func BuildReportOutputPath(o Options) string {
-	var outputPath = ReportsPath
+	outputPath := ReportsPath
 	if o.IsPreview {
-		outputPath = strings.Join([]string{outputPath, "preview"}, "/")
+		outputPath = filepath.Join(outputPath, "preview")
 	}
-	if o.ReportOutputChildPath != "" {
-		outputPath = strings.Join([]string{outputPath, o.ReportOutputChildPath}, "/")
-	}
+	outputPath = filepath.Join(outputPath, o.ReportOutputChildPath)
 	return outputPath
 }

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -36,30 +36,30 @@ import (
 	"k8s.io/test-infra/prow/flagutil"
 )
 
-func flagOptions() Options {
-	o := Options{
+func flagOptions() options {
+	o := options{
 		endpoint: flagutil.NewStrings("https://api.github.com"),
 	}
 	flag.IntVar(&o.ceiling, "ceiling", 100, "Maximum number of issues to modify, 0 for infinite")
 	flag.DurationVar(&o.merged, "merged", 24*7*time.Hour, "Filter to issues merged in the time window")
 	flag.Var(&o.endpoint, "endpoint", "GitHub's API endpoint")
 	flag.StringVar(&o.token, "token", "", "Path to github token")
-	flag.BoolVar(&o.IsPreview, "preview", false, "Whether report should be written to preview directory")
-	flag.StringVar(&o.PRBaseBranch, "pr_base_branch", PRBaseBranchDefault, fmt.Sprintf("Base branch for the PRs (default: '%s')", PRBaseBranchDefault))
-	flag.StringVar(&o.ReportOutputChildPath, "report_output_child_path", "", fmt.Sprintf("Child path below the main reporting directory '%s' (i.e. 'master', default is '')", ReportsPath))
+	flag.BoolVar(&o.isPreview, "preview", false, "Whether report should be written to preview directory")
+	flag.StringVar(&o.prBaseBranch, "pr_base_branch", PRBaseBranchDefault, fmt.Sprintf("Base branch for the PRs (default: '%s')", PRBaseBranchDefault))
+	flag.StringVar(&o.reportOutputChildPath, "report_output_child_path", "", fmt.Sprintf("Child path below the main reporting directory '%s' (i.e. 'master', default is '')", ReportsPath))
 	flag.Parse()
 	return o
 }
 
-type Options struct {
+type options struct {
 	ceiling               int
 	endpoint              flagutil.Strings
 	token                 string
 	graphqlEndpoint       string
 	merged                time.Duration
-	IsPreview             bool
-	PRBaseBranch          string
-	ReportOutputChildPath string
+	isPreview             bool
+	prBaseBranch          string
+	reportOutputChildPath string
 }
 
 const BucketName = "kubevirt-prow"
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	ReportOutputPath = BuildReportOutputPath(o)
-	PRBaseBranch = o.PRBaseBranch
+	PRBaseBranch = o.prBaseBranch
 
 	secretAgent := &secret.Agent{}
 	if err := secretAgent.Start([]string{o.token}); err != nil {
@@ -175,11 +175,11 @@ func main() {
 
 }
 
-func BuildReportOutputPath(o Options) string {
+func BuildReportOutputPath(o options) string {
 	outputPath := ReportsPath
-	if o.IsPreview {
+	if o.isPreview {
 		outputPath = filepath.Join(outputPath, "preview")
 	}
-	outputPath = filepath.Join(outputPath, o.ReportOutputChildPath)
+	outputPath = filepath.Join(outputPath, o.reportOutputChildPath)
 	return outputPath
 }

--- a/robots/flakefinder/main_test.go
+++ b/robots/flakefinder/main_test.go
@@ -1,10 +1,8 @@
-package main_test
+package main
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "kubevirt.io/project-infra/robots/flakefinder"
 )
 
 var _ = Describe("main.go", func() {
@@ -16,22 +14,22 @@ var _ = Describe("main.go", func() {
 		})
 
 		It("has default path", func() {
-			options := Options{}
+			options := options{}
 			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder"))
 		})
 
 		It("has preview if option enabled", func() {
-			options := Options{IsPreview: true}
+			options := options{isPreview: true}
 			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/preview"))
 		})
 
 		It("has child branch", func() {
-			options := Options{ReportOutputChildPath: "master"}
+			options := options{reportOutputChildPath: "master"}
 			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/master"))
 		})
 
 		It("has preview and child branch", func() {
-			options := Options{IsPreview: true, ReportOutputChildPath: "master"}
+			options := options{isPreview: true, reportOutputChildPath: "master"}
 			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/preview/master"))
 		})
 

--- a/robots/flakefinder/main_test.go
+++ b/robots/flakefinder/main_test.go
@@ -1,0 +1,40 @@
+package main_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "kubevirt.io/project-infra/robots/flakefinder"
+)
+
+var _ = Describe("main.go", func() {
+
+	When("Setting up output path", func() {
+
+		BeforeEach(func() {
+			ReportOutputPath = ReportsPath
+		})
+
+		It("has default path", func() {
+			options := Options{}
+			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder"))
+		})
+
+		It("has preview if option enabled", func() {
+			options := Options{IsPreview: true}
+			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/preview"))
+		})
+
+		It("has child branch", func() {
+			options := Options{ReportOutputChildPath: "master"}
+			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/master"))
+		})
+
+		It("has preview and child branch", func() {
+			options := Options{IsPreview: true, ReportOutputChildPath: "master"}
+			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/preview/master"))
+		})
+
+	})
+
+})


### PR DESCRIPTION
Two new configurations are now available

    --pr_base_branch=master

This parameter marks the base branch on which PRs are filtered now, i.e. only PRs that are merged into `master` in this case.

    --report_output_child_path=master

This parameter adds a further path for where the reports are written, i.e. in this case it will write to `reports/flakefinder/master`

These should help us to diversify the reports as needed.

Preview reports available [here](http://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/master/index.html).

Closes #200.