### PR TITLE
Add presets with kubevirtci secret

### DIFF
--- a/github/ci/prow/files/jobs/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-postsubmits.yaml
@@ -8,7 +8,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
-        preset-kubevirtci-docker-credential: "true"
+        preset-project-infra-kubevirtci-docker-credential: "true"
       spec:
         nodeSelector:
           type: vm

--- a/github/ci/prow/files/jobs/project-infra/project-infra-presets.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-presets.yaml
@@ -1,0 +1,17 @@
+presets:
+- labels:
+    preset-project-infra-kubevirtci-docker-credential: "true"
+  env:
+  - name: DOCKER_USER
+    value: /etc/kubevirtci-cred/username
+  - name: DOCKER_PASSWORD
+    value: /etc/kubevirtci-cred/password
+  volumes:
+  - name: kubevirtci-cred
+    secret:
+      defaultMode: 0400
+      secretName: kubevirtci-docker-credential
+  volumeMounts:
+  - name: kubevirtci-cred
+    mountPath: /etc/kubevirtci-cred
+    readOnly: true


### PR DESCRIPTION
In order to publish the container to our org in dockerhub,
we need to have the credentials mounted.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>