### PR TITLE
Fix user-guide jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/user-guide/user-guide-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/user-guide/user-guide-periodics.yaml
@@ -18,8 +18,8 @@ periodics:
           command: ["/bin/sh", "-c"]
           args:
           - |
-              /usr/local/bin/python3.7 -m venv /opt/userguide
-              . /opt/userguide/bin/activate
+              python3.7 -m venv /userguide
+              . /userguide/bin/activate
               pip3 install mkdocs mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin
               echo '*** BEGIN mkdocs.yml ***'
               cat mkdocs.yml

--- a/github/ci/prow/files/jobs/kubevirt/user-guide/user-guide-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/user-guide/user-guide-presubmits.yaml
@@ -13,8 +13,8 @@ presubmits:
             command: ["/bin/sh", "-c"]
             args:
             - |
-                /usr/local/bin/python3.7 -m venv /opt/userguide
-                . /opt/userguide/bin/activate
+                python3.7 -m venv /userguide
+                . /userguide/bin/activate
                 pip3 install mkdocs mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin
                 echo '*** BEGIN mkdocs.yml ***'
                 cat mkdocs.yml


### PR DESCRIPTION
The userguide jobs weren't working due to path permission issues, these are fixed now:

https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_user-guide/372/user-guide-presubmit-build/1352287010806566912

/cc @mazzystr 

see kubevirt/user-guide#372