### PR TITLE
Use source PR IDs instead of report PRs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:65b5a56ad2ed8e8cf47085eb9709ddb0ef1e311ef2847fe27662af76e4fa901c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -38,7 +38,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:65b5a56ad2ed8e8cf47085eb9709ddb0ef1e311ef2847fe27662af76e4fa901c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -69,7 +69,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:65b5a56ad2ed8e8cf47085eb9709ddb0ef1e311ef2847fe27662af76e4fa901c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -126,6 +126,7 @@ func main() {
 
 	logrus.Infof("Filtering PRs for base branch %s", PRBaseBranch)
 	prs := []*github.PullRequest{}
+	prIds := []int64{}
 	for nextPage := 1; nextPage > 0; {
 		pullRequests, response, err := c.PullRequests.List(ctx, o.org, o.repo, &github.PullRequestListOptions{
 			Base:        PRBaseBranch,
@@ -151,6 +152,7 @@ func main() {
 			}
 			logrus.Infof("Adding PR %v '%v' (updated at %s)", *pr.Number, *pr.Title, pr.UpdatedAt.Format(time.RFC3339))
 			prs = append(prs, pr)
+			prIds = append(prIds, *pr.ID)
 		}
 	}
 	logrus.Infof("%d pull requests found.", len(prs))
@@ -168,7 +170,7 @@ func main() {
 		reports = append(reports, r...)
 	}
 
-	err = WriteReportToBucket(ctx, client, reports, o.merged, o.org, o.repo)
+	err = WriteReportToBucket(ctx, client, reports, o.merged, o.org, o.repo, prIds)
 	if err != nil {
 		log.Fatal(fmt.Errorf("failed to write report: %v", err))
 		return

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -52,7 +52,10 @@ var _ = Describe("report.go", func() {
 		prepareWithDefaultParams := func() {
 			parameters := Params{Data: map[string]map[string]*Details{
 				"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23", Org: Org, Repo: Repo}
+			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23",
+				Org: Org, Repo: Repo,
+				PrIds: []int64{17, 42},
+			}
 
 			prepareBuffer(parameters)
 		}
@@ -85,6 +88,37 @@ var _ = Describe("report.go", func() {
 		It("contains the date", func() {
 			prepareWithDefaultParams()
 			Expect(buffer.String()).To(ContainSubstring("2019-08-23"))
+		})
+
+		It("contains the pr ids", func() {
+			prepareWithDefaultParams()
+			Expect(buffer.String()).To(ContainSubstring("#17"))
+			Expect(buffer.String()).To(ContainSubstring("#42"))
+		})
+
+		It("shows no errors if no failing tests", func() {
+			parameters := Params{Data: map[string]map[string]*Details{},
+				Headers: []string{}, Tests: []string{}, Date: "2019-08-23",
+				Org: Org, Repo: Repo,
+				PrIds: []int64{17, 42},
+			}
+
+			prepareBuffer(parameters)
+
+			Expect(buffer.String()).To(ContainSubstring("No failing tests! :)"))
+		})
+
+		It("shows pr ids if no failing tests", func() {
+			parameters := Params{Data: map[string]map[string]*Details{},
+				Headers: []string{}, Tests: []string{}, Date: "2019-08-23",
+				Org: Org, Repo: Repo,
+				PrIds: []int64{17, 42},
+			}
+
+			prepareBuffer(parameters)
+
+			Expect(buffer.String()).To(ContainSubstring("#17"))
+			Expect(buffer.String()).To(ContainSubstring("#42"))
 		})
 
 		DescribeTable("title contains repo and org", func(org, repo string) {


### PR DESCRIPTION
Use the PR Ids before filtering instead of collecting them while
checking report results. Also now link the numbers to the PRs from
github.com .

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>