### PR TITLE
Make k8s 1.15 and OS 3.11 lanes required in CDI

### DIFF
--- a/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 3h
@@ -38,7 +38,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>