### PR TITLE
HCO: clean kubevirt directory before cloning

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -35,6 +35,7 @@ periodics:
           latest_kubevirt_commit=$(curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${latest_kubevirt}/commit) &&
           go mod edit -require kubevirt.io/kubevirt@${latest_kubevirt_commit} &&
           go mod vendor &&
+          rm -rf kubevirt &&
           git clone https://github.com/kubevirt/kubevirt.git &&
           (cd kubevirt; git checkout ${latest_kubevirt_commit}) &&
           go mod edit -replace kubevirt.io/client-go=./kubevirt/staging/src/kubevirt.io/client-go &&


### PR DESCRIPTION
We are vendoring a specific version of kubevirt/client-go, but the
nightly job need to pull in the latest kubevirt/client-go, so make sure
the toplevel kubevirt directory is clean before cloning.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>