### PR TITLE
Add csv reporting for easier aggregation

### DIFF
--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -41,7 +41,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -39,7 +39,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -71,7 +71,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -40,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -73,7 +73,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+      - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -40,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -72,7 +72,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -104,7 +104,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -41,7 +41,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:7523d0dd7718c285f0330159903cf33894af5cd715a554cdfa9694e849b8bf43
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json


### PR DESCRIPTION
It was mentioned that we might want to aggregate and/or expose test flakiness i.e. via a dashboard or the like to make it measurable. One idea that came up was to just add a CSV (because it's easy to consume).

This PR introduces an additional report in CSV format that is written and stored besides the original html report.

Output would be like this:

```
"Test Name","Test Lane","Severity","Failed","Succeeded","Skipped","Jobs (JSON)"
"t1","a","red",4,1,2,"{BuildNumber: 1742,Severity: ""red"",PR: 4217,Job: ""testJob"",},"
"t1","b","yellow",5,2,3,
"t2","a","cyan",8,2,4,
"t2","b","blue",9,3,5,
```
**Note:** according to [RFC 4180](https://tools.ietf.org/html/rfc4180) double quotes within a double quoted field value have to be escaped with another double quote

Further improvements could be:
* to link to the file from within the report file.

Thoughts?
