### PR TITLE
Changed kubevirt.github.io link checker branch to source

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -5,7 +5,7 @@ periodics:
     extra_refs:
       - org: kubevirt
         repo: kubevirt.github.io
-        base_ref: master
+        base_ref: source
         path_alias: kubevirt.github.io
     spec:
       nodeSelector:


### PR DESCRIPTION
Looks like the main branch on kubevirt.github.io has been changed to `source`. Updated the job configuration to update to that.