### PR TITLE
Use docker proxy for kubevirt nightly

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -141,14 +141,19 @@ periodics:
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
     preset-kubevirtci-docker-credential: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
   spec:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+    - image: kubevirtci/bootstrap:v20201119-a5880e0
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -158,8 +163,6 @@ periodics:
         - "-c"
         - >
           cat $DOCKER_PASSWORD | docker login --username $(cat $DOCKER_USER) --password-stdin &&
-          git clone https://github.com/kubevirt/kubevirt.git &&
-          cd kubevirt &&
           export DOCKER_PREFIX='kubevirtnightlybuilds' &&
           export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)" &&
           make &&
@@ -169,8 +172,7 @@ periodics:
           build_date="$(date +%Y%m%d)" &&
           echo ${build_date} > _out/build_date &&
           bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}" &&
-          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml gs://$bucket_dir/kubevirt-operator.yaml &&
-          gsutil cp ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/kubevirt-cr.yaml &&
+          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/ &&
           gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/ &&
           gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/ &&
           gsutil cp ./_out/commit gs://$bucket_dir/commit &&
@@ -185,7 +187,6 @@ periodics:
         - name: gcs
           mountPath: /etc/gcs
           readOnly: false
-      restartPolicy: OnFailure
     volumes:
       - name: gcs
         secret:


### PR DESCRIPTION
Also replace git clone with extra_refs, and simplify copying of files to
gcs a bit.

Test job run: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-master/1331538968650452994

/cc @fgimenez 