### PR TITLE
Unblock status reconciler by removing pull-kubevirt-generate from release branches

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
@@ -572,43 +572,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    name: pull-kubevirt-generate
-    optional: true
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate
-        env:
-        - name: BAZEL_VERSION
-          value: 1.2.1
-        - name: CACHE_HOST
-          value: bazel-cache.kubevirt-prow
-        - name: CACHE_PORT
-          value: "8080"
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    branches:
-    - release-0.31
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
     name: pull-kubevirt-build
     optional: true
     skip_report: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
@@ -572,43 +572,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    name: pull-kubevirt-generate
-    optional: true
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate
-        env:
-        - name: BAZEL_VERSION
-          value: 1.2.1
-        - name: CACHE_HOST
-          value: bazel-cache.kubevirt-prow
-        - name: CACHE_PORT
-          value: "8080"
-        - name: BAZEL_REMOTE_CACHE_ENABLED
-          value: "true"
-        image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    branches:
-    - release-0.32
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
     name: pull-kubevirt-build
     optional: true
     skip_report: true


### PR DESCRIPTION
Making `pull-kubevirt-generate` required on master, but not on release
branche confuses status-reconciler. As a quick solution unblock it by
removing the unused jobs from the release-branches.

Status-reconciler sees the job the once as optional and once as required
in the current job list and fails to distinguish them. When it compares
the last known state with the current state it can't distinguish them
and thinks that the second optional job for the release branch is now
required and retriggers the jobs in an endless loop.

Note that this is only a quick-fix. We need to prevent this in the future somehow.