### PR TITLE
Revert "Remove k8snetworkplumbingwg branch protection (#370)"

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -232,6 +232,12 @@ branch-protection:
               protect: true
         kubectl-virt-plugin:
           protect: true
+    k8snetworkplumbingwg:
+      repos:
+        kubemacpool:
+          branches:
+            master:
+              protect: true
     nmstate:
       repos:
         kubernetes-nmstate:


### PR DESCRIPTION
This adds the branch protection settings for k8snetworkplumbingwg/kubemacpool again.

This reverts commit 5f93466cde82e08edf74b1dd77a12881ed8a6366.

/cc @phoracek @qinqon 