### PR TITLE
Convert boolean logging flag into command line flag

### DIFF
--- a/robots/flakefinder/flakefinder_suite_test.go
+++ b/robots/flakefinder/flakefinder_suite_test.go
@@ -1,11 +1,25 @@
 package main_test
 
 import (
+	"flag"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+type options struct {
+	printTestOutput bool
+}
+
+var testOptions = options{}
+
+func TestMain(m *testing.M) {
+	flag.BoolVar(&testOptions.printTestOutput, "print_test_output", false, "Whether test output should be printed via logger")
+	flag.Parse()
+	os.Exit(m.Run())
+}
 
 func TestFlakefinder(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/robots/flakefinder/index_test.go
+++ b/robots/flakefinder/index_test.go
@@ -66,16 +66,19 @@ var _ = Describe("index.go", func() {
 
 	When("writing the index page", func() {
 
-		printLogOutput := false
+		var htmlIndex string
 
-		logger := log.New(os.Stdout, "index.go:", log.Flags())
-
-		buffer := bytes.Buffer{}
-		WriteReportIndexPage(reportDataFiles, &buffer)
-		htmlIndex := buffer.String()
-		if printLogOutput {
-			logger.Printf(htmlIndex)
-		}
+		BeforeEach(func() {
+			if htmlIndex == "" {
+				buffer := bytes.Buffer{}
+				WriteReportIndexPage(reportDataFiles, &buffer)
+				htmlIndex = buffer.String()
+				if testOptions.printTestOutput {
+					logger := log.New(os.Stdout, "index_test.go:", log.Flags())
+					logger.Printf(htmlIndex)
+				}
+			}
+		})
 
 		It("uses all report items", func() {
 			Expect(htmlIndex).To(ContainSubstring("flakefinder-2019-08-24-672h.html"))

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -20,8 +20,6 @@ var _ = Describe("report.go", func() {
 	reportTime, e := time.Parse("2006-01-02", "2019-08-23")
 	Expect(e).ToNot(HaveOccurred())
 
-	printLogOutput := false
-
 	When("creates filename with date and merged as hours", func() {
 
 		It("creates a filename for week", func() {
@@ -38,16 +36,22 @@ var _ = Describe("report.go", func() {
 
 	When("rendering report data", func() {
 
-		buffer := bytes.Buffer{}
-		parameters := Params{Data: map[string]map[string]*Details{
-			"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{}}},
-		}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23"}
-		WriteReportToOutput(&buffer, parameters)
+		var buffer bytes.Buffer
 
-		logger := log.New(os.Stdout, "report.go:", log.Flags())
-		if printLogOutput {
-			logger.Printf(buffer.String())
-		}
+		BeforeEach(func() {
+			if buffer.String() == "" {
+				buffer = bytes.Buffer{}
+				parameters := Params{Data: map[string]map[string]*Details{
+					"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{}}},
+				}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23"}
+				WriteReportToOutput(&buffer, parameters)
+
+				if testOptions.printTestOutput {
+					logger := log.New(os.Stdout, "report_test.go:", log.Flags())
+					logger.Printf(buffer.String())
+				}
+			}
+		})
 
 		It("outputs something", func() {
 			Expect(buffer.String()).ToNot(BeEmpty())


### PR DESCRIPTION
In regards to the discussion [here](https://github.com/kubevirt/project-infra/pull/196#discussion_r327004586) I moved the boolean flag into a command line parameter.

**Note to reviewer:** I was forced to use `BeforeEach` and checking a conditional as the `flag.Parse()` is executed **after** the declarations on `When` level. I find this a little ugly and am open for suggestions. I tried with `BeforeSuite` but this is allowed only once and I wanted to keep the initialization of the variables in scope.

see #196 for details.
