### PR TITLE
Add prow deploy test image

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -156,6 +156,38 @@ postsubmits:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
+    - name: publish-prow-deploy-image
+      always_run: false
+      run_if_changed: "images/prow-deploy/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-kubevirtci-quay-credential: "true"
+      spec:
+        nodeSelector:
+          type: vm
+        containers:
+          - image: kubevirtci/bootstrap:v20201119-a5880e0
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
+                ./publish_image.sh prow-deploy quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "8Gi"
+              limits:
+                memory: "8Gi"
     - name: post-project-infra-prow-deployment
       always_run: false
       annotations:

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -165,7 +165,6 @@ postsubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -168,6 +168,34 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
+  - name: build-prow-deploy-image
+    always_run: false
+    run_if_changed: "images/prow-deploy/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      nodeSelector:
+        type: vm
+      containers:
+        - image: kubevirtci/bootstrap:v20201119-a5880e0
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              cd images
+              ./publish_image.sh -b prow-deploy quay.io kubevirtci
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
   - name: kubernetes-crud-ci-role
     always_run: false
     run_if_changed: "github/ci/kubernetes-crud/.*"

--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -25,6 +25,10 @@ RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0
   chmod a+x ./kind && \
   mv ./kind /usr/local/bin
 
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+  chmod a+x ./kubectl && \
+  mv ./kubectl /usr/local/bin
+
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt

--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -5,6 +5,8 @@ RUN git clone https://github.com/kubernetes/test-infra.git && \
   git checkout e88598c4a7f86e0564a2d8b46ce5f729247791e6 && \
   bazelisk build //prow/cmd/config-bootstrapper && \
   cp bazel-bin/prow/cmd/config-bootstrapper/linux_amd64_stripped/config-bootstrapper /usr/local/bin && \
+  bazelisk build //prow/cmd/phony && \
+  cp bazel-bin/prow/cmd/phony/linux_amd64_stripped/phony /usr/local/bin && \
   bazelisk clean --expunge && \
   cd .. && rm -rf test-infra && \
   rm -rf ~/.cache.bazel

--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -1,0 +1,30 @@
+FROM kubevirtci/bootstrap:v20210126-a12b6c0
+
+RUN git clone https://github.com/kubernetes/test-infra.git && \
+  cd test-infra && \
+  git checkout e88598c4a7f86e0564a2d8b46ce5f729247791e6 && \
+  bazelisk build //prow/cmd/config-bootstrapper && \
+  cp bazel-bin/prow/cmd/config-bootstrapper/linux_amd64_stripped/config-bootstrapper /usr/local/bin && \
+  bazelisk clean --expunge && \
+  cd .. && rm -rf test-infra && \
+  rm -rf ~/.cache.bazel
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3-venv
+
+RUN curl -Lo ./kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.7/kustomize_v3.8.7_linux_amd64.tar.gz && \
+  tar -xvf kustomize.tar.gz && \
+  mv ./kustomize /usr/local/bin && \
+  rm kustomize.tar.gz
+
+RUN curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
+  chmod a+x ./yq && \
+  mv ./yq /usr/local/bin
+
+RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.9.0/kind-linux-amd64 && \
+  chmod a+x ./kind && \
+  mv ./kind /usr/local/bin
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt

--- a/images/prow-deploy/requirements.txt
+++ b/images/prow-deploy/requirements.txt
@@ -1,0 +1,7 @@
+ansible == 2.9.6
+kubernetes == 11.0.0
+kubernetes-validate == 1.19.0
+molecule == 3.1.5
+molecule-docker == 0.2.4
+openshift == 0.11.2
+selinux == 0.2.1


### PR DESCRIPTION
Towards #859 

Besides downloading dependencies, it builds test-infra's config-bootstrapper so that we don't need to build it on tests/deployment, only this will reduce the job times in ~8min.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>