### PR TITLE
Add pip to the slave image

### DIFF
--- a/images/kubevirt-infra-bootstrap/Dockerfile
+++ b/images/kubevirt-infra-bootstrap/Dockerfile
@@ -14,4 +14,5 @@ RUN apt-get update \
         libssl-dev \
         libpython-dev \
         python3 \
+        python3-pip \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Required for ansible-kubevirt-modules

Signed-off-by: gbenhaim <galbh2@gmail.com>