### PR TITLE
Add an optional lane with a newer version of base image.

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -192,4 +192,36 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
+  - name: pull-containerized-data-importer-e2e-k8s-1.18-hpp-test-image
+    skip_branches:
+      - release-v\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"
 


### PR DESCRIPTION
The CDI tests now require libdevmapper.so to run. The base image all the
lanes are running from does not include it, but a latest version does.
This PR adds an optional lane to verify that a/ the tests run
correctly and b/ the CI works with the updated image.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>