### PR TITLE
Update pull-kubevirt-e2e-k8s-1.18 to be mandatory

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -103,7 +103,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: true
+    optional: false
     skip_report: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
Should be stable enough, and we need it as a guard.

Signed-off-by: Or Shoval <oshoval@redhat.com>