### PR TITLE
allow rerun of builds through UI

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -41,6 +41,9 @@ deck:
       optional_files:
         - artifacts/filtered.html
   tide_update_period: 1s
+  rerun_auth_config:
+    github_team_ids:
+      - 3701123 # prow-job-taskforce
 
 sinker:
   resync_period: 1m


### PR DESCRIPTION
There is no simple way to rerun a postsubmit job in Prow in the current state.

With this patch, we are adding a support for kubevirt's "prow-job-taskforce"
members to retrigger a run of a build through the Deck UI.

Signed-off-by: Petr Horacek <phoracek@redhat.com>