### PR TITLE
Improve mirror download behaviour

### DIFF
--- a/plugins/cmd/uploader/uploader.go
+++ b/plugins/cmd/uploader/uploader.go
@@ -63,9 +63,9 @@ func main() {
 
 	for _, artifact := range invalid {
 		newFileUrl := mirror.GenerateFilePath(options.bucket, &artifact)
-		err := mirror.WriteToBucket(options.dryRun, ctx, client, artifact.URLs()[0], options.bucket, artifact.SHA256())
+		err := mirror.WriteToBucket(options.dryRun, ctx, client, artifact, options.bucket)
 		if err != nil {
-			log.Fatalf("failed to upload %s to %s: %s", artifact.URLs()[0], newFileUrl, err)
+			log.Fatalf("failed to upload %s to %s: %s", artifact.Name(), newFileUrl, err)
 		}
 		artifact.AppendURL(newFileUrl)
 	}

--- a/plugins/mirror/bazel_test.go
+++ b/plugins/mirror/bazel_test.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/bazelbuild/buildtools/build"
 )
-	var data = []byte(`
+
+var data = []byte(`
 http_archive(
     name = "io_bazel_rules_container_rpm",
     sha256 = "151261f1b81649de6e36f027c945722bff31176f1340682679cade2839e4b1e1",


### PR DESCRIPTION
 * Check if we have to do an upload before opening a connection to the
   source.
 * Try to connect to the source with all available artifact urls and not
   just with the first one.

Signed-off-by: Roman Mohr <rmohr@redhat.com>