### PR TITLE
Run some kubevirt jobs in unnested mode

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presets.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presets.yaml
@@ -10,3 +10,10 @@ presets:
       value: "8080"
     - name: BAZEL_REMOTE_CACHE_ENABLED
       value: "true"
+- labels:
+    preset-kubevirt-run-unnested: "true"
+  env:
+    - name: KUBEVIRT_RUN_UNNESTED
+      value: "true"
+    - name: KUBEVIRT_CREATE_BAZELRCS
+      value: "true"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -801,23 +801,18 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-kubevirt-run-unnested: "true"
       preset-docker-mirror: "true"
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
+        - image: kubevirt/builder@sha256:676be4dbccc304687a7b32552b0b39b71dc13e149241f5ac272d3a23509fe7fb
           command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
+            - "/entrypoint.sh"
+            - "make apidocs"
           resources:
             requests:
-              memory: "4Gi"
+              memory: "1Gi"
   - name: pull-kubevirt-client-python
     cluster: ibm-prow-jobs
     skip_branches:
@@ -832,23 +827,18 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-kubevirt-run-unnested: "true"
       preset-docker-mirror: "true"
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
+        - image: kubevirt/builder@sha256:676be4dbccc304687a7b32552b0b39b71dc13e149241f5ac272d3a23509fe7fb
           command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
+            - "/entrypoint.sh"
+            - "make client-python"
           resources:
             requests:
-              memory: "4Gi"
+              memory: "1Gi"
   - name: pull-kubevirt-manifests
     cluster: ibm-prow-jobs
     skip_branches:
@@ -863,24 +853,18 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-kubevirt-run-unnested: "true"
       preset-docker-mirror: "true"
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
-          # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
+        - image: kubevirt/builder@sha256:676be4dbccc304687a7b32552b0b39b71dc13e149241f5ac272d3a23509fe7fb
           command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX=\"docker.io/kubevirt\" && make olm-verify"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
+            - "/entrypoint.sh"
+            - "make manifests DOCKER_PREFIX=\"docker.io/kubevirt\" && make olm-verify"
           resources:
             requests:
-              memory: "4Gi"
+              memory: "1Gi"
   - name: pull-kubevirt-prom-rules-verify
     cluster: ibm-prow-jobs
     skip_branches:


### PR DESCRIPTION
Makes use of the [`KUBEVIRT_RUN_UNNESTED`](https://github.com/kubevirt/kubevirt/blob/master/hack/dockerized#L6) flag provided by the `hack/dockerized` script in order to *not* run a build step in a docker container.

As we have split the once monolithic check that was run on travis-ci into several smaller ones running on prow the overhead of running docker in docker is now much bigger in total. Therefore it makes sense to just run them directly in the kubevirt builder image.

Required for this to work is a change in the kubevirt builder image that enables generating the bazelrc in order to use our bazel cache. See [`KUBEVIRT_CREATE_BAZELRCS`](https://github.com/kubevirt/kubevirt/pull/4159/files#diff-5d8e98b17562584b70f97689ddb0a030R5) in kubevirt/kubevirt#4159