### PR TITLE
Enable needs-rebase for kubernetes-nmstate only

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -164,7 +164,7 @@ external_plugins:
     events:
       - pull_request
   - name: cherrypicker
-  nmstate:
+  nmstate/kubernetes-nmstate:
   - name: needs-rebase
     events:
       - pull_request


### PR DESCRIPTION
Instead of operating on the entire org, we want just to
enable this check for a single project.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>