### PR TITLE
Make k8s-1.17 job run always but still optional for now

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -101,7 +101,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     optional: true
     skip_report: false
     decorate: true


### PR DESCRIPTION
The test suite should now pass with SELinux enabled (enforced), since https://github.com/kubevirt/kubevirt/pull/3371.
Making the 1.17 lane always run and block PRs will ensure we don't introduce new denials.