### PR TITLE
Reduce the max job execution time for windows jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -430,7 +430,7 @@ presubmits:
     optional: false
     decorate: true
     decoration_config:
-      timeout: 7h
+      timeout: 2h
       grace_period: 5m
     max_concurrency: 1 # we have one license
     labels:


### PR DESCRIPTION
The windows job runs way under one hour, reduce the maximum execution
time to 2 hours.

If something is wrong in the test scripts, it aborts earlier than right now: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4292/pull-kubevirt-e2e-windows2016/1312060536942235648. The issue there will get a fix in kubevirt/kubevirt too.