### PR TITLE
Add testgrid configuration

### DIFF
--- a/github/ci/prow/files/config.yaml
+++ b/github/ci/prow/files/config.yaml
@@ -21,6 +21,8 @@ deck:
   spyglass:
     size_limit: 500000000 # 500MB
     gcs_browser_prefix: https://gcsweb.apps.ovirt.org/gcs/
+    testgrid_config: gs://k8s-testgrid/config
+    testgrid_root: https://testgrid.k8s.io/
     lenses:
     - lens:
         name: metadata

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -353,7 +353,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -385,7 +384,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: false
     skip_report: false
     optional: true
@@ -452,7 +450,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -559,7 +556,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -591,7 +587,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -623,7 +618,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -656,7 +650,6 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -5,6 +5,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: false
     optional: true
     skip_report: true
@@ -38,6 +39,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     skip_report: false
@@ -71,6 +73,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     skip_report: false
@@ -104,6 +107,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     skip_report: false
@@ -137,6 +141,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     decorate: true
@@ -169,6 +174,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     decorate: true
@@ -202,6 +208,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     decorate: true
@@ -278,6 +285,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: true
     decorate: true
@@ -310,6 +318,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
     skip_report: false
@@ -344,6 +353,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -375,6 +385,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: false
     skip_report: false
     optional: true
@@ -408,6 +419,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       rehearsal.allowed: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: false
     skip_report: true
     optional: true
@@ -440,6 +452,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -471,6 +484,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -502,6 +516,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: false
     skip_report: true
     optional: true
@@ -544,6 +559,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -575,6 +591,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -606,6 +623,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false
@@ -638,6 +656,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
     always_run: true
     skip_report: false
     optional: false


### PR DESCRIPTION
Spyglass config pointing to https://testgrid.k8s.io/ instance and basic annotations for kubevirt/kubevirt presubmits.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>