### PR TITLE
Add missing prow configuration patches

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/yq_scripts/config.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/yq_scripts/config.yaml
@@ -11,3 +11,9 @@
 - command: update
   path: deck.spyglass.gcs_browser_prefix
   value: https://gcsweb.kubevirt.io/gcs/
+- command: update
+  path: plank.job_url_prefix_config.*
+  value: https://prow.kubevirt.io/view/gcs/
+- command: update
+  path: tide.pr_status_base_urls.*
+  value: https://prow.kubevirt.io/pr


### PR DESCRIPTION
Set the right prod URLs in two additional configuration paths.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>