### PR TITLE
Run only one kind lane per node at the time

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -511,9 +511,20 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      kind-pod: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: kind-pod
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:


### PR DESCRIPTION
Kind clusters have huge requirements on cluster resources, eat way too
many watches and threads which then renders their host catastrophically
slow and lead into other lanes failing.

With this patch, we introduce an anti-affinity, making sure that we run
only a single kind test run per host at the time.

Signed-off-by: Petr Horacek <phoracek@redhat.com>