### PR TITLE
Make srivo kind up lane mandatory

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - name: check-up-kind-1.17-sriov
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
We must not merge PRs that breaks sriov provider.

Signed-off-by: Quique Llorente <ellorent@redhat.com>