### PR TITLE
Make kubevirt prow checks required

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -735,7 +735,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     skip_report: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h
@@ -766,7 +766,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     skip_report: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h
@@ -797,7 +797,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     skip_report: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h
@@ -829,7 +829,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     skip_report: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
In order to enable gating for KubeVirt we make the following jobs required:

* pull-kubevirt-apidocs
* pull-kubevirt-client-python
* pull-kubevirt-manifests
* pull-kubevirt-prom-rules-verify

Next step will be the removal of the Travis CI run on every PR.

/cc @rmohr 