### PR TITLE
Adapt nightly HCO to new build-manifests

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -32,6 +32,7 @@ periodics:
           cd hyperconverged-cluster-operator &&
           latest_kubevirt=$(curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest) &&
           latest_kubevirt_image=$(curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${latest_kubevirt}/kubevirt-operator.yaml | grep 'OPERATOR_IMAGE' -A1 | tail -n 1 | sed 's/.*value: //g') &&
+          IFS=: read kv_image kv_tag <<< ${latest_kubevirt_image} &&
           latest_kubevirt_commit=$(curl -sL https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${latest_kubevirt}/commit) &&
           go mod edit -require kubevirt.io/kubevirt@${latest_kubevirt_commit} &&
           go mod vendor &&
@@ -48,8 +49,12 @@ periodics:
           export IMAGE_TAG="${build_date}_$(git show -s --format=%h)" &&
           make container-build-operator &&
           make container-push-operator &&
-          export OPERATOR_IMAGE=${IMAGE_REGISTRY}/${DOCKER_PREFIX}/hyperconverged-cluster-operator:${IMAGE_TAG} &&
-          export KUBEVIRT_IMAGE=${IMAGE_REGISTRY}/${latest_kubevirt_image} &&
+          sed -i "s#docker.io/kubevirt/virt-#${kv_image/-*/-}#" deploy/images.csv &&
+          sed -i "s#^KUBEVIRT_VERSION=.*#KUBEVIRT_VERSION=\"${kv_tag}\"#" hack/config &&
+          sed -i "s#quay.io/kubevirt/hyperconverged-cluster-operator#${OPERATOR_IMAGE}#" deploy/images.csv &&
+          sed -i "s#^CSV_VERSION=.*#CSV_VERSION=\"${IMAGE_TAG}\"#" hack/config &&
+          (cd ./tools/digester && go build .) &&
+          ./automation/digester/update_images.sh &&
           ./hack/build-manifests.sh &&
           REGISTRY_NAMESPACE=${DOCKER_PREFIX} CONTAINER_TAG=${IMAGE_TAG} make bundleRegistry &&
           hco_bucket="kubevirt-prow/devel/nightly/release/kubevirt/hyperconverged-cluster-operator" &&


### PR DESCRIPTION
build-manifests no longer supports passing images through environment
variables, we need to update the image files, and use update_images to
fetch the correct digests

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>