### PR TITLE
Enable the 4.3 job for NMO and make it blocking

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits.yaml
@@ -69,8 +69,8 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
CI script in nmo have been adjusted to use upstream CI, now we can run
openshift 4.3 with every build.