### PR TITLE
Enable invalidcommitmsg plugin for kubevirt org

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -131,6 +131,7 @@ tide:
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
     - do-not-merge/release-note-label-needed
+    - do-not-merge/invalid-commit-message
     - needs-rebase
     - "dco-signoff: no"
   pr_status_base_urls:

--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -44,6 +44,7 @@ plugins:
   - dog
   - cat
   - dco
+  - invalidcommitmsg
 
   kubevirt/kubevirt:
   - trigger


### PR DESCRIPTION
In order to avoid that people mention other people or close issues via
github autoclose commands in commits, let's ensure that we don't merge
them.

Both have unwanted side-effects whan e.g. backporting or closing such repos on github.