### PR TITLE
enable windows 2019 test for common templates

### DIFF
--- a/github/ci/prow/files/jobs/common-templates/common-templates-presubmits.yaml
+++ b/github/ci/prow/files/jobs/common-templates/common-templates-presubmits.yaml
@@ -180,3 +180,33 @@ presubmits:
         resources:
           requests:
             memory: "20Gi"
+  - name: pull-e2e-common-templates-windows2019
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+      - image: kubevirtci/kubevirt-infra-bootstrap:v20191209-d2766c1
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "export TARGET=windows2019 && automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "20Gi"


### PR DESCRIPTION
This PR enables win 2019 test. This job is optional, because i need to verify if win2019 can boot in prow.
//cc @dhiller 
Signed-off-by: Karel Šimon <ksimon@redhat.com>