### PR TITLE
knmstate: Skip gh-pages branch at publish job

### DIFF
--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -1,6 +1,8 @@
 postsubmits:
   nmstate/kubernetes-nmstate:
     - name: publish-kubernetes-nmstate
+      skip_branches:
+        - gh-pages
       always_run: true
       decorate: true
       max_concurrency: 1


### PR DESCRIPTION
This is a special branch to point to the project's webpage content.

Closes https://github.com/nmstate/kubernetes-nmstate/issues/628

Signed-off-by: Quique Llorente <ellorent@redhat.com>