### PR TITLE
sriov: don't show results on PRs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -394,6 +394,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
     always_run: true
     optional: true
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
This lane is unstable. We want to collect logs, so it runs on the
background, but it should not add noise to PRs.

Signed-off-by: Petr Horacek <phoracek@redhat.com>