### PR TITLE
Add docker mirror proxy

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -354,6 +354,23 @@ presets:
     mountPath: /etc/default
     readOnly: true
 - labels:
+    preset-docker-mirror-proxy: "true"
+  env:
+  - name: DOCKER_HTTP_PROXY
+    value: http://docker-mirror-proxy.kubevirt-prow.svc:3128
+  - name: DOCKER_HTTPS_PROXY
+    value: http://docker-mirror-proxy.kubevirt-prow.svc:3128
+  - name: CA_CERT_FILE
+    value: /etc/docker-mirror-proxy/ca.crt
+  volumes:
+  - name: docker-mirror-proxy-ca-cert
+    configMap:
+      name: mirror-proxy-config
+  volumeMounts:
+  - name: docker-mirror-proxy-ca-cert
+    mountPath: /etc/docker-mirror-proxy
+    readOnly: true
+- labels:
     preset-shared-images: "true"
   volumes:
   - name: shared-iso

--- a/github/ci/prow/tasks/main.yml
+++ b/github/ci/prow/tasks/main.yml
@@ -138,6 +138,20 @@
           type: Opaque
           data:
             service-account.json: "{{ gcsServiceAccount | b64encode }}"
+    - name: Create Docker mirror proxy secret
+      k8s:
+        kubeconfig: '{{ automationKubeconfig }}'
+        context: '{{ masterClusterContext }}'
+        state: present
+        namespace: "{{ prowNamespace }}"
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: docker-mirror-proxy
+          type: Opaque
+          data:
+            ca.key: "{{ dockerMirrorProxyCA.key }}"
     - name: Deploy limit range
       command: "oc --kubeconfig {{ automationKubeconfig }} --context {{ masterClusterContext }} -n {{prowNamespace}} apply -f -"
       args:

--- a/github/ci/prow/templates/mirror-proxy-config.yaml
+++ b/github/ci/prow/templates/mirror-proxy-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mirror-proxy-config
+data:
+  ca.crt: |
+{{ dockerMirrorProxyCA.crt | indent(width=4, indentfirst=True) }}

--- a/github/ci/prow/templates/mirror-proxy-service.yaml
+++ b/github/ci/prow/templates/mirror-proxy-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-mirror-proxy
+spec:
+  selector:
+    app: docker-mirror-proxy
+  ports:
+  - port: 3128

--- a/github/ci/prow/templates/mirror-proxy.yaml
+++ b/github/ci/prow/templates/mirror-proxy.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-mirror-proxy
+spec:
+  selector:
+    matchLabels:
+      app: docker-mirror-proxy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: docker-mirror-proxy
+    spec:
+      terminationGracePeriodSeconds: 180
+      serviceAccountName: "caches"
+      nodeSelector:
+        type: bare-metal-external
+        ci.kubevirt.io/cachenode: "true"
+      tolerations:
+      - key: "cachenode"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: mirror-proxy
+        image: fgimenez/docker-mirror-proxy:v0.2.0
+        env:
+        - name: ENABLE_MANIFEST_CACHE
+          value: "true"
+        volumeMounts:
+        - name: storage
+          mountPath: /docker_mirror_cache
+        - name: ca-public
+          mountPath: /ca/ca.crt
+          subPath: ca.crt
+          readOnly: true
+        - name: ca-private
+          mountPath: /ca/ca.key
+          subPath: ca.key
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 3128
+        resources:
+          requests:
+            memory: 3Gi
+          limits:
+            memory: 3Gi
+      volumes:
+      - name: ca-public
+        configMap:
+          name: mirror-proxy-config
+      - name: ca-private
+        secret:
+          secretName: docker-mirror-proxy
+      - name: storage
+        hostPath:
+          path: /var/lib/docker-mirror/proxy


### PR DESCRIPTION
Creates the mirror manifests, the secret for the proxy CA cert and the job presets. Currently using the image `fgimenez/docker-mirror-proxy:v0.1.0` built from https://github.com/fgimenez/docker-registry-proxy

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>

