### PR TITLE
sriov lanes, Add podAntiAffinity of sriov-pod-multi

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.20.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.20.yaml
@@ -384,6 +384,13 @@ presubmits:
                   values:
                   - "true"
               topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.23.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.23.yaml
@@ -320,6 +320,13 @@ presubmits:
                   values:
                   - "true"
               topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.24.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.24.yaml
@@ -386,6 +386,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.26.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.26.yaml
@@ -417,6 +417,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.29.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.29.yaml
@@ -390,6 +390,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -390,6 +390,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.31.yaml
@@ -421,6 +421,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.32.yaml
@@ -421,6 +421,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.33.yaml
@@ -420,6 +420,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -452,6 +452,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.35.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.35.yaml
@@ -177,6 +177,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -177,6 +177,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -235,6 +235,13 @@ presubmits:
                   values:
                   - "true"
               topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -28,6 +28,13 @@ presubmits:
                     values:
                       - "true"
               topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod-multi
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         command:


### PR DESCRIPTION
There is an effort of creating a multi sriov POC.
It will allow running multi sriov lane on the same node, simultaneously.

In order to be able to run it on CI, with minimal interference
to the official jobs, this commit suggests adding a new
`podAntiAffinity`, so official jobs won't be run when the POC
is running (manually triggered only for now), and vice versa.

For example, It will allow us to easily investigate the blocker of the POC,
which appears to be a real issue unrelated to sriov
https://github.com/kubevirt/kubevirt/issues/3886.
Running multi jobs at the same time, allows to simulate
this issue easier, so the investigation should be easier.

Signed-off-by: Or Shoval <oshoval@redhat.com>