### PR TITLE
Disalbe status reconciler until it works again

### DIFF
--- a/github/ci/prow/templates/statusreconciler-deployment.yaml
+++ b/github/ci/prow/templates/statusreconciler-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: statusreconciler
 spec:
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Status reconciler recrates required jobs in the ibm cluster over and
over.