### PR TITLE
Include all the required modules in ansible requirements

### DIFF
--- a/github/ci/README.md
+++ b/github/ci/README.md
@@ -72,7 +72,7 @@ installerPullToken: 'pullSecret: {"auths":{"cloud.openshift.com":{"auth":"test",
 
 Create a virtual environment and activate it:
 ```
-python3 -m venv venv --system-site-packages
+python3 -m venv venv
 source ./venv/bin/activate
 ```
 Now you can install ansible and the required dependencies in the virtual environment:

--- a/github/ci/kubernetes_crud/README.md
+++ b/github/ci/kubernetes_crud/README.md
@@ -103,7 +103,7 @@ This role uses molecule for testing.
 From `github/ci/kubernetes_crud/`, create a python virtualenv and install all
 the required packages:
 
-    python3 -m venv venv --system-site-packages
+    python3 -m venv venv
     source ./venv/bin/activate
     pip install -r requirements.txt
 

--- a/github/ci/kubernetes_crud/requirements.txt
+++ b/github/ci/kubernetes_crud/requirements.txt
@@ -3,3 +3,4 @@ kubernetes == 11.0.0
 kubernetes-validate == 1.19.0
 molecule == 3.1.5
 openshift == 0.11.2
+selinux == 0.2.1

--- a/github/ci/requirements.txt
+++ b/github/ci/requirements.txt
@@ -1,3 +1,4 @@
 ansible == 2.10.3
 kubernetes == 11.0.0
 openshift == 0.11.2
+selinux == 0.2.1


### PR DESCRIPTION
Instead of relying on virtual environments created with `--system-site-packages` (and depending on what is installed in the host) declare all the needed packages in requirements.txt.

cc/ @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>