### PR TITLE
sriov: silence tar extracting

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -491,7 +491,7 @@ presubmits:
             apt update &&
             apt install gettext-base -y &&
             wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz &&
-            tar -xvzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
+            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&
             export TARGET=kind-k8s-sriov-1.17.0 &&
             automation/test.sh


### PR DESCRIPTION
It generates a lot of noise in CI. Let's drop it.

Signed-off-by: Petr Horacek <phoracek@redhat.com>