### PR TITLE
cnao, 0.42: Increase lifecycle test timeouts

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
@@ -8,8 +8,8 @@ presubmits:
       optional: false
       decorate: true
       decoration_config:
-        timeout: 3h
-        grace_period: 5m
+        timeout: 4h
+        grace_period: 10m
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"


### PR DESCRIPTION
With the latest release at 0.42 branch we are hitting 3h limit [1],
let's increment that and also the grace period.

[1] https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/667/pull-e2e-cluster-network-addons-operator-lifecycle-k8s/1329739606412759040