### PR TITLE
Add Quique as reviewer and approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ filters:
       - phoracek
       - aglitke
       - fgimenez
+      - qinqon
     approvers:
       - davidvossel
       - vladikr
@@ -16,6 +17,7 @@ filters:
       - phoracek
       - aglitke
       - fgimenez
+      - qinqon
     emeritus_approvers:
       - cynepco3hahue
       - danielBelenky


### PR DESCRIPTION
Quique is a maintainer of CNAO and knsmtate repositories, where he needs
to be able to adjust our CI. He also contributed many PRs in the past to
this project where he proved understanding of Prow manipulation and thus
should be capable of maintaining the project.

Signed-off-by: Petr Horáček <phoracek@redhat.com>