### PR TITLE
Change cnao flakefinder daily to cron

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -33,7 +33,7 @@ periodics:
       secret:
         secretName: gcs
 - name: periodic-publish-cnao-flakefinder-daily-report
-  interval: 24h
+  cron: "15 1 * * *"
   decorate: true
   spec:
     nodeSelector:


### PR DESCRIPTION
Change to cron, as the job should run daily after midnight UTC to make
the data available for the next build officer.

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>

/cc @vatsalparekh @qinqon 