### PR TITLE
Add bootstrap image with docker mirror proxy support

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -57,3 +57,30 @@ postsubmits:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
+    - name: publish-bootstrap-image
+      always_run: false
+      run_if_changed: "images/bootstrap/.*"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+        preset-project-infra-kubevirtci-docker-credential: "true"
+      spec:
+        nodeSelector:
+          type: vm
+        containers:
+          - image: gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd images && ./publish_image.sh bootstrap docker.io kubevirtci"
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "1Gi"
+              limits:
+                memory: "1Gi"

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -67,6 +67,32 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
+  - name: build-bootstrap-image
+    always_run: false
+    run_if_changed: "images/bootstrap/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-kubevirtci-docker-credential: "true"
+    spec:
+      nodeSelector:
+        type: vm
+      containers:
+        - image: gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "cd images && ./publish_image.sh -b bootstrap docker.io kubevirtci"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
   - name: kubernetes-crud-ci-role
     always_run: false
     run_if_changed: "github/ci/kubernetes-crud/.*"

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7
+
+RUN cp /usr/local/bin/runner.sh /usr/local/bin/runner_orig.sh
+
+COPY "runner.sh" \
+  "/usr/local/bin/"

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+setup_docker_proxy(){
+    if [ ! -z "${DOCKER_HTTP_PROXY}" ]; then
+        echo "Setting docker daemon http_proxy env var to ${DOCKER_HTTP_PROXY}"
+        echo "export http_proxy=${DOCKER_HTTP_PROXY}" | \
+            tee --append /etc/default/docker
+    fi
+
+    if [ ! -z "${DOCKER_HTTPS_PROXY}" ]; then
+        echo "Setting docker daemon https_proxy env var to ${DOCKER_HTTPS_PROXY}"
+        echo "export https_proxy=${DOCKER_HTTPS_PROXY}" | \
+            tee --append /etc/default/docker
+    fi
+}
+
+setup_ca(){
+    if [ -f "${CA_CERT_FILE}" ]; then
+        echo "Adding ${CA_CERT_FILE} as a trusted root CA"
+        cp "${CA_CERT_FILE}" /usr/local/share/ca-certificates/
+
+        update-ca-certificates
+    fi
+}
+
+main(){
+    setup_docker_proxy
+
+    setup_ca
+
+    /usr/local/bin/runner_orig.sh "${@}"
+}
+
+main "${@}"


### PR DESCRIPTION
The image is based on `gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7` and includes a wrapper around `/usr/local/bin/runner.sh` that:
* verifies if there are env vars defined for setting up HTTP proxy, renaming them as needed. The docker daemon process requires `HTTP_PROXY` and `HTTPS_PROXY` env vars to be defined, we plan to use the more specific `DOCKER_HTTP_PROXY` and `DOCKER_HTTPS_PROXY` in presets.
* optionally adds a CA certificate to the system-wide trusted root authority, this will allow connecting the docker daemon with the mirror proxy using TLS.
