### PR TITLE
Start periodic job for KubeVirt nightly build shortly after 1 AM

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-periodics.yaml
@@ -93,7 +93,7 @@ periodics:
       secret:
         secretName: gcs
 - name: periodic-kubevirt-push-nightly-build-master
-  cron: "02 05 * * *"
+  cron: "2 1 * * *"
   decorate: true
   decoration_config:
     timeout: 1h


### PR DESCRIPTION
Set current schedule more close to midnight.