### PR TITLE
Release tool improvments

### DIFF
--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -598,7 +598,7 @@ func (r *releaseData) verifyPromoteRC() error {
 	re := regexp.MustCompile(`^v\d*\.\d*.\d*-rc.\d*$`)
 	match := re.FindString(r.promoteRC)
 	if match == "" {
-		return fmt.Errorf("--promote-rc must point to a release candidate tag in the form of v[x].[y].[z]-rc.[n]. Example v0.31.0-rc.1 is valid and will result in the promotion of official v0.31.0 release")
+		return fmt.Errorf("--promote-rc=%s is invalid.  must point to a release candidate tag in the form of v[x].[y].[z]-rc.[n]. Example v0.31.0-rc.1 is valid and will result in the promotion of official v0.31.0 release", r.promoteRC)
 	}
 
 	tagSemver, err := semver.NewVersion(match)
@@ -801,7 +801,7 @@ func (r *releaseData) autoDetectData(autoReleaseCadance string, autoPromoteAfter
 		if v.Patch() == 0 {
 			currentMinorRelease = fmt.Sprintf("v%d.%d.0", v.Major(), v.Minor())
 			nextMinorRelease = fmt.Sprintf("v%d.%d.0", v.Major(), v.Minor()+1)
-			nextMinorReleaseRC = fmt.Sprintf("v%d.%d.0-rc.1", v.Major(), v.Minor()+1)
+			nextMinorReleaseRC = fmt.Sprintf("v%d.%d.0-rc.0", v.Major(), v.Minor()+1)
 			nextMinorReleaseBranch = fmt.Sprintf("release-%d.%d", v.Major(), v.Minor()+1)
 
 			log.Printf("Last Minor Release Series: v%d.%d", v.Major(), v.Minor())
@@ -855,7 +855,7 @@ func (r *releaseData) autoDetectData(autoReleaseCadance string, autoPromoteAfter
 		rcNumber, err := strconv.Atoi(strings.TrimPrefix(*release.TagName, rcTemplate))
 		if err != nil {
 			continue
-		} else if rcNumber > highestRC {
+		} else if rcNumber >= highestRC {
 			highestRC = rcNumber
 			rcPromotionCandidate = release
 		}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -377,7 +377,7 @@ func (r *releaseData) getReleaseNote(number int) (string, error) {
 				note = strings.TrimPrefix(note, "-")
 				// best effort at catching "none" if the label didn't catch it
 				if !strings.Contains(note, "NONE") && strings.ToLower(note) != "none" {
-					note = fmt.Sprintf("[PR %d][%s] %s", number, *pr.User.Login, note)
+					note = fmt.Sprintf("[PR #%d][%s] %s", number, *pr.User.Login, note)
 					return note, nil
 				}
 			}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -289,18 +289,18 @@ func (r *releaseData) checkoutUpstream() error {
 }
 
 func (r *releaseData) makeTag(branch string) error {
-	_, err := gitCommand("-C", r.repoDir, "pull", "origin", branch)
-	if err != nil {
-		return err
-	}
-
 	if r.promoteRC != "" {
-		_, err = gitCommand("-C", r.repoDir, "checkout", r.promoteRC)
+		_, err := gitCommand("-C", r.repoDir, "checkout", r.promoteRC)
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err = gitCommand("-C", r.repoDir, "checkout", branch)
+		_, err := gitCommand("-C", r.repoDir, "checkout", branch)
+		if err != nil {
+			return err
+		}
+
+		_, err = gitCommand("-C", r.repoDir, "pull", "origin", branch)
 		if err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ func (r *releaseData) makeTag(branch string) error {
 
 	r.generateReleaseNotes()
 
-	_, err = gitCommand("-C", r.repoDir, "tag", "-s", r.tag, "-F", r.releaseNotesFile)
+	_, err := gitCommand("-C", r.repoDir, "tag", "-s", r.tag, "-F", r.releaseNotesFile)
 
 	if !r.dryRun {
 		_, err = gitCommand("-C", r.repoDir, "push", r.repoUrl, r.tag)

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -394,24 +394,9 @@ func (r *releaseData) forkProwJobs() error {
 
 	gitbranch := fmt.Sprintf("%s_%s_%s_configs", r.org, r.repo, r.newBranch)
 
-	_, err := gitCommand("-C", r.infraDir, "checkout", "-b", gitbranch)
+	_, err := gitCommand("-C", r.infraDir, "checkout", "-B", gitbranch)
 
-	// if err, then branch likely already exists
-	// attempt to check out the branch, if that fails then
-	// return an error.
-	if err != nil {
-		_, err := gitCommand("-C", r.infraDir, "checkout", gitbranch)
-		if err != nil {
-			return err
-		}
-
-		_, err = gitCommand("-C", r.infraDir, "pull", "origin", gitbranch)
-		if err != nil {
-			return err
-		}
-	}
-
-	if _, err := os.Stat(fullJobConfig); err != nil && os.IsNotExist(err) {
+	if _, err = os.Stat(fullJobConfig); err != nil && os.IsNotExist(err) {
 		// no job to fork for this project
 		return nil
 	}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -657,6 +657,9 @@ func (r *releaseData) getBlockers(branch string) (*blockerListCacheEntry, error)
 			PerPage: 10000,
 		},
 	}
+
+	prListOptions.State = "all"
+	issueListOptions.State = "all"
 	if branch == "master" {
 		// there's never a reason to list all PRs/Issues (both open and closed) in the entire project for master
 		// We do care about open and closed PRS for stable branches though
@@ -893,6 +896,7 @@ func (r *releaseData) autoDetectData(autoReleaseCadance string, autoPromoteAfter
 				highestRC++
 				nextMinorReleaseRC = fmt.Sprintf("%s%d", rcTemplate, highestRC)
 				shouldMakeNewRC = true
+				log.Printf("Cutting new RC due to blocker %s", nextMinorReleaseRC)
 			}
 		} else if secondsDiff >= promoteAfterSeconds {
 

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -34,8 +34,8 @@ func standardSetup() releaseData {
 		Time: time.Date(2020, time.January, 1, 7, 0, 0, 0, time.UTC),
 	}
 
-	v1RC1 := "v0.1.0-rc.1"
-	v1RC1CreatedAt := &github.Timestamp{
+	v1RC0 := "v0.1.0-rc.1"
+	v1RC0CreatedAt := &github.Timestamp{
 		Time: time.Date(2020, time.January, 1, 1, 0, 0, 0, time.UTC),
 	}
 
@@ -50,8 +50,8 @@ func standardSetup() releaseData {
 			Assets:     []*github.ReleaseAsset{{ID: &idPtr}},
 		},
 		{
-			TagName:    &v1RC1,
-			CreatedAt:  v1RC1CreatedAt,
+			TagName:    &v1RC0,
+			CreatedAt:  v1RC0CreatedAt,
 			Draft:      &falsePtr,
 			Prerelease: &truePtr,
 			Assets:     []*github.ReleaseAsset{{ID: &idPtr}},
@@ -101,13 +101,13 @@ func TestAutoRelease(t *testing.T) {
 			name:           "Expect new branch and rc",
 			now:            time.Date(2020, time.February, 1, 1, 0, 0, 0, time.UTC),
 			expectedBranch: "release-0.2",
-			expectedTag:    "v0.2.0-rc.1",
+			expectedTag:    "v0.2.0-rc.0",
 		},
 		{
 			name:           "Expect new branch to be blocked",
 			now:            time.Date(2020, time.February, 1, 1, 0, 0, 0, time.UTC),
 			expectedBranch: "release-0.2",
-			expectedTag:    "v0.2.0-rc.1",
+			expectedTag:    "v0.2.0-rc.0",
 			hasBlocker:     true,
 		},
 		{
@@ -175,10 +175,10 @@ func TestAutoRelease(t *testing.T) {
 }
 
 func TestAutoPromoteRC(t *testing.T) {
-	v2RC1 := "v0.2.0-rc.1"
+	v2RC0 := "v0.2.0-rc.0"
 	v2Branch := "release-0.2"
 	v2 := "v0.2.0"
-	v2RC1CreatedAt := &github.Timestamp{
+	v2RC0CreatedAt := &github.Timestamp{
 		Time: time.Date(2020, time.February, 1, 1, 0, 0, 0, time.UTC),
 	}
 
@@ -253,8 +253,8 @@ func TestAutoPromoteRC(t *testing.T) {
 		r := standardSetup()
 		defer standardCleanup(&r)
 		r.allReleases = append(r.allReleases, &github.RepositoryRelease{
-			TagName:   &v2RC1,
-			CreatedAt: v2RC1CreatedAt,
+			TagName:   &v2RC0,
+			CreatedAt: v2RC0CreatedAt,
 		})
 		r.allBranches = append(r.allBranches, &github.Branch{Name: &v2Branch})
 
@@ -346,11 +346,11 @@ func TestAutoPromoteRC(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("got unexpected error %s", err)
-		} else if tc.expectPromotion && r.promoteRC != v2RC1 {
+		} else if tc.expectPromotion && r.promoteRC != v2RC0 {
 			t.Errorf("expected to autopromote RC")
 		} else if !tc.expectPromotion && r.promoteRC != "" {
 			t.Errorf("did not expect to autopromote RC")
-		} else if tc.expectNewRC && r.tag != "v0.2.0-rc.2" {
+		} else if tc.expectNewRC && r.tag != "v0.2.0-rc.1" {
 			t.Errorf("expected new RC")
 		} else if !tc.expectNewRC && r.tag != "" {
 			t.Errorf("did not expect new RC")

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -431,8 +431,8 @@ func TestNewTag(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [clone https://fake-token@github.com/fake-org/fake-repo.git %s/fake-org/https-fake-repo]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))
-	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo pull origin release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo checkout release-0.2]", r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo pull origin release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s v0.2.0 -F %s/fake-org/https-fake-repo/v0.2.0-release-notes.txt]", r.cacheDir, r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo push https://fake-token@github.com/fake-org/fake-repo.git v0.2.0]", r.cacheDir))
 

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -390,7 +390,7 @@ func TestCutNewBranch(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [clone https://fake-token@github.com/kubevirt/project-infra.git %s/kubevirt/https-project-infra]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra config user.email fake-email@fake.fake]", r.cacheDir))
-	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra checkout -b fake-org_fake-repo_release-0.2_configs]", r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra checkout -B fake-org_fake-repo_release-0.2_configs]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [clone https://fake-token@github.com/fake-org/fake-repo.git %s/fake-org/https-fake-repo]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -391,7 +391,6 @@ func TestCutNewBranch(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra config user.email fake-email@fake.fake]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra checkout -b fake-org_fake-repo_release-0.2_configs]", r.cacheDir))
-	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra pull origin fake-org_fake-repo_release-0.2_configs]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [clone https://fake-token@github.com/fake-org/fake-repo.git %s/fake-org/https-fake-repo]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))


### PR DESCRIPTION
- Adds `#` character to PRs in release notes so they appear as links. 

- Fixes issue with branch cache. We need to clear
  branch cache and re-generate in the event a new branch
  is created

- Fixes issue with branching prow configs. Only attempt
  to pull the latest branch code for the prow config if
  the branch already exists.
