### PR TITLE
rename ovs-cni e2e tests target

### DIFF
--- a/github/ci/prow/files/jobs/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow/files/jobs/ovs-cni/ovs-cni-presubmits.yaml
@@ -31,4 +31,4 @@ presubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
               - "-c"
-              - "automation/check-patch.sh"
+              - "automation/check-patch.e2e.sh"


### PR DESCRIPTION
Needed for: https://github.com/kubevirt/ovs-cni/pull/115

Signed-off-by: Petr Horacek <phoracek@redhat.com>