### PR TITLE
Fix generate verify job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -651,7 +651,10 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify"
+            - >-
+                cp /etc/bazel.bazelrc ./ci.bazelrc &&
+                make generate &&
+                make check-git-tree-state && make check-for-binaries
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
This change ensures that the targets that we execute after we run
generate, will be executed in the same environment and will be able to
consume the changes that were done by generate.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>