### PR TITLE
hide ipv6 lane

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -500,8 +500,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: false
-    skip_report: false
+    optional: true
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
The IPv6 lane on kubevirt is utterly broken with pass rate around 10 %.
We should disable it to reduce the noise and investigate why is the
provider and lane failing.

Signed-off-by: Petr Horacek <phoracek@redhat.com>