### PR TITLE
adding kustomize tool to bootstrap Docker file

### DIFF
--- a/images/kubevirt-infra-bootstrap/Dockerfile
+++ b/images/kubevirt-infra-bootstrap/Dockerfile
@@ -16,3 +16,10 @@ RUN apt-get update \
         python3 \
         python3-pip \
         && rm -rf /var/lib/apt/lists/*
+RUN export KUSTOMIZE_DIR=/opt/kustomize \
+    && mkdir -p $KUSTOMIZE_DIR \
+    && cd $KUSTOMIZE_DIR \
+    && wget "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz" \
+    && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz \
+    && rm kustomize_v3.5.4_linux_amd64.tar.gz \
+    && echo "export PATH=$KUSTOMIZE_DIR:$PATH" >> $HOME/.bashrc


### PR DESCRIPTION
[kustomize](https://kustomize.io/) is a tool used to customize application configuration files. 

Currently [kubemacpool project](https://github.com/k8snetworkplumbingwg/kubemacpool) uses this tool during the ci tests, and so there is a need to add it to the Bootstrap Docker file (currently failing due to this). 

Signed-off-by: Ram Lavi <ralavi@redhat.com>