### PR TITLE
hide results of SR-IOV lane

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -428,7 +428,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
     always_run: true
     optional: true
-    skip_report: false
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
It is failing 100 % of the time. Let's just use it to gather some data
in the background for now.

There is no value in showing always-failing lane on all PRs.

Signed-off-by: Petr Horacek <phoracek@redhat.com>