### PR TITLE
Add missing gh token to testgrid config upload job

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -370,3 +370,10 @@ postsubmits:
           - kubevirt
           securityContext:
             runAsUser: 0
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token


### PR DESCRIPTION
Will fix errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/post-project-infra-upload-testgrid-config/1351551792164376576

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>