### PR TITLE
sriov provider - Sriov multi job POC

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -272,6 +272,82 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
+  - name: pull-kubevirt-e2e-kind-1.17-sriov
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 30m
+    max_concurrency: 10
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      sriov-pod: "true"
+      rehearsal.allowed: "true"
+    spec:
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - image: kubevirtci/bootstrap:v20201119-a5880e0
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/bash"
+        - "-c"
+        - >
+            apt update &&
+            apt install gettext-base -y &&
+            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
+            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
+            export PATH=/usr/local/go/bin:$PATH &&
+            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
+            export TARGET=kind-k8s-sriov-1.17.0;
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
+            automation/test.sh;
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "29Gi"
+        volumeMounts:
+          #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+          - name: modules
+            mountPath: /lib/modules
+            readOnly: true
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: vfio
+            mountPath: /dev/vfio/
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio/
+            type: Directory
 
   - name: pull-kubevirt-check-tests-for-flakes
     skip_branches:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -272,14 +272,14 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
-  - name: pull-kubevirt-e2e-kind-1.17-sriov
+  - name: pull-kubevirt-e2e-kind-1.17-sriov-multi
     skip_branches:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: true
-    optional: false
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni-multi
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 4h
@@ -289,11 +289,11 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      sriov-pod: "true"
+      #sriov-pod: "true" # we control this lane by extended resources (prow/sriov)
       rehearsal.allowed: "true"
     spec:
       nodeSelector:
-        hardwareSupport: sriov-nic
+        hardwareSupport: sriov-nic-multi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -326,6 +326,9 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
+            prow/sriov: "1"
+          limits:
+            prow/sriov: "1"
         volumeMounts:
           #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
           - name: modules

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -72,24 +72,24 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
-  - name: check-up-kind-1.17-sriov
+  - name: check-up-kind-1.17-sriov-multi
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: true
-    optional: false
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni-multi
+    always_run: false
+    optional: true
     decorate: true
     decoration_config:
       timeout: 1h
-    max_concurrency: 1
+    max_concurrency: 10
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-installer-pull-token: "true"
-      sriov-pod: "true"
+      #sriov-pod: "true" # we control this lane by extended resources (prow/sriov)
       rehearsal.allowed: "true"
     spec:
       nodeSelector:
-        hardwareSupport: sriov-nic
+        hardwareSupport: sriov-nic-multi
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -122,6 +122,9 @@ presubmits:
         resources:
           requests:
             memory: "15Gi"
+            prow/sriov: "1"
+          limits:
+            prow/sriov: "1"
         volumeMounts:
           #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
           - name: modules

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -72,6 +72,78 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
+  - name: check-up-kind-1.17-sriov
+    annotations:
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-installer-pull-token: "true"
+      sriov-pod: "true"
+      rehearsal.allowed: "true"
+    spec:
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - image: kubevirtci/bootstrap:v20201119-a5880e0
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/bash"
+        - "-c"
+        - >
+            apt update &&
+            apt install gettext-base -y &&
+            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
+            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
+            export PATH=/usr/local/go/bin:$PATH &&
+            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
+            export KUBEVIRT_NUM_NODES=2;
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
+            make cluster-up;
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "15Gi"
+        volumeMounts:
+          #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+          - name: modules
+            mountPath: /lib/modules
+            readOnly: true
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: vfio
+            mountPath: /dev/vfio/
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio/
+            type: Directory
 
   - name: check-provision-k8s-1.18
     always_run: true


### PR DESCRIPTION
In order to test multi sriov jobs POC, we need those new lanes that will
allow us to run jobs on one node in CNV cluster, with minimal interfering to the real jobs.
`check-up-kind-1.17-sriov-multi`
`pull-kubevirt-e2e-kind-1.17-sriov-multi`

The node `ovirt-srv17.phx.ovirt.org`  was updated to not run offical sriov jobs,
but to run the special jobs that this PR suggests.
Allowing them to run more than one job at the same time, on the mentioned node (only).

In order to run the multi sriov POC on CNI node,
This PR updates the CNI to use the
updated multi sriov CNI [1], which allocate only 1 PF per call.
It also uses extended resources named `prow/sriov`
in order to control how many jobs can run
simultaneously on the node [2].

Depends on (which were applied manually to `ovirt-srv17.phx.ovirt.org`):
[1] https://github.com/kubevirt/project-infra/pull/801
[2] https://github.com/kubevirt/project-infra/pull/784
