### PR TITLE
SRIOV lane jobs: use bash

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -200,7 +200,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
+        - "/bin/bash"
         - "-c"
         - >
             apt update &&
@@ -210,7 +210,7 @@ presubmits:
             export PATH=/usr/local/go/bin:$PATH &&
             export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
             export TARGET=kind-k8s-sriov-1.17.0;
-            trap "make cluster-down" EXIT ERR SIGINT SIGTERM;
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
             automation/test.sh;
         # docker-in-docker needs privileged mode
         securityContext:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
         command:
         - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
+        - "/bin/bash"
         - "-c"
         - >
             apt update &&
@@ -42,7 +42,7 @@ presubmits:
             export PATH=/usr/local/go/bin:$PATH &&
             export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
             export KUBEVIRT_NUM_NODES=2;
-            trap "make cluster-down" EXIT ERR SIGINT SIGTERM;
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
             make cluster-up;
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
`sh` shell does not support catching ERR interrupts
with 'trap' due to that we get `trap: ERR: bad trap` errors:
- check-up-kind-1.17-sriov
   https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/492/check-up-kind-1.17-sriov/1331963388397359104#1:build-log.txt%3A84
-  pull-kubevirt-e2e-kind-1.17-sriov
   https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/4581/pull-kubevirt-e2e-kind-1.17-sriov/1331948919290073090#1:build-log.txt%3A84

This PR changes SRIOV  lanes jobs to use `bash` instead