### PR TITLE
Mount lib modules

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -328,3 +328,14 @@ presets:
     - name: kubevirtci-cred
       mountPath: /etc/kubevirtci-cred
       readOnly: true
+- labels:
+    preset-mount-lib-modules: "true"
+  volumes:
+    - name: modules
+      hostPath:
+        path: /lib/modules
+        type: Directory
+  volumeMounts:
+    - name: modules
+      mountPath: /lib/modules
+      readOnly: true

--- a/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -47,6 +47,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+        preset-mount-lib-modules: "true"
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -17,6 +17,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+        preset-mount-lib-modules: "true"
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -79,6 +80,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+        preset-mount-lib-modules: "true"
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -48,6 +49,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -80,6 +82,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -112,6 +115,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -144,6 +148,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -176,6 +181,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -114,6 +114,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -147,6 +148,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -180,6 +182,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -244,6 +247,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -636,6 +640,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -46,6 +46,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+        preset-mount-lib-modules: "true"
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -18,6 +18,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+      preset-mount-lib-modules: "true"
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -47,6 +47,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+        preset-mount-lib-modules: "true"
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -144,6 +145,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+        preset-mount-lib-modules: "true"
       spec:
         nodeSelector:
           type: bare-metal-external


### PR DESCRIPTION
As part of https://github.com/kubevirt/kubevirtci/pull/445 we need prow to mount `/lib/modules` so dnsmasq.sh can load ip6table kernel modules in case they are not loaded already at cluster-up.