### PR TITLE
Change weekly flakefinder report to run as cron

### DIFF
--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: periodic-publish-kubemacpool-flakefinder-weekly-report
-    interval: 24h
+    cron: "50 0 * * *"
     decorate: true
     spec:
       nodeSelector:

--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-publish-cnao-flakefinder-weekly-report
-  interval: 24h
+  cron: "55 0 * * *"
   decorate: true
   spec:
     nodeSelector:

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-publish-cdi-flakefinder-weekly-report
-  interval: 24h
+  cron: "0 1 * * *"
   decorate: true
   spec:
     nodeSelector:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -33,7 +33,7 @@ periodics:
         secret:
           secretName: gcs
 - name: periodic-publish-kubevirt-flakefinder-weekly-report
-  interval: 24h
+  cron: "45 0 * * *"
   decorate: true
   spec:
     nodeSelector:

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-publish-knmstate-flakefinder-weekly-report
-  interval: 24h
+  cron: "5 1 * * *"
   decorate: true
   spec:
     nodeSelector:


### PR DESCRIPTION
As of latest changes to flakefinder the report data coverage interval
is normalized against start of resp. end of day to avoid overlapping PRs
in two adjacent reports. Now the flakefinder weekly reports are run
somewhere during the day using `interval` which may lead to them running
late in the day and therefore not being available.

We use cron and let them run somewhere after midnight (also adding some
variance) to have them available at the start of the day for when the
build officer starts working.

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>