### PR TITLE
Disable sriov lane until provider is stabilized on release-0.30 branch

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -331,7 +331,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
     branches:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -346,7 +346,7 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
     max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-k8s-sriov-1.17.0
+    name: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     skip_report: true
     spec:


### PR DESCRIPTION
This is following PR for https://github.com/kubevirt/project-infra/pull/483

kubevirt-bot running the wrong sriov-lane jobs on PRs from kubevirt `release-0.30` branch
https://prow.apps.ovirt.org/?job=pull-kubevirt-e2e-kind-k8s-sriov-1.17.0
This PR disable sriov lane job also on kubevirt `release-0.30` branch until https://github.com/kubevirt/kubevirt/pull/3509 is merged to master and to `release-0.30` branch.

This PR also rename the job name to `pull-kubevirt-e2e-kind-1.17-sriov` in order to align with the sriov lane prow  job configuration on kubevirt master branch.