### PR TITLE
add OCP job to knmstate

### DIFF
--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
       annotations:
         fork-per-release: "true"
       always_run: true
-      optional: false
+      optional: true
       decorate: true
       decoration_config:
         timeout: 3h
@@ -93,3 +93,35 @@ presubmits:
               - "/bin/sh"
               - "-c"
               - "automation/check-patch.e2e-okd.sh"
+    - name: pull-kubernetes-nmstate-e2e-ocp
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+        preset-shared-images: "true"
+        preset-kubevirtci-quay-credential: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "29Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && automation/check-patch.e2e-ocp.sh"


### PR DESCRIPTION
We want to test against D/S too. The underlying system and the
NetworkManager version there may be different. Also, OCP lane seems
to be more stable than OKD.

This also mark the OKD lane as optional since it is consistently
*not* working.

Signed-off-by: Petr Horacek <phoracek@redhat.com>