### PR TITLE
Checkout kubevirt sources for conformance tests

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -198,6 +198,12 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
     preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      path_alias: kubevirt
+      workdir: true
   spec:
     nodeSelector:
       type: bare-metal-external


### PR DESCRIPTION
In the current conformance tests periodic, we've never fetched KubeVirt
sources. This patch should fix it.

The nightly fails now: https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-push-nightly-conformance/1307145148014006272/build-log.txt

Signed-off-by: Petr Horacek <phoracek@redhat.com>