### PR TITLE
sriov: run lane on each PR

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -392,7 +392,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
SR-IOV deployments are broken more often than not, and that is
easily explained since it does not vote in CI, and does not even
run.

This is a step in that direction; run it, but don't have it voting.
We intend to actively debug the sriov lane, and nurture it back to
a healthy state, then have it voting in CI.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>