### PR TITLE
labels: Rename topic/network to sig/network

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -145,18 +145,30 @@ default:
       target: both
       prowPlugin: lifecycle
       addedBy: prow
-    - name: topic/network
+    - name: sig/network
       color: c5def5
       target: both
-    - name: topic/security
+      previously:
+        - name: topic/network
+          color: c5def5
+    - name: sig/security
       color: c5def5
       target: both
-    - name: topic/storage
+      previously:
+        - name: topic/security
+          color: c5def5
+    - name: sig/storage
       color: c5def5
       target: both
-    - name: topic/virtualization
+      previously:
+        - name: topic/storage
+          color: c5def5
+    - name: sig/virtualization
       color: c5def5
       target: both
+      previously:
+        - name: topic/virtualization
+          color: c5def5
 repos:
   kubevirt/kubevirt:
     labels:


### PR DESCRIPTION
The label plugin supports labeling using a command only specific types
and "topic" is not one of them.

"sig" is a supported type and is equivalent in meaning to the "topic"
one.
With this change, one can label a PR or issue using the
`/sig network` comment.