### PR TITLE
Add quay.io presets to the project-infra jobs

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -114,7 +114,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh kubekins-e2e quay.io kubevirtci
             # docker-in-docker needs privileged mode

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presets.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presets.yaml
@@ -15,3 +15,19 @@ presets:
   - name: kubevirtci-cred
     mountPath: /etc/kubevirtci-cred
     readOnly: true
+- labels:
+    preset-kubevirtci-quay-credential: "true"
+  env:
+  - name: QUAY_USER
+    value: /etc/kubevirtci-cred/username
+  - name: QUAY_PASSWORD
+    value: /etc/kubevirtci-cred/password
+  volumes:
+  - name: kubevirtci-cred
+    secret:
+      defaultMode: 0400
+      secretName: kubevirtci-quay-credential
+  volumeMounts:
+  - name: kubevirtci-cred
+    mountPath: /etc/kubevirtci-cred
+    readOnly: true


### PR DESCRIPTION
We are missing the quay preset in project-infra. It gets silently not injected, causing jobs to fail which try to upload something to quay.