### PR TITLE
Add ci-search readme

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -221,14 +221,16 @@ postsubmits:
               curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
               chmod +x ./yq && mv ./yq /usr/local/bin/yq
 
-              # unencrypt and put in place secrets
+              # unencrypt secrets
               target_dir=$(mktemp -d)
               git clone https://kubevirt-bot:$(cat ${GITHUB_TOKEN})@github.com/kubevirt/secrets ${target_dir}
               gpg --allow-secret-key-import --import /etc/pgp/token
               gpg --decrypt ${target_dir}/secrets.tar.asc > secrets.tar
               tar -xvf secrets.tar
-              yq r main.yml 'kubeconfig' > ${target_dir}/kubeconfig
-              export KUBECONFIG=${target_dir}/kubeconfig
+
+              # put in place kubeconfig
+              mkdir -p ~/.kube
+              yq r main.yml 'kubeconfig' > ~/.kube/config
 
               ./github/ci/services/cert-manager/hack/deploy.sh production
           resources:
@@ -287,8 +289,8 @@ postsubmits:
               tar -xvf secrets.tar
 
               # put in place kubeconfig
-              yq r main.yml 'kubeconfig' > ${target_dir}/kubeconfig
-              export KUBECONFIG=${target_dir}/kubeconfig
+              mkdir -p ~/.kube
+              yq r main.yml 'kubeconfig' > ~/.kube/config
 
               # put in place bugzilla api key
               yq r main.yml 'bugzilla.apiKey' > github/ci/services/ci-search/secrets/production/bugzilla-credentials

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -209,7 +209,7 @@ presubmits:
           secretName: gcs
   - name: cert-manager-deploy-test
     always_run: false
-    run_if_changed: "github/ci/services/cert-manager/.*|github/ci/services/common/.*|vendor/.*"
+    run_if_changed: "github/ci/services/cert-manager/.*|github/ci/services/common/.*|vendor/.*|WORKSPACE"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -237,8 +237,6 @@ presubmits:
 
               # create test cluster
               kind create cluster
-              kind get kubeconfig > $(pwd)/kubeconfig
-              export KUBECONFIG=$(pwd)/kubeconfig
 
               ./github/ci/services/cert-manager/hack/deploy.sh testing
 
@@ -253,7 +251,7 @@ presubmits:
               memory: "16Gi"
   - name: ci-search-deploy-test
     always_run: false
-    run_if_changed: "github/ci/services/ci-search/.*|github/ci/services/common/.*|vendor/.*"
+    run_if_changed: "github/ci/services/ci-search/.*|github/ci/services/common/.*|vendor/.*|WORKSPACE"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -281,8 +279,6 @@ presubmits:
 
               # create test cluster
               kind create cluster
-              kind get kubeconfig > $(pwd)/kubeconfig
-              export KUBECONFIG=$(pwd)/kubeconfig
 
               ./github/ci/services/ci-search/hack/deploy.sh testing
 

--- a/github/ci/services/ci-search/README.md
+++ b/github/ci/services/ci-search/README.md
@@ -1,0 +1,30 @@
+# ci-search
+
+Customization and deployment of [Openshift's ci-search] on Kubevirt CI cluster.
+It uses internally these bazel [gitops rules].
+
+## Deployment
+
+You need:
+* a kubernetes configuration at `~/.kube/config` with an user allowed to
+create [these resources](./manifests).
+* [bazelisk] installed.
+
+Then, from the root of project-infra run:
+```
+$ ./github/ci/services/ci-search/hack/deploy.sh production
+```
+
+## Tests
+
+Can be tested locally using [kind] and [bazelisk], from the root of project-infra:
+```
+$ kind create cluster
+$ ./github/ci/services/ci-search/hack/deploy.sh testing
+$ bazelisk test //github/ci/services/ci-search/e2e:go_default_test --test_output=all --test_arg=-test.v
+```
+
+[gitops rules]: https://github.com/adobe/rules_gitops#:~:text=Bazel%20GitOps%20Rules,kustomize%20overlays%20for%20their%20services.
+[Openshift's ci-search]: https://github.com/openshift/ci-search
+[kind]: https://github.com/kubernetes-sigs/kind
+[bazelisk]: https://github.com/bazelbuild/bazelisk


### PR DESCRIPTION
Besides $subject it tweaks the ci-search and cert-manager deployment and test jobs:
* tests are triggered on `WORKSPACE` changes too
* no need to extract kind config in tests, rely on the default config file.
* for deployments, use config file instead of env var.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>