### PR TITLE
Bump to a config-forker which creates unique job-names

### DIFF
--- a/releng/release-tool/Dockerfile.release-tool-base
+++ b/releng/release-tool/Dockerfile.release-tool-base
@@ -18,7 +18,7 @@ RUN set -x && \
     source /etc/profile.d/gimme.sh && \
     git clone https://github.com/kubernetes/test-infra.git && \
     cd /test-infra && \
-    git checkout fd0699b906b0593a33ba2bddd3b1ae8822f42dd8 && \
+    git checkout def51b2596d3a0a7b19d49596d5afc4ab3354855 && \
     cd /test-infra/robots/pr-creator && \
     go install && \
     cd /test-infra/releng/config-forker && \


### PR DESCRIPTION
The new referenced commit contains https://github.com/kubernetes/test-infra/pull/19009 which should make us more resilient to statusreconciler issues. Note that this PR got reverted later on due to some context expectations  in k8s release scripts in the later pipeline stages.