### PR TITLE
Use bash for running the nightly script

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -27,7 +27,7 @@ periodics:
         value: /etc/gcs/service-account.json
       command:
         - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
+        - "/bin/bash"
         - "-c"
         - >
           cat $DOCKER_PASSWORD | docker login --username $(cat $DOCKER_USER) --password-stdin &&


### PR DESCRIPTION
/bin/sh points to /bin/dash and doesn't support the <<< redirection.
Switch to bash.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>