### PR TITLE
Rename build-officer to build-watcher

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -2,13 +2,13 @@
 default:
   labels:
     - color: 8452c9
-      name: triage/build-officer
+      name: triage/build-watcher
       target: issues
-      description: Discovered by a kubevirt build-officer. Pay attention to these issues to keep CI healthy.
+      description: Discovered by a kubevirt build-watcher. Pay attention to these issues to keep CI healthy.
       prowPlugin: label
       addedBy: anyone
       previously:
-        - name: build-officer
+        - name: triage/build-officer
           color: 8452c9
     - color: c2e0c6
       name: release-note


### PR DESCRIPTION
Renaming according the rebrand.

Signed-off-by: Or Shoval <oshoval@redhat.com>