### PR TITLE
SRIOV lane, Prevent Resources Leak

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -207,8 +207,10 @@ presubmits:
             wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
             tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&
-            export TARGET=kind-k8s-sriov-1.17.0 &&
-            automation/test.sh
+            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
+            export TARGET=kind-k8s-sriov-1.17.0;
+            trap "make cluster-down" EXIT ERR SIGINT SIGTERM;
+            automation/test.sh;
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -182,6 +182,7 @@ presubmits:
       preset-docker-mirror: "true"
       preset-shared-images: "true"
       sriov-pod: "true"
+      rehearsal.allowed: "true"
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -55,6 +55,7 @@ presubmits:
       preset-docker-mirror: "true"
       preset-kubevirtci-installer-pull-token: "true"
       sriov-pod: "true"
+      rehearsal.allowed: "true"
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -81,8 +81,9 @@ presubmits:
             tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&
             export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
-            export KUBEVIRT_NUM_NODES=2 &&
-            make cluster-up
+            export KUBEVIRT_NUM_NODES=2;
+            trap "make cluster-down" EXIT ERR SIGINT SIGTERM;
+            make cluster-up;
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Sriov lane uses [KIND](https://github.com/kubernetes-sigs/kind) infrastructure.
Unlike QEMU VM's based kubevirtci providers where the nodes are VM's and isolated in terms of access to host resources
it is enough to let the prow job pod terminate to cleanup all the resources, using KIND requires 
"gracefully" teardown using `kind` binary to prevent resurrects leak as suggested at https://github.com/kubernetes-sigs/kind/issues/759.

At the current sate if for any reasoner sriov lane is interrupted or failed there will be no cluster deletion using `kind`
 
This PR ensures that sriov lane job will teardown the KIND cluster that was created inside the prow job pod
gracefully using `kind` binary in any case.