### PR TITLE
Use a base image with the right config-forker

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,7 +79,7 @@ container_pull(
     name = "release-tool-base",
     registry = "index.docker.io",
     repository = "kubevirtci/release-tool-base",
-    tag = "v20200630-7042ca83147056a92bdf4752e53e8164fc432486",
+    tag = "v20210120-b86882c9314933ba1a0c77965ed9d54a747f7957",
 )
 
 load(

--- a/releng/release-tool/Dockerfile.release-tool-base
+++ b/releng/release-tool/Dockerfile.release-tool-base
@@ -16,9 +16,10 @@ RUN set -x && \
     cd / && \
     export GO111MODULE=on && \
     source /etc/profile.d/gimme.sh && \
-    git clone https://github.com/kubernetes/test-infra.git && \
+    # we need https://github.com/kubernetes/test-infra/pull/20535 merged
+    git clone https://github.com/rmohr/test-infra.git && \
     cd /test-infra && \
-    git checkout def51b2596d3a0a7b19d49596d5afc4ab3354855 && \
+    git checkout 4cf6b44c611e528555998ebb3839ae90c00061fb && \
     cd /test-infra/robots/pr-creator && \
     go install && \
     cd /test-infra/releng/config-forker && \


### PR DESCRIPTION
One commit landed which pulled in the right config-forker library to a
dockerfile, but this base image was then never for the build.

Follow up of #777.
