### PR TITLE
Disable K8s-1.18 always_run

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -101,7 +101,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
+    always_run: false
     optional: true
     skip_report: false
     decorate: true


### PR DESCRIPTION
Since yesterday that it was pushed, prow has problems,
that looks like starvation, hence disabling it might
give hint on what happens.

Signed-off-by: Or Shoval <oshoval@redhat.com>