### PR TITLE
Cleanup owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,11 +4,7 @@ filters:
       - davidvossel
       - rmohr
       - stu-gott
-      - booxter
       - vladikr
-      - slintes
-      - cynepco3hahue
-      - danielBelenky
       - dhiller
       - gbenhaim
       - qinqon
@@ -20,8 +16,6 @@ filters:
       - davidvossel
       - vladikr
       - rmohr
-      - cynepco3hahue
-      - danielBelenky
       - dhiller
       - gbenhaim
       - qinqon
@@ -29,3 +23,6 @@ filters:
       - stu-gott
       - jean-edouard
       - fgimenez
+    emeritus_approvers:
+      - cynepco3hahue
+      - danielBelenky


### PR DESCRIPTION
Remove some reviewer suggestions from people which are not or only
sporadically working on kubevirt at this point in time and move two
approvers to the emeritus section for the same reason.

This is needed to get more meaningful reviewers and approvers assigned.