### PR TITLE
Adjust kubevirt jobs to the simplified provision layout

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.14.6
+  - name: pull-kubevirt-e2e-k8s-1.14
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -89,14 +89,14 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "export TARGET=k8s-1.14.6 && automation/test.sh"
+        - "export TARGET=k8s-1.14 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.15.1-ceph
+  - name: pull-kubevirt-e2e-k8s-1.15-ceph
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -121,14 +121,14 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.15.1 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph' && automation/test.sh"
+            - "export TARGET=k8s-1.15 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph' && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.17.0
+  - name: pull-kubevirt-e2e-k8s-1.17
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -154,14 +154,14 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.17.0 && automation/test.sh"
+            - "export TARGET=k8s-1.17 && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.16.2
+  - name: pull-kubevirt-e2e-k8s-1.16
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -186,7 +186,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.16.2 && automation/test.sh"
+            - "export TARGET=k8s-1.16 && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Adjust the kubevirt jobs to use the new provision layout in kubevirtci.

Once #358 is merged, this one can go in.
