### PR TITLE
Make coveralls non-required until it is fixed

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -194,7 +194,6 @@ branch-protection:
           required_status_checks:
             contexts:
               - continuous-integration/travis-ci/pr
-              - coverage/coveralls
         project-infra:
           branches:
             master:


### PR DESCRIPTION
coveralls does not report back right now with our custom prow job. Making the coveralls report optional to not block merges on kubevirt.