### PR TITLE
Always run k8s-1.16 test lane

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -133,8 +133,8 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
As the k8s-1.16 provider has been merged we should enable it.

/cc @rmohr 