### PR TITLE
Make travis ci non required

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -195,9 +195,6 @@ branch-protection:
       repos:
         kubevirt:
           protect: true
-          required_status_checks:
-            contexts:
-              - continuous-integration/travis-ci/pr
         project-infra:
           branches:
             master:


### PR DESCRIPTION
In order to be able to remove Travis CI, we first need to make it non required.

/cc @rmohr @danielBelenky 