### PR TITLE
Configure docker userland binary paths

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -76,7 +76,12 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Docker in Docker enabled, initializing..."
     printf '=%.0s' {1..80}; echo
     # If we have opted in to docker in docker, start the docker daemon,
-    /usr/bin/dockerd -p /var/run/docker.pid --data-root=/docker-graph >/var/log/dockerd.log 2>&1 &
+    /usr/bin/dockerd \
+        -p /var/run/docker.pid \
+        --data-root=/docker-graph \
+        --init-path /usr/libexec/docker/docker-init \
+        --userland-proxy-path /usr/libexec/docker/docker-proxy \
+            >/var/log/dockerd.log 2>&1 &
     # the service can be started but the docker socket not ready, wait for ready
     WAIT_N=0
     MAX_WAIT=5


### PR DESCRIPTION
Help docker a little to find docker-init and docker-proxy binaries.

Fixes the following issue with docker in docker:

```
15:10:07: docker: Error response from daemon: driver failed programming external connectivity on endpoint dazzling_hugle (0ce88d806c12357c12b16dc78102518e2b3b3f2286fca99538a655d7080951cf): exec: "docker-proxy": executable file not found in $PATH.
```

Signed-off-by: Roman Mohr <rmohr@redhat.com>