### PR TITLE
Add missing options to transfigure upload call

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -368,6 +368,9 @@ postsubmits:
           - github/ci/prow/files/jobs
           - github/ci/testgrid/gen-config.yaml
           - kubevirt
+          - test-infra
+          - kubevirt-bot
+          - rmohr+kubebot@redhat.com
           securityContext:
             runAsUser: 0
           volumeMounts:


### PR DESCRIPTION
The upload jobs were failing like here https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/post-project-infra-upload-testgrid-config/1351931293503328256 

The problem is that the gh token we use is associated with a user that doesn't have a public email set, this causes that the email is shown as empty here https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/post-project-infra-upload-testgrid-config/1351931293503328256#1:build-log.txt%3A2 and finally causes an error in this line of the transfigure.sh script https://github.com/kubernetes/test-infra/blob/master/testgrid/cmd/transfigure/transfigure.sh#L171

Tested locally and worked successfully, this PR was generated with these changes https://github.com/kubernetes/test-infra/pull/20554

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>