### PR TITLE
Bump plank resources in automated Prow deploy.

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   # templated resources
   - resources/admin-rbac.yaml
 
+patchesStrategicMerge:
+  - patches/StrategicMerge/plank_deployment_replicas.yaml
 
 patches:
   - target:

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/plank_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/plank_deployment.yaml
@@ -1,6 +1,3 @@
 - op: add
-  path: /spec/template/spec/containers/0/args/1
-  value: --github-endpoint=http://ghproxy
-- op: add
-  path: /spec/template/spec/containers/0/args/1
-  value: --github-endpoint=https://api.github.com
+  path: /spec/template/spec/containers/0/resources
+  value: {"requests": {"memory": "1Gi"}, "limits": {"memory": "1Gi"}}

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/StrategicMerge/plank_deployment_replicas.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/StrategicMerge/plank_deployment_replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plank
+spec:
+  replicas: 1

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/kustomization.yaml
@@ -15,6 +15,7 @@ patchesStrategicMerge:
   - patches/StrategicMerge/hook_deployment.yaml
   - patches/StrategicMerge/nginx-ingress.yaml
   - patches/StrategicMerge/deck_deployment_replicas.yaml
+  - patches/StrategicMerge/plank_deployment_replicas.yaml
 
 patches:
   - target:

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/patches/JsonRFC6902/plank_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/patches/JsonRFC6902/plank_deployment.yaml
@@ -1,6 +1,3 @@
 - op: add
-  path: /spec/template/spec/containers/0/args/1
-  value: --github-endpoint=http://ghproxy
-- op: add
-  path: /spec/template/spec/containers/0/args/1
-  value: --github-endpoint=https://api.github.com
+  path: /spec/template/spec/containers/0/resources
+  value: {"requests": {"memory": "1Gi"}, "limits": {"memory": "1Gi"}}

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/patches/StrategicMerge/plank_deployment_replicas.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/patches/StrategicMerge/plank_deployment_replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plank
+spec:
+  replicas: 1


### PR DESCRIPTION
Applies the same changes as in #799 to increase plank resources. 

Also includes patches to set plank deployment replicas to 1, defaults to 0 here https://github.com/kubevirt/project-infra/blob/master/github/ci/prow-deploy/kustom/base/manifests/test_infra/e88598c4a7f86e0564a2d8b46ce5f729247791e6/plank_deployment.yaml#L26 looks like prow-controller-manager is preferred upstream, in the latest versions plank has been completely removed.

cc/ @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>