### PR TITLE
Disable sriov lane until provider is stabilized

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -425,7 +425,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: true
+    always_run: false
     optional: true
     skip_report: true
     decorate: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -419,7 +419,7 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-kubevirt-e2e-kind-k8s-sriov-1.17.0
+  - name: pull-kubevirt-e2e-kind-1.17-sriov
     skip_branches:
     - release-\d+\.\d+
     annotations:


### PR DESCRIPTION
This PR set the sriov-lane job to not run on every PR change,
until those PR are merged 
https://github.com/kubevirt/kubevirtci/pull/378
https://github.com/kubevirt/kubevirt/pull/3509

This PR also rename the job name to `pull-kubevirt-e2e-kind-1.17-sriov`, as preparation to changing provider name:
from: kind-k8s-sriov-1.17.0
to: kind-1.17-sriov
