### PR TITLE
Add label for openshift CI

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -354,3 +354,11 @@ repos:
         target: pr
         addedBy: anyone
         prowPlugin: label
+  kubevirt/hyperconverged-cluster-operator:
+    labels:
+      - color: e11d21
+        description: Needed to be compatible with openshift CI
+        name: tide/merge-blocker
+        target: prs
+        addedBy: openshift-ci
+        prowPlugin: label


### PR DESCRIPTION
Fixes an issue where openshifts prow instance wants to set that label.
It is a no-op for us right now to unblock openshift CI.