### PR TITLE
hco: move to OCP 4.4 and k8s 1.17.0 and add a new config for release-2.4 branch

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -1,0 +1,64 @@
+periodics: null
+postsubmits: {}
+presubmits:
+  kubevirt/hyperconverged-cluster-operator:
+  - always_run: true
+    branches:
+    - release-2.4
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17.0
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - export TARGET=k8s-1.17.0 && automation/test.sh
+        image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20191223-f0a2baa
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-2.4
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-kubevirtci-quay-credential: "true"
+      preset-shared-images: "true"
+    max_concurrency: 6
+    name: pull-hyperconverged-cluster-operator-e2e-ocp-4.4
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -c
+        - cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true
+          quay.io && export TARGET=ocp-4.4 && automation/test.sh
+        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubevirt/hyperconverged-cluster-operator:
-  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.15.1
+  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17.0
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -25,14 +25,14 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "export TARGET=k8s-1.15.1 && automation/test.sh"
+        - "export TARGET=k8s-1.17.0 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-hyperconverged-cluster-operator-e2e-ocp-4.3
+  - name: pull-hyperconverged-cluster-operator-e2e-ocp-4.4
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -58,7 +58,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
         - "-c"
-        - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && export TARGET=ocp-4.3 && automation/test.sh"
+        - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && export TARGET=ocp-4.4 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
hco: move to OCP 4.4 and k8s 1.17.0 and add a new config for release-2.4 branch