### PR TITLE
Create presubmit for kubevirt orgs config changes

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -345,3 +345,45 @@ presubmits:
         - kubevirt
         securityContext:
           runAsUser: 0
+  - name: pull-kubevirt-org-github-config-updater
+    run_if_changed: '^github/ci/prow/files/orgs\.yaml$'
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      workdir: true
+    max_concurrency: 1
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+      - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        command: [ "/bin/sh", "-c" ]
+        args:
+        - |
+          set -e
+          TEST_INFRA_DIR=$(cd ../.. && cd kubernetes/test-infra && pwd)
+          REPO_DIR=$(cd ../.. && cd kubevirt/project-infra && pwd)
+          cd $TEST_INFRA_DIR
+          bazel run //prow/cmd/peribolos -- \
+            -github-endpoint=http://ghproxy \
+            -github-endpoint=https://api.github.com \
+            -config-path $REPO_DIR/github/ci/prow/files/orgs.yaml \
+            -github-token-path /etc/github/oauth \
+            -confirm=false
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+        resources:
+          requests:
+            memory: "200Mi"
+      volumes:
+      - name: token
+        secret:
+          secretName: oauth-token


### PR DESCRIPTION
The presubmit is intended to run peribolos over the new configuration in
order to catch configuration errors before they are getting committed.

/cc @fgimenez @rmohr 