### PR TITLE
enable sriov lane

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -375,7 +375,8 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
     max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.17-sriov
+    name: pull-kubevirt-e2e-kind-1.17-sriov-release-0.30
+    context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     skip_report: true
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
@@ -407,7 +407,8 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
     max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.17-sriov
+    name: pull-kubevirt-e2e-kind-1.17-sriov-release-0.31
+    context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     spec:
       affinity:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
@@ -406,7 +406,8 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
     max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.17-sriov
+    name: pull-kubevirt-e2e-kind-1.17-sriov-release-0.32
+    context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     skip_report: true
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
@@ -406,7 +406,8 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
     max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.17-sriov
+    name: pull-kubevirt-e2e-kind-1.17-sriov-release-0.33
+    context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     spec:
       affinity:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -437,7 +437,8 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
     max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.17-sriov
+    name: pull-kubevirt-e2e-kind-1.17-sriov-release-0.34
+    context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     spec:
       affinity:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -169,12 +169,13 @@ presubmits:
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: false
+    always_run: true
     optional: true
+    skip_report: false
     decorate: true
     decoration_config:
-      timeout: 3h
-      grace_period: 20m
+      timeout: 4h
+      grace_period: 30m
     max_concurrency: 10
     labels:
       preset-dind-enabled: "true"
@@ -203,7 +204,7 @@ presubmits:
         - >
             apt update &&
             apt install gettext-base -y &&
-            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz &&
+            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
             tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&
             export TARGET=kind-k8s-sriov-1.17.0 &&


### PR DESCRIPTION
Enable SRIOV lane back
Also:
- Increase job timeout.
- Set golang download silent to reduce noise in the job log.

This PR should be merged only after https://github.com/kubevirt/kubevirt/pull/4424

Signed-off-by: Or Mergi <ormergi@redhat.com>

