### PR TITLE
Require linear history on kubevirtci

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -183,6 +183,8 @@ branch-protection:
           branches:
             master:
               protect: true
+              required_status_checks:
+                strict: true
         containerized-data-importer:
           branches:
             master:


### PR DESCRIPTION
To avoid the problem of concurrent changes to i.e. a base image and providers provisioned being merged concurrently we can enable the linear history on kubevirtci.