### PR TITLE
sriov release 0.37, Add sriov-poc-multi podAntiAffinity

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -213,6 +213,13 @@ presubmits:
                 values:
                 - "true"
             topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname            
       containers:
       - command:
         - /usr/local/bin/runner.sh


### PR DESCRIPTION
In order to run the multi sriov POC side by side
with the official sriov jobs, a new podAntiAffinity
was introduced.

Add it also to the new release job 0.37
see #843

Signed-off-by: Or Shoval <oshoval@redhat.com>