### PR TITLE
changing kustomize path to /usr/bin

### DIFF
--- a/images/kubevirt-infra-bootstrap/Dockerfile
+++ b/images/kubevirt-infra-bootstrap/Dockerfile
@@ -22,4 +22,4 @@ RUN export KUSTOMIZE_DIR=/opt/kustomize \
     && wget "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz" \
     && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz \
     && rm kustomize_v3.5.4_linux_amd64.tar.gz \
-    && echo "export PATH=$KUSTOMIZE_DIR:$PATH" >> $HOME/.bashrc
+    && ln -s $KUSTOMIZE_DIR/kustomize /usr/bin/kustomize


### PR DESCRIPTION
Since dash is commonly used in project infra, in order to allow access to kustomize for containers using the Dockerfile base image, we need to move kustomize to /usr/bin folder.

The former copying to .bashrc is relevent only for /bin/bash applications. copying to this path will work for both shells.

Signed-off-by: Ram Lavi <ralavi@redhat.com>