### PR TITLE
updating the base image so that kustomize will be accessible to dash

### DIFF
--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool-presubmits.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
           type: vm
           zone: ci
         containers:
-          - image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20200226-3b9263d
+          - image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20200303-ed11c77
             securityContext:
               privileged: true
             command:
@@ -51,7 +51,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20200226-3b9263d
+          - image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20200303-ed11c77
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Following the [PR #375](https://github.com/kubevirt/project-infra/pull/375) where a sym link was added to make kustomize ready for dash shell, we update the [kubemacpool](https://github.com/k8snetworkplumbingwg/kubemacpool) image for prow tests.

Signed-off-by: Ram Lavi <ralavi@redhat.com>
