### PR TITLE
Add nelsonspbr to org members

### DIFF
--- a/github/ci/prow/files/orgs.yaml
+++ b/github/ci/prow/files/orgs.yaml
@@ -115,6 +115,7 @@ orgs:
       - mykaul
       - n1r1
       - nellyc
+      - nelsonspbr
       - nertpinx
       - nirarg
       - nunnatsa


### PR DESCRIPTION
I am currently contributing to kubevirt/common-templates and others as part of Red Hat's SSP team.

Signed-off-by: Nelson Mimura Gonzalez <nelson@ibm.com>