### PR TITLE
Set Kubevirt SRIOV lane mandatory

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -170,8 +170,7 @@ presubmits:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
     always_run: true
-    optional: true
-    skip_report: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 4h


### PR DESCRIPTION
Kubevrit SRIOV lane should be mandatory and block a given PR if it fails.

Now that SRIOV lane is stabilized and all flaky tests are resolved it is possible to set 
it mandatory.

Please share if there are any problems we should fix first before merging this PR.