### PR TITLE
Add fedora base image jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presubmits.yaml
@@ -1389,3 +1389,54 @@ presubmits:
           resources:
             requests:
               memory: "1Gi"
+
+  - name: check-fedora
+    always_run: false
+    optional: true
+    decorate: true
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "cd cluster-provision/fedora/ && ./build.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+
+  - name: push-fedora
+    always_run: false
+    optional: true
+    decorate: true
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-kubevirtci-docker-credential: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd cluster-provision/fedora/ && ./build.sh && ./publish.sh "
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"


### PR DESCRIPTION
We are creating a k8s provider based of fedora [1], for that we need a pair of jobs to to build the base images for those, same we have for centos nodes.

[1] https://github.com/kubevirt/kubevirtci/pull/246

Signed-off-by: Quique Llorente <ellorent@redhat.com>