### PR TITLE
Add automatic branch protection via prow job for kubevirt org and possibly virtblocks org 

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -96,14 +96,16 @@ branch-protection:
   required_status_checks:
     contexts:
     - dco
+    - continuous-integration/travis-ci
+    - continuous-integration/travis-ci/pr
+    - coverage/coveralls
+# does not work as golang regex does not support PCRE
+#  exclude:
+#  - ^(?!!master)$
   orgs:
     kubevirt:
       repos:
         kubevirt:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
-            - coverage/coveralls
           branches:
             master:
               protect: true
@@ -113,6 +115,39 @@ branch-protection:
           branches:
             master:
               protect: true
+        kubevirtci:
+          branches:
+            master:
+              protect: true
+        containerized-data-importer:
+          branches:
+            master:
+              protect: true
+        hyperconverged-cluster-operator:
+          branches:
+            master:
+              protect: true
+        user-guide:
+          branches:
+            master:
+              protect: true
+        cluster-network-addons-operator:
+          branches:
+            master:
+              protect: true
+        ovs-cni:
+          branches:
+            master:
+              protect: true
+        common-templates:
+          branches:
+            master:
+              protect: true
+# need to add KubeVirt to admins
+#    virtblocks:
+#      repos:
+#        virtblocks:
+#          protect: true
 
 push_gateway:
   endpoint: pushgateway

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -92,35 +92,31 @@ tide:
           from-branch-protection: true
 
 branch-protection:
+#  protect: true
+  required_status_checks:
+    contexts:
+      - dco
   orgs:
     kubevirt:
-      # TODO: enable dco within branch protection for whole org
-#      protect: true
-#      required_status_checks:
-#        contexts:
-#          - dco
       repos:
         kubevirt:
-          protect: true
           required_status_checks:
             contexts:
-            - dco
-            - continuous-integration/travis-ci
-            - coverage/coveralls
-            # we do not include the presubmit jobs here as they should get included automatically
+              - continuous-integration/travis-ci
+              - coverage/coveralls
+          branches:
+            master:
+              protect: true
+            release-*:
+              protect: true
         project-infra:
-          protect: true
           required_status_checks:
             contexts:
-            - dco
-            - pull-project-infra-test-flakefinder
-            - check-prow-config
-    # TODO: enable dco within branch protection for whole org
-#    virtblocks:
-#      protect: true
-#      required_status_checks:
-#        contexts:
-#          - dco
+              - pull-project-infra-test-flakefinder
+              - check-prow-config
+          branches:
+            master:
+              protect: true
 
 push_gateway:
   endpoint: pushgateway

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -91,18 +91,23 @@ tide:
           skip-unknown-contexts: true
           from-branch-protection: true
 
-# we don't enable the branch protector itself yet, but want to
-# let tide know that travis-ci is needed
 branch-protection:
   orgs:
     kubevirt:
+      # TODO: enable dco within branch protection for whole org
+#      protect: true
+#      required_status_checks:
+#        contexts:
+#          - dco
       repos:
         kubevirt:
           protect: true
           required_status_checks:
             contexts:
+            - dco
             - continuous-integration/travis-ci
             - coverage/coveralls
+            # we do not include the presubmit jobs here as they should get included automatically
         project-infra:
           protect: true
           required_status_checks:
@@ -110,6 +115,12 @@ branch-protection:
             - dco
             - pull-project-infra-test-flakefinder
             - check-prow-config
+    # TODO: enable dco within branch protection for whole org
+#    virtblocks:
+#      protect: true
+#      required_status_checks:
+#        contexts:
+#          - dco
 
 push_gateway:
   endpoint: pushgateway

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -103,6 +103,13 @@ branch-protection:
             contexts:
             - continuous-integration/travis-ci
             - coverage/coveralls
+        project-infra:
+          protect: true
+          required_status_checks:
+            contexts:
+            - dco
+            - pull-project-infra-test-flakefinder
+            - check-prow-config
 
 push_gateway:
   endpoint: pushgateway

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -96,7 +96,6 @@ branch-protection:
   required_status_checks:
     contexts:
     - dco
