### PR TITLE
Cleanup okd lanes

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -92,3 +92,33 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
+
+- name: periodic-kubevirt-e2e-okd-4.1
+  interval: 24h
+  annotations:
+    fork-per-release: "true"
+  decorate: true
+  decoration_config:
+    timeout: 7h
+    grace_period: 5m
+  max_concurrency: 6
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror: "true"
+    preset-shared-images: "true"
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+      command:
+      - "/usr/local/bin/runner.sh"
+      - "/bin/sh"
+      - "-c"
+      - "export TARGET=okd-4.1 && automation/test.sh"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "29Gi"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -115,7 +115,7 @@ periodics:
       - "/usr/local/bin/runner.sh"
       - "/bin/sh"
       - "-c"
-      - "export TARGET=okd-4.1 && automation/test.sh"
+      - "git clone https://github.com/kubevirt/kubevirt.git && cd kubevirt && export TARGET=okd-4.1 && automation/test.sh"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.13.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.13.yaml
@@ -4,11 +4,40 @@ presubmits:
   kubevirt/kubevirt:
   - always_run: true
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-kubevirt-e2e-k8s-1.11.0
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=k8s-1.11.0 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-0.13
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -31,102 +60,13 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    branches:
-    - release-0.22
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    max_concurrency: 6
-    name: pull-kubevirt-e2e-k8s-1.13.3
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - export TARGET=k8s-1.13.3 && automation/test.sh
-        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - always_run: true
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    max_concurrency: 6
-    name: pull-kubevirt-e2e-k8s-1.14.6
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - export TARGET=k8s-1.14.6 && automation/test.sh
-        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    branches:
-    - release-0.22
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    max_concurrency: 6
-    name: pull-kubevirt-e2e-k8s-1.15.1-ceph
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - export TARGET=k8s-1.15.1 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph'
-          && automation/test.sh
-        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    branches:
-    - release-0.22
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -149,14 +89,13 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -179,14 +118,13 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -209,14 +147,13 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -241,17 +178,17 @@ presubmits:
         type: bare-metal-external
   - always_run: false
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    name: pull-kubevirt-e2e-okd-4.1
+    name: pull-kubevirt-e2e-okd-4.1.0
     optional: true
     spec:
       containers:
@@ -259,7 +196,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=okd-4.1 && automation/test.sh
+        - export TARGET=okd-4.1.0 && automation/test.sh
         image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         name: ""
         resources:
@@ -271,17 +208,17 @@ presubmits:
         type: bare-metal-external
   - always_run: false
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    name: pull-kubevirt-e2e-okd-4.2
+    name: pull-kubevirt-e2e-okd-4.1.2
     optional: true
     spec:
       containers:
@@ -289,7 +226,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=okd-4.2 && automation/test.sh
+        - export TARGET=okd-4.1.2 && automation/test.sh
         image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         name: ""
         resources:
@@ -301,11 +238,11 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     branches:
-    - release-0.22
+    - release-0.13
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 7h0m0s
+      timeout: 6h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.13.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.13.yaml
@@ -1,4 +1,3 @@
-periodics: null
 postsubmits: {}
 presubmits:
   kubevirt/kubevirt:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.17.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.17.yaml
@@ -89,7 +89,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-0.17
     decorate: true
@@ -118,7 +119,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-0.17
     decorate: true
@@ -147,7 +149,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    optional: true
     branches:
     - release-0.17
     decorate: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.20.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits-0.20.yaml
@@ -165,8 +165,8 @@ presubmits:
       - release-0.20
     annotations:
       fork-per-release: "true"
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 6h
@@ -197,8 +197,8 @@ presubmits:
       - release-0.20
     annotations:
       fork-per-release: "true"
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 6h
@@ -229,8 +229,8 @@ presubmits:
       - release-0.20
     annotations:
       fork-per-release: "true"
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 6h
@@ -399,7 +399,7 @@ presubmits:
             memory: "29Gi"
         volumeMounts:
           #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
-          - name: modules   
+          - name: modules
             mountPath: /lib/modules
             readOnly: true
           - name: cgroup

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -165,8 +165,8 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 7h
@@ -197,8 +197,8 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 7h
@@ -367,7 +367,7 @@ presubmits:
             memory: "29Gi"
         volumeMounts:
           #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
-          - name: modules   
+          - name: modules
             mountPath: /lib/modules
             readOnly: true
           - name: cgroup

--- a/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
@@ -259,59 +259,6 @@ presubmits:
             requests:
               memory: "15Gi"
 
-  - name: check-provision-okd-4.2
-    always_run: false
-    optional: true
-    decorate: true
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-kubevirtci-installer-pull-token: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "cd cluster-provision/okd/4.2 && INSTALLER_PULL_SECRET=$INSTALLER_PULL_SECRET ./provision.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "15Gi"
-
-  - name: push-okd-4.2
-    always_run: false
-    optional: true
-    decorate: true
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-kubevirtci-docker-credential: "true"
-      preset-kubevirtci-installer-pull-token: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-c"
-            - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd cluster-provision/okd/4.2 && INSTALLER_PULL_SECRET=$INSTALLER_PULL_SECRET ./provision.sh && ./publish.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "15Gi"
-
   - name: check-provision-k8s-1.10.11
     always_run: false
     optional: true


### PR DESCRIPTION
- Add okd-4.1 periodic job
- Make all os-3.11 lanes optional (from 0.17+)
- Remove provision and push for OKD 4.2