### PR TITLE
Make pull-kubevirt-build required

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
@@ -565,6 +565,7 @@ presubmits:
     branches:
     - release-0.31
     cluster: ibm-prow-jobs
+    context: pull-kubevirt-build
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
@@ -572,7 +572,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    name: pull-kubevirt-build
+    name: pull-kubevirt-build-release-0.31
     optional: true
     skip_report: true
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
@@ -565,6 +565,7 @@ presubmits:
     branches:
     - release-0.32
     cluster: ibm-prow-jobs
+    context: pull-kubevirt-build
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
@@ -572,7 +572,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    name: pull-kubevirt-build
+    name: pull-kubevirt-build-release-0.32
     optional: true
     skip_report: true
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
@@ -610,6 +610,7 @@ presubmits:
     branches:
     - release-0.33
     cluster: ibm-prow-jobs
+    context: pull-kubevirt-build
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
@@ -617,7 +617,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    name: pull-kubevirt-build
+    name: pull-kubevirt-build-release-0.33
     optional: true
     skip_report: true
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -585,9 +585,9 @@ presubmits:
       preset-bazel-cache: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    name: pull-kubevirt-build
-    optional: true
-    skip_report: true
+    name: pull-kubevirt-build-release-0.34
+    optional: false
+    skip_report: false
     spec:
       containers:
       - command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -577,6 +577,7 @@ presubmits:
     branches:
     - release-0.34
     cluster: ibm-prow-jobs
+    context: pull-kubevirt-build
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -630,8 +630,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    skip_report: true
-    optional: true
+    skip_report: false
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
It is important to see this job, in order to see if `make` detected
uncommited code-changes, similare to the generate job.

Signed-off-by: Roman Mohr <rmohr@redhat.com>