### PR TITLE
Enable flaky tests check

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -545,7 +545,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
With regard to kubevirt/kubevirt#3053 we still need to enable the check so that it runs on changes.