### PR TITLE
knmstate, publish: Use env var for github email

### DIFF
--- a/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -25,6 +25,8 @@ postsubmits:
               value: "../project-infra/hack/git-askpass.sh"
             - name: GITHUB_USER
               value: kubevirt-bot
+            - name: GITHUB_EMAIL
+              value: rmohr+kubebot@redhat.com
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"


### PR DESCRIPTION
To keep kubevirtbot email at project-infra this change pass it as env
var so publish.sh can consume it.

Signed-off-by: Quique Llorente <ellorent@redhat.com>