### PR TITLE
Run kubevirt e2e tests without the buider image to make them more lightweight

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -163,7 +163,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: kubevirtci/bootstrap:v20201119-a5880e0
+    - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -231,7 +231,7 @@ periodics:
     preset-shared-images: "true"
   spec:
     containers:
-    - image: kubevirtci/bootstrap:v20201119-a5880e0
+    - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -287,7 +287,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -321,7 +321,7 @@ periodics:
   max_concurrency: 1
   spec:
     containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -377,7 +377,7 @@ periodics:
   max_concurrency: 1
   spec:
     containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presets.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presets.yaml
@@ -10,3 +10,8 @@ presets:
       value: "8080"
     - name: BAZEL_REMOTE_CACHE_ENABLED
       value: "true"
+- labels:
+    preset-bazel-unnested: "true"
+  env:
+    - name: KUBEVIRT_RUN_UNNESTED
+      value: "true"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -23,6 +23,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: kubevirtci/bootstrap:v20201119-a5880e0
+          env:
+          - name: KUBEVIRT_RUN_UNNESTED
+            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -57,6 +60,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: kubevirtci/bootstrap:v20201119-a5880e0
+          env:
+          - name: KUBEVIRT_RUN_UNNESTED
+            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -91,6 +97,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: kubevirtci/bootstrap:v20201119-a5880e0
+          env:
+          - name: KUBEVIRT_RUN_UNNESTED
+            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -125,6 +134,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: kubevirtci/bootstrap:v20201119-a5880e0
+          env:
+          - name: KUBEVIRT_RUN_UNNESTED
+            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -158,6 +170,9 @@ presubmits:
         type: bare-metal-external
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+        - name: KUBEVIRT_RUN_UNNESTED
+          value: "true"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -191,6 +206,9 @@ presubmits:
         type: bare-metal-external
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+        - name: KUBEVIRT_RUN_UNNESTED
+          value: "true"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -244,6 +262,9 @@ presubmits:
               topologyKey: kubernetes.io/hostname
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+        - name: KUBEVIRT_RUN_UNNESTED
+          value: "true"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
@@ -343,6 +364,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: kubevirtci/bootstrap:v20201119-a5880e0
+          env:
+          - name: KUBEVIRT_RUN_UNNESTED
+            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -18,14 +18,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-          env:
-          - name: KUBEVIRT_RUN_UNNESTED
-            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -55,14 +54,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-          env:
-          - name: KUBEVIRT_RUN_UNNESTED
-            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -92,14 +90,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-          env:
-          - name: KUBEVIRT_RUN_UNNESTED
-            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -129,14 +126,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-          env:
-          - name: KUBEVIRT_RUN_UNNESTED
-            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -165,14 +161,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-        env:
-        - name: KUBEVIRT_RUN_UNNESTED
-          value: "true"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -201,14 +196,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-        env:
-        - name: KUBEVIRT_RUN_UNNESTED
-          value: "true"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -236,8 +230,8 @@ presubmits:
     max_concurrency: 10
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-unnested: "true"
       sriov-pod: "true"
       rehearsal.allowed: "true"
     spec:
@@ -262,9 +256,6 @@ presubmits:
               topologyKey: kubernetes.io/hostname
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-        env:
-        - name: KUBEVIRT_RUN_UNNESTED
-          value: "true"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
@@ -359,14 +350,13 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
-          env:
-          - name: KUBEVIRT_RUN_UNNESTED
-            value: "true"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: KUBEVIRT_RUN_UNNESTED
             value: "true"
@@ -59,7 +59,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: KUBEVIRT_RUN_UNNESTED
             value: "true"
@@ -96,7 +96,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: KUBEVIRT_RUN_UNNESTED
             value: "true"
@@ -133,7 +133,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: KUBEVIRT_RUN_UNNESTED
             value: "true"
@@ -169,7 +169,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
         - name: KUBEVIRT_RUN_UNNESTED
           value: "true"
@@ -205,7 +205,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
         - name: KUBEVIRT_RUN_UNNESTED
           value: "true"
@@ -261,7 +261,7 @@ presubmits:
                   - "true"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
         - name: KUBEVIRT_RUN_UNNESTED
           value: "true"
@@ -329,7 +329,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -363,7 +363,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: KUBEVIRT_RUN_UNNESTED
             value: "true"
@@ -397,7 +397,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -429,7 +429,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -461,7 +461,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -493,7 +493,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -525,7 +525,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -556,7 +556,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
         env:
           - name: COVERALLS_TOKEN_FILE
             value: /root/.docker/secrets/coveralls/token
@@ -598,7 +598,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -629,7 +629,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -660,7 +660,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
           command:
             - "/usr/local/bin/runner.sh"
@@ -692,7 +692,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
           command:
             - "/usr/local/bin/runner.sh"

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -261,8 +261,7 @@ presubmits:
         - "/bin/bash"
         - "-c"
         - >
-            apt update &&
-            apt install gettext-base -y &&
+            dnf install -y gettext &&
             wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
             tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
             export PATH=/usr/local/go/bin:$PATH &&

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -268,7 +268,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"
@@ -318,7 +318,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           env:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -295,7 +295,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -331,7 +331,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210129-9f1d6a8
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"


### PR DESCRIPTION
Change all main presubmits and postsubmits for kubevirt to the new fedora based bootstrap image. This new image allows running the e2e tests without nesting.