### PR TITLE
sriov lanes, Add podAntiAffinity of sriov-pod-multi

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.20.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.20.yaml
@@ -383,6 +383,10 @@ presubmits:
                   operator: In
                   values:
                   - "true"
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
               topologyKey: kubernetes.io/hostname
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.23.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.23.yaml
@@ -319,7 +319,11 @@ presubmits:
                   operator: In
                   values:
                   - "true"
-              topologyKey: kubernetes.io/hostname
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname              
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.24.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.24.yaml
@@ -385,6 +385,10 @@ presubmits:
                 operator: In
                 values:
                 - "true"
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
             topologyKey: kubernetes.io/hostname
       containers:
       - command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.26.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.26.yaml
@@ -416,7 +416,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.29.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.29.yaml
@@ -389,7 +389,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -389,7 +389,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
@@ -420,7 +420,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
@@ -420,7 +420,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
@@ -419,7 +419,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -451,7 +451,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.35.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.35.yaml
@@ -176,7 +176,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -176,7 +176,11 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -234,7 +234,11 @@ presubmits:
                   operator: In
                   values:
                   - "true"
-              topologyKey: kubernetes.io/hostname
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname              
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -27,7 +27,11 @@ presubmits:
                     operator: In
                     values:
                       - "true"
-              topologyKey: kubernetes.io/hostname
+                  - key: sriov-pod-multi
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname              
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:


### PR DESCRIPTION
There is an effort of creating a multi sriov POC.
In order to be able to run it on CI, with minimal interference to
the official jobs, this commit suggests adding a cross
`podAntiAffinity`, so official jobs won't be run when the POC
is running (manually triggered only for now), and vice versa.

This will allow us to continue testing the effort with minimal interruption.

Signed-off-by: Or Shoval <oshoval@redhat.com>