### PR TITLE
ci-search: add job-uri-prefix

### DIFF
--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         - --interval=10m
         - --path=/var/lib/ci-search/
         - --deck-uri=https://prow.apps.ovirt.org/
+        - --job-uri-prefix=https://prow.apps.ovirt.org/view/gs/
         - --bugzilla-url=https://bugzilla.redhat.com/rest
         - --bugzilla-search=OPEN version:4.7,4.6,4.5,4.4,4.3,4.2 product="Container Native Virtualization (CNV)" AND delta_ts>-2w
         - --bugzilla-token-file=/etc/bugzilla/api


### PR DESCRIPTION
This will make the links in https://search.ci.kubevirt.io/ results point to https://prow.apps.ovirt.org/view/gcs

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>