### PR TITLE
Change vm-import-operator job from post to pre

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -1,4 +1,4 @@
-postsubmits:
+presubmits:
   kubevirt/vm-import-operator:
   - name: pull-vm-import-operator-e2e-k8s-1.16
     always_run: true


### PR DESCRIPTION
This PR changes vm-import-operator post-submit job to pre-submit.

Signed-off-by: Ondra Machacek <omachace@redhat.com>