### PR TITLE
Increase memory requirements for Prometheus pod

### DIFF
--- a/github/ci/prometheus/templates/prometheus.yaml
+++ b/github/ci/prometheus/templates/prometheus.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
-  name: prometheus 
+  name: prometheus
   labels:
     app: prometheus
     version: v2.7.1
@@ -38,10 +38,10 @@ spec:
           resources:
             limits:
               cpu: 10m
-              memory: 10Mi
+              memory: 100Mi
             requests:
               cpu: 10m
-              memory: 10Mi
+              memory: 100Mi
 
         - name: prometheus-server
           image: "prom/prometheus:v2.7.1"
@@ -70,11 +70,10 @@ spec:
           resources:
             limits:
               cpu: 200m
-              memory: 1000Mi
+              memory: 8Gi
             requests:
               cpu: 200m
-              memory: 1000Mi
-            
+              memory: 8Gi
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config


### PR DESCRIPTION
The pod was constantly being OOM killed.

Note: this is a temporary solution. Until we set up a more
serious Prometheus deployment.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>