### PR TITLE
add CNAO GitHub release automation

### DIFF
--- a/github/ci/prow/files/jobs/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -1,0 +1,31 @@
+postsubmits:
+  kubevirt/cluster-network-addons-operator:
+    - name: release-cluster-network-addons-operator
+      run_if_changed: "version/version.go"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+        preset-kubevirtci-quay-credential: "true"
+      spec:
+        nodeSelector:
+          type: vm
+          zone: ci
+        containers:
+          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - "GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/oauth) ./automation/release.sh"
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - name: github-token
+                mountPath: /etc/github
+        volumes:
+          - name: github-token
+            secret:
+              secretName: oauth-token


### PR DESCRIPTION
Building of the images is still done via Travis. That will be resolved in
a follow-up PR.

CNAO automation PR: https://github.com/kubevirt/cluster-network-addons-operator/pull/330