### PR TITLE
Automate the master index page creation for the flakefinder entry page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ deps-update:
 	sed -i "s|^.*data = \[\"//prow/plugins:config-src\"\],||g" vendor/k8s.io/test-infra/pkg/genyaml/BUILD.bazel
 	$(bazelbin) run //:gazelle
 
+gazelle:
+	bazel run //:gazelle -- robots/
+
 install-bazelisk:
 	go get -u github.com/bazelbuild/bazelisk

--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -41,7 +41,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -39,7 +39,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -71,7 +71,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -40,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -73,7 +73,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+      - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -40,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -72,7 +72,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -104,7 +104,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -192,7 +192,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: index.docker.io/kubevirtci/indexpagecreator@sha256:c7231c5dabf1c7f168626025d60a16ca50312c5216bfddb82c1e7d96e297e19c
+      - image: index.docker.io/kubevirtci/indexpagecreator@sha256:bbdf645306c9bce0f03c7446317043656429b9bec951d5d2f102138ac3f99e61
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -184,3 +184,28 @@ periodics:
     - name: token
       secret:
         secretName: oauth-token
+- name: periodic-update-flakefinder-indexpage
+  interval: 24h
+  decorate: true
+  spec:
+    nodeSelector:
+      type: vm
+      zone: ci
+    containers:
+      - image: index.docker.io/kubevirtci/indexpagecreator@sha256:c7231c5dabf1c7f168626025d60a16ca50312c5216bfddb82c1e7d96e297e19c
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+        command:
+          - "/app/robots/indexpagecreator/app.binary"
+        args:
+          - --dry-run=false
+        volumeMounts:
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: true
+    volumes:
+      - name: gcs
+        secret:
+          secretName: gcs
+

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -41,7 +41,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/flakefinder/BUILD.bazel
+++ b/robots/flakefinder/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "kubevirt.io/project-infra/robots/flakefinder",
     visibility = ["//visibility:public"],
     deps = [
+        "//robots/pkg/flakefinder:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/google/go-github/v28/github:go_default_library",
         "//vendor/github.com/joshdk/go-junit:go_default_library",
@@ -56,6 +57,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//robots/pkg/flakefinder:go_default_library",
         "//vendor/github.com/google/go-github/v28/github:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",

--- a/robots/flakefinder/downloader.go
+++ b/robots/flakefinder/downloader.go
@@ -55,18 +55,6 @@ func readGcsObject(ctx context.Context, client *storage.Client, bucket, object s
 	return ioutil.ReadAll(reader)
 }
 
-func readGcsObjectAttrs(ctx context.Context, client *storage.Client, bucket, object string) (attrs *storage.ObjectAttrs, err error) {
-	logrus.Infof("Trying to read gcs object attrs '%s' in bucket '%s'\n", object, bucket)
-	attrs, err = client.Bucket(bucket).Object(object).Attrs(ctx)
-	if err == storage.ErrObjectNotExist {
-		return nil, err
-	}
-	if err != nil {
-		return nil, fmt.Errorf("Cannot read attrs from %s in bucket '%s'", object, bucket)
-	}
-	return
-}
-
 func FindUnitTestFiles(ctx context.Context, client *storage.Client, bucket, repo string, pr *github.PullRequest, startOfReport time.Time) ([]*Result, error) {
 
 	dirOfPrJobs := path.Join("pr-logs", "pull", strings.ReplaceAll(repo, "/", "_"), strconv.Itoa(*pr.Number))
@@ -106,7 +94,7 @@ func FindUnitTestFileForJob(ctx context.Context, client *storage.Client, bucket 
 		dirOfStartedJSON := path.Join(buildDirPath, startedJSON)
 
 		// Fetch file attributes to check whether this test result should be included into the report
-		attrsOfFinishedJsonFile, err := readGcsObjectAttrs(ctx, client, bucket, dirOfFinishedJSON)
+		attrsOfFinishedJsonFile, err := flakefinder.ReadGcsObjectAttrs(ctx, client, bucket, dirOfFinishedJSON)
 		if err == storage.ErrObjectNotExist {
 			// build still running?
 			continue

--- a/robots/flakefinder/index.go
+++ b/robots/flakefinder/index.go
@@ -27,7 +27,6 @@ import (
 	"html/template"
 	"io"
 	"kubevirt.io/project-infra/robots/pkg/flakefinder"
-	"log"
 	"os"
 	"path"
 	"sort"
@@ -95,7 +94,7 @@ func CreateReportIndex(ctx context.Context, client *storage.Client, org, repo st
 	if printIndexPageToStdOut {
 		err = WriteReportIndexPage(reportDirGcsObjects, os.Stdout, org, repo)
 	} else {
-		reportIndexObjectWriter := CreateOutputWriter(client, ctx)
+		reportIndexObjectWriter := flakefinder.CreateOutputWriter(client, ctx, ReportOutputPath)
 		err = WriteReportIndexPage(reportDirGcsObjects, reportIndexObjectWriter, org, repo)
 		if err != nil {
 			return fmt.Errorf("failed generating index page: %v", err)
@@ -105,15 +104,7 @@ func CreateReportIndex(ctx context.Context, client *storage.Client, org, repo st
 			return fmt.Errorf("failed closing index page writer: %v", err)
 		}
 	}
-
 	return nil
-}
-
-func CreateOutputWriter(client *storage.Client, ctx context.Context) io.WriteCloser {
-	reportIndexObject := client.Bucket(flakefinder.BucketName).Object(path.Join(ReportOutputPath, "index.html"))
-	log.Printf("Report index page will be written to gs://%s/%s", flakefinder.BucketName, reportIndexObject.ObjectName())
-	reportIndexObjectWriter := reportIndexObject.NewWriter(ctx)
-	return reportIndexObjectWriter
 }
 
 func WriteReportIndexPage(reportDirGcsObjects []string, reportIndexObjectWriter io.Writer, org, repo string) error {

--- a/robots/flakefinder/index.go
+++ b/robots/flakefinder/index.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/api/iterator"
 	"html/template"
 	"io"
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 	"log"
 	"os"
 	"path"
@@ -109,8 +110,8 @@ func CreateReportIndex(ctx context.Context, client *storage.Client, org, repo st
 }
 
 func CreateOutputWriter(client *storage.Client, ctx context.Context) io.WriteCloser {
-	reportIndexObject := client.Bucket(BucketName).Object(path.Join(ReportOutputPath, "index.html"))
-	log.Printf("Report index page will be written to gs://%s/%s", BucketName, reportIndexObject.ObjectName())
+	reportIndexObject := client.Bucket(flakefinder.BucketName).Object(path.Join(ReportOutputPath, "index.html"))
+	log.Printf("Report index page will be written to gs://%s/%s", flakefinder.BucketName, reportIndexObject.ObjectName())
 	reportIndexObjectWriter := reportIndexObject.NewWriter(ctx)
 	return reportIndexObjectWriter
 }
@@ -147,7 +148,7 @@ func PrepareDataForTemplate(reportDirGcsObjects []string, org string, repo strin
 	indexMap := make(map[string]ReportFilesRow)
 
 	for _, reportFileName := range reportDirGcsObjects {
-		date := strings.Replace(reportFileName, ReportFilePrefix, "", -1)
+		date := strings.Replace(reportFileName, flakefinder.ReportFilePrefix, "", -1)
 		date = strings.Replace(date, ".html", "", -1)
 		mergedDuration := ReportFileMergedDuration(date[strings.LastIndex(date, "-")+1:])
 		if mergedDuration != Day && mergedDuration != Week && mergedDuration != FourWeeks {
@@ -176,7 +177,7 @@ func PrepareDataForTemplate(reportDirGcsObjects []string, org string, repo strin
 // their basenames
 func getReportItemsFromBucketDirectory(client *storage.Client, ctx context.Context) ([]string, error) {
 	var reportDirGcsObjects []string
-	it := client.Bucket(BucketName).Objects(ctx, &storage.Query{
+	it := client.Bucket(flakefinder.BucketName).Objects(ctx, &storage.Query{
 		Prefix:    ReportOutputPath + "/",
 		Delimiter: "/",
 	})
@@ -197,7 +198,7 @@ func getReportItemsFromBucketDirectory(client *storage.Client, ctx context.Conte
 func FilterReportItemsForIndexPage(fileNames []string) []string {
 	result := make([]string, 0)
 	for _, fileName := range fileNames {
-		if !strings.HasPrefix(fileName, ReportFilePrefix) || !strings.HasSuffix(fileName, ".html") {
+		if !strings.HasPrefix(fileName, flakefinder.ReportFilePrefix) || !strings.HasSuffix(fileName, ".html") {
 			continue
 		}
 		result = append(result, fileName)

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -35,6 +35,8 @@ import (
 	"golang.org/x/oauth2"
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/flagutil"
+
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 )
 
 func flagOptions() options {
@@ -48,7 +50,7 @@ func flagOptions() options {
 	flag.StringVar(&o.token, "token", "", "Path to github token")
 	flag.BoolVar(&o.isPreview, "preview", false, "Whether report should be written to preview directory")
 	flag.StringVar(&o.prBaseBranch, "pr_base_branch", PRBaseBranchDefault, fmt.Sprintf("Base branch for the PRs (default: '%s')", PRBaseBranchDefault))
-	flag.StringVar(&o.reportOutputChildPath, "report_output_child_path", "", fmt.Sprintf("Child path below the main reporting directory '%s' (i.e. 'master', default is '')", ReportsPath))
+	flag.StringVar(&o.reportOutputChildPath, "report_output_child_path", "", fmt.Sprintf("Child path below the main reporting directory '%s' (i.e. 'master', default is '')", flakefinder.ReportsPath))
 	flag.StringVar(&o.org, "org", Org, fmt.Sprintf("GitHub org name (default is '%s')", Org))
 	flag.StringVar(&o.repo, "repo", Repo, fmt.Sprintf("GitHub org name (default is '%s')", Repo))
 	flag.BoolVar(&o.today, "today", false, "Whether to create a report for the current day only (i.e. using data starting from report day 00:00Z till now)")
@@ -77,16 +79,12 @@ type options struct {
 	today  bool
 }
 
-const BucketName = "kubevirt-prow"
-const ReportsPath = "reports/flakefinder"
-const PreviewPath = "preview"
-const ReportFilePrefix = "flakefinder-"
 const MaxNumberOfReportsToLinkTo = 50
 const PRBaseBranchDefault = "master"
 const Org = "kubevirt"
 const Repo = "kubevirt"
 
-var ReportOutputPath = ReportsPath
+var ReportOutputPath = flakefinder.ReportsPath
 var PRBaseBranch string
 
 func main() {
@@ -167,7 +165,7 @@ func main() {
 	}
 	reports := []*Result{}
 	for _, pr := range prs {
-		r, err := FindUnitTestFiles(ctx, client, BucketName, strings.Join([]string{o.org, o.repo}, "/"), pr, startOfReport)
+		r, err := FindUnitTestFiles(ctx, client, flakefinder.BucketName, strings.Join([]string{o.org, o.repo}, "/"), pr, startOfReport)
 		if err != nil {
 			log.Printf("failed to load JUnit file for %v: %v", pr.Number, err)
 		}
@@ -245,9 +243,9 @@ func GetReportInterval(o options, till time.Time) (startOfReport, endOfReport ti
 // "reports/flakefinder/preview/kubevirt/kubevirt"
 //
 func BuildReportOutputPath(o options) string {
-	outputPath := ReportsPath
+	outputPath := flakefinder.ReportsPath
 	if o.isPreview {
-		outputPath = filepath.Join(outputPath, PreviewPath)
+		outputPath = filepath.Join(outputPath, flakefinder.PreviewPath)
 	}
 	outputPath = filepath.Join(outputPath, o.reportOutputChildPath)
 	return outputPath

--- a/robots/flakefinder/main_test.go
+++ b/robots/flakefinder/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 	"time"
 )
 
@@ -11,7 +12,7 @@ var _ = Describe("main.go", func() {
 	When("Setting up output path", func() {
 
 		BeforeEach(func() {
-			ReportOutputPath = ReportsPath
+			ReportOutputPath = flakefinder.ReportsPath
 		})
 
 		It("has default path", func() {

--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -23,8 +23,6 @@ import (
 	"cloud.google.com/go/storage"
 	"context"
 	"fmt"
-	"html/template"
-	"io"
 	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 	"log"
 	"os"
@@ -35,7 +33,7 @@ import (
 	"github.com/joshdk/go-junit"
 )
 
-const tpl = `
+const ReportTemplate = `
 <!DOCTYPE html>
 <html>
 <head>
@@ -340,10 +338,10 @@ func Report(results []*Result, reportOutputWriter *storage.Writer, org string, r
 	}
 	var err error
 	if !isDryRun && reportOutputWriter != nil {
-		err = WriteReportToOutput(reportOutputWriter, parameters)
+		err = flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, reportOutputWriter)
 	}
 	if isDryRun || writeToStdout {
-		err = WriteReportToOutput(os.Stdout, parameters)
+		err = flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, os.Stdout)
 	}
 
 	if err != nil {
@@ -487,13 +485,3 @@ const (
 	Fine            = "green"
 	Unimportant     = "unimportant"
 )
-
-func WriteReportToOutput(writer io.Writer, parameters Params) error {
-	t, err := template.New("report").Parse(tpl)
-	if err != nil {
-		return fmt.Errorf("failed to load report template: %v", err)
-	}
-
-	err = t.Execute(writer, parameters)
-	return err
-}

--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 	"log"
 	"os"
 	"path"
@@ -218,9 +219,9 @@ type Job struct {
 }
 
 // WriteReportToBucket creates the actual formatted report file from the report data and writes it to the bucket
-func WriteReportToBucket(ctx context.Context, client *storage.Client, reports []*Result, merged time.Duration, org, repo string, prNumbers []int, writeToStdout, isDryRun bool, startOfReport, endOfReport time.Time) (err error) {
-	reportObject := client.Bucket(BucketName).Object(path.Join(ReportOutputPath, CreateReportFileName(endOfReport, merged)))
-	log.Printf("Report will be written to gs://%s/%s", BucketName, reportObject.ObjectName())
+func WriteReportToBucket(ctx context.Context, client *storage.Client, reports []*Result, merged time.Duration, org, repo string, prNumbers []int, writeToStdout bool, isDryRun bool, startOfReport, endOfReport time.Time) (err error) {
+	reportObject := client.Bucket(flakefinder.BucketName).Object(path.Join(ReportOutputPath, CreateReportFileName(endOfReport, merged)))
+	log.Printf("Report will be written to gs://%s/%s", flakefinder.BucketName, reportObject.ObjectName())
 	var reportOutputWriter *storage.Writer
 	if !isDryRun {
 		reportOutputWriter = reportObject.NewWriter(ctx)
@@ -239,7 +240,7 @@ func WriteReportToBucket(ctx context.Context, client *storage.Client, reports []
 }
 
 func CreateReportFileName(reportTime time.Time, merged time.Duration) string {
-	return fmt.Sprintf(ReportFilePrefix+"%s-%03dh.html", reportTime.Format("2006-01-02"), int(merged.Hours()))
+	return fmt.Sprintf(flakefinder.ReportFilePrefix+"%s-%03dh.html", reportTime.Format("2006-01-02"), int(merged.Hours()))
 }
 
 func Report(results []*Result, reportOutputWriter *storage.Writer, org string, repo string, prNumbers []int, writeToStdout bool, isDryRun bool, startOfReport, endOfReport time.Time) error {

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -3,6 +3,7 @@ package main_test
 import (
 	"bytes"
 	"fmt"
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 	"log"
 	"os"
 	"time"
@@ -41,7 +42,7 @@ var _ = Describe("report.go", func() {
 
 		prepareBuffer := func(parameters Params) {
 			buffer = bytes.Buffer{}
-			err := WriteReportToOutput(&buffer, parameters)
+			err := flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, &buffer)
 			Expect(err).ToNot(HaveOccurred())
 			if testOptions.printTestOutput {
 				logger := log.New(os.Stdout, "report_test.go:", log.Flags())

--- a/robots/indexpagecreator/BUILD.bazel
+++ b/robots/indexpagecreator/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/robots/indexpagecreator",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robots/pkg/flakefinder:go_default_library",
+        "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+    ],
+)
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "app",
+    embed = [":go_default_library"],
+)
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+
+container_push(
+    name = "push",
+    format = "Docker",
+    image = ":app",
+    registry = "index.docker.io",
+    repository = "kubevirtci/indexpagecreator",
+)
+
+go_binary(
+    name = "indexpagecreator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/indexpagecreator/Makefile
+++ b/robots/indexpagecreator/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all clean format test push
+all: format build push
+bazelbin := bazelisk
+
+format:
+	gofmt -w .
+
+build:
+	$(bazelbin) build //robots/indexpagecreator:*
+
+push:
+	$(bazelbin) run //robots/indexpagecreator:push
+	bash -x ./update-jobs-with-latest-indexpagecreator-image.sh

--- a/robots/indexpagecreator/main.go
+++ b/robots/indexpagecreator/main.go
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2020 Red Hat, Inc.
+ *
+ */
+
+package main
+
+func main() {
+
+}

--- a/robots/indexpagecreator/main.go
+++ b/robots/indexpagecreator/main.go
@@ -19,6 +19,121 @@
 
 package main
 
-func main() {
+import (
+	"cloud.google.com/go/storage"
+	"context"
+	"flag"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
 
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
+)
+
+const template = `
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>flakefinder projects overview</title>
+		<style>
+		table, th, td {
+			border: 1px solid black;
+		}
+		</style>
+	</head>
+	<body>
+		<h1>Projects</h1>
+		<table>
+			<tr>
+				<th>Project</th>
+			</tr>{{ range $col, $reportDir := $.ReportDirs }}
+			<tr>
+				<td><a href="{{ $reportDir }}/index.html">{{ $reportDir }}</a></td>
+			</tr>{{ end }}
+		</table>
+		<div>Page created at: {{ $.Date }}</div>
+	</body>
+</html>
+`
+
+type IndexParams struct {
+	ReportDirs []string
+	Date       string
+}
+
+func flagOptions() options {
+	o := options{}
+	flag.BoolVar(&o.isDryRun, "dry-run", true, "Whether index page should be written to target directory or just printed to console")
+	flag.Parse()
+	return o
+}
+
+type options struct {
+	isDryRun bool
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	o := flagOptions()
+
+	ctx := context.Background()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		log.Fatalf("Failed to create new storage client: %v.\n", err)
+	}
+
+	reportDirs, err := getReportDirectories(ctx, client)
+	if err != nil {
+		log.Fatalf("error listing gcs objects: %v", err)
+	}
+	logrus.Infof("Report Directories: %v", reportDirs)
+
+	date := time.Now().Format("2006-01-02 15:04:05")
+	params := IndexParams{ReportDirs: reportDirs, Date: date}
+	if o.isDryRun {
+		err = flakefinder.WriteTemplateToOutput(template, params, os.Stdout)
+		if err != nil {
+			log.Fatalf("error writing report output: %v", err)
+		}
+	} else {
+		reportIndexObjectWriter := flakefinder.CreateOutputWriter(client, ctx, flakefinder.ReportsPath)
+		err = flakefinder.WriteTemplateToOutput(template, params, reportIndexObjectWriter)
+		if err != nil {
+			log.Fatalf("error writing report output: %v", err)
+		}
+		reportIndexObjectWriter.Close()
+	}
+}
+
+func getReportDirectories(ctx context.Context, client *storage.Client) (reportDirs []string, err error) {
+	directories, err := flakefinder.ListGcsObjects(ctx, client, flakefinder.BucketName, flakefinder.ReportsPath+"/", "/")
+	if err != nil {
+		return nil, fmt.Errorf("error listing gcs objects: %v", err)
+	}
+	for _, partialDir := range directories {
+		if partialDir == "preview" {
+			continue
+		}
+		orgDir := filepath.Join(flakefinder.ReportsPath, partialDir)
+		subdirectories, err := flakefinder.ListGcsObjects(ctx, client, flakefinder.BucketName, orgDir+"/", "/")
+		if err != nil {
+			return nil, fmt.Errorf("error listing gcs objects: %v", err)
+		}
+		for _, subdirectory := range subdirectories {
+			repoDir := filepath.Join(orgDir, subdirectory)
+			_, err := flakefinder.ReadGcsObjectAttrs(ctx, client, flakefinder.BucketName, filepath.Join(repoDir, "index.html"))
+			if err == storage.ErrObjectNotExist {
+				continue
+			}
+			reportDirs = append(reportDirs, fmt.Sprintf("%s/%s", partialDir, subdirectory))
+		}
+	}
+	sort.Sort(sort.StringSlice(reportDirs))
+	return reportDirs, nil
 }

--- a/robots/indexpagecreator/update-jobs-with-latest-indexpagecreator-image.sh
+++ b/robots/indexpagecreator/update-jobs-with-latest-indexpagecreator-image.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+docker pull kubevirtci/indexpagecreator
+sha_id=$(docker images --digests kubevirtci/indexpagecreator | grep 'latest ' | head -1 | awk '{ print $3 }')
+
+for file in $(grep -l 'image: .*/kubevirtci/indexpagecreator' ../../github/ci/prow/files/jobs/**/**/*-periodics.yaml); do
+    sed -i -E 's/index\.docker\.io\/kubevirtci\/indexpagecreator@sha256\:[a-z0-9]+/'"index\.docker\.io\/kubevirtci\/indexpagecreator@$sha_id"'/g' \
+        "$file"
+done

--- a/robots/indexpagecreator/update-jobs-with-latest-indexpagecreator-image.sh
+++ b/robots/indexpagecreator/update-jobs-with-latest-indexpagecreator-image.sh
@@ -5,6 +5,6 @@ docker pull kubevirtci/indexpagecreator
 sha_id=$(docker images --digests kubevirtci/indexpagecreator | grep 'latest ' | head -1 | awk '{ print $3 }')
 
 for file in $(grep -l 'image: .*/kubevirtci/indexpagecreator' ../../github/ci/prow/files/jobs/**/**/*-periodics.yaml); do
-    sed -i -E 's/index\.docker\.io\/kubevirtci\/indexpagecreator@sha256\:[a-z0-9]+/'"index\.docker\.io\/kubevirtci\/indexpagecreator@$sha_id"'/g' \
+    sed -i -E 's#index.docker.io/kubevirtci/indexpagecreator@sha256:[a-z0-9]+#index.docker.io/kubevirtci/indexpagecreator@'"$sha_id"'#g' \
         "$file"
 done

--- a/robots/pkg/flakefinder/BUILD.bazel
+++ b/robots/pkg/flakefinder/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["flakefinder.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/flakefinder",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/cloud.google.com/go/storage:go_default_library",
+        "//vendor/github.com/sirupsen/logrus:go_default_library",
+        "//vendor/google.golang.org/api/iterator:go_default_library",
+    ],
+)

--- a/robots/pkg/flakefinder/flakefinder.go
+++ b/robots/pkg/flakefinder/flakefinder.go
@@ -1,0 +1,45 @@
+package flakefinder
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	BucketName       = "kubevirt-prow"
+	ReportsPath      = "reports/flakefinder"
+	ReportFilePrefix = "flakefinder-"
+	PreviewPath      = "preview"
+)
+
+//listGcsObjects get the slice of gcs objects under a given path
+func ListGcsObjects(ctx context.Context, client *storage.Client, bucketName, prefix, delim string) (
+	[]string, error) {
+
+	var objects []string
+	it := client.Bucket(bucketName).Objects(ctx, &storage.Query{
+		Prefix:    prefix,
+		Delimiter: delim,
+	})
+
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return objects, fmt.Errorf("error iterating: %v", err)
+		}
+
+		if attrs.Prefix != "" {
+			objects = append(objects, path.Base(attrs.Prefix))
+		}
+	}
+	logrus.Info("end of listGcsObjects(...)")
+	return objects, nil
+}


### PR DESCRIPTION
This PR introduces automation for updating the [flakefinder project overview page](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/index.html), which is serving as global entry page for all projects covered by flakefinder reports.

There are two parts:
- the page creation tool that is contained within a container image
- the job executing the tool on a 24h schedule

Furthermore:
- the code that could be reused has been moved into the flakefinder package
- the bazel files have been updated to enable building tool binary and container image with it
- another script to update the images on all jobs after push has been added

