### PR TITLE
Since ipv6 lane is green - make it required

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -466,8 +466,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: true
-    skip_report: true
+    optional: false
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
Since ipv6 was introduced to kubevirt few PRs broke the lane.
To avoid this situation in the future, the lane should be required.