### PR TITLE
If things look bad in CI, the one hour retest is an issue

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
 - name: periodic-project-infra-retester
-  interval: 1h  # Retest at most 1 PR every hour, which should not DOS the queue.
+  interval: 3h  # Retest at most 1 PR every three hours, which should not DOS the queue.
   decorate: true
   spec:
     containers:


### PR DESCRIPTION
Let's only retrigger jobs all three hours for now and see if it is a
good compromise.