### PR TITLE
Make k8s-1.19 lane mandatory

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -97,6 +97,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
+    context: pull-kubevirt-e2e-k8s-1.19
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -106,7 +107,7 @@ presubmits:
       preset-docker-mirror: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.19
+    name: pull-kubevirt-e2e-k8s-1.19-release-0.34
     optional: true
     skip_report: true
     spec:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
     always_run: true
-    optional: true
+    optional: false
     skip_report: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
Also, change the job name for the forked release branch job to avoid
triggering the status reconciler bug.