### PR TITLE
Reenable k8s-1.19 to run always

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -102,7 +102,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
In order to retrieve more data about the stability of the lane, we enable it to run on every PR.

/cc @rmohr @danielBelenky 