### PR TITLE
sriov cni, Add NetworkAttachmentDefinition missing namespace

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
+++ b/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
@@ -106,6 +106,7 @@ apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
   name: sriov-passthrough-cni
+  namespace: multus-cni-ns
 spec:
   config: |
     {


### PR DESCRIPTION
Prow jobs use network multus-cni-ns/sriov-passthrough-cni. 
CI has the NAD deployed in multus-cni-ns as the jobs expect [1],
but the NAD manifest doesnt state which namespace to use, 
so the NAD will be created in the default cluster namespace,
and will be unreachable by the jobs.

[1]
```
#  oc get net-attach-def --all-namespaces
NAMESPACE           NAME                          AGE
multus-cni-ns       sriov-passthrough-cni         1y
```

Signed-off-by: Or Shoval <oshoval@redhat.com>