### PR TITLE
Remove travis protection from hostpath provisioner and operator.

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -154,16 +154,10 @@ branch-protection:
           branches:
             master:
               protect: true
-              required_status_checks:
-                contexts:
-                  - continuous-integration/travis-ci/pr
         hostpath-provisioner-operator:
           branches:
             master:
               protect: true
-              required_status_checks:
-                contexts:
-                  - continuous-integration/travis-ci/pr
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>