### PR TITLE
Add anchors to test reports

### DIFF
--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -148,12 +148,14 @@ const tpl = `
 <table>
     <tr>
         <td></td>
+        <td></td>
         {{ range $header := $.Headers }}
         <td>{{ $header }}</td>
         {{ end }}
     </tr>
     {{ range $row, $test := $.Tests }}
     <tr>
+        <td><div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a><div></td>
         <td>{{ $test }}</td>
         {{ range $col, $header := $.Headers }}
         {{if not (index $.Data $test $header) }}


### PR DESCRIPTION
In order to point people to specific lines in the reports, add anchors to every line.
![anchors](https://user-images.githubusercontent.com/4534621/83006717-ecbebc80-a012-11ea-95dd-e739b66acace.png)
