### PR TITLE
add ^ anchor to run_if_changed in macvtap-cni postsubmits

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -25,7 +25,7 @@ postsubmits:
             securityContext:
               privileged: true
     - name: release-macvtap-cni
-      run_if_changed: "version/version.go"
+      run_if_changed: "^version/version.go"
       decorate: true
       max_concurrency: 1
       labels:


### PR DESCRIPTION
Currently, prow's postsubmits script is set to run
if the file name in field 'run_if_changed' is changed.
However, this field is actually a [regex](https://github.com/kubernetes/test-infra/blob/8c49c0c2b8fce773ea5c254971e98c867314a63d/prow/config/jobs.go#L308)
and as such, it follows a greedy approach where any file with that name
changes - regardless of it's preceding  path - the postsubmits will be initiated.
In order to make sure the regex picks up only the file we want - we anchor the field value.

Signed-off-by: Ram Lavi <ralavi@redhat.com>