### PR TITLE
flakefinder: add rolling window report

### DIFF
--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -14,6 +14,7 @@ periodics:
           command:
             - "/app/robots/flakefinder/app.binary"
           args:
+            - --dry-run=false
             - --token=/etc/github/oauth
             - --merged=168h
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
@@ -47,6 +48,7 @@ periodics:
           command:
             - "/app/robots/flakefinder/app.binary"
           args:
+            - --dry-run=false
             - --token=/etc/github/oauth
             - --merged=24h
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
@@ -80,6 +82,7 @@ periodics:
           command:
             - "/app/robots/flakefinder/app.binary"
           args:
+            - --dry-run=false
             - --token=/etc/github/oauth
             - --merged=672h
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool

--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -34,14 +34,14 @@ periodics:
           secret:
             secretName: gcs
   - name: periodic-publish-kubemacpool-flakefinder-daily-report
-    interval: 24h
+    cron: "30 0 * * *"
     decorate: true
     spec:
       nodeSelector:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -41,7 +41,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -40,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -73,7 +73,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -14,6 +14,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=kubevirt/containerized-data-importer
@@ -46,6 +47,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=kubevirt/containerized-data-importer
@@ -78,6 +80,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=kubevirt/containerized-data-importer

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -33,14 +33,14 @@ periodics:
       secret:
         secretName: gcs
 - name: periodic-publish-cdi-flakefinder-daily-report
-  interval: 24h
+  cron: "35 0 * * *"
   decorate: true
   spec:
     nodeSelector:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -73,7 +73,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1,4 +1,36 @@
 periodics:
+  - name: periodic-publish-kubevirt-flakefinder-hourly-rolling-window-report
+    interval: 1h
+    decorate: true
+    spec:
+      nodeSelector:
+        type: vm
+        zone: ci
+      containers:
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+          env:
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: /etc/gcs/service-account.json
+          command:
+            - "/app/robots/flakefinder/app.binary"
+          args:
+            - --dry-run=false
+            - --token=/etc/github/oauth
+            - --merged=1h
+            - --report_output_child_path=kubevirt/kubevirt
+          volumeMounts:
+            - name: token
+              mountPath: /etc/github
+            - name: gcs
+              mountPath: /etc/gcs
+              readOnly: true
+      volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: gcs
+          secret:
+            secretName: gcs
 - name: periodic-publish-kubevirt-flakefinder-weekly-report
   interval: 24h
   decorate: true
@@ -14,6 +46,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=kubevirt/kubevirt
@@ -45,6 +78,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=kubevirt/kubevirt
@@ -76,6 +110,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=kubevirt/kubevirt

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1,13 +1,13 @@
 periodics:
 - name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
-  interval: 1h
+  cron: "5 * * * *"
   decorate: true
   spec:
     nodeSelector:
       type: vm
       zone: ci
     containers:
-      - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+      - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -16,7 +16,8 @@ periodics:
         args:
           - --dry-run=false
           - --token=/etc/github/oauth
-          - --merged=1h
+          - --merged=24h
+          - --today=1h
           - --report_output_child_path=kubevirt/kubevirt
         volumeMounts:
           - name: token
@@ -39,7 +40,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -64,14 +65,14 @@ periodics:
       secret:
         secretName: gcs
 - name: periodic-publish-kubevirt-flakefinder-daily-report
-  interval: 24h
+  cron: "25 0 * * *"
   decorate: true
   spec:
     nodeSelector:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -103,7 +104,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1,36 +1,36 @@
 periodics:
-  - name: periodic-publish-kubevirt-flakefinder-hourly-rolling-window-report
-    interval: 1h
-    decorate: true
-    spec:
-      nodeSelector:
-        type: vm
-        zone: ci
-      containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/gcs/service-account.json
-          command:
-            - "/app/robots/flakefinder/app.binary"
-          args:
-            - --dry-run=false
-            - --token=/etc/github/oauth
-            - --merged=1h
-            - --report_output_child_path=kubevirt/kubevirt
-          volumeMounts:
-            - name: token
-              mountPath: /etc/github
-            - name: gcs
-              mountPath: /etc/gcs
-              readOnly: true
-      volumes:
-        - name: token
-          secret:
-            secretName: oauth-token
-        - name: gcs
-          secret:
-            secretName: gcs
+- name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
+  interval: 1h
+  decorate: true
+  spec:
+    nodeSelector:
+      type: vm
+      zone: ci
+    containers:
+      - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+        command:
+          - "/app/robots/flakefinder/app.binary"
+        args:
+          - --dry-run=false
+          - --token=/etc/github/oauth
+          - --merged=1h
+          - --report_output_child_path=kubevirt/kubevirt
+        volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: true
+    volumes:
+      - name: token
+        secret:
+          secretName: oauth-token
+      - name: gcs
+        secret:
+          secretName: gcs
 - name: periodic-publish-kubevirt-flakefinder-weekly-report
   interval: 24h
   decorate: true
