### PR TITLE
fix k8s-1.17 lane name

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -14,14 +14,14 @@ presubmits:
       preset-docker-mirror: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17.0
+    name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
     spec:
       containers:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=k8s-1.17.0 && automation/test.sh
+        - export TARGET=k8s-1.17 && automation/test.sh
         image: docker.io/kubevirtci/kubevirt-infra-bootstrap:v20191223-f0a2baa
         name: ""
         resources:

--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubevirt/hyperconverged-cluster-operator:
-  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17.0
+  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -25,7 +25,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "export TARGET=k8s-1.17.0 && automation/test.sh"
+        - "export TARGET=k8s-1.17 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
kubevirt-ci lane for k8s-1.17 is named "k8s-1.17", and not "k8s-1.17.0".
This PR updates the ${TARGET} var to be corresponding with the actual name of the kubevirt-ci provider.
https://github.com/kubevirt/kubevirtci/tree/master/cluster-up/cluster/k8s-1.17