### PR TITLE
The 1.19 lane ran for some time now

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
+    always_run: false
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
Let's reduce CI load, analyze the results and either fix it or let it
replace the 1.16 k8s version.

Signed-off-by: Roman Mohr <rmohr@redhat.com>