### PR TITLE
Add optional k8s-1.18 lanes to CDI.

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -1,5 +1,37 @@
 presubmits:
   kubevirt/containerized-data-importer:
+  - name: pull-containerized-data-importer-e2e-k8s-1.18-hpp
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"
   - name: pull-containerized-data-importer-e2e-k8s-1.16-hpp
     skip_branches:
       - release-\d+\.\d+
@@ -122,6 +154,70 @@ presubmits:
             - "/bin/sh"
             - "-c"
             - "export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=ember_lvm && export SNAPSHOT_SC=ember-csi-lvm && export BLOCK_SC=ember-csi-lvm && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"
+  - name: pull-containerized-data-importer-e2e-k8s-1.18-upg
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && export MULTI_UPGRADE=true && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"
+  - name: pull-containerized-data-importer-e2e-k8s-1.18-nfs
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=nfs && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Soon to replace k8s-1.16 lanes, we'd like to keep up to date with the latest k8s releases.
This is copy-pasted from the k8s-1.16 lanes with the version swapped and changing optional to true.

Would quickly error out until https://github.com/kubevirt/containerized-data-importer/pull/1252 is merged.