### PR TITLE
Fix ci-search-deploy-test job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -209,7 +209,7 @@ presubmits:
           secretName: gcs
   - name: cert-manager-deploy-test
     always_run: false
-    run_if_changed: "github/ci/services/cert-manager.*"
+    run_if_changed: "github/ci/services/cert-manager/.*|github/ci/services/common/.*|vendor/.*"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -253,15 +253,15 @@ presubmits:
               memory: "16Gi"
   - name: ci-search-deploy-test
     always_run: false
-    run_if_changed: "github/ci/services/ci-search.*"
+    run_if_changed: "github/ci/services/ci-search/.*|github/ci/services/common/.*|vendor/.*"
     decorate: true
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    nodeSelector:
-      type: bare-metal-external
     skip_report: true
     spec:
+      nodeSelector:
+        type: bare-metal-external
       securityContext:
         runAsUser: 0
       containers:


### PR DESCRIPTION
Same nodeSelector fix as in #806 but for ci-search-deploy-test. It also includes changes to trigger presubmit tests for cert-manager and ci-search deploy on changes of its own code, the common services library and vendor.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>