### PR TITLE
Support `rpm` workspace artifacts in the mirror plugin

### DIFF
--- a/plugins/mirror/bazel.go
+++ b/plugins/mirror/bazel.go
@@ -53,7 +53,7 @@ func WriteWorkspace(dryRun bool, workspace *build.File, path string) error {
 }
 
 func GetArtifacts(workspace *build.File) (artifacts []Artifact, err error) {
-	for _, ruleName := range []string{"http_archive", "http_file"} {
+	for _, ruleName := range []string{"http_archive", "http_file", "rpm"} {
 		rules := workspace.Rules(ruleName)
 		for _, rule := range rules {
 			artifacts = append(artifacts, Artifact{

--- a/plugins/mirror/bazel_test.go
+++ b/plugins/mirror/bazel_test.go
@@ -14,6 +14,13 @@ http_archive(
     urls = ["https://github.com/rmohr/rules_container_rpm/archive/v0.0.5.tar.gz"],
 )
 
+rpm(
+    name = "io_bazel_rules_container_rpm1",
+    sha256 = "151261f1b81649de6e36f027c945722bff31176f1340682679cade2839e4b1e1",
+    strip_prefix = "rules_container_rpm-0.0.5",
+    urls = ["https://github.com/rmohr/rules_container_rpm/archive/v0.0.5.tar.gz"],
+)
+
 http_archive(
     name = "io_bazel_rules_container_rpm1",
     sha256 = "151261f1b81649de6e36f027c945722bff31176f1340682679cade2839e4b1e1",
@@ -48,12 +55,12 @@ func Test(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(artifacts) != 4 {
-		t.Fatalf("expect 4 artifacts, found %v", len(artifacts))
+	if len(artifacts) != 5 {
+		t.Fatalf("expect 5 artifacts, found %v", len(artifacts))
 	}
 
 	invalid := FilterArtifactsWithoutMirror(artifacts, regexp.MustCompile(`^https://kubevirt.storage.googleapis.com/.+`))
-	if len(invalid) != 2 {
-		t.Fatalf("expect 2 invalid artifacts, found %v", len(artifacts))
+	if len(invalid) != 3 {
+		t.Fatalf("expect 3 invalid artifacts, found %v", len(invalid))
 	}
 }


### PR DESCRIPTION
Mirror `rpm` bazel artifacts to our GCS store.

A preparation for https://github.com/kubevirt/kubevirt/pull/4703.