@@ -39,7 +39,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -71,7 +71,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -103,7 +103,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -41,7 +41,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ad137520705acfd87285aa1cf9a2c7808a67c51f17fabba85356c877fac31712
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -34,14 +34,14 @@ periodics:
       secret:
         secretName: gcs
 - name: periodic-publish-knmstate-flakefinder-daily-report
-  interval: 24h
+  cron: "45 0 * * *"
   decorate: true
   spec:
     nodeSelector:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -75,7 +75,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:ebb25a32fc0a2a491ac3ee05d720f701eb2f31c4c4dce0c32f2df51f62828998
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:90ebab2793e603c10e5996a6efcf8d123fdf4aa97f76be16ba4ee6ef8f33403e
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -14,6 +14,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=nmstate/kubernetes-nmstate
@@ -47,6 +48,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=nmstate/kubernetes-nmstate
@@ -80,6 +82,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=nmstate/kubernetes-nmstate

--- a/robots/flakefinder/index.go
+++ b/robots/flakefinder/index.go
@@ -67,7 +67,6 @@ const indexTpl = `
 type ReportFileMergedDuration string
 
 const (
-	Hourly    ReportFileMergedDuration = "001h"
 	Day       ReportFileMergedDuration = "024h"
 	Week      ReportFileMergedDuration = "168h"
 	FourWeeks ReportFileMergedDuration = "672h"
@@ -151,7 +150,7 @@ func PrepareDataForTemplate(reportDirGcsObjects []string, org string, repo strin
 		date := strings.Replace(reportFileName, ReportFilePrefix, "", -1)
 		date = strings.Replace(date, ".html", "", -1)
 		mergedDuration := ReportFileMergedDuration(date[strings.LastIndex(date, "-")+1:])
-		if mergedDuration != Day && mergedDuration != Week && mergedDuration != FourWeeks && mergedDuration != Hourly {
+		if mergedDuration != Day && mergedDuration != Week && mergedDuration != FourWeeks {
 			mergedDuration = Week
 		} else {
 			date = strings.Replace(date, fmt.Sprintf("-%s", mergedDuration), "", -1)
@@ -161,7 +160,6 @@ func PrepareDataForTemplate(reportDirGcsObjects []string, org string, repo strin
 				FourWeeks: "",
 				Week:      "",
 				Day:       "",
-				Hourly:    "",
 			}}
 			reportFilesRow.ReportFiles[mergedDuration] = reportFileName
 			indexMap[date] = reportFilesRow

--- a/robots/flakefinder/index_test.go
+++ b/robots/flakefinder/index_test.go
@@ -124,6 +124,7 @@ var _ = Describe("index.go", func() {
 						"672h": "flakefinder-2019-08-24-672h.html",
 						"168h": "flakefinder-2019-08-24-168h.html",
 						"024h": "flakefinder-2019-08-24-024h.html",
+						"001h": "",
 					},
 				},
 				{
@@ -132,6 +133,7 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "",
 						"024h": "flakefinder-2019-08-23-024h.html",
+						"001h": "",
 					},
 				},
 				{
@@ -140,6 +142,7 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "",
 						"024h": "flakefinder-2019-08-22-024h.html",
+						"001h": "",
 					},
 				},
 				{
@@ -148,6 +151,7 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-24-168h.html",
 						"024h": "",
+						"001h": "",
 					},
 				},
 				{
@@ -156,6 +160,7 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-17-168h.html",
 						"024h": "",
+						"001h": "",
 					},
 				},
 			}))
@@ -178,6 +183,7 @@ var _ = Describe("index.go", func() {
 						"672h": "flakefinder-2019-08-24-672h.html",
 						"168h": "",
 						"024h": "flakefinder-2019-08-24-024h.html",
+						"001h": "",
 					},
 				},
 				{
@@ -186,6 +192,7 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-24.html",
 						"024h": "",
+						"001h": "",
 					},
 				},
 				{
@@ -194,6 +201,7 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-17.html",
 						"024h": "",
+						"001h": "",
 					},
 				},
 			}))

--- a/robots/flakefinder/index_test.go
+++ b/robots/flakefinder/index_test.go
@@ -124,7 +124,6 @@ var _ = Describe("index.go", func() {
 						"672h": "flakefinder-2019-08-24-672h.html",
 						"168h": "flakefinder-2019-08-24-168h.html",
 						"024h": "flakefinder-2019-08-24-024h.html",
-						"001h": "",
 					},
 				},
 				{
@@ -133,7 +132,6 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "",
 						"024h": "flakefinder-2019-08-23-024h.html",
-						"001h": "",
 					},
 				},
 				{
@@ -142,7 +140,6 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "",
 						"024h": "flakefinder-2019-08-22-024h.html",
-						"001h": "",
 					},
 				},
 				{
@@ -151,7 +148,6 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-24-168h.html",
 						"024h": "",
-						"001h": "",
 					},
 				},
 				{
@@ -160,7 +156,6 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-17-168h.html",
 						"024h": "",
-						"001h": "",
 					},
 				},
 			}))
@@ -183,7 +178,6 @@ var _ = Describe("index.go", func() {
 						"672h": "flakefinder-2019-08-24-672h.html",
 						"168h": "",
 						"024h": "flakefinder-2019-08-24-024h.html",
-						"001h": "",
 					},
 				},
 				{
@@ -192,7 +186,6 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-24.html",
 						"024h": "",
-						"001h": "",
 					},
 				},
 				{
@@ -201,7 +194,6 @@ var _ = Describe("index.go", func() {
 						"672h": "",
 						"168h": "flakefinder-2019-07-17.html",
 						"024h": "",
-						"001h": "",
 					},
 				},
 			}))

--- a/robots/flakefinder/main.go
+++ b/robots/flakefinder/main.go
@@ -41,6 +41,7 @@ func flagOptions() options {
 	o := options{
 		endpoint: flagutil.NewStrings("https://api.github.com"),
 	}
+	flag.BoolVar(&o.isDryRun, "dry-run", true, "Whether report should be only printed to standard out instead of written to gcs") // TODO: incompatible change, requires setting flags on jobs
 	flag.IntVar(&o.ceiling, "ceiling", 100, "Maximum number of issues to modify, 0 for infinite")
 	flag.DurationVar(&o.merged, "merged", 24*7*time.Hour, "Filter to issues merged in the time window")
 	flag.Var(&o.endpoint, "endpoint", "GitHub's API endpoint")
@@ -50,12 +51,15 @@ func flagOptions() options {
 	flag.StringVar(&o.reportOutputChildPath, "report_output_child_path", "", fmt.Sprintf("Child path below the main reporting directory '%s' (i.e. 'master', default is '')", ReportsPath))
 	flag.StringVar(&o.org, "org", Org, fmt.Sprintf("GitHub org name (default is '%s')", Org))
 	flag.StringVar(&o.repo, "repo", Repo, fmt.Sprintf("GitHub org name (default is '%s')", Repo))
-	flag.BoolVar(&o.stdout, "stdout", false, "write generated report to stdout (default is false)")
+	flag.BoolVar(&o.stdout, "stdout", false, "(Deprecated, use dry-run instead) write generated report to stdout (default is false)")
 	flag.Parse()
 	return o
 }
 
 type options struct {
+	isDryRun bool
+
+	// Deprecated: no function
 	ceiling               int
 	endpoint              flagutil.Strings
 	token                 string
@@ -66,7 +70,9 @@ type options struct {
 	reportOutputChildPath string
 	org                   string
 	repo                  string
-	stdout                bool
+
+	// Deprecated: replaced by dry-run
+	stdout bool
 }
 
 const BucketName = "kubevirt-prow"
@@ -112,19 +118,30 @@ func main() {
 
 	c := github.NewClient(tc)
 
-	// we are fetching reports from start of day to avoid working against a moving target.
+	startOfReport := time.Now().Add(-o.merged)
+
+	// we normalize the start of the report against start of day vs. start of the hour to avoid working against a
+	// moving target.
 	// In general a user would expect to find all pull requests of the previous day in a 24h report, regardless of
 	// when the report has been run at the current day, which, depending on time of day when the report had been run,
 	// would not always be the case.
 	// Consider i.e. if the report is run late in the afternoon the user might wonder why the PR merged in the morning
 	// the day before was not included.
-	startOfReport := time.Now().Add(-o.merged)
-	startOfDay := startOfReport.Format("2006-01-02") + "T00:00:00Z"
-	logrus.Infof("Fetching Prs starting from %v", startOfDay)
-	startOfReport, err = time.Parse(time.RFC3339, startOfDay)
-	if err != nil {
-		log.Fatalf("Failed to parse time %+v: %+v", startOfDay, err)
+
+	var startOfDayOrHour string
+
+	// in case of reports for at least a day we are fetching reports from start of day
+	if o.merged.Hours() < 24 {
+		// in case of less than a day we are fetching reports from start of the hour
+		startOfDayOrHour = startOfReport.Format("2006-01-02T15:00:00Z07:00")
+	} else {
+		startOfDayOrHour = startOfReport.Format("2006-01-02") + "T00:00:00Z"
 	}
+	startOfReport, err = time.Parse(time.RFC3339, startOfDayOrHour)
+	if err != nil {
+		log.Fatalf("Failed to parse time %+v: %+v", startOfDayOrHour, err)
+	}
+	logrus.Infof("Fetching Prs starting from %v", startOfReport)
 
 	logrus.Infof("Filtering PRs for base branch %s", PRBaseBranch)
 	prs := []*github.PullRequest{}
@@ -172,18 +189,17 @@ func main() {
 		reports = append(reports, r...)
 	}
 
-	err = WriteReportToBucket(ctx, client, reports, o.merged, o.org, o.repo, prNumbers, o.stdout)
+	err = WriteReportToBucket(ctx, client, reports, o.merged, o.org, o.repo, prNumbers, o.stdout, o.isDryRun, startOfReport)
 	if err != nil {
 		log.Fatal(fmt.Errorf("failed to write report: %v", err))
 		return
 	}
 
-	if !o.stdout {
-		err = CreateReportIndex(ctx, client, o.org, o.repo)
-		if err != nil {
-			log.Fatal(fmt.Errorf("failed to create report index page: %v", err))
-			return
-		}
+	printIndexPageToStdOut := o.isDryRun && o.stdout
+	err = CreateReportIndex(ctx, client, o.org, o.repo, printIndexPageToStdOut)
+	if err != nil {
+		log.Fatal(fmt.Errorf("failed to create report index page: %v", err))
+		return
 	}
 }
 

--- a/robots/flakefinder/main_test.go
+++ b/robots/flakefinder/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("main.go", func() {
@@ -31,6 +32,83 @@ var _ = Describe("main.go", func() {
 		It("has preview and child branch", func() {
 			options := options{isPreview: true, reportOutputChildPath: "master"}
 			Expect(BuildReportOutputPath(options)).To(BeEquivalentTo("reports/flakefinder/preview/master"))
+		})
+
+	})
+
+	parseAndFailTime := func(timeAsString string) time.Time {
+		time, err := time.Parse(time.RFC3339, timeAsString)
+		Expect(err).To(Not(HaveOccurred()))
+		return time
+	}
+
+	parseAndFailDuration := func(durationAsString string) time.Duration {
+		duration, err := time.ParseDuration(durationAsString)
+		Expect(err).To(Not(HaveOccurred()))
+		return duration
+	}
+
+	optionsWithDurationAndToday := func(durationAsString string, today bool) options {
+		return options{
+			merged: parseAndFailDuration(durationAsString),
+			today:  today,
+		}
+	}
+
+	reportExecutionTime := "2020-06-30T03:04:05Z"
+
+	previousDayStartFromExecutionTime := "2020-06-29T00:00:00Z"
+	previousDayEndFromExecutionTime := "2020-06-29T23:59:59.999Z"
+
+	When("on 24h report GetReportInterval", func() {
+
+		It("has start of previous day as report start time", func() {
+			startOfReport, _ := GetReportInterval(optionsWithDurationAndToday("24h", false), parseAndFailTime(reportExecutionTime))
+
+			Expect(startOfReport).To(BeEquivalentTo(parseAndFailTime(previousDayStartFromExecutionTime)))
+		})
+
+		It("has previous day end as report end time", func() {
+			_, endOfReport := GetReportInterval(optionsWithDurationAndToday("24h", false), parseAndFailTime(reportExecutionTime))
+
+			Expect(endOfReport).To(BeEquivalentTo(parseAndFailTime(previousDayEndFromExecutionTime)))
+		})
+
+	})
+
+	currentDayStartFromExecutionTime := "2020-06-30T00:00:00Z"
+
+	When("on 24h report GetReportInterval if today is set", func() {
+
+		It("it has start of current day as report start time", func() {
+			startOfReport, _ := GetReportInterval(optionsWithDurationAndToday("24h", true), parseAndFailTime(reportExecutionTime))
+
+			Expect(startOfReport).To(BeEquivalentTo(parseAndFailTime(currentDayStartFromExecutionTime)))
+		})
+
+		It("has report execution time as report end time", func() {
+			_, endOfReport := GetReportInterval(optionsWithDurationAndToday("24h", true), parseAndFailTime(reportExecutionTime))
+
+			Expect(endOfReport).To(BeEquivalentTo(parseAndFailTime(reportExecutionTime)))
+		})
+
+	})
+
+	previousHourStartFromExecutionTime := "2020-06-30T02:00:00Z"
+	previousHourEndFromExecutionTime := "2020-06-30T02:59:59.999Z"
+
+	When("on 1h report GetReportInterval", func() {
+
+		It("has previous hour as report time start", func() {
+			startOfReport, _ := GetReportInterval(optionsWithDurationAndToday("1h", false), parseAndFailTime(reportExecutionTime))
+
+			Expect(startOfReport).To(BeEquivalentTo(parseAndFailTime(previousHourStartFromExecutionTime)))
+		})
+
+		It("has current hour as report time end", func() {
+			_, endOfReport := GetReportInterval(optionsWithDurationAndToday("1h", false), parseAndFailTime(reportExecutionTime))
+
+			Expect(endOfReport).To(BeEquivalentTo(parseAndFailTime(previousHourEndFromExecutionTime)))
 		})
 
 	})

--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -143,13 +143,12 @@ const tpl = `
 <h1>flakefinder report for {{ $.Org }}/{{ $.Repo }}</h1>
 
 <div>
