### PR TITLE
Fix target calculation for kubevirt periodic master e2e

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -473,7 +473,7 @@ periodics:
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
           - |
-            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '1p')
+            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '2p')
             automation/test.sh
         # docker-in-docker needs privileged mode
         securityContext:
@@ -508,7 +508,7 @@ periodics:
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
           - |
-            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '1p')
+            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '3p')
             automation/test.sh
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
There was an error in the way we calculated the target for the previous and previous-previous supported k8s versions, because of that all the kubevirt periodic master e2e were executed against the latest k8s version. 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>