### PR TITLE
Add retry to push of kubevirt nightly

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -162,20 +162,32 @@ periodics:
         - "/bin/sh"
         - "-c"
         - >
-          cat $DOCKER_PASSWORD | docker login --username $(cat $DOCKER_USER) --password-stdin &&
-          export DOCKER_PREFIX='kubevirtnightlybuilds' &&
-          export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)" &&
-          make &&
-          make push &&
-          make build-functests &&
-          git show -s --format=%H > _out/commit &&
-          build_date="$(date +%Y%m%d)" &&
-          echo ${build_date} > _out/build_date &&
-          bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}" &&
-          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/ &&
-          gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/ &&
-          gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/ &&
-          gsutil cp ./_out/commit gs://$bucket_dir/commit &&
+          set -e;
+          docker login --username $(cat $DOCKER_USER) --password-stdin < $DOCKER_PASSWORD;
+          export DOCKER_PREFIX='kubevirtnightlybuilds';
+          export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)";
+          make;
+          counter=3;
+          while [ $counter -gt 0 ]; do
+              set +e;
+              make push;
+              retval=$?;
+              set -e;
+              if [ $retval -eq 0 ]; then
+                  break;
+              fi;
+              (( counter-- ));
+              sleep 120;
+          done;
+          make build-functests;
+          git show -s --format=%H > _out/commit;
+          build_date="$(date +%Y%m%d)";
+          echo ${build_date} > _out/build_date;
+          bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}";
+          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/;
+          gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/;
+          gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/;
+          gsutil cp ./_out/commit gs://$bucket_dir/commit;
           gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
Adds a scripted retry to the push of the KubeVirt nightly images built,
as since a couple days the push is failing with a simple EOF. Suspicion
is that the rate limit is somehow responsible for this to occur.

/cc @fgimenez