### PR TITLE
Cache bazel 4.0 in bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -21,7 +21,8 @@ RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/downloa
      cd /usr/local/bin && ln -s bazelisk bazel
 
 # Cache the most commonly used bazel versions inside the image
-RUN USE_BAZEL_VERSION=3.4.1 bazel version
+RUN USE_BAZEL_VERSION=3.4.1 bazel version && \
+  USE_BAZEL_VERSION=4.0.0 bazel version
 
 COPY "runner.sh" \
   "/usr/local/bin/"


### PR DESCRIPTION
Include first bazel LTS version in bootstrap's bazelisk cache, details about the release here https://blog.bazel.build/2021/01/19/bazel-4-0.html

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>