### PR TITLE
Disable pull-kubevirt-e2e-k8s-1.16-ceph auto run

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -69,7 +69,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
+    always_run: false
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
Cluster up of it is broken, it uses resources,
and alter prow statistics with its failures.
Since it fails all the time, we dont need the statistics.

See 
https://github.com/kubevirt/kubevirt/issues/3622

Signed-off-by: Or Shoval <oshoval@redhat.com>