### PR TITLE
Add a script to provide github credentials to git

### DIFF
--- a/hack/git-askpass.sh
+++ b/hack/git-askpass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+GITHUB_TOKEN=${GITHUB_TOKEN:-/etc/github/oauth}
+
+cat $GITHUB_TOKEN


### PR DESCRIPTION
In order to savely provide github credentials to git, let's use
GIT_ASKPASS and a small helper binary which will print the github token
provided to stdout.

Unblocks work on #352 which needs this script.