### PR TITLE
SRIOV lane: Mount in memory directory for backing in-memory etcd data

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -178,6 +178,7 @@ presubmits:
       grace_period: 30m
     max_concurrency: 10
     labels:
+      rehearsal.allowed: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
@@ -227,6 +228,8 @@ presubmits:
             mountPath: /sys/fs/cgroup
           - name: vfio
             mountPath: /dev/vfio/
+          - name: etcd-data-dir
+            mountPath: /mnt/kind-cluster-etcd
       volumes:
         - name: modules
           hostPath:
@@ -240,6 +243,9 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
+        - name: etcd-data-dir
+          emptyDir:
+            medium: Memory
 
   - name: pull-kubevirt-check-tests-for-flakes
     skip_branches:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
       timeout: 1h
     max_concurrency: 1
     labels:
+      rehearsal.allowed: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-kubevirtci-installer-pull-token: "true"
@@ -37,7 +38,7 @@ presubmits:
         - >
             apt update &&
             apt install gettext-base -y &&
-            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz &&
+            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
             tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&
             export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
@@ -59,6 +60,8 @@ presubmits:
             mountPath: /sys/fs/cgroup
           - name: vfio
             mountPath: /dev/vfio/
+          - name: etcd-data-dir
+            mountPath: /mnt/kind-cluster-etcd
       volumes:
         - name: modules
           hostPath:
@@ -72,6 +75,9 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
+        - name: etcd-data-dir
+          emptyDir:
+            medium: Memory
 
   - name: check-provision-k8s-1.18
     always_run: true


### PR DESCRIPTION
Currently we encounter bad performance of KIND cluster on DinD setup, 
we get 'etcdserver: timeout errors' on SRIOV lane jobs causesing jobs to fail often.

In such cases it is recommended to run in-memory etcd 
kubernetes-sigs/kind#1922
kubernetes-sigs/kind#845
Running etcd in memory should improve performance and make sriov lane more stabilized

This PR provides in memory directory for backing etcd data directory 
https://github.com/kubevirt/kubevirtci/pull/478