### PR TITLE
Reenable goveralls on every run, make it report again

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -436,8 +436,8 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     optional: true
     decorate: true
     decoration_config:
@@ -463,6 +463,8 @@ presubmits:
           privileged: true
         resources:
           requests:
+            memory: "6Gi"
+          limits:
             memory: "8Gi"
         volumeMounts:
           - name: kubevirtci-coveralls


### PR DESCRIPTION
Also lower request to 6GB, set limit of 8GB

Signed-off-by: Daniel Hiller <daniel.hiller.1972@gmail.com>
