### PR TITLE
Add missing K8s context to the playbook

### DIFF
--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -290,11 +290,15 @@
       k8s:
         state: present
         namespace: "{{ prowNamespace }}"
+        kubeconfig: '{{ automationKubeconfig }}'
+        context: '{{ masterClusterContext }}'
         definition: "{{ lookup('template', '{{ role_path }}/templates/release-blocker_deployment.yaml') | from_yaml }}"
     - name: Deploy release-blocker-service
       k8s:
         state: present
         namespace: "{{ prowNamespace }}"
+        kubeconfig: '{{ automationKubeconfig }}'
+        context: '{{ masterClusterContext }}'
         definition: "{{ lookup('template', '{{ role_path }}/templates/release-blocker_service.yaml') | from_yaml }}"
     - name: Deploy prow-deck-rbac
       command: "oc --kubeconfig {{ automationKubeconfig }} --context {{ masterClusterContext }} -n {{prowJobsNamespace}} apply -f -"


### PR DESCRIPTION
Without explicitly specifying the context, the module uses the default
systems KUBECONFIG. We want to use the KUBECONFIG from the vars to
ensure that we have enough permissions to deploy all the components.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>