### PR TITLE
Disable statusreconciler

### DIFF
--- a/github/ci/prow/templates/statusreconciler-deployment.yaml
+++ b/github/ci/prow/templates/statusreconciler-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: statusreconciler
 spec:
-  replicas: 1
+  replicas: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Status reconciler recreates required jobs in the ibm cluster over and over.