### PR TITLE
knmstate, publish: Use GIT_ASKPASS

### DIFF
--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -6,6 +6,10 @@ postsubmits:
       always_run: true
       decorate: true
       max_concurrency: 1
+      extra_refs:
+      - org: kubevirt
+        repo: project-infra
+        base_ref: master
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -16,6 +20,11 @@ postsubmits:
           zone: ci
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+            env:
+            - name: GIT_ASKPASS
+              value: "../project-infra/hack/git-askpass.sh"
+            - name: GITHUB_USER
+              value: kubevirt-bot
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"


### PR DESCRIPTION
One of the publish step is to push into the `gh-pages` branch, for that we need the github token for kubevirt-bot user, best way to pass this to git is using the special [GIT_ASKPASS](https://git-scm.com/docs/gitcredentials#_requesting_credentials) that points to a script that dumps the token to git.