### PR TITLE
Specify repo, so we don't default to "kubevirt"

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -17,6 +17,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
+      - --repo=cluster-network-addons-operator
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -48,6 +49,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
+      - --repo=cluster-network-addons-operator
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -79,6 +81,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
+      - --repo=cluster-network-addons-operator
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
This is inspired by looking at [flakefinder reports for CNAO](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/cluster-network-addons-operator/index.html)

They seem to point at kubevirt/kubevirt rather than kubevirt/cluster-network-addons-operator, I was blindly searching for what could've caused it.