### PR TITLE
Create job to build and push kubevirt nightly to docker

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -285,3 +285,19 @@ presets:
   volumeMounts:
   - name: shared-iso
     mountPath: /var/lib/stdci/shared/kubevirt-images/
+- labels:
+    preset-kubevirtci-docker-credential: "true"
+  env:
+    - name: DOCKER_USER
+      value: /etc/kubevirtci-cred/username
+    - name: DOCKER_PASSWORD
+      value: /etc/kubevirtci-cred/password
+  volumes:
+    - name: kubevirtci-cred
+      secret:
+        defaultMode: 0400
+        secretName: kubevirtci-docker-credential
+  volumeMounts:
+    - name: kubevirtci-cred
+      mountPath: /etc/kubevirtci-cred
+      readOnly: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -92,3 +92,38 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
+- name: periodic-kubevirt-push-nightly-build-master
+  cron: "02 05 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  max_concurrency: 1
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror: "true"
+    preset-shared-images: "true"
+    preset-kubevirtci-docker-credential: "true"
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+      command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - >
+          cat $DOCKER_PASSWORD | docker login --username $(cat $DOCKER_USER) --password-stdin &&
+          git clone https://github.com/kubevirt/kubevirt.git &&
+          cd kubevirt &&
+          export DOCKER_PREFIX='kubevirtnightlybuilds' &&
+          export DOCKER_TAG='latest' &&
+          make &&
+          make push
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "29Gi"

--- a/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presets.yaml
+++ b/github/ci/prow/files/jobs/kubevirtci/kubevirtci-presets.yaml
@@ -1,21 +1,5 @@
 presets:
 - labels:
-    preset-kubevirtci-docker-credential: "true"
-  env:
-  - name: DOCKER_USER
-    value: /etc/kubevirtci-cred/username
-  - name: DOCKER_PASSWORD
-    value: /etc/kubevirtci-cred/password
-  volumes:
-  - name: kubevirtci-cred
-    secret:
-      defaultMode: 0400
-      secretName: kubevirtci-docker-credential
-  volumeMounts:
-  - name: kubevirtci-cred
-    mountPath: /etc/kubevirtci-cred
-    readOnly: true
-- labels:
     preset-kubevirtci-quay-credential: "true"
   env:
   - name: QUAY_USER


### PR DESCRIPTION
In order to consume the build from openshift ci (see openshift/release#8123) we push the images to docker registry beforehand.