### PR TITLE
Enable Kubemacpool tests on CNAO lane

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -130,9 +130,10 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: false
+      always_run: true
       optional: true
       decorate: true
+      skip_report: false
       decoration_config:
         timeout: 3h
         grace_period: 25m


### PR DESCRIPTION
This PR enables Kubemacpool tests on CNAO lane and it will report back.
This lane is optional.