### PR TITLE
Publish kubevirt images to quay.io

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -143,7 +143,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
-    preset-kubevirtci-docker-credential: "true"
+    preset-kubevirtci-quay-credential: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -157,14 +157,15 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
+      - name: DOCKER_PREFIX
+        value: quay.io/kubevirt
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
         - >
           set -e;
-          docker login --username $(cat $DOCKER_USER) --password-stdin < $DOCKER_PASSWORD;
-          export DOCKER_PREFIX='kubevirtnightlybuilds';
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io;
           export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)";
           make;
           counter=3;

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -1,0 +1,36 @@
+postsubmits:
+  kubevirt/kubevirt:
+  - name: push-release-kubevirt-images
+    branches:
+    - ^release-\d+\.\d+
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          DOCKER_TAG="$(git tag --points-at HEAD | head -1)" make bazel-push-images
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"


### PR DESCRIPTION
These postsubmit jobs are equivalent to these travis jobs https://github.com/kubevirt/kubevirt/blob/master/.travis.yml#L22-L42 but pushing to quay.io instead of dockerhub. Both prow and travis jobs can run in parallel for a while, as soon as we verify that all is ok we can switch kubevirt code to use the quay images and remove the jobs from travis. 

The repositories have been added to quay.io/kubevirt with a description to distinguish them "Part of kubevirt/kubevirt artifacts", some image names like `conformance` or `tests` can be ambiguous. kubevirtbot user has write access on all of them. 

Successful executions:
push-latest-kubevirt-images: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/push-latest-kubevirt-images/1334400323929772032

push-latest-functest-images: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/push-latest-functest-images/1334412153821597696

push-release-kubevirt-images: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/push-release-kubevirt-images/1334417061262135296

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>