### PR TITLE
Update rerun_auth_config to the not deprecated form

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -47,9 +47,10 @@ deck:
       required_files:
         - podinfo.json
   tide_update_period: 1s
-  rerun_auth_config:
-    github_team_ids:
-      - 3701123 # prow-job-taskforce
+  rerun_auth_configs:
+    '*':
+      github_team_ids:
+        - 3701123 # prow-job-taskforce
 
 sinker:
   resync_period: 1m


### PR DESCRIPTION
Get rid of

```
{"component":"unset","file":"prow/config/config.go:1234","func":"k8s.io/test-infra/prow/config.(*Config).validateComponentConfig","level":"warning","msg":"rerun_auth_config will be deprecated in July 2020, and it will be replaced with rerun_auth_configs['*'].","severity":"warning","time":"2020-08-26T08:35:32Z"}
```

Signed-off-by: Roman Mohr <rmohr@redhat.com>