### PR TITLE
Introduce sriov patch nodes script

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -27,3 +27,43 @@ plugin on all the relevant K8s nodes.
 │   └── sriov-passthrough-cni
 └── README.md
 ```
+
+## Prow job usage:
+
+In order to use the CNI and allocate one SR-IOV PF:
+1. Add one of the following annotation to the prow job yaml (both are doing the same):
+
+    [1] `k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni`
+
+    [2] `k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'`
+
+2. Check if `pull-kubevirt-e2e-kind-1.17-sriov` job at [3] has requests/limits of `prow/sriov`, if it does, make sure it request only 1 `prow/sriov`. see [4] for example.
+This will let k8s know that only one PF is allocated (each PF is represented by one `prow/sriov` resource).
+K8s uses these resources in order to know how many jobs can run simultaneously.
+Each SR-IOV node of the CI cluster has `prow/sriov` capacity according to the amount of it's available physical PFs.
+
+[3] https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+
+[4] 
+```bash
+requests:
+  prow/sriov: "1"
+limits:
+  prow/sriov: "1"
+```
+
+* In case 2 PFs are required, please do the following changes:
+
+1. Use the following annotation instead those in the previous [1] section.
+
+    `k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}, {"interface":"net2","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'`
+
+2. Follow [2] of the previous section, but instead of 1 `prow/sriov`, use 2, in order to let k8s know that 2 PFs are
+allocated per job, each PF is represented by a `prow/sriov` resource.
+
+```bash
+requests:
+  prow/sriov: "2"
+limits:
+  prow/sriov: "2"
+```

--- a/hack/patch_node.sh
+++ b/hack/patch_node.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+
+# This script can be used in order to create/remove/update k8s extended resources named prow/sriov
+# see https://kubernetes.io/docs/tasks/administer-cluster/extended-resource-node for more details.
+# The resource will be created node wise, so each sriov node should be configured according
+# the desired capacity (according how many PFs it has, and how many jobs are actually desired to run simultaneously).
+# After creation, the resource would appear as allocatable on node's yaml after around 20 seconds.
+# The following command can be used in order to check it was created successfully.
+# timeout 60s bash -c "until oc get node $NODE -oyaml | grep prow/sriov | grep $CAPACITY | wc -l | grep 2; do sleep 1; done"
+
+# Usage:
+# ./patch_node.sh <NODE_NAME> <CAPACITY>
+
+PROXY_PORT=9999
+if which oc &> /dev/null; then
+  BINARY=oc
+elif which kubectl &> /dev/null; then
+  BINARY=kubectl
+else
+  echo "error: oc / kubectl not found"
+  exit 1
+fi
+
+function finish {
+  rc=$?
+  if jobs -p | xargs kill; then
+    echo -e "\nProxy deleted"
+  fi
+  exit "$rc"
+}
+
+function validate_parameters {
+  local node=$1
+  local capacity=$2
+  if ! $BINARY get node "$node" &> /dev/null; then
+    echo "error: node $node not found"
+    exit 1
+  fi
+
+  if [ -z "${capacity##*[!0-9]*}" ]; then
+    echo "error: capacity $capacity must be greater or equal 0"
+    exit 1
+  fi
+}
+
+function run_proxy {
+  $BINARY proxy -p $PROXY_PORT &
+  sleep 3
+  jobs 1 | grep -q Running
+}
+
+function patch_node {
+  local node=$1
+  local capacity=$2
+  if [ "$capacity" -ne 0 ]; then
+    curl --header "Content-Type: application/json-patch+json" \
+      --request PATCH \
+      --data '[{"op": "add", "path": "/status/capacity/prow~1sriov", "value": "'$capacity'"}]' \
+      http://localhost:$PROXY_PORT/api/v1/nodes/"$node"/status
+  else
+    curl --header "Content-Type: application/json-patch+json" \
+      --request PATCH \
+      --data '[{"op": "remove", "path": "/status/capacity/prow~1sriov"}]' \
+      http://localhost:$PROXY_PORT/api/v1/nodes/"$node"/status
+  fi
+}
+
+function main() {
+  local node=$1
+  local capacity=$2
+  if [ -z "$node" ] || [ -z "$capacity" ]; then
+    echo "syntax error, use: $0 <NODE_NAME> <CAPACITY>"
+    exit 1
+  fi
+
+  validate_parameters "$node" "$capacity"
+
+  trap finish EXIT
+  run_proxy
+
+  patch_node "$node" "$capacity"
+}
+
+main "$@"


### PR DESCRIPTION
The script is meant to create/remove/update extended resources
named `prow/sriov`, in order to control how many
jobs each sriov node can run simultaneously
according how many sriov PFs it has.

After creating the resources, they would appear as allocatable,
after around 30 seconds.

Verified that It survives node reboot.

Signed-off-by: Or Shoval <oshoval@redhat.com>