### PR TITLE
knmstate, publish: Add github credentials to push to gh-pages branch

### DIFF
--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -18,10 +18,18 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && ./automation/publish.sh"
+              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/oauth) ./automation/publish.sh"
+            # docker-in-docker needs privileged mode
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
+            volumeMounts:
+              - name: github-token
+                mountPath: /etc/github
+        volumes:
+          - name: github-token
+            secret:
+              secretName: oauth-token
 
     - name: release-kubernetes-nmstate
       decorate: true


### PR DESCRIPTION
The publish.sh is going to update also the documentation page that
is living at "gh-pages" branch, to push there we need the credentials.