### PR TITLE
Add permissions for hook to list ProwJobs

### DIFF
--- a/github/ci/prow/templates/hook-rbac.yaml
+++ b/github/ci/prow/templates/hook-rbac.yaml
@@ -10,6 +10,7 @@ rules:
     verbs:
       - create
       - get
+      - list
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
This permission is needed in order to track running jobs on a remote
cluster.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>