### PR TITLE
Fix rename by adding previously

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -199,6 +199,9 @@ repos:
       - name: good-first-issue
         color: 128A0C
         target: issues
+        previously:
+          - name: good first issue
+            color: 128A0C
       - name: help wanted
         color: 128A0C
         target: issues


### PR DESCRIPTION
Forgot to add `previously` to rename existing label as of #617.