### PR TITLE
Enable reporting for k8s-1.19

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -104,7 +104,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: true
-    skip_report: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
Enable the reporting for k8s-1.19 lane, as [it seems stable enough](https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-2020-10-22-168h.html). We don't make it mandatory yet for now.

/cc @rmohr 