### PR TITLE
Disable always run for 1.19 again

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
+    always_run: false
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
After having pulled some data for stability we disable 1.19 always_run again.

/cc @rmohr @danielBelenky 