### PR TITLE
Update base image for testing.

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -20,12 +20,12 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -52,12 +52,12 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -84,12 +84,12 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=ceph && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=ceph && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -116,12 +116,12 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=ember_lvm && export SNAPSHOT_SC=ember-csi-lvm && export BLOCK_SC=ember-csi-lvm && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=ember_lvm && export SNAPSHOT_SC=ember-csi-lvm && export BLOCK_SC=ember-csi-lvm && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -148,12 +148,12 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && export MULTI_UPGRADE=true && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && export MULTI_UPGRADE=true && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -180,48 +180,15 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=nfs && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.18-hpp-test-image
-    skip_branches:
-      - release-v\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
         - image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "ln /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=nfs && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
             requests:
               memory: "29Gi"
-


### PR DESCRIPTION
Functional tests need libdevmapper to be present and available in the
test image. This PR updates the image and creates a link to the
required version of the library.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>