### PR TITLE
Build kubevirt-infra-bootstrap image on top of kubevirtci/bootstrap

### DIFF
--- a/images/kubevirt-infra-bootstrap/Dockerfile
+++ b/images/kubevirt-infra-bootstrap/Dockerfile
@@ -1,20 +1,21 @@
-FROM gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+FROM kubevirtci/bootstrap:v20201119-a5880e0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-upgrade \
         ansible \
-        intltool \
-        osinfo-db-tools \
-        libosinfo-1.0 \
-        expect python-gi \
-        python3-yaml \
-        make \
-        rsync \
+        expect \
         git \
-        libssl-dev \
+        intltool \
+        libosinfo-1.0 \
         libpython-dev \
+        libssl-dev \
+        make \
+        osinfo-db-tools \
+        python-gi \
         python3 \
         python3-pip \
+        python3-yaml \
+        rsync \
         && rm -rf /var/lib/apt/lists/*
 RUN export KUSTOMIZE_DIR=/opt/kustomize \
     && mkdir -p $KUSTOMIZE_DIR \


### PR DESCRIPTION
This will allow us to migrate the jobs based on the kubevirt-infra-bootstrap image to use the docker proxy. Also the packages to be installed are now alphabetically ordered.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>