### PR TITLE
Execute periodic e2e from master twice a day

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -415,7 +415,7 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "0 22 * * *"
+  cron: "0 22,10 * * *"
   decorate: true
   decoration_config:
     timeout: 7h
@@ -450,7 +450,7 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "0 22 * * *"
+  cron: "0 22,10 * * *"
   decorate: true
   decoration_config:
     timeout: 7h
@@ -485,7 +485,7 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "0 22 * * *"
+  cron: "0 22,10 * * *"
   decorate: true
   decoration_config:
     timeout: 7h


### PR DESCRIPTION
Now that we have verified that the periodic e2e lanes are working as expected let's increase the frequency to execute them twice a day, we have still margin thanks to the 7h timeout. 

Besides getting more feedback from them executing on working hours would run them on real conditions, the executions when no one else is using the cluster might give good results because of low resource usage. 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>