### PR TITLE
Increase mem request and limit to 1Gi for plank

### DIFF
--- a/github/ci/prow/templates/plank-deployment.yaml
+++ b/github/ci/prow/templates/plank-deployment.yaml
@@ -53,6 +53,11 @@ spec:
         - name: remote-cluster-kubeconfig
           mountPath: /etc/remote_cluster_config
           readOnly: true
+        resources:
+          requests:
+            memory: 1Gi
+          limits:
+            memory: 1Gi
       volumes:
       - name: oauth
         secret:


### PR DESCRIPTION
Plank was OOMKilled regularly and thus in CrashLoopBackoff, therefore we increase mem request and limit to 1Gi.

/cc @rmohr 