### PR TITLE
Bump ceph lane to use 1.16 provider , make it optional

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -64,13 +64,13 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.15-ceph
+  - name: pull-kubevirt-e2e-k8s-1.16-ceph
     skip_branches:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 7h
@@ -89,7 +89,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.15 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph' && automation/test.sh"
+            - "export TARGET=k8s-1.16 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph' && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
We bump the ceph lane to use k8s-1.16 and to avoid friction we make the lane optional.