### PR TITLE
update kubemacpool base image for prow tests

### DIFF
--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool-presubmits.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
           type: vm
           zone: ci
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20200226-3b9263d
             securityContext:
               privileged: true
             command:
@@ -51,7 +51,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20200226-3b9263d
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Following the insertion of prow tests to [kubemacpool project](https://github.com/k8snetworkplumbingwg/kubemacpool/), PRs are failing because kustomize tool is [needed](https://github.com/k8snetworkplumbingwg/kubemacpool/blob/b69c56e0ef0d080b5391aef151273e2746b0bb25/Makefile#L39). 
After updating the project-infra Dockerfile in an already merged [PR](https://github.com/kubevirt/project-infra/pull/373), changing the kubemacpool base image tag should solve the failing PRs.

Signed-off-by: Ram Lavi <ralavi@redhat.com>