### PR TITLE
Add Kubemacpool functests on CNAO job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -125,3 +125,34 @@ presubmits:
               - "/bin/sh"
               - "-c"
               - "automation/check-patch.e2e-workflow-okd.sh"
+    - name: pull-e2e-cluster-network-addons-operator-kubemacpool-functests
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+      always_run: false
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "29Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-kubemacpool-functests.sh"


### PR DESCRIPTION
This PR Adds new job in order to test KubeMacPool functests on
latest CNAO builds.
This is necessary in order to catch bugs and prevent more issues that 
related to how KubeMacPool integrates with CNAO, 
especially on CNAO releases and KubeMacPool bumps.

This PR is need for https://github.com/kubevirt/cluster-network-addons-operator/pull/408