### PR TITLE
Fix popup bug

### DIFF
--- a/robots/flakefinder/report.go
+++ b/robots/flakefinder/report.go
@@ -98,25 +98,12 @@ const tpl = `
             padding: 8px 8px;
             position: absolute;
             z-index: 1;
-            bottom: 125%;
             left: 50%;
             margin-left: -110px;
         }
 
         .nowrap {
             white-space: nowrap;
-        }
-
-        /* Popup arrow */
-        .popup .popuptext::after {
-            content: "";
-            position: absolute;
-            top: 100%;
-            left: 50%;
-            margin-left: -5px;
-            border-width: 5px;
-            border-style: solid;
-            border-color: #555 transparent transparent transparent;
         }
 
         /* Toggle this class - hide and show the popup */


### PR DESCRIPTION
Move popup to the bottom below the cell so that it is displayed always. Also remove the arrow pointing to the bottom.

Example report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/kubevirt/kubevirt/flakefinder-2020-07-01-168h.html

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>