### PR TITLE
Make k8s-1.19 lane always run

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
Let the new k8s-1.19 lane run always (not reporting though). If it looks stable enough we are going to make it report.