### PR TITLE
Add presubmit to check labels.yaml

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -387,3 +387,65 @@ presubmits:
       - name: token
         secret:
           secretName: oauth-token
+  - name: pull-prow-kubevirt-labels-update-precheck
+    run_if_changed: '^github/ci/prow/files/labels\.yaml$'
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    max_concurrency: 1
+    spec:
+      nodeSelector:
+        type: vm
+        zone: ci
+      containers:
+      - name: label-sync
+        image: gcr.io/k8s-prow/label_sync:v20200623-9f5410055c
+        command: [ "/app/label_sync/app.binary" ]
+        args:
+        - --config=github/ci/prow/files/labels.yaml
+        - --confirm=false
+        - --orgs=kubevirt
+        - --token=/etc/github/oauth
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      restartPolicy: Never
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token
+  - name: pull-prow-nmstate-labels-update-precheck
+    run_if_changed: '^github/ci/prow/files/labels\.yaml$'
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    max_concurrency: 1
+    spec:
+      nodeSelector:
+        type: vm
+        zone: ci
+      containers:
+      - name: label-sync
+        image: gcr.io/k8s-prow/label_sync:v20200623-9f5410055c
+        command: [ "/app/label_sync/app.binary" ]
+        args:
+        - --config=github/ci/prow/files/labels.yaml
+        - --confirm=false
+        - --only=nmstate/kubernetes-nmstate
+        - --token=/etc/github/oauth
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      restartPolicy: Never
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token


### PR DESCRIPTION
Last night due to an invalid label update the label-sync jobs stopped working:
* https://shift.ovirt.org:8443/console/project/kubevirt-prow/browse/pods/label-sync-kubevirt-1611789420-hrbg7
* https://shift.ovirt.org:8443/console/project/kubevirt-prow/browse/pods/label-sync-nmstate-1611789420-h724l

This was caused due to a duplicate label. This PR introduces a presubmit that runs label_sync against the new configuration. 

Example run here: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/888/pull-prow-labels-update-precheck/1354758422972600320

/cc @fgimenez @rmohr 