### PR TITLE
prow-deploy: bump kubevirtci tag

### DIFF
--- a/github/ci/prow-deploy/molecule/default/collect_resource.yml
+++ b/github/ci/prow-deploy/molecule/default/collect_resource.yml
@@ -19,7 +19,7 @@
     ARTIFACTS_DIR: "{{ artifacts_dir }}"
     KUBECTL_CMD: "{{ kubectl_prow }}"
     KUBEVIRT_PROVIDER: "{{ kubevirtci_provider }}"
-    KUBEVIRTCI_TAG: "{{ kubevirt_tag }}"
+    KUBEVIRTCI_TAG: "{{ kubevirtci_tag }}"
 
   loop: "{{ resource_list.resources }}"
   loop_control:

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -9,7 +9,7 @@ kubevirtci_provider: k8s-1.19
 kubevirt_num_nodes: 2
 kubevirt_num_secondary_nics: 1
 kubevirt_memory_size: 16384
-kubevirt_tag: 2101060913-2e49157
+kubevirtci_tag: 2101060913-2e49157
 kubeconfig_path: '{{ kubevirtci_dir }}/_ci-configs/{{ kubevirtci_provider }}/.kubeconfig'
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/'
 
@@ -18,4 +18,4 @@ shell_environment:
   KUBEVIRT_NUM_NODES: "{{ kubevirt_num_nodes }}"
   KUBEVIRT_NUM_SECONDARY_NICS: "{{ kubevirt_num_secondary_nics }}"
   KUBEVIRT_MEMORY_SIZE: "{{ kubevirt_memory_size }}"
-  KUBEVIRTCI_TAG: "{{ kubevirt_tag }}"
+  KUBEVIRTCI_TAG: "{{ kubevirtci_tag }}"

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -9,7 +9,7 @@ kubevirtci_provider: k8s-1.19
 kubevirt_num_nodes: 2
 kubevirt_num_secondary_nics: 1
 kubevirt_memory_size: 16384
-kubevirt_tag: 2010091151-ea2c81d
+kubevirt_tag: 2101060913-2e49157
 kubeconfig_path: '{{ kubevirtci_dir }}/_ci-configs/{{ kubevirtci_provider }}/.kubeconfig'
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/'
 


### PR DESCRIPTION
This will prevent errors like:
```
"./cluster-up/up.sh", "unknown flag: --run-etcd-on-memory
```
here https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/811/prow-deploy-test/1346802302165454848

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>