### PR TITLE
Remove k8snetworkplumbingwg branch protection

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -232,12 +232,6 @@ branch-protection:
               protect: true
         kubectl-virt-plugin:
           protect: true
-    k8snetworkplumbingwg:
-      repos:
-        kubemacpool:
-          branches:
-            master:
-              protect: true
     nmstate:
       repos:
         kubernetes-nmstate:


### PR DESCRIPTION
Fails on k8snetworkplumbingwg dues to permission issues, so we're removing it for now.