### PR TITLE
Increase pod timeout for k8s check provision and push

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -399,6 +399,8 @@ presubmits:
     run_if_changed: "cluster-provision/k8s/.*"
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -424,6 +426,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -450,6 +454,8 @@ presubmits:
     run_if_changed: "cluster-provision/k8s/.*"
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -475,6 +481,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -501,6 +509,8 @@ presubmits:
     run_if_changed: "cluster-provision/k8s/.*"
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
@@ -526,6 +536,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Recently the pods on 1.16 ran into timeout when running the sonobuoy
conformance tests at the end. We increase the timeout values for the
jobs to 3 hours in order to give the tests enough time to finish.

Example: https://prow.apps.ovirt.org/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/407/check-provision-k8s-1.16/1283650167454568448