### PR TITLE
Add dry-run flag for cnao jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -14,6 +14,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
@@ -46,6 +47,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
@@ -78,6 +80,7 @@ periodics:
       command:
       - "/app/robots/flakefinder/app.binary"
       args:
+      - --dry-run=false
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator


### PR DESCRIPTION
Fix the job config for the flakefinder jobs.

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>