### PR TITLE
Run Travis test script on Prow

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -609,3 +609,120 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
+  - name: pull-kubevirt-generate
+    cluster: ibm-prow-jobs
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
+          env:
+            - name: BAZEL_VERSION
+              value: "1.2.1"
+            - name: CACHE_HOST
+              value: bazel-cache.kubevirt-prow
+            - name: CACHE_PORT
+              value: "8080"
+            - name: BAZEL_REMOTE_CACHE_ENABLED
+              value: "true"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make generate"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+  - name: pull-kubevirt-build
+    cluster: ibm-prow-jobs
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
+          env:
+            - name: BAZEL_VERSION
+              value: "1.2.1"
+            - name: CACHE_HOST
+              value: bazel-cache.kubevirt-prow
+            - name: CACHE_PORT
+              value: "8080"
+            - name: BAZEL_REMOTE_CACHE_ENABLED
+              value: "true"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+  - name: pull-kubevirt-unit-test
+    cluster: ibm-prow-jobs
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
+          env:
+            - name: BAZEL_VERSION
+              value: "1.2.1"
+            - name: CACHE_HOST
+              value: bazel-cache.kubevirt-prow
+            - name: CACHE_PORT
+              value: "8080"
+            - name: BAZEL_REMOTE_CACHE_ENABLED
+              value: "true"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make test"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"


### PR DESCRIPTION
This is the first step of migrating all our CI workloads to Prow. Our
worker nodes have more juice than what Travis gives us and it will allow
us to make a pipeline out of this job in the future.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>