### PR TITLE
Periodically update kubevirtci cluster major and minor versions

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -276,7 +276,7 @@ periodics:
         args:
           - "-c"
           - bazel_dir=$(mktemp -d) &&
-            curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
+            curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
             hack/git-pr.sh -c "bazelisk run //plugins/cmd/uploader:uploader -- -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt &&
@@ -297,3 +297,85 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
+- name: periodic-kubevirtci-cluster-patchversion-updater
+  interval: 24h
+  max_concurrency: 1
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: master
+    workdir: true
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: master
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+      - image: "kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab"
+        env:
+        - name: GIT_ASKPASS
+          value: ../project-infra/hack/git-askpass.sh
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - bazel_dir=$(mktemp -d) &&
+            curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
+            chmod a+x ${bazel_dir}/bazelisk &&
+            export PATH=${PATH}:${bazel_dir} &&
+            hack/git-pr.sh -c "bazelisk run //robots/kubevirtci-bumper:kubevirtci-bumper -- -ensure-last-three-minor-of v1 --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+        resources:
+          requests:
+            memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token
+- name: periodic-kubevirtci-cluster-minorversion-updater
+  interval: 24h
+  max_concurrency: 1
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: master
+    workdir: true
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: master
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+      - image: "kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab"
+        env:
+        - name: GIT_ASKPASS
+          value: ../project-infra/hack/git-askpass.sh
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - bazel_dir=$(mktemp -d) &&
+            curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
+            chmod a+x ${bazel_dir}/bazelisk &&
+            export PATH=${PATH}:${bazel_dir} &&
+            hack/git-pr.sh -c "bazelisk run //robots/kubevirtci-bumper:kubevirtci-bumper -- -ensure-last --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+        resources:
+          requests:
+            memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token


### PR DESCRIPTION
One periodic updates the current latest three k8s releases to the latest
patch version, the other periodic checks if there is a new minor
version, copies the scripts over to the new minor version provider.