### PR TITLE
add restcoverage lens and remove deprecated `viewer` config

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -40,6 +40,13 @@ deck:
         - artifacts/filtered.cov
       optional_files:
         - artifacts/filtered.html
+    - lens:
+        name: restcoverage
+        config:
+          threshold_warning: 50
+          threshold_error: 10
+      required_files:
+        - artifacts/rest-coverage.json
   tide_update_period: 1s
   rerun_auth_config:
     github_team_ids:


### PR DESCRIPTION
This PR should get in if https://github.com/kubernetes/test-infra/pull/14778 will be merged.
The prow upgrade will be required.