### PR TITLE
Disable automatic running of OKD and remove coveralls branch protection.

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -121,7 +121,6 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - continuous-integration/travis-ci/pr
-                  - coverage/coveralls
         hyperconverged-cluster-operator:
           branches:
             master:

--- a/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 3h
@@ -38,7 +38,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 3h
@@ -69,8 +69,8 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
coveralls is not configured properly and the results are never reported so the branch protection is not helping.
Disable automatic running of OKD lane to reduce load on system.

Signed-off-by: Alexander Wels <awels@redhat.com>