### PR TITLE
cnao, increase lifecycle lane timeout on master

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       optional: false
       decorate: true
       decoration_config:
-        timeout: 3h
+        timeout: 4h
         grace_period: 5m
       max_concurrency: 6
       labels:


### PR DESCRIPTION
following #730, we increase the lifecycle lane of CNAO during release