### PR TITLE
Always run kind-k8s-1.17.0-ipv6

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt-presubmits.yaml
@@ -465,8 +465,9 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     optional: true
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
Ipv6 support was introduced to kubevirt in
PR https://github.com/kubevirt/kubevirt/pull/3112

kind-k8s-1.17.0-ipv6 was green prior merging the PR.
To avoid regressions, the lane is changed to be always run.

However, since currently there are some flaky tests, the lane will
still be optional and skip reports until it stays green.
