### PR TITLE
ci-search: set fs group for mounted volumes

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -204,7 +204,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
           env:
           - name: GITHUB_TOKEN
             value: /etc/github/oauth
@@ -213,10 +213,6 @@ postsubmits:
             - "/bin/bash"
             - "-c"
             - |
-              # install bazelisk
-              curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64
-              chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk
-
               # install yq
               curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
               chmod +x ./yq && mv ./yq /usr/local/bin/yq
@@ -264,7 +260,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
           env:
           - name: GITHUB_TOKEN
             value: /etc/github/oauth
@@ -273,10 +269,6 @@ postsubmits:
             - "/bin/bash"
             - "-c"
             - |
-              # install bazelisk
-              curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64
-              chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk
-
               # install yq
               curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
               chmod +x ./yq && mv ./yq /usr/local/bin/yq

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -218,19 +218,13 @@ presubmits:
     spec:
       nodeSelector:
         type: bare-metal-external
-      securityContext:
-        runAsUser: 0
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
             - |
-              # install bazelisk
-              curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64
-              chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk
-
               # install kind
               curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
               chmod +x ./kind && mv ./kind /usr/local/bin/kind
@@ -244,6 +238,7 @@ presubmits:
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
+            runAsUser: 0
           resources:
             requests:
               memory: "16Gi"
@@ -260,19 +255,13 @@ presubmits:
     spec:
       nodeSelector:
         type: bare-metal-external
-      securityContext:
-        runAsUser: 0
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
             - |
-              # install bazelisk
-              curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64
-              chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk
-
               # install kind
               curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
               chmod +x ./kind && mv ./kind /usr/local/bin/kind
@@ -286,6 +275,7 @@ presubmits:
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
+            runAsUser: 0
           resources:
             requests:
               memory: "16Gi"

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -208,7 +208,7 @@ presubmits:
         secret:
           secretName: gcs
   - name: cert-manager-deploy-test
-    always_run: false
+    optional: false
     run_if_changed: "github/ci/services/cert-manager/.*|github/ci/services/common/.*|vendor/.*|WORKSPACE"
     decorate: true
     labels:
@@ -245,7 +245,7 @@ presubmits:
             limits:
               memory: "16Gi"
   - name: ci-search-deploy-test
-    always_run: false
+    optional: false
     run_if_changed: "github/ci/services/ci-search/.*|github/ci/services/common/.*|vendor/.*|WORKSPACE"
     decorate: true
     labels:

--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -28,6 +28,8 @@ spec:
         - --bugzilla-url=https://bugzilla.redhat.com/rest
         - --bugzilla-search=OPEN version:4.7,4.6,4.5,4.4,4.3,4.2 product="Container Native Virtualization (CNV)" AND delta_ts>-2w
         - --bugzilla-token-file=/etc/bugzilla/api
+      securityContext:
+        fsGroup: 1000
       volumes:
       - name: bugzilla-token
         secret:

--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -24,7 +24,7 @@ spec:
         - --config=/etc/ci-search/config.yaml
         - --interval=10m
         - --path=/var/lib/ci-search/
-        - --deck-uri=https://prow.kubevirt.io
+        - --deck-uri=https://prow.apps.ovirt.org/
         - --bugzilla-url=https://bugzilla.redhat.com/rest
         - --bugzilla-search=OPEN version:4.7,4.6,4.5,4.4,4.3,4.2 product="Container Native Virtualization (CNV)" AND delta_ts>-2w
         - --bugzilla-token-file=/etc/bugzilla/api


### PR DESCRIPTION
The pods were crashlooping:
```
$ kubectl logs search-0 -n ci-search
I0112 12:29:59.483273       1 reaper_linux.go:59] Launching periodic reaper
I0112 12:29:59.483460       1 reaper_linux.go:69] Reaped: []
F0112 12:29:59.483357       1 main.go:57] error: unable to create directory for artifact: mkdir /var/lib/ci-search/bugs: permission denied
```
Signed-off-by: Federico Gimenez <fgimenez@redhat.com>