### PR TITLE
Move SR-IOV passthrough CNI to this repo

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/Dockerfile
+++ b/cni-plugins/sriov-passthrough-cni/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:7.6.1810
+
+ENV SRC_DIR=/plugin-src
+ARG PLUGIN_BIN=plugin/sriov-passthrough-cni
+ARG PLUGIN_CONF=plugin/90-sriov-passthrough-cni.conf
+ARG INSTALL_SCRIPT=install-plugin
+
+RUN mkdir -p $SRC_DIR
+COPY $PLUGIN_BIN $SRC_DIR
+COPY $PLUGIN_CONF $SRC_DIR
+COPY $INSTALL_SCRIPT /bin
+
+ENTRYPOINT ["install-plugin"]

--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -1,0 +1,29 @@
+# SR-IOV passthrough CNI
+
+This is a CNI ([container network interface](https://github.com/containernetworking/cni))
+plugin that passes all physical and virtual functions of a SR-IOV nic into the
+namespace of a pod that requests it.
+
+## Where it used
+
+We use this CNI plugin in our CI to test SR-IOV functionality in KubeVirt.
+
+## Notes
+
+We use [multus-cni](https://github.com/intel/multus-cni) to attach the VFs and
+PFs to the pod as a secondary network. We then use a `DaemonSet` to deploy the
+plugin on all the relevant K8s nodes.
+
+## Directory structure
+
+```
+.
+├── deploy  # The manifests used to deploy the plugin and its pre-requisites.
+│   └── multus-cni.yaml
+├── Dockerfile      # The Dockerfile that we use to pack the plugin in.
+├── install-plugin  # The script that actually installs the plugin.
+├── plugin  # The plugin itself.
+│   ├── 90-sriov-passthrough-cni.conf
+│   └── sriov-passthrough-cni
+└── README.md
+```

--- a/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
+++ b/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multus-cni-ns
+  labels:
+    name: multus-cni-ns
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: network-attachment-definitions.k8s.cni.cncf.io
+spec:
+  group: k8s.cni.cncf.io
+  version: v1
+  names:
+    plural: network-attachment-definitions
+    singular: network-attachment-definition
+    kind: NetworkAttachmentDefinition
+    shortNames:
+    - net-attach-def
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            config:
+              type: string
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: multus
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: multus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: multus
+subjects:
+- kind: ServiceAccount
+  name: multus
+  namespace: multus-cni-ns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: multus
+  namespace: multus-cni-ns
+---
+kind: SecurityContextConstraints
+apiVersion: v1
+metadata:
+  name: scc-admin
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+allowHostDirVolumePlugin: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegedContainer: true
+users:
+  - system:serviceaccount:multus-cni-ns:multus
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: multus-cni-config
+  namespace: multus-cni-ns
+  labels:
+    tier: node
+    app: multus
+data:
+  00-multus.conf: |
+    {
+      "name": "multus-cni",
+      "type": "multus",
+      "delegates": [{
+        "type": "openshift-sdn",
+        "name": "openshift.1",
+        "masterplugin": true
+      }],
+      "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig",
+      "logFile": "/var/log/multus.log",
+      "logLevel": "debug"
+    }
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-passthrough-cni
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.0",
+      "type": "sriov-passthrough-cni"
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: multus-cni
+  namespace: multus-cni-ns
+  labels:
+    tier: node
+    app: multus
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus
+    spec:
+      hostNetwork: true
+      serviceAccountName: multus
+      nodeSelector:
+        sriov-nic: 'true'
+      containers:
+        - name: kube-multus
+          command: ["/entrypoint.sh"]
+          args: ["--multus-conf-file=/usr/src/multus-cni/images/00-multus.conf"]
+          image: 'docker.io/nfvpe/multus:v3.1'
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cni
+              mountPath: /host/etc/cni/net.d
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+            - name: multus-cfg
+              mountPath: /usr/src/multus-cni/images/
+        - name: kube-sriov-passthrough-cni
+          command: ["install-plugin"]
+          args: ["/host/opt/cni/bin", "/host/etc/cni/net.d"]
+          image: 'quay.io/pod_utils/sriov-passthrough-cni:v1.0'
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+            limits:
+              cpu: "100m"
+              memory: "50Mi"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: cni
+              mountPath: /host/etc/cni/net.d
+            - name: cnibin
+              mountPath: /host/opt/cni/bin
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+        - name: multus-cfg
+          configMap:
+            name: multus-cni-config

--- a/cni-plugins/sriov-passthrough-cni/install-plugin
+++ b/cni-plugins/sriov-passthrough-cni/install-plugin
@@ -1,0 +1,21 @@
+#!/bin/bash -xe
+
+# Usage:
+# ./install_plugin CNI_BIN_DST CNI_CONF_DST
+
+readonly CNI_BIN_SRC=/plugin-src/sriov-passthrough-cni
+readonly CNI_CONF_SRC=/plugin-src/90-sriov-passthrough-cni.conf
+
+function install_plugin() {
+    local cni_bin_dst="${1:?}"
+    local cni_conf_dst="${2:?}"
+
+    cp "$CNI_BIN_SRC" "$cni_bin_dst"
+    chmod 755 "$cni_bin_dst"
+
+    cp "$CNI_CONF_SRC" "$cni_conf_dst"
+    chmod 644 "$cni_conf_dst"
+}
+
+install_plugin "$@"
+sleep infinity

--- a/cni-plugins/sriov-passthrough-cni/plugin/90-sriov-passthrough-cni.conf
+++ b/cni-plugins/sriov-passthrough-cni/plugin/90-sriov-passthrough-cni.conf
@@ -1,0 +1,5 @@
+{
+  "cniVersion": "0.3.1",
+  "name": "sriov-passthrough-cni",
+  "type": "sriov-passthrough-cni"
+}

--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+readonly IP=169.255.0.0
+readonly SUBNET_MASK=24
+readonly GW_IP=169.255.0.1
+readonly CONTAINER_NETNS_LINK="/var/run/netns/$CNI_CONTAINERID"
+readonly LOGFILE=/var/log/pfcni.log
+
+function main() {
+    case "$CNI_COMMAND" in
+        ADD)
+            log "Received ADD command. CNI_ARGS: $CNI_ARGS"
+            setup_netns
+            # add_veth_pair
+            flip_vfs_to_default_drivers
+            setns_sriov_ifs
+            gen_result_config
+            ;;
+        DELETE)
+            log "Received DELETE command."
+            ip netns del "$CNI_CONTAINERID" ||:
+            ;;
+    esac
+}
+
+function flip_vfs_to_default_drivers() {
+    for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
+        pfroot=$(dirname $file)
+
+        # flip all available VFs to default driver
+        echo 0 > $pfroot/sriov_numvfs
+        cat $file > $pfroot/sriov_numvfs
+    done
+}
+
+function from_cni_args() {
+    local var_name="${1:?}"
+    sed -nE "s/.+?${var_name}=([^;]*?)(;.+?|$)/\1/p" <<< "$CNI_ARGS"
+}
+
+function setup_netns() {
+    mkdir -p /var/run/netns
+    ln -sfT "$CNI_NETNS" "$CONTAINER_NETNS_LINK"
+}
+
+function setns_sriov_ifs() {
+  local sriov_vfs=( /sys/class/net/*/device/virtfn* )
+  local ifs_arr ifs_name
+  for vf in "${sriov_vfs[@]}"; do
+    ifs_arr=( "$vf"/net/* )
+    for ifs in "${ifs_arr[@]}"; do
+        ifs_name="${ifs%%\/net\/*}"
+        ifs_name="${ifs##*\/}"
+        log "Adding vf: $ifs_name to netns $CNI_CONTAINERID"
+        ip link set "$ifs_name" netns "$CNI_CONTAINERID"
+    done
+  done
+
+  local sriov_pfs=( /sys/class/net/*/device/sriov_numvfs )
+  local ifs_name
+  for ifs in "${sriov_pfs[@]}"; do
+    ifs_name="${ifs%%/device/*}"
+    ifs_name="${ifs_name##*/}"
+        log "Adding pf: $ifs_name to netns $CNI_CONTAINERID"
+    ip link set "$ifs_name" netns "$CNI_CONTAINERID"
+  done
+
+}
+
+add_veth_pair() {
+    local container_name
+    container_name="$(from_cni_args K8S_POD_NAME)"
+    local host_if="veth-1-${container_name}"
+    local container_if="veth-2-${container_name}"
+    ip link add "$container_if" type veth peer name "$host_if"
+    ip link set "$host_if" up
+    ip link set "$container_if" netns "$CNI_CONTAINERID"
+    ip netns exec "$CNI_CONTAINERID" ip link set "$container_if" down
+    ip netns exec "$CNI_CONTAINERID" ip link set "$container_if" name \
+        "$CNI_IFNAME"
+    ip netns exec "$CNI_CONTAINERID" ip link set "$container_if" up
+    ip netns exec "$CNI_CONTAINERID" ip addr add "$IP/$SUBNET_MASK" \
+        dev "$container_if"
+}
+
+function gen_result_config() {
+  local mac
+  mac="$(
+    ip netns exec "$CNI_CONTAINERID" ip link show "$CNI_IFNAME" | \
+        grep link | awk '{print $2}')"
+
+  tee -a "$LOGFILE" <<-EOF
+    {
+        "cniVersion": "0.3.1",
+        "interfaces": [
+          {
+            "name":"$CNI_IFNAME",
+            "mac": "$mac",
+            "sandbox": "$CNI_NETNS"
+          }
+        ],
+        "ips": [
+          {
+            "version": "4",
+            "address": "$IP/$SUBNET_MASK",
+            "interface": 0
+          }
+        ]
+    }
+EOF
+}
+
+function log {
+    echo "[$(date --rfc-3339=seconds)]: $*" >> "$LOGFILE"
+}
+
+main "$@"


### PR DESCRIPTION
We use this plugin to test KubeVirt with SR-IOV hardware. Up until now,
this plugin was stored in a separate repo outside of the KubeVirt org
without any good reason. Moving it here will increase it's visibility.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>