### PR TITLE
make rook ceph lane mandatory

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -624,8 +624,8 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     skip_report: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
Want to always test snapshot/restore.

This has been running on demand successfully for me for awhile.

Signed-off-by: Michael Henriksen <mhenriks@redhat.com>