### PR TITLE
Enable sriov lane back on master branch

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -431,8 +431,8 @@ presubmits:
     skip_report: false
     decorate: true
     decoration_config:
-      timeout: 5h
-      grace_period: 5m
+      timeout: 3h
+      grace_period: 20m
     max_concurrency: 10
     labels:
       preset-dind-enabled: "true"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -426,7 +426,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: false
+    always_run: true
     optional: true
     skip_report: true
     decorate: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -428,7 +428,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
     always_run: true
     optional: true
-    skip_report: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
This PR enable sriov lane to run on every change, report and decrease timeout.

This should be merged only after https://github.com/kubevirt/kubevirtci/pull/378 and 
https://github.com/kubevirt/kubevirt/pull/3509 are merged.
