### PR TITLE
Fix git commit reference in nightly publish job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -157,10 +157,10 @@ periodics:
           git clone https://github.com/kubevirt/kubevirt.git &&
           cd kubevirt &&
           export DOCKER_PREFIX='kubevirtnightlybuilds' &&
-          export DOCKER_TAG="$(date +%Y%m%d)_$(git show --format=%h)" &&
+          export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)" &&
           make &&
           make push &&
-          git show --format=%H > _out/commit &&
+          git show -s --format=%H > _out/commit &&
           build_date="$(date +%Y%m%d)" &&
           echo ${build_date} > _out/build_date &&
           bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}" &&


### PR DESCRIPTION
The current git command doesn't supress the git diff and it can cause a
recursive variable references itself error from make.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>