### PR TITLE
Use new location for commenter images

### DIFF
--- a/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/project-infra/project-infra-periodics.yaml
@@ -46,9 +46,9 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20200204-7e8cd997a
+    - image: gcr.io/k8s-prow/commenter:v20200204-7e8cd997a
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=org:kubevirt
@@ -81,9 +81,9 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20200204-7e8cd997a
+    - image: gcr.io/k8s-prow/commenter:v20200204-7e8cd997a
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=org:kubevirt
@@ -119,9 +119,9 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: gcr.io/k8s-testimages/commenter:v20200204-7e8cd997a
+    - image: gcr.io/k8s-prow/commenter:v20200204-7e8cd997a
       command:
-      - /commenter
+      - /app/robots/commenter/app.binary
       args:
       - |-
         --query=org:kubevirt


### PR DESCRIPTION
The commenter bot is only updated at `gcr.io/k8s-prow/commenter` for some time now. Some jobs still point to the old location. These jobs are now broken because I updated to a newer tag. Fixing this.