### PR TITLE
flakefinder: Create switch skip_results_before_start_of_report

### DIFF
--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -20,6 +20,7 @@ periodics:
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
             - --org=k8snetworkplumbingwg
             - --repo=kubemacpool
+            - --skip_results_before_start_of_report=false
           volumeMounts:
             - name: token
               mountPath: /etc/github
@@ -41,7 +42,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -54,6 +55,7 @@ periodics:
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
             - --org=k8snetworkplumbingwg
             - --repo=kubemacpool
+            - --skip_results_before_start_of_report=false
           volumeMounts:
             - name: token
               mountPath: /etc/github
@@ -75,7 +77,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+        - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -88,6 +90,7 @@ periodics:
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
             - --org=k8snetworkplumbingwg
             - --repo=kubemacpool
+            - --skip_results_before_start_of_report=false
           volumeMounts:
             - name: token
               mountPath: /etc/github

--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -19,6 +19,7 @@ periodics:
       - --merged=168h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -40,7 +41,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -52,6 +53,7 @@ periodics:
       - --merged=24h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -73,7 +75,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -85,6 +87,7 @@ periodics:
       - --merged=672h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -19,6 +19,7 @@ periodics:
       - --merged=168h
       - --report_output_child_path=kubevirt/containerized-data-importer
       - --repo=containerized-data-importer
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -40,7 +41,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -52,6 +53,7 @@ periodics:
       - --merged=24h
       - --report_output_child_path=kubevirt/containerized-data-importer
       - --repo=containerized-data-importer
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -73,7 +75,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -85,6 +87,7 @@ periodics:
       - --merged=672h
       - --report_output_child_path=kubevirt/containerized-data-importer
       - --repo=containerized-data-importer
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+      - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -19,6 +19,7 @@ periodics:
           - --merged=24h
           - --today=true
           - --report_output_child_path=kubevirt/kubevirt
+          - --skip_results_before_start_of_report=false
         volumeMounts:
           - name: token
             mountPath: /etc/github
@@ -40,7 +41,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -51,6 +52,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=kubevirt/kubevirt
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -72,7 +74,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -83,6 +85,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=kubevirt/kubevirt
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -104,7 +107,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -115,6 +118,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=kubevirt/kubevirt
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -20,6 +20,7 @@ periodics:
       - --report_output_child_path=nmstate/kubernetes-nmstate
       - --org=nmstate
       - --repo=kubernetes-nmstate
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -41,7 +42,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -54,6 +55,7 @@ periodics:
       - --report_output_child_path=nmstate/kubernetes-nmstate
       - --org=nmstate
       - --repo=kubernetes-nmstate
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -75,7 +77,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: index.docker.io/kubevirtci/flakefinder@sha256:76bc7808037b8f04dea9a783a85b9abf62dce6c26b63c3e0b4145d0033450de9
+    - image: index.docker.io/kubevirtci/flakefinder@sha256:a039322bd563b76f92f86d7c116eda1f0d98282a963f145b272438c5e823f2e6
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -88,6 +90,7 @@ periodics:
       - --report_output_child_path=nmstate/kubernetes-nmstate
       - --org=nmstate
       - --repo=kubernetes-nmstate
+      - --skip_results_before_start_of_report=false
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
By default flakefinder omits test results on PRs that happened earlier
than the start of the report interval, which makes daily and weekly
reports incomparable.

Add a switch that can turn this off.

Disable omitting test failures for existing job configurations by
switch.

Fixes #596