-	Data range from {{ $.StartOfReport }} till {{ $.Date }}
+	Data range from {{ $.StartOfReport }} till {{ $.EndOfReport }}
 </div>
 
 <div>
 {{ if $.PrNumbers }} Source PRs: {{ range $key := $.PrNumbers }}<a href="https://github.com/{{ $.Org }}/{{ $.Repo }}/pull/{{ $key }}">#{{ $key }}</a>, {{ end }}
-{{ else }}
-	No PRs merged 😞
+{{ else }} No PRs merged 😞
 {{ end }}
 </div>
 
@@ -206,14 +205,14 @@ const tpl = `
 `
 
 type Params struct {
-	Data          map[string]map[string]*Details
+	StartOfReport string
+	EndOfReport   string
 	Headers       []string
 	Tests         []string
+	Data          map[string]map[string]*Details
 	PrNumbers     []int
-	Date          string
 	Org           string
 	Repo          string
-	StartOfReport string
 }
 
 type Details struct {
@@ -232,14 +231,14 @@ type Job struct {
 }
 
 // WriteReportToBucket creates the actual formatted report file from the report data and writes it to the bucket
-func WriteReportToBucket(ctx context.Context, client *storage.Client, reports []*Result, merged time.Duration, org, repo string, prNumbers []int, writeToStdout, isDryRun bool, startOfReport time.Time) (err error) {
-	reportObject := client.Bucket(BucketName).Object(path.Join(ReportOutputPath, CreateReportFileName(time.Now(), merged)))
+func WriteReportToBucket(ctx context.Context, client *storage.Client, reports []*Result, merged time.Duration, org, repo string, prNumbers []int, writeToStdout, isDryRun bool, startOfReport, endOfReport time.Time) (err error) {
+	reportObject := client.Bucket(BucketName).Object(path.Join(ReportOutputPath, CreateReportFileName(endOfReport, merged)))
 	log.Printf("Report will be written to gs://%s/%s", BucketName, reportObject.ObjectName())
 	var reportOutputWriter *storage.Writer
 	if !isDryRun {
 		reportOutputWriter = reportObject.NewWriter(ctx)
 	}
-	err = Report(reports, reportOutputWriter, org, repo, prNumbers, writeToStdout, isDryRun, startOfReport)
+	err = Report(reports, reportOutputWriter, org, repo, prNumbers, writeToStdout, isDryRun, startOfReport, endOfReport)
 	if err != nil {
 		return fmt.Errorf("failed on generating report: %v", err)
 	}
@@ -256,7 +255,7 @@ func CreateReportFileName(reportTime time.Time, merged time.Duration) string {
 	return fmt.Sprintf(ReportFilePrefix+"%s-%03dh.html", reportTime.Format("2006-01-02"), int(merged.Hours()))
 }
 
-func Report(results []*Result, reportOutputWriter *storage.Writer, org string, repo string, prNumbers []int, writeToStdout bool, isDryRun bool, startOfReport time.Time) error {
+func Report(results []*Result, reportOutputWriter *storage.Writer, org string, repo string, prNumbers []int, writeToStdout bool, isDryRun bool, startOfReport, endOfReport time.Time) error {
 	data := map[string]map[string]*Details{}
 	headers := []string{}
 	tests := []string{}
@@ -346,7 +345,7 @@ func Report(results []*Result, reportOutputWriter *storage.Writer, org string, r
 		Headers:       headers,
 		Tests:         testsSortedByRelevance,
 		PrNumbers:     prNumbers,
-		Date:          time.Now().Format(time.RFC3339),
+		EndOfReport:   endOfReport.Format(time.RFC3339),
 		Org:           org,
 		Repo:          repo,
 		StartOfReport: startOfReport.Format(time.RFC3339),

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -105,7 +105,7 @@ var _ = Describe("report.go", func() {
 
 			prepareBuffer(parameters)
 
-			Expect(buffer.String()).To(ContainSubstring("No failing tests! :)"))
+			Expect(buffer.String()).To(ContainSubstring("No failing tests!"))
 		})
 
 		It("shows pr ids if no failing tests", func() {

--- a/robots/flakefinder/report_test.go
+++ b/robots/flakefinder/report_test.go
@@ -52,7 +52,7 @@ var _ = Describe("report.go", func() {
 		prepareWithDefaultParams := func() {
 			parameters := Params{Data: map[string]map[string]*Details{
 				"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23",
+			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23",
 				Org: Org, Repo: Repo,
 				PrNumbers: []int{17, 42},
 			}
@@ -98,7 +98,7 @@ var _ = Describe("report.go", func() {
 
 		It("shows no errors if no failing tests", func() {
 			parameters := Params{Data: map[string]map[string]*Details{},
-				Headers: []string{}, Tests: []string{}, Date: "2019-08-23",
+				Headers: []string{}, Tests: []string{}, EndOfReport: "2019-08-23",
 				Org: Org, Repo: Repo,
 				PrNumbers: []int{17, 42},
 			}
@@ -110,7 +110,7 @@ var _ = Describe("report.go", func() {
 
 		It("shows pr ids if no failing tests", func() {
 			parameters := Params{Data: map[string]map[string]*Details{},
-				Headers: []string{}, Tests: []string{}, Date: "2019-08-23",
+				Headers: []string{}, Tests: []string{}, EndOfReport: "2019-08-23",
 				Org: Org, Repo: Repo,
 				PrNumbers: []int{17, 42},
 			}
@@ -124,7 +124,7 @@ var _ = Describe("report.go", func() {
 		DescribeTable("title contains repo and org", func(org, repo string) {
 			parameters := Params{Data: map[string]map[string]*Details{
 				"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23", Org: org, Repo: repo}
+			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
 
 			prepareBuffer(parameters)
 
@@ -140,7 +140,7 @@ var _ = Describe("report.go", func() {
 				"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{
 					{BuildNumber: 1742, Severity: "red", PR: 1427, Job: "testblah"},
 				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23", Org: org, Repo: repo}
+			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
 
 			prepareBuffer(parameters)
 
@@ -156,7 +156,7 @@ var _ = Describe("report.go", func() {
 				"t1": {"a": &Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*Job{
 					{BuildNumber: 1742, Severity: "red", PR: 1427, Job: "testblah"},
 				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, Date: "2019-08-23", Org: org, Repo: repo}
+			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
 
 			prepareBuffer(parameters)
 


### PR DESCRIPTION
Setting `--today=true` will now lead to a report with data range from start of day until report start.

Furthermore report start _and_ end dates are now normalized to avoid overlapping of fetched PRs. Report end will now be  normalized to the end of the previous day when report generation has been triggered.

I.e. 024h report was triggered on 2020-06-30T03:04:00Z, then
report data will contain PRs
from 2020-06-29T00:00:00Z
till 2020-06-29T23:59:59.999Z

Added `--dry-run` in the process, so that we won't overwrite files on gcp any more, thus making local testing easier. If `--dry-run` is used, the generated reports and index page are written to standard out instead.

Report examples entry link is here, what you will see is three examples of the new reports, top line (30-06) contains an example of a rolling window report, the line below contains two examples of a daily and a weekly report.

Example: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/kubevirt/kubevirt/index.html

Further updates:
* changed the daily job runs to cron, running shortly after midnight UTC, added the rolling window report just for kubevirt/kubevirt for now 

Fixes #492 