### PR TITLE
Enable sriov lane back on release 0.30 branch

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -338,8 +338,8 @@ presubmits:
     - release-0.30
     decorate: true
     decoration_config:
-      grace_period: 5m0s
-      timeout: 5h0m0s
+      grace_period: 20m0s
+      timeout: 3h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -331,7 +331,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
     branches:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -348,7 +348,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
-    skip_report: true
+    skip_report: false
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
This PR enable sriov lane to run on every change, report and decrease timeout.

This should be merged only after kubevirt/kubevirt#3695 are merged.
