### PR TITLE
labels: change good first issue label name

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -196,7 +196,7 @@ repos:
       - name: for/users
         color: fef2c0
         target: both
-      - name: good first issue
+      - name: good-first-issue
         color: 128A0C
         target: issues
       - name: help wanted


### PR DESCRIPTION
The label `good first issue` , is not triggred by the bot when
asked. Changing it's name to `good-first-issue` should solve it.

Signed-off-by: alonSadan <asadan@redhat.com>