### PR TITLE
Enable DCO plugin for virtblocks org

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -17,6 +17,7 @@ plugins:
 
   virtblocks:
   - trigger
+  - dco
 
   kubevirt:
   - size
@@ -105,6 +106,7 @@ triggers:
   trusted_org: kubevirt
 - repos:
   - virtblocks/virtblocks
+
 
 approve:
 - repos:


### PR DESCRIPTION
Enable the DCO plugin for the virtblocks org.