### PR TITLE
switch SR-IOV test lane to 1.17.0

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -418,7 +418,7 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-kubevirt-e2e-kind-k8s-sriov-1.14.2
+  - name: pull-kubevirt-e2e-kind-k8s-sriov-1.17.0
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -455,7 +455,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "apt update && apt install gettext-base -y && export TARGET=kind-k8s-sriov-1.14.2 && automation/test.sh"
+        - "apt update && apt install gettext-base -y && export TARGET=kind-k8s-sriov-1.17.0 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
It not only contains newer version of Kubernetes, but also up-to-date
version of the SR-IOV operator and CNI.

Signed-off-by: Petr Horacek <phoracek@redhat.com>