### PR TITLE
Ignore pull-kubevirt-goveralls for batch jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -770,7 +770,7 @@ presubmits:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
           - "-c"
-          - "cp /etc/bazel.bazelrc ./ci.bazelrc && make goveralls"
+          - "cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then make goveralls; fi"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
When tide does try to batch merge do not run the coverage job. It seems as if it overrides the coverage on the PR which then seems to get lost somehow.
