### PR TITLE
Add kubernetes_crud role

### DIFF
--- a/github/ci/kubernetes_crud/README.md
+++ b/github/ci/kubernetes_crud/README.md
@@ -1,0 +1,117 @@
+# Kubernetes CRUD role
+
+Kubernetes CRUD role is an high level interface between ansible
+and kubernetes operation
+
+It offers a declarative approach on batch deployment
+saving thje developer from having to specify common kubernetes
+option for every manifest application.
+
+## How does it work ?
+
+To use the role is enough to call with some required variables
+
+    - set_fact:
+        manifest_base: /path/to/base/manifest/dir
+
+    - name: Batch operation
+      include_role:
+        name: kubernetes_crud
+      vars:
+        # kuberneted-crud vars
+        default_kubeconfig_path: /path/to/kubeconfig
+        default_namespace: namespace
+        default_context: context
+        steps: "{{ steps }}"
+        # manifest vars
+        memory_limit: 512Mi
+        
+### The steps
+
+Steps is a list of dictionaries that will contains the details of all
+operations in the batch.
+
+    steps:
+       - desc: A kubernetes operation
+         op: apply_manifest
+         manifest: relative/path/to/manifest
+       - desc: Another kubernetes operation
+         op: create_namespace
+         namespace: my_namespace
+
+### Implemented operations
+
+- apply_manifest: Applies a manifest
+- remove_manifest: Removes a manifest
+- create_namespace: Created a namespace
+- remove_namespace: Removes a namespace
+
+#### Steps parameters
+
+A single step accepts the following parameters:
+
+- kubeconfig_path: the path to the kubeconfig, if not specified **default_kubeconfig_path** will be used
+- op: the operation to perform, if omitted **default_crud_operation** will be used.
+- description: A description for the step, if omitted it will be set the same as **op**
+- namespace: the namespace to use, if omitted **default_namespace** will be used. For create_namespace, it will be name
+ of the namespace to create
+- context: the context to use, if omitted **default_context** will be used
+- fatal_validation: for apply and remove manifest, specify if the validation has the power to block the operation
+, defaults to *true*
+- strict_validation: Select if the validation should be strict
+
+Specify to apply/remove manifest
+
+- manifest_inline: Specify a manifest as a YAML string literal
+- manifest: Load the manifest from a path relative to **manifest_base**
+- manifest_template: Load the manifest from a path relative to **manifest_base** and renders it as jinja2 template
+- manifest_url: Load the manifest from a url
+
+## Examples
+
+
+        steps:
+          - desc: Create test namespace
+            namespace: test-namespace
+            op: create_namespace
+
+          - desc: Apply service from a manifest directly
+            manifest: "test-plain.yaml"
+
+          - desc: Apply LimitRange from manifest rendered from template
+            manifest_template: "test-template.yml.j2"
+
+          - desc: Apply Service account from invalid remote manifest (and test
+            manifest_url: "file://{{ role_path }}/molecule/files/manifests/test-url.yaml"
+            fatal_validation: false
+            strict_validation: false
+
+          - desc: Apply label to a node from inline manifest
+            manifest_inline: |
+              apiVersion: v1
+              kind: Node
+              metadata:
+                name: node01
+                labels:
+                  test_label_key: test-label-value
+
+## Developers info
+
+# How to test ?
+
+This role uses molecule for testing.
+Create a python virtualenv and install molecule
+
+then you can launch
+
+    molecule test
+    
+ The test will launch a kubevirtci instance, test the operation of the role, then shut down
+ the instance.
+ The command above calls in turn 5 other playbook that can be called singularly to perform testing step by step
+ 
+ * molecule prepare: will launch kubevirtci as test cluster.
+ * molecule converge: will invoke the role to perform some operations
+ * molecule verify: Will test that operations succeeded correctly
+ * molecule cleanup: will revert to a clean state for the test cluster
+ * molecule destroy: will shut down kubevirtci test cluster

--- a/github/ci/kubernetes_crud/molecule/default/cleanup.yml
+++ b/github/ci/kubernetes_crud/molecule/default/cleanup.yml
@@ -1,0 +1,63 @@
+- hosts: localhost
+  vars:
+    kubevirtci_dir: /tmp/kubevirtci
+    kubevirtci_provider: k8s-1.18
+    kubeconfig: '{{ kubevirtci_dir }}/_ci-configs/{{ kubevirtci_provider }}/.kubeconfig'
+    kubecontext: kubernetes-admin@kubernetes
+  tasks:
+    - name: Test remove manifest
+      include_role:
+        name: kubernetes_crud
+      vars:
+        default_namespace: test-namespace
+        default_kubeconfig_path: '{{ kubeconfig }}'
+        default_context: '{{ kubecontext }}'
+        manifest_base: "{{ role_path }}/molecule/files/manifests"
+        steps:
+          - desc: Remove manifest
+            op: remove_manifest
+            manifest: "test-plain.yaml"
+
+    - name: Gather info on created service
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: Service
+        namespace: test-namespace
+        name: test-service
+      register: query
+
+    - name: Verify service exists
+      assert:
+        that: query.resources == []
+        success_msg: "Service correctly removed"
+        fail_msg: "Service still exists"
+
+    - name: Test remove namespace
+      include_role:
+        name: kubernetes_crud
+      vars:
+        default_kubeconfig_path: '{{ kubeconfig }}'
+        default_context: '{{ kubecontext }}'
+        manifest_base: "{{ role_path }}/molecule/files/manifests"
+        steps:
+          - desc: Remove namespace
+            op: remove_namespace
+            namespace: test-namespace
+
+    - name: Gather info on created namespace
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: Namespace
+        name: test-namespace
+      register: query
+
+    - name: Verify namespace does not exists
+      assert:
+        that: query.resources == []
+        success_msg: "Namespace correctly removed"
+        fail_msg: "Namespace still exists"
+

--- a/github/ci/kubernetes_crud/molecule/default/converge.yml
+++ b/github/ci/kubernetes_crud/molecule/default/converge.yml
@@ -1,0 +1,41 @@
+- hosts: localhost
+  vars:
+    kubevirtci_dir: /tmp/kubevirtci
+    kubevirtci_provider: k8s-1.18
+    kubeconfig: '{{ kubevirtci_dir }}/_ci-configs/{{ kubevirtci_provider }}/.kubeconfig'
+    kubecontext: kubernetes-admin@kubernetes
+  tasks:
+    - name: Test namespace creation
+      include_role:
+        name: kubernetes_crud
+      vars:
+        memory_limit: 512Mi
+        default_kubeconfig_path: '{{ kubeconfig }}'
+        default_namespace: test-namespace
+        manifest_base: "{{ role_path }}/molecule/files/manifests"
+        default_context: '{{ kubecontext }}'
+        steps:
+          - desc: Create test namespace
+            namespace: test-namespace
+            op: create_namespace
+
+          - desc: Apply service from a manifest directly
+            manifest: "test-plain.yaml"
+
+          - desc: Apply LimitRange from manifest rendered from template
+            manifest_template: "test-template.yml.j2"
+
+          - desc: Apply Service account from invalid remote manifest (and testing validation override)
+            manifest_url: "file://{{ role_path }}/molecule/files/manifests/test-url.yaml"
+            # Needed as the manifest contains an invalid timestamp
+            fatal_validation: false
+            strict_validation: false
+
+          - desc: Apply label to a node from inline manifest
+            manifest_inline: |
+              apiVersion: v1
+              kind: Node
+              metadata:
+                name: node01
+                labels:
+                  test_label_key: test-label-value

--- a/github/ci/kubernetes_crud/molecule/default/destroy.yml
+++ b/github/ci/kubernetes_crud/molecule/default/destroy.yml
@@ -1,0 +1,9 @@
+- hosts: localhost
+  vars:
+    kubevirtci_dir: /tmp/kubevirtci
+  tasks:
+    - name: Teardown kubevirtci cluster
+      command: make cluster-down
+      changed_when: false
+      args:
+        chdir: "{{ kubevirtci_dir }}"

--- a/github/ci/kubernetes_crud/molecule/default/molecule.yml
+++ b/github/ci/kubernetes_crud/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+driver:
+  name: delegated
+
+platforms:
+  - name: instance  # must be able to `ssh host`, edit your ~/.ssh/config
+    options:
+      managed: False
+
+provisioner:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - prepare
+    - converge
+    - verify
+    - cleanup
+    - destroy
+

--- a/github/ci/kubernetes_crud/molecule/default/prepare.yml
+++ b/github/ci/kubernetes_crud/molecule/default/prepare.yml
@@ -1,0 +1,20 @@
+- hosts: localhost
+  vars:
+    kubevirtci_dir: /tmp/kubevirtci
+    kubevirtci_provider: k8s-1.18
+  tasks:
+    - name: Clone kubevirtci repo
+      git:
+        repo: https://github.com/kubevirt/kubevirtci.git
+        dest: "{{ kubevirtci_dir }}"
+        version: master
+
+    - name: Launch kubevirtci cluster
+      command: make cluster-up
+      changed_when: false
+      args:
+        chdir: "{{ kubevirtci_dir }}"
+      environment:
+        KUBEVIRT_PROVIDER: "{{ kubevirtci_provider }}"
+        KUBEVIRT_NUM_NODES: 2
+        KUBEVIRT_NUM_SECONDARY_NICS: 1

--- a/github/ci/kubernetes_crud/molecule/default/verify.yml
+++ b/github/ci/kubernetes_crud/molecule/default/verify.yml
@@ -1,0 +1,86 @@
+- hosts: localhost
+  vars:
+    kubevirtci_dir: /tmp/kubevirtci
+    kubevirtci_provider: k8s-1.18
+    kubeconfig: '{{ kubevirtci_dir }}/_ci-configs/{{ kubevirtci_provider }}/.kubeconfig'
+    kubecontext: kubernetes-admin@kubernetes
+  tasks:
+    - name: Gather info on created namespace
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: Namespace
+        name: test-namespace
+      register: query
+
+    - name: Verify namespace exists
+      assert:
+        that: query.resources != []
+        success_msg: "Namespace correctly created"
+        fail_msg: "Namespace was not created"
+
+    - name: Gather info on created service
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: Service
+        namespace: test-namespace
+        name: test-service
+      register: query
+
+    - name: Verify service exists
+      assert:
+        that: query.resources != []
+        success_msg: "Service correctly created"
+        fail_msg: "Service was not created"
+
+    - name: Gather info on created service account
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: ServiceAccount
+        namespace: test-namespace
+        name: test-service-account
+      register: query
+
+    - name: Verify service exists
+      assert:
+        that: query.resources != []
+        success_msg: "Service Account correctly created"
+        fail_msg: "Service Account was not created"
+
+    - name: Gather info on created LimitRange
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: LimitRange
+        namespace: test-namespace
+        name: test-limit-range
+      register: query
+
+    - name: Verify LimitRange exists and is correctly rendered
+      assert:
+        that:
+          - query.resources != []
+          - query.resources.0.spec.limits.0.default.memory == "512Mi"
+        success_msg: "LimitRange correctly created and correctly rendered"
+        fail_msg: "LimitRange was not created or correctly rendered"
+
+    - name: Gather info on label
+      k8s_info:
+        kubeconfig: "{{ kubeconfig }}"
+        context: "{{ kubecontext }}"
+        api_version: v1
+        kind: Node
+        name: node01
+      register: query
+
+    - name: Verify node label
+      assert:
+        that: query.resources.0.metadata.labels.test_label_key == "test-label-value"
+        success_msg: "Node correctly labelled"
+        fail_msg: "Node was not labelled"

--- a/github/ci/kubernetes_crud/molecule/files/manifests/test-plain.yaml
+++ b/github/ci/kubernetes_crud/molecule/files/manifests/test-plain.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  selector:
+    app: test-service
+  ports:
+  - port: 5000

--- a/github/ci/kubernetes_crud/molecule/files/manifests/test-template.yml.j2
+++ b/github/ci/kubernetes_crud/molecule/files/manifests/test-template.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: test-limit-range
+spec:
+  limits:
+  - default:
+      memory: "{{ memory_limit }}"
+    defaultRequest:
+      memory: "{{ memory_limit }}"
+    type: Container

--- a/github/ci/kubernetes_crud/molecule/files/manifests/test-url.yaml
+++ b/github/ci/kubernetes_crud/molecule/files/manifests/test-url.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "test-service-account"
+  # timestamp invalid on purpose
+  creationTimestamp: null

--- a/github/ci/kubernetes_crud/tasks/_manifest_source.yaml
+++ b/github/ci/kubernetes_crud/tasks/_manifest_source.yaml
@@ -1,0 +1,48 @@
+# Load the manifest from the specified source into a temporary file
+# Fail if the file is empty
+
+- name: "{{ name_header }} : Set temporary file path"
+  tempfile:
+    state: file
+    prefix: kubernetes-crud-rendered-manifest-
+  register: resource_tempfile
+
+- name: "{{ name_header }} : Load manifest as url"
+  when: manifest_url != "" # noqa 602
+  get_url:
+    force: true
+    url: "{{ manifest_url }}"
+    dest: "{{ resource_tempfile.path }}"
+  register: result
+
+- name: "{{ name_header }} : Load manifest as file"
+  copy:
+    src: '{{ manifest_base }}/{{ manifest_path }}'
+    dest: '{{ resource_tempfile.path }}'
+    force: yes
+    mode: 0600
+  when: manifest_path != "" # noqa 602
+
+- name: "{{ name_header }} : Load manifest as template"
+  when: manifest_template_path != "" # noqa 602
+  template:
+    src: "{{ manifest_base }}/{{ manifest_template_path }}"
+    dest: "{{ resource_tempfile.path }}"
+    mode: 0600
+
+- name: "{{ name_header }} : Render inline template"
+  when: manifest_inline != "" # noqa 602
+  copy:
+    content: "{{ manifest_inline }}"
+    dest: "{{ resource_tempfile.path }}"
+    mode: 0600
+
+- name: "{{ name_header }} : stat source file"
+  stat:
+    path: "{{ resource_tempfile.path }}"
+  register: resource
+
+- name: "{{ name_header }} : Fail if resource file is empty"
+  fail:
+    msg: "Invalid manifest source"
+  when: resource.stat.size == 0

--- a/github/ci/kubernetes_crud/tasks/apply_manifest.yaml
+++ b/github/ci/kubernetes_crud/tasks/apply_manifest.yaml
@@ -1,0 +1,19 @@
+- name: "{{ name_header }} : Render manifest source file"
+  include_tasks: _manifest_source.yaml
+
+- name: "{{ name_header }} : invoke kubectl"
+  no_log: not show_sensitive
+  k8s:
+    kubeconfig: '{{ kubeconfig_path }}'
+    context: '{{ context }}'
+    state: present
+    namespace: "{{ namespace }}"
+    validate:
+      fail_on_error: "{{ fatal_validation|bool }}"
+      strict: "{{ strict_validation|bool }}"
+    src: "{{ resource_tempfile.path }}"
+
+- name: "{{ name_header }} : remove source file"
+  file:
+    path: "{{ resource_tempfile.path }}"
+    state: absent

--- a/github/ci/kubernetes_crud/tasks/create_namespace.yaml
+++ b/github/ci/kubernetes_crud/tasks/create_namespace.yaml
@@ -1,0 +1,10 @@
+- name: "{{ name_header }} : invoke kubectl"
+  k8s:
+      kubeconfig: '{{ kubeconfig_path }}'
+      context: '{{ context }}'
+      state: present
+      kind: Namespace
+      name: "{{ namespace }}"
+      validate:
+          fail_on_error: "{{ fatal_validation }}"
+          strict: "{{ strict_validation }}"

--- a/github/ci/kubernetes_crud/tasks/main.yaml
+++ b/github/ci/kubernetes_crud/tasks/main.yaml
@@ -1,0 +1,44 @@
+# Check if there's a handler for every operation
+- name: Gather operations
+  set_fact:
+    operations: "{{ steps | selectattr('op', 'defined') | map(attribute='op') | list | unique }}"
+- name: Expand operations list with default operation
+  set_fact:
+    operations: "{{ operations + [default_crud_operation] }}"
+- name: Check existence of operation handlers
+  stat:
+    path: "{{ role_path }}/tasks/{{ operation }}.yaml"
+  loop: "{{ operations }}"
+  loop_control:
+    loop_var: operation
+  register: required_handlers
+
+- name: Fail if any requested handler is not available
+  fail:
+    msg: Some handler was not found
+  when: required_handlers.results | selectattr('stat.exists', 'equalto', False) | list  != []
+
+# Loop over all steps. Ansible first creates a queue of includes
+# Then launches the loop
+- name: Gathering steps
+  vars:
+    kubeconfig_path: "{{ step.kubeconfig|default(default_kubeconfig_path) }}"
+    op: "{{ step.op|default(default_crud_operation) }}"
+    description: "{{ step.desc|default(op) }}"
+    namespace: "{{ step.namespace|default(default_namespace) }}"
+    context: "{{ step.context|default(default_context) }}"
+    fatal_validation: "{{ step.fatal_validation|default(default_fatal_validation) }}"
+    strict_validation: "{{ step.strict_validation|default(default_strict_validation) }}"
+    manifest_inline: "{{ step.manifest_inline|default('') }}"
+    manifest_path: "{{ step.manifest|default('') }}"
+    manifest_template_path: "{{ step.manifest_template|default('') }}"
+    manifest_url: "{{ step.manifest_url|default('') }}"
+    name_header: "Step {{ step_num + 1 }}/{{ ansible_loop.length }}: {{ op }} : {{ description }}"
+  include_tasks: "{{ op }}.yaml"
+  loop: "{{ steps }}"
+  loop_control:
+    label: "{{ step.desc|default(op) }}"
+    index_var: step_num
+    loop_var: step
+    extended: yes
+

--- a/github/ci/kubernetes_crud/tasks/remove_manifest.yaml
+++ b/github/ci/kubernetes_crud/tasks/remove_manifest.yaml
@@ -1,0 +1,19 @@
+- name: "{{ name_header }} : Render manifest source file"
+  include_tasks: _manifest_source.yaml
+
+- name: "{{ name_header }} : invoke kubectl"
+  no_log: not show_sensitive
+  k8s:
+    kubeconfig: '{{ kubeconfig_path }}'
+    context: '{{ context }}'
+    state: absent
+    namespace: "{{ namespace }}"
+    validate:
+      fail_on_error: "{{ fatal_validation|bool }}"
+      strict: "{{ strict_validation|bool }}"
+    src: "{{ resource_tempfile.path }}"
+
+- name: "{{ name_header }} : remove source file"
+  file:
+    path: "{{ resource_tempfile.path }}"
+    state: absent

--- a/github/ci/kubernetes_crud/tasks/remove_namespace.yaml
+++ b/github/ci/kubernetes_crud/tasks/remove_namespace.yaml
@@ -1,0 +1,12 @@
+- name: "{{ name_header }} : invoke kubectl (wait to confim deletion)"
+  k8s:
+    wait: true
+    wait_timeout: 180
+    kubeconfig: '{{ kubeconfig_path }}'
+    context: '{{ context }}'
+    state: absent
+    kind: Namespace
+    name: "{{ namespace }}"
+    validate:
+      fail_on_error: "{{ fatal_validation }}"
+      strict: "{{ strict_validation }}"

--- a/github/ci/kubernetes_crud/vars/main.yaml
+++ b/github/ci/kubernetes_crud/vars/main.yaml
@@ -1,0 +1,4 @@
+default_fatal_validation: yes
+default_strict_validation: yes
+
+default_crud_operation: apply_manifest

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -67,3 +67,32 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
+  - name: kubernetes-crud-ci-role
+    always_run: false
+    run_if_changed: "github/ci/kubernetes-crud/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-kubevirtci-docker-credential: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: gabrielecerami/kubevirt-ci-testenv
+          # docker run \
+          # -v /project-infra:/opt/source/project-infra
+          # -v /dev/kvm:/dev/kvm
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "source /opt/virtualenv/bin/activate && cd github/ci/kubernetes_crud/ &&  molecule test"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"

--- a/images/kubevirt-ci-testenv/Dockerfile
+++ b/images/kubevirt-ci-testenv/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/k8s-testimages/bootstrap
+
+RUN mkdir -p /opt/source/
+RUN apt-get update
+RUN apt-get install -y python3.7 python3-virtualenv python3-selinux git make
+RUN python3 -m virtualenv -p python3 /opt/virtualenv
+
+RUN /bin/bash -c 'source /opt/virtualenv/bin/activate; pip install -U pip setuptools molecule kubernetes kubernetes-validate openshift'


### PR DESCRIPTION
this role a is a generic interface between ansible and batch deployments
of kuberneted manifests.
It allows to write steps in a declarative way avoiding duplication of
common parameters such as kubeconfig or context.
This role will be used by the upcoming rewrite of role to deploy prow
and its dependencies.

Signed-off-by: Gabriele Cerami <gcerami@redhat.com>