### PR TITLE
For node-maintenance-operator - always run 4.3 CI env.

### DIFF
--- a/github/ci/prow/files/jobs/node-maintenance-operator/node-maintenance-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/node-maintenance-operator/node-maintenance-operator-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
CI script in nmo have been adjusted to use upstream CI, now we can run
openshift 4.3 with every build. This PR should enable a test task for  openshift 4.3 with every build of node maintenance operator.

Signed-off-by: Michael Moser <mmoser@redhat.com>