### PR TITLE
Make peribolos job update org configuration

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -432,7 +432,7 @@ periodics:
                 -github-endpoint=https://api.github.com \
                 -config-path $REPO_DIR/github/ci/prow/files/orgs.yaml \
                 -github-token-path /etc/github/oauth \
-                -confirm=false
+                -confirm=true
         volumeMounts:
         - name: token
           mountPath: /etc/github


### PR DESCRIPTION
We've had two successful runs: https://prow.apps.ovirt.org/?job=periodic-kubevirt-org-github-config-updater

Let's enable updating.