### PR TITLE
Mitigate docker hub push fails on EOF with RestartPolicy=OnFailure

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -185,6 +185,7 @@ periodics:
         - name: gcs
           mountPath: /etc/gcs
           readOnly: false
+      restartPolicy: OnFailure
     volumes:
       - name: gcs
         secret:


### PR DESCRIPTION
In recent times the push to docker hub started to fail with just a short
error like this:

```
Error pushing image to ...: unable to push image to ...: Put
https://index.docker.io/v2/kubevirtnightlybuilds/...: EOF
```

Locally this could be reproduced once, on second and third try it
succeeded. Therefore we change the container restartPolicy to OnFailure
to retry the push.