### PR TITLE
Increase timeout for publish-kubevirtci

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -7,6 +7,8 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
+      decoration_config:
+        timeout: 3h
       max_concurrency: 1
       extra_refs:
       - org: kubevirt


### PR DESCRIPTION
Aiming to fix failures like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/publish-kubevirtci/1357277772417863680

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>