### PR TITLE
Give kubevirtci bumpers explicit bump branch names

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -327,7 +327,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/kubevirtci-bumper:kubevirtci-bumper -- -ensure-last-three-minor-of v1 --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci
+            hack/git-pr.sh -c "bazelisk run //robots/kubevirtci-bumper:kubevirtci-bumper -- -ensure-last-three-minor-of v1 --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci -b patch-version-bump
         volumeMounts:
         - name: token
           mountPath: /etc/github
@@ -368,7 +368,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci
+            hack/git-pr.sh -c "bazelisk run //robots/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci -b minor-version-bump
         volumeMounts:
         - name: token
           mountPath: /etc/github


### PR DESCRIPTION
Ensure that every kubevirtci bump job has its own unique branch in
kubevirt-bot/kubevirti.