### PR TITLE
Make kind ipv6 lane optional due to instablility

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -500,8 +500,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: false
-    skip_report: false
+    optional: true
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
Deployment of kubevirt on this lane fails most of the time.
Make it optional and non reporting to unblock other prs.

Temporary fix for kubevirt/kubevirt#3569