### PR TITLE
Enable reporting to GitHub for new kubevirt jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -734,7 +734,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    skip_report: true
+    skip_report: false
     optional: true
     decorate: true
     decoration_config:
@@ -765,7 +765,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    skip_report: true
+    skip_report: false
     optional: true
     decorate: true
     decoration_config:
@@ -796,7 +796,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    skip_report: true
+    skip_report: false
     optional: true
     decorate: true
     decoration_config:
@@ -828,7 +828,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    skip_report: true
+    skip_report: false
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
Enable reporting to GitHub for the following jobs:
* [pull-kubevirt-apidocs](https://prow.apps.ovirt.org/?job=pull-kubevirt-apidocs)
* [pull-kubevirt-client-python](https://prow.apps.ovirt.org/?job=pull-kubevirt-client-python)
* [pull-kubevirt-manifests](https://prow.apps.ovirt.org/?job=pull-kubevirt-manifests)
* [pull-kubevirt-prom-rules-verify](https://prow.apps.ovirt.org/?job=pull-kubevirt-prom-rules-verify)

/cc @danielBelenky