### PR TITLE
Re-enable statusreconciler and store the state on GCS

### DIFF
--- a/github/ci/prow/templates/statusreconciler-deployment.yaml
+++ b/github/ci/prow/templates/statusreconciler-deployment.yaml
@@ -43,10 +43,15 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --job-config-path=/etc/job-config
+        - --gcs-credentials-file=/etc/gcs/service-account.json
+        - --status-path=gs://kubevirt-status-reconciler/status-reconciler-status
         ports:
           - name: http
             containerPort: 8888
         volumeMounts:
+        - name: gcs
+          mountPath: /etc/gcs
+          readOnly: true
         - name: oauth
           mountPath: /etc/github
           readOnly: true
@@ -72,3 +77,6 @@ spec:
       - name: plugins
         configMap:
           name: plugins
+      - name: gcs
+        secret:
+          secretName: gcs

--- a/github/ci/prow/templates/statusreconciler-deployment.yaml
+++ b/github/ci/prow/templates/statusreconciler-deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: statusreconciler
 spec:
-  replicas: 0
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
Newer status reconcilers can save the state and better calculate differences. This PR does not re-enable the statusreconciler, since tests showed that it still fails with the same issue like before.