### PR TITLE
Fix sriov check-up job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -339,7 +339,8 @@ presubmits:
             wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz &&
             tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&
-            KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
+            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
+            export KUBEVIRT_NUM_NODES=2 &&
             make cluster-up
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
This PR fixes `check-up-kind-1.17-sriov` job by adding missing `export` to `KUBEVIRT_PROVIDER`
and exports `KUBEVIRT_NUM_NODES=2`.
