### PR TITLE
always run SR-IOV test lane on KubeVirt

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -426,7 +426,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: false
+    always_run: true
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
But run it in background. Let's collect some info about lane's stability
before we start showing the results.

Signed-off-by: Petr Horacek <phoracek@redhat.com>