### PR TITLE
Allow non org admins but project owners to override jobs

### DIFF
--- a/github/ci/prow/files/plugins.yaml
+++ b/github/ci/prow/files/plugins.yaml
@@ -379,3 +379,6 @@ lgtm:
   - kubevirt/kubevirt-template-validator
   - kubevirt/kubevirt-ssp-operator
   review_acts_as_lgtm: true
+
+override:
+  allow_top_level_owners: true


### PR DESCRIPTION
Right now users need to be github org admins to be able to override
a job since [1] merged at prow users at OWNERS file can override
them if configured, this commit activate that feature.

[1] https://github.com/kubernetes/test-infra/pull/14538