### PR TITLE
Fix script that updates flakefinder image shas in periodics

### DIFF
--- a/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -39,7 +39,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -71,7 +71,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:2f5ef931baa9ccf0ec1b011317189c7ecaafd3e545d6b35ee9f91871bd3c6c1d
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/update-jobs-with-latest-flakefinder-image.sh
+++ b/robots/flakefinder/update-jobs-with-latest-flakefinder-image.sh
@@ -4,5 +4,7 @@ set -euo pipefail
 docker pull kubevirtci/flakefinder
 sha_id=$(docker images --digests kubevirtci/flakefinder | grep 'latest ' | awk '{ print $3 }')
 
-sed -i -E 's/index\.docker\.io\/kubevirtci\/flakefinder@sha256\:[a-z0-9]+/'"index\.docker\.io\/kubevirtci\/flakefinder@$sha_id"'/g' \
-    ../../github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+for file in $(grep -l 'image: .*/kubevirtci/flakefinder' ../../github/ci/prow/files/jobs/**/*-periodics.yaml); do
+    sed -i -E 's/index\.docker\.io\/kubevirtci\/flakefinder@sha256\:[a-z0-9]+/'"index\.docker\.io\/kubevirtci\/flakefinder@$sha_id"'/g' \
+        "$file"
+done


### PR DESCRIPTION
Updated the image shas for cdi to use latest flakefinder version.

Fixed the update script. The script only updated the shas for kubevirt/kubevirt,
this fix now updates any *-periodics.yaml below github/ci/prow/files/jobs containing 
flakefinder image references.

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>