### PR TITLE
Add docker proxy compatible kubekins-e2e image

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -84,3 +84,33 @@ postsubmits:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
+    - name: publish-kubekins-e2e-image
+      always_run: false
+      run_if_changed: "images/kubekins-e2e/.*"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-kubevirtci-quay-credential: "true"
+      spec:
+        nodeSelector:
+          type: vm
+        containers:
+          - image: kubevirtci/bootstrap:v20201119-a5880e0
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
+                ./publish_image.sh kubekins-e2e quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "1Gi"
+              limits:
+                memory: "1Gi"

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -93,6 +93,34 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
+  - name: build-kubekins-e2e-image
+    always_run: false
+    run_if_changed: "images/kubekins-e2e/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      nodeSelector:
+        type: vm
+      containers:
+        - image: kubevirtci/bootstrap:v20201119-a5880e0
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              cd images
+              ./publish_image.sh -b kubekins-e2e quay.io kubevirtci
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
   - name: kubernetes-crud-ci-role
     always_run: false
     run_if_changed: "github/ci/kubernetes-crud/.*"

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+
+RUN cp /usr/local/bin/runner.sh /usr/local/bin/runner_orig.sh
+
+COPY "runner.sh" \
+  "/usr/local/bin/"

--- a/images/kubekins-e2e/runner.sh
+++ b/images/kubekins-e2e/runner.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2020 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+setup_ca(){
+    if [ -f "${CA_CERT_FILE}" ]; then
+        echo "Adding ${CA_CERT_FILE} as a trusted root CA"
+        cp "${CA_CERT_FILE}" /usr/local/share/ca-certificates/
+
+        update-ca-certificates
+    fi
+}
+
+main(){
+    setup_ca
+
+    /usr/local/bin/runner_orig.sh "${@}"
+}
+
+main "${@}"


### PR DESCRIPTION
There are a few jobs that use `gcr.io/k8s-testimages/kubekins-e2e`, this PR creates an image based on it that includes a modified runner to include our proxy CA certificate in the trusted root, same as we did in #704. The repository is already created on quay.io. 

cc/ @dhiller

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>