### PR TITLE
Add job to upload testing manifests for releases

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -267,3 +267,107 @@ periodics:
         resources:
           requests:
             memory: "29Gi"
+# FIXME: temporary job, to be deleted when the releases are done by prow
+- name: periodic-kubevirt-update-release-0.34-testing-manifests
+  cluster: ibm-prow-jobs
+  cron: "45 0 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror: "true"
+    preset-shared-images: "true"
+  max_concurrency: 1
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - >
+            release_xy="0.34" &&
+            export release_version="$(
+                curl --fail -s https://api.github.com/repos/kubevirt/kubevirt/releases |
+                jq -r '(.[].tag_name | select( test("-(rc|alpha|beta)") | not ) )' |
+                sort -rV | grep "v$release_xy" | head -1
+            )" &&
+            git checkout "${release_version}" &&
+            make manifests &&
+            gsutil cp -r _out/manifests/testing gs://kubevirt-prow/devel/release/kubevirt/kubevirt/${release_version}/manifests/
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "4Gi"
+        volumeMounts:
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: false
+    volumes:
+      - name: gcs
+        secret:
+          secretName: gcs
+# FIXME: temporary job, to be deleted when the releases are done by prow
+- name: periodic-kubevirt-update-release-0.35-testing-manifests
+  cluster: ibm-prow-jobs
+  cron: "45 0 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror: "true"
+    preset-shared-images: "true"
+  max_concurrency: 1
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+        env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - >
+            release_xy="0.35" &&
+            export release_version="$(
+                curl --fail -s https://api.github.com/repos/kubevirt/kubevirt/releases |
+                jq -r '(.[].tag_name | select( test("-(rc|alpha|beta)") | not ) )' |
+                sort -rV | grep "v$release_xy" | head -1
+            )" &&
+            git checkout "${release_version}" &&
+            make manifests &&
+            gsutil cp -r _out/manifests/testing gs://kubevirt-prow/devel/release/kubevirt/kubevirt/${release_version}/manifests/
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "4Gi"
+        volumeMounts:
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: false
+    volumes:
+      - name: gcs
+        secret:
+          secretName: gcs


### PR DESCRIPTION
The openshift-ci periodics require the testing manifests to be uploaded
to gcs so that they can get deployed from there during the nightly smoke
test preparations. This job uploads them automatically for the
0.34 and 0.35 release.

Fixes kubevirt/kubevirt#4562

/cc @fgimenez @oshoval 