### PR TITLE
Fix autoowners job failing to commit by adding GIT_AUTHOR variables

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -170,10 +170,13 @@ periodics:
       - >
         mkdir -p /tmp && cd /tmp &&
         echo 'cat /etc/github/oauth' > /tmp/git-askpass-helper.sh &&
+        chmod +x /tmp/git-askpass-helper.sh &&
         export GIT_ASKPASS=/tmp/git-askpass-helper.sh &&
         git clone https://github.com/kubevirt/project-infra.git &&
         cd project-infra &&
-        autoowners --dry-run=false --github-login=kubevirt-bot --org=kubevirt --repo=project-infra --assign=dhiller --target-dir=. --target-subdir=github/ci/prow/files --config-subdir=jobs --github-token-path=/etc/github/oauth
+        autoowners --dry-run=false --github-login=kubevirt-bot --org=kubevirt --repo=project-infra --assign=dhiller --target-dir=. --target-subdir=github/ci/prow/files --config-subdir=jobs --github-token-path=/etc/github/oauth &&
+        git commit --amend --signoff --no-edit &&
+        git push -f "https://kubevirt-bot@github.com/kubevirt-bot/project-infra.git" HEAD:autoowners
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -160,14 +160,20 @@ periodics:
         value: kubevirt-bot
       - name: GIT_COMMITTER_EMAIL
         value: rmohr+kubebot@redhat.com
+      - name: GIT_AUTHOR_NAME
+        value: kubevirt-bot
+      - name: GIT_AUTHOR_EMAIL
+        value: rmohr+kubebot@redhat.com
       command:
       - "/bin/sh"
       - "-c"
       - >
         mkdir -p /tmp && cd /tmp &&
+        echo 'cat /etc/github/oauth' > /tmp/git-askpass-helper.sh &&
+        export GIT_ASKPASS=/tmp/git-askpass-helper.sh &&
         git clone https://github.com/kubevirt/project-infra.git &&
         cd project-infra &&
-        autoowners --dry-run=true --github-login=kubevirt-bot --org=kubevirt --repo=project-infra --assign=dhiller --target-dir=. --target-subdir=github/ci/prow/files --config-subdir=jobs --github-token-path=/etc/github/oauth
+        autoowners --dry-run=false --github-login=kubevirt-bot --org=kubevirt --repo=project-infra --assign=dhiller --target-dir=. --target-subdir=github/ci/prow/files --config-subdir=jobs --github-token-path=/etc/github/oauth
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
The current job is failing on commit. By adding the GIT_AUTHOR environment variables and adding the GIT_ASKPASS step I got so far as it can create the commit, push to the fork, but now it fails when trying to create the PR against kubevirt/project-infra:

```
...
time="2020-05-08T12:49:30Z" level=info msg="GetFile(virtblocks, virtblocks, OWNERS, )" client=github                           
time="2020-05-08T12:49:36Z" level=info msg="GetFile(virtblocks, virtblocks, OWNERS_ALIASES, )" client=github                                                                                                                                                  
time="2020-05-08T12:49:43Z" level=warning msg="Ignoring the repo with no OWNERS file in the upstream repo." orgRepo=virtblocks/virtblocks                              
time="2020-05-08T12:49:44Z" level=info msg="Making git commit..."                 
[master 7bb251d] Sync OWNERS files by autoowners job at Fri, 08 May 2020 12:49:44 UTC   
 4 files changed, 5 insertions(+)                                                                                              
time="2020-05-08T12:49:44Z" level=info msg="Pushing to remote..."                                              
remote:                                                                                                                        
remote: Create a pull request for 'autoowners' on GitHub by visiting:                                   
remote:      https://github.com/kubevirt-bot/project-infra/pull/new/autoowners                                  
remote:                                                                                                                        
To https://kubevirt-bot:CENSORED@github.com/kubevirt-bot/project-infra.git                   
 * [new branch]      HEAD -> autoowners                                                                                        
time="2020-05-08T12:49:48Z" level=info msg="Creating or updating PR..."                                      
time="2020-05-08T12:49:48Z" level=info msg="Looking for a PR to reuse..."                                                                                                                                                                                     
time="2020-05-08T12:49:48Z" level=info msg="User()" client=github                                              
time="2020-05-08T12:49:48Z" level=info msg="FindIssues(is:open is:pr archived:false in:title repo:kubevirt/project-infra author:kubevirt-bot author:kubevirt-bot Sync OWNERS files)" client=github                                                            
time="2020-05-08T12:49:48Z" level=info msg="No reusable issues found"                                                                                                                                                                                         
time="2020-05-08T12:49:48Z" level=info msg="CreatePullRequest(kubevirt, project-infra, Sync OWNERS files by autoowners job at Fri, 08 May 2020 12:49:44 UTC)" client=github                                                                                   
time="2020-05-08T12:49:48Z" level=fatal msg="PR creation failed." error="failed to ensure PR exists: create error: unexpected end of JSON input"                                                                                                              
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"prow/entrypoint/run.go:80","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","time":"2020-05-08T12:49:48Z"}
```
(taken from `oc logs -c test 0b1b77d0-912a-11ea-a911-e86a64a85ba2`)

I figure that maybe the scope of the personal access token might be missing the [rights to create the PR against the repository](https://github.com/MicrosoftDocs/azure-devops-docs/issues/1303#issuecomment-511757716), but am not sure what token (there are four) has been configured in our prow instance.

@rmohr maybe you can chime in here? Or @danielBelenky maybe?