### PR TITLE
Disable goveralls prow job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -435,9 +435,9 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: true
-    skip_report: false
-    optional: false
+    always_run: false
+    skip_report: true
+    optional: true
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
At the moment it seems that the goveralls check can't be run as it
consumes too much memory on the node. Disable reporting and make it
optional to be able to investigate the problem.