### PR TITLE
Add stdout flag to flakefinder, default is false

### DIFF
--- a/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -39,7 +39,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -71,7 +71,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -38,7 +38,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -69,7 +69,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -40,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -73,7 +73,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:1d359b10c91008c2f5a027fc56dbad9d7618361c6f0f8cdc461bddbbced4c2f5
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:f8e40e466fcd746ad3701876005a2ef3d7ec6abe61163fadc8fe75c6b1c259d8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -50,6 +50,7 @@ func flagOptions() options {
 	flag.StringVar(&o.reportOutputChildPath, "report_output_child_path", "", fmt.Sprintf("Child path below the main reporting directory '%s' (i.e. 'master', default is '')", ReportsPath))
 	flag.StringVar(&o.org, "org", Org, fmt.Sprintf("GitHub org name (default is '%s')", Org))
 	flag.StringVar(&o.repo, "repo", Repo, fmt.Sprintf("GitHub org name (default is '%s')", Repo))
+	flag.BoolVar(&o.stdout, "stdout", false, "write generated report to stdout (default is false)")
 	flag.Parse()
 	return o
 }
@@ -65,6 +66,7 @@ type options struct {
 	reportOutputChildPath string
 	org                   string
 	repo                  string
+	stdout                bool
 }
 
 const BucketName = "kubevirt-prow"
@@ -170,7 +172,7 @@ func main() {
 		reports = append(reports, r...)
 	}
 
-	err = WriteReportToBucket(ctx, client, reports, o.merged, o.org, o.repo, prNumbers)
+	err = WriteReportToBucket(ctx, client, reports, o.merged, o.org, o.repo, prNumbers, o.stdout)
 	if err != nil {
 		log.Fatal(fmt.Errorf("failed to write report: %v", err))
 		return

--- a/robots/flakefinder/update-jobs-with-latest-flakefinder-image.sh
+++ b/robots/flakefinder/update-jobs-with-latest-flakefinder-image.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 docker pull kubevirtci/flakefinder
-sha_id=$(docker images --digests kubevirtci/flakefinder | grep 'latest ' | awk '{ print $3 }')
+sha_id=$(docker images --digests kubevirtci/flakefinder | grep 'latest ' | head -1 | awk '{ print $3 }')
 
 for file in $(grep -l 'image: .*/kubevirtci/flakefinder' ../../github/ci/prow/files/jobs/**/*-periodics.yaml); do
     sed -i -E 's/index\.docker\.io\/kubevirtci\/flakefinder@sha256\:[a-z0-9]+/'"index\.docker\.io\/kubevirtci\/flakefinder@$sha_id"'/g' \


### PR DESCRIPTION
In order to avoid triggering the kubevirtprow bot (who thinks there is
an error in the logs and sounds an alarm then) we introduce a flag to
enable switching stdout printing of report (default is off).

References:
* [slack message](https://coreos.slack.com/archives/CTFN306KC/p1582048325001900)
* [log output](https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-publish-kubevirt-flakefinder-weekly-report/1229810288421769216)

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>