### PR TITLE
Add ipv6 config for docker daemon

### DIFF
--- a/github/ci/prow/files/docker-daemon-mirror.conf
+++ b/github/ci/prow/files/docker-daemon-mirror.conf
@@ -1,3 +1,5 @@
 DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"
 DOCKER_OPTS="${DOCKER_OPTS} --registry-mirror=http://docker-mirror.kubevirt-prow.svc:5000 --insecure-registry=http://docker-mirror.kubevirt-prow.svc:5000"
 DOCKER_OPTS="${DOCKER_OPTS} --mtu=1450"
+DOCKER_OPTS="${DOCKER_OPTS} --ipv6"
+DOCKER_OPTS="${DOCKER_OPTS} --fixed-cidr-v6 2001:db8:1::/64"


### PR DESCRIPTION
To run ipv6 jobs we need docker daemon to be properly configured as stated here  kubevirt/kubevirtci#241.

Signed-off-by: Quique Llorente <ellorent@redhat.com>