### PR TITLE
Use k8s-prow git image as base

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -192,20 +192,12 @@ periodics:
     work_dir: true
   spec:
     containers:
-    - image: quay.io/kubevirtci/autoowners@sha256:8e0d1d3171afcda91e2948e361ba19b637578af17a09b78d04b09aa424e38828
+    - image: quay.io/kubevirtci/autoowners@sha256:c40b91c8452aba2c2966facd054dad1a8f9a55a9f34779c7afd3ece0da8e3633
       env:
       - name: GIT_ASKPASS
         value: "./hack/git-askpass.sh"
-      - name: GIT_AUTHOR_NAME
-        value: kubevirt-bot
-      - name: GIT_AUTHOR_EMAIL
-        value: rmohr+kubebot@redhat.com
-      - name: GIT_COMMITTER_NAME
-        value: kubevirt-bot
-      - name: GIT_COMMITTER_EMAIL
-        value: rmohr+kubebot@redhat.com
       command:
-        - "autoowners"
+      - "autoowners"
       args:
       - --dry-run=false
       - --self-approve=true

--- a/images/autoowners/Dockerfile
+++ b/images/autoowners/Dockerfile
@@ -7,18 +7,10 @@ RUN mkdir -p /go/src/github.com/openshift/ && \
     cd ci-tools/ && \
     export GOPROXY=off && \
     export GOFLAGS=-mod=vendor && \
-    go install ./cmd/autoowners/...
+    env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/autoowners ./cmd/autoowners/...
 
-FROM centos:7
+FROM gcr.io/k8s-prow/git:v20200605-44f6c96
 
 COPY --from=builder /go/bin/autoowners /usr/bin/autoowners
-
-RUN yum install -y git
-
-# change ownership to allow access
-# when selinux is enabled
-RUN mkdir -p /etc/github && \
-    chgrp -R 0 /etc/github && \
-    chmod -R g+rwX /etc/github
 
 ENTRYPOINT ["/usr/bin/autoowners"]


### PR DESCRIPTION
Also compile statically linked binary and remove superfluous env vars from job.

[Test run](https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-project-infra-autoowners/1348704465342959616)

/cc @fgimenez 
