### PR TITLE
Add command line options org and repo for report generation.

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:c16e906eafd7f3065a9b6481f10641fbb26f555302e4f802557e32c67d42cace
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -37,7 +37,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:c16e906eafd7f3065a9b6481f10641fbb26f555302e4f802557e32c67d42cace
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -67,7 +67,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:c16e906eafd7f3065a9b6481f10641fbb26f555302e4f802557e32c67d42cace
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json


### PR DESCRIPTION
Adds command line parameters for GitHub `org` and `repo`, so that the report generation is no longer hardcoded on kubevirt/kubevirt but can instead be done for any project that stores it's test run results in a similar location on our prow instance. Test format must be same as used for kubevirt/kubevirt, though.

Based on this PR we can add additional job specs for cdi.

/cc @rmohr @awels 