-    - continuous-integration/travis-ci
     - continuous-integration/travis-ci/pr
     - coverage/coveralls
 # does not work as golang regex does not support PCRE

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -110,10 +110,6 @@ branch-protection:
             release-*:
               protect: true
         project-infra:
-          required_status_checks:
-            contexts:
-              - pull-project-infra-test-flakefinder
-              - check-prow-config
           branches:
             master:
               protect: true

--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -95,15 +95,15 @@ branch-protection:
 #  protect: true
   required_status_checks:
     contexts:
-      - dco
+    - dco
   orgs:
     kubevirt:
       repos:
         kubevirt:
           required_status_checks:
             contexts:
-              - continuous-integration/travis-ci
-              - coverage/coveralls
+            - continuous-integration/travis-ci
+            - coverage/coveralls
           branches:
             master:
               protect: true

--- a/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
@@ -152,18 +152,20 @@ periodics:
 # It's suggested to run the branch protector as a periodic job, not using that CronJob, so you get logs.
 # https://github.com/kubernetes/test-infra/issues/11581#issuecomment-468802223
 - name: periodic-project-infra-branchprotector
-  interval: 1h  # Re-establish branch protection every hour
+  interval: 1h
   decorate: true
   spec:
     containers:
       - args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --confirm=true
+        - --confirm
         - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         command:
         - /app/prow/cmd/branchprotector/app.binary
-        image: gcr.io/k8s-prow/branchprotector:v20190221-d14461a
+        image: gcr.io/k8s-prow/branchprotector:v20190926-a128cddb1
         imagePullPolicy: Always
         name: ""
         resources:

--- a/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
@@ -148,3 +148,44 @@ periodics:
     - name: token
       secret:
         secretName: oauth-token
+
+# It's suggested to run the branch protector as a periodic job, not using that CronJob, so you get logs.
+# https://github.com/kubernetes/test-infra/issues/11581#issuecomment-468802223
+- name: periodic-project-infra-branchprotector
+  interval: 1h  # Re-establish branch protection every hour
+  decorate: true
+  spec:
+    containers:
+      - args:
+        - --config-path=/etc/config/config.yaml
+        - --job-config-path=/etc/job-config
+        - --confirm=true
+        - --github-token-path=/etc/github/oauth
+        command:
+        - /app/prow/cmd/branchprotector/app.binary
+        image: gcr.io/k8s-prow/branchprotector:v20190221-d14461a
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 500m
+        volumeMounts:
+        - mountPath: /etc/github
+          name: token
+          readOnly: true
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token
+    - name: config
+      configMap:
+        name: config
+    - name: job-config
+      configMap:
+        name: job-config


### PR DESCRIPTION
[Branchprotector](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector) is a tool to configure [GitHub branch protection](https://help.github.com/articles/about-protected-branches/). This i.e. enables to require status checks to succeed on PRs, so that these only then can get merged.

The job executing Branchprotector regularly enforces the configured rules on several levels, i.e. branch, repo, org or even over multiple orgs.

This gives us the opportunity to centralize the configuration of required status checks in one place, in the Prow plugin configuration that is located in `project-infra`.

All repository maintainers of the kubevirt org having repo admin rights, please reply with a list of required status checks and the branches you would like to protect. In the easiest case these would be just **all**. This way we can incorporate the checks into the configuration, so that the branch protection configuration won't get deleted once we enable the org wide branch protection.

Please note that `presubmit` jobs marked as `optional: false` are picked up automatically. 

As an example you can see the branch protection rules for the [repo `project-infra`](https://github.com/kubevirt/project-infra) here:

![image](https://user-images.githubusercontent.com/809335/65856682-8f2e7f00-e362-11e9-9e8a-8e7192e688f0.png)

![image](https://user-images.githubusercontent.com/809335/65856694-93f33300-e362-11e9-81cd-4b0e51b046b6.png)

![image](https://user-images.githubusercontent.com/809335/65856704-9a81aa80-e362-11e9-8614-5c4626909926.png)

This is derived from the [config.yaml](https://github.com/kubevirt/project-infra/pull/209/files#diff-3818e252b2f35bd93cd7815848eeb1f7R94) in this PR.

I.e. you can see that the `dco` check is defined at the top level, and that the requirement for the status check is switched on by the flag `protect: true` for the master branch only.