### PR TITLE
Update k8s multus provision path

### DIFF
--- a/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
@@ -515,108 +515,6 @@ presubmits:
             requests:
               memory: "8Gi"
 
-  - name: check-provision-k8s-multus-1.12.2
-    always_run: false
-    optional: true
-    decorate: true
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "cd cluster-provision/k8s-multus/1.12.2/ && ./provision.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "8Gi"
-
-  - name: push-k8s-multus-1.12.2
-    always_run: false
-    optional: true
-    decorate: true
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-kubevirtci-docker-credential: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-c"
-            - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd cluster-provision/k8s-multus/1.12.2/ && ./provision.sh && ./publish.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "8Gi"
-
-  - name: check-provision-k8s-multus-1.13.3
-    always_run: false
-    optional: true
-    decorate: true
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "cd cluster-provision/k8s-multus/1.13.3/ && ./provision.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "8Gi"
-
-  - name: push-k8s-multus-1.13.3
-    always_run: false
-    optional: true
-    decorate: true
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-kubevirtci-docker-credential: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-c"
-            - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd cluster-provision/k8s-multus/1.13.3/  && ./provision.sh && ./publish.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "8Gi"
-
   - name: check-provision-k8s-multus-1.15.1
     always_run: false
     optional: true
@@ -634,7 +532,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "cd cluster-provision/k8s-multus/1.15.1/ && ./provision.sh"
+            - "cd cluster-provision/k8s/multus-1.15.1/ && ./provision.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -660,7 +558,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
-            - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd cluster-provision/k8s-multus/1.15.1/  && ./provision.sh && ./publish.sh"
+            - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd cluster-provision/k8s/multus-1.15.1/  && ./provision.sh && ./publish.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
This PR change the path for building the multus provider.

This PR also remove older versions of k8s multus.

related to: https://github.com/kubevirt/kubevirtci/pull/147

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/project-infra/217)
<!-- Reviewable:end -->
