### PR TITLE
Add ci-health to prometheus scrape targets

### DIFF
--- a/github/ci/prometheus/templates/prometheus-config.yaml
+++ b/github/ci/prometheus/templates/prometheus-config.yaml
@@ -7,7 +7,7 @@ data:
   prometheus.yml: |
     global:
       scrape_interval: 15s
-    
+
     scrape_configs:
       - job_name: 'prometheus'
         static_configs:
@@ -22,3 +22,7 @@ data:
       - job_name: 'token-counter'
         static_configs:
           - targets: ['token-counter-metrics']
+      - job_name: 'ci-health'
+        metrics_path: /ci-health/output/metrics
+        static_configs:
+          - targets: ['fgimenez.github.io']


### PR DESCRIPTION
ci-health now publishes a metrics file in Prometheus format as part of the artifacts http://fgimenez.github.io/ci-health/output/metrics with these changes this file will be scraped by prometheus and we will be able to see the evolution of the metrics over time in grafana dashboards.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>