### PR TITLE
Allow more executions in parallel of the core kubevirt/kubevirt lanes

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -109,7 +109,7 @@ presubmits:
     decoration_config:
       timeout: 7h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -142,7 +142,7 @@ presubmits:
     decoration_config:
       timeout: 7h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -174,7 +174,7 @@ presubmits:
     decoration_config:
       timeout: 7h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -206,7 +206,7 @@ presubmits:
     decoration_config:
       timeout: 7h
       grace_period: 5m
-    max_concurrency: 10
+    max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -554,7 +554,7 @@ presubmits:
     decoration_config:
       timeout: 7h
       grace_period: 5m
-    max_concurrency: 6
+    max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"


### PR DESCRIPTION
Make use of the two new nodes which got added.