### PR TITLE
Add label definition for dco-signoff

### DIFF
--- a/github/ci/prow/files/labels.yaml
+++ b/github/ci/prow/files/labels.yaml
@@ -177,6 +177,18 @@ default:
       previously:
         - name: topic/virtualization
           color: c5def5
+    - color: e11d21
+      description: Indicates the PR's author has not DCO signed all their commits.
+      name: "dco-signoff: no"
+      target: prs
+      prowPlugin: dco
+      addedBy: prow
+    - color: bfe5bf
+      description: Indicates the PR's author has DCO signed all their commits.
+      name: "dco-signoff: yes"
+      target: prs
+      prowPlugin: dco
+      addedBy: prow
 repos:
   kubevirt/kubevirt:
     labels:


### PR DESCRIPTION
The definitions were missing, so the labels didn't have a color. In order to make existence of those labels more prominent as it's required for merging, we add these.