### PR TITLE
Add branch protection to kubevirt org

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -91,9 +91,10 @@ tide:
           skip-unknown-contexts: true
           from-branch-protection: true
 
-# we don't enable the branch protector itself yet, but want to
-# let tide know that travis-ci is needed
 branch-protection:
+  required_status_checks:
+    contexts:
+    - dco
   orgs:
     kubevirt:
       repos:
@@ -101,8 +102,52 @@ branch-protection:
           protect: true
           required_status_checks:
             contexts:
-            - continuous-integration/travis-ci
-            - coverage/coveralls
+              - continuous-integration/travis-ci/pr
+              - coverage/coveralls
+        project-infra:
+          branches:
+            master:
+              protect: true
+        kubevirtci:
+          branches:
+            master:
+              protect: true
+        containerized-data-importer:
+          branches:
+            master:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - continuous-integration/travis-ci/pr
+        hyperconverged-cluster-operator:
+          branches:
+            master:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - continuous-integration/travis-ci/pr
+                  - coverage/coveralls
+        user-guide:
+          branches:
+            master:
+              protect: true
+              required_pull_request_reviews:
+                dismiss_stale_reviews: true
+                required_approving_review_count: 1
+              required_status_checks:
+                strict: true
+        cluster-network-addons-operator:
+          branches:
+            master:
+              protect: true
+        ovs-cni:
+          branches:
+            master:
+              protect: true
+        common-templates:
+          branches:
+            master:
+              protect: true
 
 push_gateway:
   endpoint: pushgateway

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -333,3 +333,8 @@
   command: "oc -n {{prowNamespace}} apply -f -"
   args:
     stdin: "{{ lookup('template', '{{ role_path }}/templates/ghproxy.yaml')}}"
+- name: Deploy branch-protector cron job
+  k8s:
+    state: present
+    namespace: "{{ prowNamespace }}"
+    definition: "{{ lookup('template', '{{ role_path }}/templates/branch-protector.yaml') | from_yaml }}"

--- a/github/ci/prow/templates/branch-protector.yaml
+++ b/github/ci/prow/templates/branch-protector.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  namespace: default
+  name: branch-protector
+spec:
+  schedule: "54 * * * *"  # Every hour at 54 minutes past the hour
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        app: branchprotector
+    spec:
+      template:
+        spec:
+          containers:
+            - name: branchprotector
+              image: gcr.io/k8s-prow/branchprotector:v20191001-edcabf6dd
+              args:
+                - --config-path=/etc/config/config.yaml
+                - --job-config-path=/etc/job-config
+                - --github-token-path=/etc/github/oauth
+                - --confirm
+                - --github-endpoint=http://ghproxy
+                - --github-endpoint=https://api.github.com
+              volumeMounts:
+                - name: oauth
+                  mountPath: /etc/github
+                  readOnly: true
+                - name: config
+                  mountPath: /etc/config
+                  readOnly: true
+                - name: job-config
+                  mountPath: /etc/job-config
+                  readOnly: true
+          restartPolicy: Never
+          volumes:
+            - name: oauth
+              secret:
+                secretName: oauth-token
+            - name: config
+              configMap:
+                name: config
+            - name: job-config
+              configMap:
+                name: job-config

--- a/github/ci/prow/templates/branch-protector.yaml
+++ b/github/ci/prow/templates/branch-protector.yaml
@@ -1,7 +1,6 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  namespace: default
   name: branch-protector
 spec:
   schedule: "54 * * * *"  # Every hour at 54 minutes past the hour


### PR DESCRIPTION
Branch protection config:
- For minimal set of repositories enable dco check as required on master
- For kubevirt additionally enable dco check on all branches

Added job to execute branch protector.