### PR TITLE
Added generic script to modify arbitrary repos and create PRs

### DIFF
--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Taken from https://github.com/kubernetes/test-infra/blob/4d7f26e59a5e186eef3a7de55486b7a40bbd79d7/hack/autodeps.sh
+# and modified for kubevirt.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+usage() {
+    echo "Usage: $(basename "$0") -c \"<command>\" [-s \"<summary>\"] [-l <github-login>] [-t </path/to/github/token>] [-p </path/to/github/repo>] [-n \"<git-name>\"] [-e <git-email>]  [-b <pr-branch>] [-o <org>] [-r <repo>] [-m </path/where/command/should/be/run>]">&2
+}
+
+command=
+summary=
+user=kubevirt-bot
+token=/etc/github/oauth
+repo_path=$(pwd)
+git_name=kubevirt-bot
+git_email=rmohr+kubebot@redhat.com
+branch=autoupdate
+org=kubevirt
+repo=kubevirt
+command_path=$(pwd)
+
+while getopts ":c:s:l:t:p:n:e:b:o:r:m" opt; do
+    case "${opt}" in
+        c )
+            command="${OPTARG}"
+            ;;
+        s )
+            summary="${OPTARG}"
+            ;;
+        l )
+            user="${OPTARG}"
+            ;;
+        t )
+            token="${OPTARG}"
+            ;;
+        p )
+            repo_path="${OPTARG}"
+            ;;
+        n )
+            git_name="${OPTARG}"
+            ;;
+        e )
+            git_email="${OPTARG}"
+            ;;
+        b )
+            branch="${OPTARG}"
+            ;;
+        o )
+            org="${OPTARG}"
+            ;;
+        r )
+            repo="${OPTARG}"
+            ;;
+        m )
+            command_path="${OPTARG}"
+            ;;
+        \? )
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "${command}" ]; then
+    usage
+    exit 1
+fi
+
+if [ -z "${summary}" ]; then
+    summary="Run ${command}"
+fi
+
+cd "${command_path}"
+eval "${command}"
+
+cd "${repo_path}"
+echo "git config user.name=${git_name} user.email=${git_email}..." >&2
+git config user.name "${git_name}"
+git config user.email "${git_email}"
+
+if ! git config user.name &>/dev/null && git config user.email &>/dev/null; then
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    exit 1
+fi
+
+git add -A
+if git diff --name-only --exit-code HEAD; then
+    echo "Nothing changed" >&2
+    exit 0
+fi
+
+git commit -s -m "${summary}"
+git push -f "https://${user}@github.com/${user}/${repo}.git" HEAD:"${branch}"
+
+echo "Creating PR to merge ${user}:${branch} into master..." >&2
+pr-creator \
+    --github-token-path="${token}" \
+    --org="${org}" --repo="${repo}" --branch=master \
+    --title="${summary}" --match-title="${summary}" \
+    --body="Automatic run of \"$command\". Please review" \
+    --source="${user}":"${branch}" \
+    --confirm

--- a/plugins/cmd/uploader/uploader.go
+++ b/plugins/cmd/uploader/uploader.go
@@ -15,8 +15,8 @@ import (
 )
 
 type options struct {
-	dryRun bool
-	bucket string
+	dryRun        bool
+	bucket        string
 	workspacePath string
 }
 
@@ -65,7 +65,7 @@ func main() {
 		newFileUrl := mirror.GenerateFilePath(options.bucket, &artifact)
 		err := mirror.WriteToBucket(options.dryRun, ctx, client, artifact.URLs()[0], options.bucket, artifact.SHA256())
 		if err != nil {
-			log.Fatalf("failed to upload %s to %s", artifact.URLs()[0], newFileUrl)
+			log.Fatalf("failed to upload %s to %s: %s", artifact.URLs()[0], newFileUrl, err)
 		}
 		artifact.AppendURL(newFileUrl)
 	}


### PR DESCRIPTION
The script tries to generalize functionality present in https://github.com/kubevirt/kubevirt/blob/master/hack/autobump-generic.sh or https://github.com/kubevirt/kubevirt/blob/master/hack/autobump-kubevirt.sh. It uses getopts to define the options, there are default values for most of them, the only required is the command to execute.

It allows defining the path where the command should be executed (with `-m`) and the path of the target repo, there are cases when they need to be different (for instance, when using the uploader plugin https://github.com/kubevirt/project-infra/tree/master/plugins/cmd/uploader).

Signed-off-by: Federico Gimenez <federico.gimenez@gmail.com>