### PR TITLE
Go 1.13 for flakefinder

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
         type: vm
         zone: ci
       containers:
-      - image: golang:1.12
+      - image: golang:1.13
         env:
           - name: GO111MODULE
             value: "on"

--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -148,12 +148,14 @@ const tpl = `
 <table>
     <tr>
         <td></td>
+        <td></td>
         {{ range $header := $.Headers }}
         <td>{{ $header }}</td>
         {{ end }}
     </tr>
     {{ range $row, $test := $.Tests }}
     <tr>
+        <td><div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a><div></td>
         <td>{{ $test }}</td>
         {{ range $col, $header := $.Headers }}
         {{if not (index $.Data $test $header) }}


### PR DESCRIPTION
New code we merged into vendor requires go 1.13 already.