### PR TITLE
sriov CNI, Allocate only one sriov PF

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/Dockerfile
+++ b/cni-plugins/sriov-passthrough-cni/Dockerfile
@@ -2,12 +2,10 @@ FROM centos:7.6.1810
 
 ENV SRC_DIR=/plugin-src
 ARG PLUGIN_BIN=plugin/sriov-passthrough-cni
-ARG PLUGIN_CONF=plugin/90-sriov-passthrough-cni.conf
 ARG INSTALL_SCRIPT=install-plugin
 
 RUN mkdir -p $SRC_DIR
 COPY $PLUGIN_BIN $SRC_DIR
-COPY $PLUGIN_CONF $SRC_DIR
 COPY $INSTALL_SCRIPT /bin
 
 ENTRYPOINT ["install-plugin"]

--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -23,7 +23,6 @@ plugin on all the relevant K8s nodes.
 ├── Dockerfile      # The Dockerfile that we use to pack the plugin in.
 ├── install-plugin  # The script that actually installs the plugin.
 ├── plugin  # The plugin itself.
-│   ├── 90-sriov-passthrough-cni.conf
 │   └── sriov-passthrough-cni
 └── README.md
 ```

--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -1,7 +1,7 @@
 # SR-IOV passthrough CNI
 
 This is a CNI ([container network interface](https://github.com/containernetworking/cni))
-plugin that passes all physical and virtual functions of a SR-IOV nic into the
+plugin that passes one physical SR-IOV nic into the
 namespace of a pod that requests it.
 
 ## Where it used

--- a/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
+++ b/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
@@ -156,7 +156,7 @@ spec:
               mountPath: /usr/src/multus-cni/images/
         - name: kube-sriov-passthrough-cni
           command: ["install-plugin"]
-          args: ["/host/opt/cni/bin", "/host/etc/cni/net.d"]
+          args: ["/host/opt/cni/bin"]
           image: 'quay.io/pod_utils/sriov-passthrough-cni:v1.0'
           resources:
             requests:
@@ -168,8 +168,6 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
-            - name: cni
-              mountPath: /host/etc/cni/net.d
             - name: cnibin
               mountPath: /host/opt/cni/bin
       volumes:

--- a/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
+++ b/cni-plugins/sriov-passthrough-cni/deploy/multus-cni.yaml
@@ -157,7 +157,7 @@ spec:
         - name: kube-sriov-passthrough-cni
           command: ["install-plugin"]
           args: ["/host/opt/cni/bin"]
-          image: 'quay.io/pod_utils/sriov-passthrough-cni:v1.0'
+          image: 'quay.io/kubevirtci/sriov-passthrough-cni:v1.1'
           resources:
             requests:
               cpu: "100m"

--- a/cni-plugins/sriov-passthrough-cni/install-plugin
+++ b/cni-plugins/sriov-passthrough-cni/install-plugin
@@ -1,20 +1,15 @@
 #!/bin/bash -xe
 
 # Usage:
-# ./install_plugin CNI_BIN_DST CNI_CONF_DST
+# ./install_plugin CNI_BIN_DST
 
 readonly CNI_BIN_SRC=/plugin-src/sriov-passthrough-cni
-readonly CNI_CONF_SRC=/plugin-src/90-sriov-passthrough-cni.conf
 
 function install_plugin() {
     local cni_bin_dst="${1:?}"
-    local cni_conf_dst="${2:?}"
 
     cp "$CNI_BIN_SRC" "$cni_bin_dst"
     chmod 755 "$cni_bin_dst"
-
-    cp "$CNI_CONF_SRC" "$cni_conf_dst"
-    chmod 644 "$cni_conf_dst"
 }
 
 install_plugin "$@"

--- a/cni-plugins/sriov-passthrough-cni/plugin/90-sriov-passthrough-cni.conf
+++ b/cni-plugins/sriov-passthrough-cni/plugin/90-sriov-passthrough-cni.conf
@@ -1,5 +1,0 @@
-{
-  "cniVersion": "0.3.1",
-  "name": "sriov-passthrough-cni",
-  "type": "sriov-passthrough-cni"
-}

--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -11,7 +11,6 @@ function main() {
         ADD)
             log "Received ADD command. CNI_ARGS: $CNI_ARGS"
             setup_netns
-            # add_veth_pair
             flip_vfs_to_default_drivers
             setns_sriov_ifs
             gen_result_config
@@ -31,11 +30,6 @@ function flip_vfs_to_default_drivers() {
         echo 0 > $pfroot/sriov_numvfs
         cat $file > $pfroot/sriov_numvfs
     done
-}
-
-function from_cni_args() {
-    local var_name="${1:?}"
-    sed -nE "s/.+?${var_name}=([^;]*?)(;.+?|$)/\1/p" <<< "$CNI_ARGS"
 }
 
 function setup_netns() {
@@ -65,22 +59,6 @@ function setns_sriov_ifs() {
     ip link set "$ifs_name" netns "$CNI_CONTAINERID"
   done
 
-}
-
-add_veth_pair() {
-    local container_name
-    container_name="$(from_cni_args K8S_POD_NAME)"
-    local host_if="veth-1-${container_name}"
-    local container_if="veth-2-${container_name}"
-    ip link add "$container_if" type veth peer name "$host_if"
-    ip link set "$host_if" up
-    ip link set "$container_if" netns "$CNI_CONTAINERID"
-    ip netns exec "$CNI_CONTAINERID" ip link set "$container_if" down
-    ip netns exec "$CNI_CONTAINERID" ip link set "$container_if" name \
-        "$CNI_IFNAME"
-    ip netns exec "$CNI_CONTAINERID" ip link set "$container_if" up
-    ip netns exec "$CNI_CONTAINERID" ip addr add "$IP/$SUBNET_MASK" \
-        dev "$container_if"
 }
 
 function gen_result_config() {

--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -5,14 +5,14 @@ readonly SUBNET_MASK=24
 readonly GW_IP=169.255.0.1
 readonly CONTAINER_NETNS_LINK="/var/run/netns/$CNI_CONTAINERID"
 readonly LOGFILE=/var/log/pfcni.log
+readonly PF_COUNT=1
 
 function main() {
     case "$CNI_COMMAND" in
         ADD)
             log "Received ADD command. CNI_ARGS: $CNI_ARGS"
             setup_netns
-            flip_vfs_to_default_drivers
-            setns_sriov_ifs
+            setns_sriov_pfs
             gen_result_config
             ;;
         DELETE)
@@ -22,43 +22,36 @@ function main() {
     esac
 }
 
-function flip_vfs_to_default_drivers() {
-    for file in $(find /sys/devices/ -name *sriov_totalvfs*); do
-        pfroot=$(dirname $file)
-
-        # flip all available VFs to default driver
-        echo 0 > $pfroot/sriov_numvfs
-        cat $file > $pfroot/sriov_numvfs
-    done
-}
-
 function setup_netns() {
     mkdir -p /var/run/netns
     ln -sfT "$CNI_NETNS" "$CONTAINER_NETNS_LINK"
 }
 
-function setns_sriov_ifs() {
-  local sriov_vfs=( /sys/class/net/*/device/virtfn* )
-  local ifs_arr ifs_name
-  for vf in "${sriov_vfs[@]}"; do
-    ifs_arr=( "$vf"/net/* )
-    for ifs in "${ifs_arr[@]}"; do
-        ifs_name="${ifs%%\/net\/*}"
-        ifs_name="${ifs##*\/}"
-        log "Adding vf: $ifs_name to netns $CNI_CONTAINERID"
-        ip link set "$ifs_name" netns "$CNI_CONTAINERID"
-    done
+function setns_sriov_pfs() {
+  local pf_array=()
+  local -r sriov_pfs=( $(find /sys/class/net/*/device/sriov_numvfs) )
+  if [ "${#sriov_pfs[@]}" -eq 0 ]; then
+    log "FATAL: No sriov PFs found"
+    exit 1
+  fi
+
+  for pf in "${sriov_pfs[@]}"; do
+    local pf_name="${pf%%/device/*}"
+    pf_name="${pf_name##*/}"
+    if ip link set "$pf_name" netns "$CNI_CONTAINERID"; then
+      if timeout 5s bash -c "until ip netns exec $CNI_CONTAINERID ip link show $pf_name > /dev/null; do sleep 1; done"; then
+        log "Added $pf_name to netns $CNI_CONTAINERID"
+        pf_array+=("$pf_name")
+        if [ "${#pf_array[@]}" -eq "$PF_COUNT" ]; then
+          log "Allocated requested number of PFs"
+          return 0
+        fi
+      fi
+    fi
   done
 
-  local sriov_pfs=( /sys/class/net/*/device/sriov_numvfs )
-  local ifs_name
-  for ifs in "${sriov_pfs[@]}"; do
-    ifs_name="${ifs%%/device/*}"
-    ifs_name="${ifs_name##*/}"
-        log "Adding pf: $ifs_name to netns $CNI_CONTAINERID"
-    ip link set "$ifs_name" netns "$CNI_CONTAINERID"
-  done
-
+  log "FATAL: Could not allocate enough PFs"
+  exit 1
 }
 
 function gen_result_config() {


### PR DESCRIPTION
In order to allow running multi sriov clusters simultaneously,
allocate only one sriov PF per CNI call.
    
In case no PFs exist, exit with an error, so the job won't
start without PF.
It may occur in case the container was forcely deleted,
and then it takes a few minutes for the PF
to reappear in `/sys/class/net`.
The CNI will exit, delete the old NS, and a new container will
be created and retrigger CNI that would try again, until
the PF reappears.

This update makes the CNI re-entrant as well,
by detecting possible collisions in case two jobs try to take the same PF
at the same time.
One of them will succeed, and the other will advance to the next available PF.
Prow will schedule jobs according the number of PFs on the node (will be done on other PR).
This way we are guaranteed to be safe.

The CNI doesn't mess with VFs at all, kubevirtci rule is to do so.

Additional changes:
* Remove unneeded conf file.
    The NAD configuration that is used is the
    `NetworkAttachmentDefinition`, not the conf file one.
    Hence remove it.
* Remove unneeded veth code.

Note:
In order to allocate more than one PF for job, call this CNI twice.

CNI container image: `quay.io/kubevirtci/sriov-passthrough-cni:v1.1`

Signed-off-by: Or Shoval <oshoval@redhat.com>