### PR TITLE
Temporary disable OCP 4.4 lanes on HCO repo

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -31,34 +31,34 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
-    branches:
-    - release-2.4
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-kubevirtci-quay-credential: "true"
-      preset-shared-images: "true"
-    max_concurrency: 6
-    name: pull-hyperconverged-cluster-operator-e2e-ocp-4.4
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -c
-        - cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true
-          quay.io && export TARGET=ocp-4.4 && automation/test.sh
-        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
+#  - always_run: true
+#    branches:
+#    - release-2.4
+#    decorate: true
+#    decoration_config:
+#      grace_period: 5m0s
+#      timeout: 7h0m0s
+#    labels:
+#      preset-dind-enabled: "true"
+#      preset-docker-mirror: "true"
+#      preset-kubevirtci-quay-credential: "true"
+#      preset-shared-images: "true"
+#    max_concurrency: 6
+#    name: pull-hyperconverged-cluster-operator-e2e-ocp-4.4
+#    spec:
+#      containers:
+#      - command:
+#        - /usr/local/bin/runner.sh
+#        - /bin/bash
+#        - -c
+#        - cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true
+#          quay.io && export TARGET=ocp-4.4 && automation/test.sh
+#        image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+#        name: ""
+#        resources:
+#          requests:
+#            memory: 29Gi
+#        securityContext:
+#          privileged: true
+#      nodeSelector:
+#        type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -32,36 +32,36 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-hyperconverged-cluster-operator-e2e-ocp-4.4
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-kubevirtci-quay-credential: "true"
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/bash"
-        - "-c"
-        - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && export TARGET=ocp-4.4 && automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"
+#  - name: pull-hyperconverged-cluster-operator-e2e-ocp-4.4
+#    skip_branches:
+#    - release-\d+\.\d+
+#    annotations:
+#      fork-per-release: "true"
+#    always_run: true
+#    optional: false
+#    decorate: true
+#    decoration_config:
+#      timeout: 7h
+#      grace_period: 5m
+#    max_concurrency: 6
+#    labels:
+#      preset-kubevirtci-quay-credential: "true"
+#      preset-dind-enabled: "true"
+#      preset-docker-mirror: "true"
+#      preset-shared-images: "true"
+#    spec:
+#      nodeSelector:
+#        type: bare-metal-external
+#      containers:
+#      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+#        command:
+#        - "/usr/local/bin/runner.sh"
+#        - "/bin/bash"
+#        - "-c"
+#        - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && export TARGET=ocp-4.4 && automation/test.sh"
+#        # docker-in-docker needs privileged mode
+#        securityContext:
+#          privileged: true
+#        resources:
+#          requests:
+#            memory: "29Gi"


### PR DESCRIPTION
Temporary disable OCP 4.4 lanes on HCO repo
because is still not stable enough to be
used on development tests.

Signed-off-by: Simone Tiraboschi <stirabos@redhat.com>