### PR TITLE
Assign to prow-job-taskforce

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -212,6 +212,7 @@ periodics:
       - "autoowners"
       args:
       - --dry-run=false
+      - --assign=kubevirt/prow-job-taskforce
       - --self-approve=true
       - --github-login=kubevirt-bot
       - --github-endpoint=http://ghproxy

--- a/github/ci/prow/files/orgs.yaml
+++ b/github/ci/prow/files/orgs.yaml
@@ -512,7 +512,6 @@ orgs:
           - davidvossel
           - codificat
           - rmohr
-          - danielBelenky
           - kubevirt-bot
         members:
           - vladikr
@@ -559,7 +558,6 @@ orgs:
         description: Allow people to assign tasks to themselves
         maintainers:
           - rmohr
-          - danielBelenky
         members:
           - booxter
           - MarSik
@@ -636,9 +634,8 @@ orgs:
         maintainers:
           - dhiller
           - rmohr
-          - danielBelenky
-        members:
           - fgimenez
+        members:
           - phoracek
         privacy: closed
       sig-security:


### PR DESCRIPTION
There were tests failing on the PR which prohibited the automatic merge.
In order to make sure we catch issues with the autoowners job
let's assign it to this group to get notified in case something goes
wrong.

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @fgimenez @rmohr 