### PR TITLE
Add flakefinder report generation for cdi

### DIFF
--- a/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-publish-flakefinder-weekly-report
+- name: periodic-publish-cdi-flakefinder-weekly-report
   interval: 24h
   decorate: true
   spec:
@@ -31,7 +31,7 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
-- name: periodic-publish-flakefinder-daily-report
+- name: periodic-publish-cdi-flakefinder-daily-report
   interval: 24h
   decorate: true
   spec:
@@ -63,7 +63,7 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
-- name: periodic-publish-flakefinder-four-weekly-report
+- name: periodic-publish-cdi-flakefinder-four-weekly-report
   interval: 168h
   decorate: true
   spec:

--- a/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -16,7 +16,8 @@ periodics:
       args:
       - --token=/etc/github/oauth
       - --merged=168h
-      - --report_output_child_path=kubevirt/kubevirt
+      - --report_output_child_path=kubevirt/containerized-data-importer
+      - --repo=containerized-data-importer
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -47,7 +48,8 @@ periodics:
       args:
       - --token=/etc/github/oauth
       - --merged=24h
-      - --report_output_child_path=kubevirt/kubevirt
+      - --report_output_child_path=kubevirt/containerized-data-importer
+      - --repo=containerized-data-importer
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -78,7 +80,8 @@ periodics:
       args:
       - --token=/etc/github/oauth
       - --merged=672h
-      - --report_output_child_path=kubevirt/kubevirt
+      - --report_output_child_path=kubevirt/containerized-data-importer
+      - --repo=containerized-data-importer
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-publish-flakefinder-weekly-report
+- name: periodic-publish-kubevirt-flakefinder-weekly-report
   interval: 24h
   decorate: true
   spec:
@@ -30,7 +30,7 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
-- name: periodic-publish-flakefinder-daily-report
+- name: periodic-publish-kubevirt-flakefinder-daily-report
   interval: 24h
   decorate: true
   spec:
@@ -61,7 +61,7 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
-- name: periodic-publish-flakefinder-four-weekly-report
+- name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   interval: 168h
   decorate: true
   spec:


### PR DESCRIPTION
Add daily, weekly and monthly job for cdi, adjust output path
for kubevirt.

New report urls will be
* http://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/containerized-data-importer/index.html
* https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/index.html

/cc @awels @rmohr 

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>