### PR TITLE
Skip reporting of status to GitHub for 1.16 ceph lane

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -71,6 +71,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: true
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
The recently bumped lane has issues, therefore we disable status
reporting to not cause more friction.

Relates to kubevirt/kubevirt#3622