### PR TITLE
Make kubevirts generate prowjob required

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -615,8 +615,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    skip_report: true
-    optional: true
+    skip_report: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
Move the "generate" step off of travis to reduce the runtime there.