### PR TITLE
hco: use a gcb image for executing the nightly job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+    - image: gcr.io/k8s-testimages/gcb-docker-gcloud:v20200713-e9b3d9d
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json


### PR DESCRIPTION
For the periodic job to function properly we need golang which is
missing from the bootstrap image.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>