### PR TITLE
[rehearsal] Rebase PRs on target branch

### DIFF
--- a/external-plugins/rehearse/plugin/go.mod
+++ b/external-plugins/rehearse/plugin/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/prometheus/common v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	k8s.io/api v0.17.3
 	k8s.io/client-go v9.0.0+incompatible


### PR DESCRIPTION
First rebase PRs on the latest state of the target branch to reliably
get the real diff to master. This is needed to avoid a situation where
jobs are still present on the base ref on a PR and not on the target
branch anymore.