### PR TITLE
SRIOV Lanes Jobs: Remove Rehearsal Plugin Labels

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -182,7 +182,6 @@ presubmits:
       preset-docker-mirror: "true"
       preset-shared-images: "true"
       sriov-pod: "true"
-      rehearsal.allowed: "true"
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -14,7 +14,6 @@ presubmits:
       preset-docker-mirror: "true"
       preset-kubevirtci-installer-pull-token: "true"
       sriov-pod: "true"
-      rehearsal.allowed: "true"
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic


### PR DESCRIPTION
There are rehearsal plugin labels leftovers on sriov lane jobs
this PR removes them to prevent invoking the lane on any rehearsal plugin usage

Signed-off-by: Or Mergi <ormergi@redhat.com>