### PR TITLE
Set kubevirt presubmit checks to always run

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -733,7 +733,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     skip_report: true
     optional: true
     decorate: true
@@ -764,7 +764,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     skip_report: true
     optional: true
     decorate: true
@@ -795,7 +795,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     skip_report: true
     optional: true
     decorate: true
@@ -827,7 +827,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     skip_report: true
     optional: true
     decorate: true


### PR DESCRIPTION
Enables the presubmits for kubevirt/kubevirt

* pull-kubevirt-apidocs
* pull-kubevirt-client-python
* pull-kubevirt-manifests
* pull-kubevirt-prom-rules-verify

to run on every PR push.

/cc @danielBelenky 