### PR TITLE
Update sinker role

### DIFF
--- a/github/ci/prow/templates/sinker-rbac.yaml
+++ b/github/ci/prow/templates/sinker-rbac.yaml
@@ -17,6 +17,24 @@ rules:
     verbs:
       - delete
       - list
+      - watch
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - prow-sinker-leaderlock
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - create
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
sinker now requires access to a new config-map and it needs to be able
to get and list prowjobs

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>