### PR TITLE
Make k8s 1.20 lane run always

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
+    always_run: true
     optional: true
     skip_report: true
     decorate: true


### PR DESCRIPTION
Now that we have the issues fixed, we want to run the 1.20 lane always.

/cc @qinqon @fgimenez 