### PR TITLE
Add e2e job for virtblocks

### DIFF
--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-presubmits.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: quay.io/virtblocks/buildenv:1.0.2
+        - image: quay.io/virtblocks/buildenv:1.1.0
           command:
             - "make"
             - "build"
@@ -19,7 +19,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: quay.io/virtblocks/buildenv:1.0.2
+        - image: quay.io/virtblocks/buildenv:1.1.0
           command:
             - "make"
             - "test"
@@ -33,7 +33,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: quay.io/virtblocks/buildenv:1.0.2
+        - image: quay.io/virtblocks/buildenv:1.1.0
           command:
             - "make"
             - "run-examples"
@@ -47,7 +47,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: quay.io/virtblocks/buildenv:1.0.2
+        - image: quay.io/virtblocks/buildenv:1.1.0
           command:
             - "make"
             - "vet"
@@ -61,7 +61,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-        - image: quay.io/virtblocks/buildenv:1.0.2
+        - image: quay.io/virtblocks/buildenv:1.1.0
           command:
             - "make"
             - "verify-fmt"
@@ -77,7 +77,7 @@ presubmits:
       nodeSelector:
         type: bare-metal
       containers:
-        - image: rmohr/virtblocks-qemu:latest
+        - image: quay.io/virtblocks/buildenv:1.1.0
           command:
             - "make"
             - "functest"

--- a/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-presubmits.yaml
+++ b/github/ci/prow/files/jobs/virtblocks/virtblocks/virtblocks-presubmits.yaml
@@ -70,3 +70,22 @@ presubmits:
               value: "on"
             - name: XDG_CACHE_HOME
               value: "/tmp/.cache"
+  - name: pull-virtblocks-e2e
+    decorate: true
+    always_run: true
+    spec:
+      nodeSelector:
+        type: bare-metal
+      containers:
+        - image: rmohr/virtblocks-qemu:latest
+          command:
+            - "make"
+            - "functest"
+          env:
+            - name: GO111MODULE
+              value: "on"
+            - name: XDG_CACHE_HOME
+              value: "/tmp/.cache"
+          # for /dev/kvm right now required
+          securityContext:
+            privileged: true


### PR DESCRIPTION
Add an e2e job which runs on machines with /dev/kvm and update to the new builder image which contains golang and qemu.