### PR TITLE
Fix ci-search deployment

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -293,7 +293,7 @@ postsubmits:
               yq r main.yml 'kubeconfig' > ~/.kube/config
 
               # put in place bugzilla api key
-              yq r main.yml 'bugzilla.apiKey' > github/ci/services/ci-search/secrets/production/bugzilla-credentials
+              yq r main.yml 'bugzilla.apiKey' > github/ci/services/ci-search/secrets/production/bugzilla-credentials/api
 
               ./github/ci/services/ci-search/hack/deploy.sh production
           resources:


### PR DESCRIPTION
Bugzilla token was not being properly created and the main pod was not able to be created.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>