### PR TITLE
Increase lifecycle job timeout to 4h

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
       optional: true
       decorate: true
       decoration_config:
-        timeout: 3h
+        timeout: 4h
         grace_period: 5m
       max_concurrency: 6
       labels:


### PR DESCRIPTION
Addind a new releas to CNAO reach the 3h limit since an upgrade of all
the releases is done, this PR increment the timeout to 4h to fix that.

Signed-off-by: Quique Llorente <ellorent@redhat.com>