### PR TITLE
sriov, Change CNI annotation style

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -207,7 +207,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false

--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubevirt/kubevirtci:
   - name: check-up-kind-1.17-sriov
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     always_run: true
     optional: false
     decorate: true


### PR DESCRIPTION
With this updated annotation style,
one can call the same CNI twice by duplicating the annotation,
(must be in the same annotation line) and changing only the interface name.
    
It will allows to call the updated CNI which allocate only one PF
twice, in order to allocate 2 PFs for migration.
Without it, duplicating the line, resulted in pod with just one annotation, as the
duplicated entry was deduped.

Example
`      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}, {"interface":"net2","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'`

Signed-off-by: Or Shoval <oshoval@redhat.com>