### PR TITLE
Ensure bash is used in user-guide jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/user-guide/user-guide-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/user-guide/user-guide-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
         region: primary
       containers:
         - image: docker.io/library/python:3.7
-          command: ["/bin/sh", "-c"]
+          command: ["/bin/bash", "-c"]
           args:
           - |
               python3.7 -m venv /tmp/userguide


### PR DESCRIPTION
'source' is a bash built-in command and it is not available in sh. It may lead to job failure if the interpreter does not point to bash:

    /bin/sh: 1: source: not found

Example of failing job in PR https://github.com/kubevirt/user-guide/pull/378 : https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_user-guide/378/user-guide-presubmit-build/1351077164841177088