### PR TITLE
use upstream docker-registry-proxy and set proxy-connect timeouts

### DIFF
--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - manifests/local/docker-daemon_configmap.yaml
   - manifests/local/docker-mirror_deployment.yaml
   - manifests/local/docker-mirror_service.yaml
+  - manifests/local/docker-mirror-proxy_deployment.yaml
   - manifests/local/docker-mirror-proxy_service.yaml
   - manifests/local/exporter-deployment.yaml
   - manifests/local/exporter-rbac.yaml

--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - manifests/local/docker-mirror_deployment.yaml
   - manifests/local/docker-mirror_service.yaml
   - manifests/local/docker-mirror-proxy_deployment.yaml
+  - manifests/local/docker-mirror-proxy_pvc.yaml
   - manifests/local/docker-mirror-proxy_service.yaml
   - manifests/local/exporter-deployment.yaml
   - manifests/local/exporter-rbac.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/docker-mirror-proxy_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/docker-mirror-proxy_deployment.yaml
@@ -76,5 +76,5 @@ spec:
         secret:
           secretName: docker-mirror-proxy
       - name: storage
-        hostPath:
-          path: /var/lib/docker-mirror/proxy
+        persistentVolumeClaim:
+          claimName: docker-mirror-proxy

--- a/github/ci/prow-deploy/kustom/base/manifests/local/docker-mirror-proxy_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/docker-mirror-proxy_deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-mirror-proxy
+spec:
+  selector:
+    matchLabels:
+      app: docker-mirror-proxy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: docker-mirror-proxy
+    spec:
+      terminationGracePeriodSeconds: 180
+      serviceAccountName: "caches"
+      nodeSelector:
+        type: bare-metal-external
+        ci.kubevirt.io/cachenode: "true"
+      tolerations:
+      - key: "cachenode"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: mirror-proxy
+        image: rpardini/docker-registry-proxy:0.6.2
+        env:
+        - name: ENABLE_MANIFEST_CACHE
+          value: "true"
+        - name: ALLOW_PUSH
+          value: "true"
+        - name: PROXY_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_READ_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_SEND_TIMEOUT
+          value: "600s"
+        - name: SEND_TIMEOUT
+          value: "600s"
+        - name: CLIENT_BODY_TIMEOUT
+          value: "600s"
+        - name: CLIENT_HEADER_TIMEOUT
+          value: "600s"
+        - name: PROXY_READ_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_SEND_TIMEOUT
+          value: "600s"
+        volumeMounts:
+        - name: storage
+          mountPath: /docker_mirror_cache
+        - name: ca-public
+          mountPath: /ca/ca.crt
+          subPath: ca.crt
+          readOnly: true
+        - name: ca-private
+          mountPath: /ca/ca.key
+          subPath: ca.key
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 3128
+        resources:
+          requests:
+            memory: 3Gi
+          limits:
+            memory: 3Gi
+      volumes:
+      - name: ca-public
+        configMap:
+          name: mirror-proxy-config
+      - name: ca-private
+        secret:
+          secretName: docker-mirror-proxy
+      - name: storage
+        hostPath:
+          path: /var/lib/docker-mirror/proxy

--- a/github/ci/prow-deploy/kustom/base/manifests/local/docker-mirror-proxy_pvc.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/docker-mirror-proxy_pvc.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: docker-mirror-proxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi

--- a/github/ci/prow/templates/mirror-proxy.yaml
+++ b/github/ci/prow/templates/mirror-proxy.yaml
@@ -23,10 +23,32 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: mirror-proxy
-        image: fgimenez/docker-registry-proxy:v0.2.0
+        image: rpardini/docker-registry-proxy:0.6.2
         env:
         - name: ENABLE_MANIFEST_CACHE
           value: "true"
+        - name: ALLOW_PUSH
+          value: "true"
+        - name: PROXY_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_READ_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_SEND_TIMEOUT
+          value: "600s"
+        - name: SEND_TIMEOUT
+          value: "600s"
+        - name: CLIENT_BODY_TIMEOUT
+          value: "600s"
+        - name: CLIENT_HEADER_TIMEOUT
+          value: "600s"
+        - name: PROXY_READ_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_SEND_TIMEOUT
+          value: "600s"
         volumeMounts:
         - name: storage
           mountPath: /docker_mirror_cache

--- a/github/ci/remote-cluster/templates/mirror-proxy.yaml
+++ b/github/ci/remote-cluster/templates/mirror-proxy.yaml
@@ -15,10 +15,32 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: mirror-proxy
-        image: fgimenez/docker-registry-proxy:v0.2.0
+        image: rpardini/docker-registry-proxy:0.6.2
         env:
         - name: ENABLE_MANIFEST_CACHE
           value: "true"
+        - name: ALLOW_PUSH
+          value: "true"
+        - name: PROXY_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_READ_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_SEND_TIMEOUT
+          value: "600s"
+        - name: SEND_TIMEOUT
+          value: "600s"
+        - name: CLIENT_BODY_TIMEOUT
+          value: "600s"
+        - name: CLIENT_HEADER_TIMEOUT
+          value: "600s"
+        - name: PROXY_READ_TIMEOUT
+          value: "600s"
+        - name: PROXY_CONNECT_TIMEOUT
+          value: "600s"
+        - name: PROXY_SEND_TIMEOUT
+          value: "600s"
         volumeMounts:
         - name: storage
           mountPath: /docker_mirror_cache


### PR DESCRIPTION
These changes will prevent errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/publish-bootstrap-image/1354780192060477440 when pushing big layers through our proxy. 

I've also taken the opportunity to switch to the upstream docker-registry-proxy image now that https://github.com/rpardini/docker-registry-proxy/issues/70 is fixed and our previous upstream PRs have already landed.

Finally, I've added the proxy deployment to the automated prow-deploy, was missing there. 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>