### PR TITLE
Fix the bot command list link

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -292,6 +292,7 @@ approve:
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
+  commandHelpLink: https://go.k8s.io/bot-commands
 
 lgtm:
 - repos:


### PR DESCRIPTION
The prow version we use has a bug where
the link for the list of bot commands is
broken if not explicitely set.
Setting it to its "default" value.

Fixed upstream by:
https://github.com/kubernetes/test-infra/pull/18097