### PR TITLE
Remove the old build-officer label

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -157,10 +157,6 @@ default:
     - name: topic/virtualization
       color: c5def5
       target: both
-    - name: build-officer
-      color: 8452c9
-      target: issues
-      addedBy: anyone
 repos:
   kubevirt/kubevirt:
     labels:


### PR DESCRIPTION
It is replaced with triage/build-officer, so that people can use the
label plugin for assigning it.