### PR TITLE
Replace kubevirt multus lane with k8s-cnao-1.17

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -193,45 +193,13 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-multus-1.13.3
+  - name: pull-kubevirt-e2e-k8s-cnao-1.17
     skip_branches:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 10
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "export TARGET=k8s-multus-1.13.3 && automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-cnao-1.17
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
Has being already tested multiple times.

Testing PR with kubevirt automation change: https://github.com/kubevirt/kubevirt/pull/3131

Prow job https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/3131/pull-kubevirt-e2e-k8s-cnao-1.17/1242422026359017472

Signed-off-by: Quique Llorente <ellorent@redhat.com>