### PR TITLE
Use go mod vendor after updating client-go

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -25,7 +25,7 @@ periodics:
         - "-c"
         - >
           cat $DOCKER_PASSWORD | docker login --username $(cat $DOCKER_USER) --password-stdin &&
-          wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz &&
+          wget -q https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz &&
           tar -C /usr/local -xf go*.tar.gz &&
           export PATH=/usr/local/go/bin:$PATH &&
           git clone https://github.com/kubevirt/hyperconverged-cluster-operator.git &&
@@ -39,6 +39,8 @@ periodics:
           git clone https://github.com/kubevirt/kubevirt.git &&
           (cd kubevirt; git checkout ${latest_kubevirt_commit}) &&
           go mod edit -replace kubevirt.io/client-go=./kubevirt/staging/src/kubevirt.io/client-go &&
+          go mod vendor &&
+          go mod tidy &&
           build_date="$(date +%Y%m%d)" &&
           export IMAGE_REGISTRY=docker.io &&
           export DOCKER_PREFIX=kubevirtnightlybuilds &&


### PR DESCRIPTION
The nightly build will fail to compile if kubevirt/client-go is up to
date.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>