### PR TITLE
Fix nodeSelector declaration for presubmit jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -160,9 +160,9 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    nodeSelector:
-      type: bare-metal-external
     spec:
+      nodeSelector:
+        type: bare-metal-external
       securityContext:
         runAsUser: 0
       containers:
@@ -214,10 +214,10 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    nodeSelector:
-      type: bare-metal-external
     skip_report: true
     spec:
+      nodeSelector:
+        type: bare-metal-external
       securityContext:
         runAsUser: 0
       containers:


### PR DESCRIPTION
`nodeSelector` was declared in the wrong place for `prow-deploy-test` and `cert-manager-deploy-test` jobs, causing connectivity errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/794/prow-deploy-test/1346377627543277568 when the job was not scheduled on a bare metal node

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>