### PR TITLE
Set TARGET_COMMIT to base sha

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -597,7 +597,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "automation/repeated_test.sh"
+            - "TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Prow checks out the base branch and merges the pr branch
on top of it, so the last merge commit is ofcourse the
current HEAD. This leads to "no files changed" when trying to
fetch changed files after last merge commit (which is done
by default in the script.
Therefore we explicitly set TARGET_COMMIT to the base branch
sha.

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>