### PR TITLE
Add sippy deployment

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -374,6 +374,63 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
+    - name: post-project-infra-sippy-deployment
+      always_run: false
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      run_if_changed: "github/ci/services/sippy.*"
+      branches:
+      - ^master$
+      labels:
+        preset-docker-mirror-proxy: "true"
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+          env:
+          - name: GITHUB_TOKEN
+            value: /etc/github/oauth
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              # install yq
+              curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+              chmod +x ./yq && mv ./yq /usr/local/bin/yq
+
+              # unencrypt secrets
+              target_dir=$(mktemp -d)
+              git clone https://kubevirt-bot:$(cat ${GITHUB_TOKEN})@github.com/kubevirt/secrets ${target_dir}
+              gpg --allow-secret-key-import --import /etc/pgp/token
+              gpg --decrypt ${target_dir}/secrets.tar.asc > secrets.tar
+              tar -xvf secrets.tar
+
+              # put in place kubeconfig
+              mkdir -p ~/.kube
+              yq r main.yml 'kubeconfig' > ~/.kube/config
+
+              ./github/ci/services/sippy/hack/deploy.sh production
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          - name: pgp-bot-key
+            mountPath: /etc/pgp
+            readOnly: true
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: pgp-bot-key
+          secret:
+            secretName: pgp-bot-key
     - name: post-project-infra-upload-testgrid-config
       run_if_changed: '^(github/ci/prow/files/jobs/.*)|(github/ci/testgrid/gen-config\.yaml)$'
       branches:

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -356,6 +356,42 @@ presubmits:
               memory: "16Gi"
             limits:
               memory: "16Gi"
+  - name: pull-project-infra-sippy-deploy-test
+    optional: false
+    run_if_changed: "github/ci/services/sippy/.*|github/ci/services/common/.*|vendor/.*|WORKSPACE"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              # install kind
+              curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+              chmod +x ./kind && mv ./kind /usr/local/bin/kind
+
+              # create test cluster
+              kind create cluster
+
+              ./github/ci/services/sippy/hack/deploy.sh testing
+
+              bazelisk test //github/ci/services/sippy/e2e:go_default_test --test_output=all --test_arg=-test.v
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          resources:
+            requests:
+              memory: "16Gi"
+            limits:
+              memory: "16Gi"
   - name: pull-project-infra-check-testgrid-config
     run_if_changed: '^(github/ci/prow/files/jobs/.*)|(github/ci/testgrid/gen-config\.yaml)$'
     decorate: true

--- a/github/ci/services/sippy/BUILD.bazel
+++ b/github/ci/services/sippy/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@com_adobe_rules_gitops//gitops:defs.bzl", "k8s_deploy")
+
+[
+    k8s_deploy(
+        name = NAME,
+        cluster = CLUSTER,
+        manifests = glob([
+            "manifests/*.yaml",
+        ]),
+        patches = glob([
+            "patches/*.yaml",
+        ]),
+        secrets_srcs = glob([
+            "secrets/%s/**/*" % NAME,
+        ]),
+        namespace = "sippy",
+        user = USER,
+    )
+    for NAME, CLUSTER, USER in [
+        ("testing", "kind-kind", "kind-kind"),
+        ("production", "ibm-cluster", "ibm-prow-jobs-automation"),
+    ]
+]

--- a/github/ci/services/sippy/README.md
+++ b/github/ci/services/sippy/README.md
@@ -1,0 +1,30 @@
+# sippy
+
+Customization and deployment of [sippy] on Kubevirt CI cluster. It uses
+internally these bazel [gitops rules].
+
+## Deployment
+
+You need:
+* a kubernetes configuration at `~/.kube/config` with an user allowed to create
+[these resources](./manifests).
+* [bazelisk] installed.
+
+Then, from the root of project-infra run:
+```
+$ ./github/ci/services/sippy/hack/deploy.sh production
+```
+
+## Tests
+
+Can be tested locally using [kind] and [bazelisk], from the root of project-infra:
+```
+$ kind create cluster
+$ ./github/ci/services/sippy/hack/deploy.sh testing
+$ bazelisk test //github/ci/services/sippy/e2e:go_default_test --test_output=all --test_arg=-test.v
+```
+
+[gitops rules]: https://github.com/adobe/rules_gitops#:~:text=Bazel%20GitOps%20Rules,kustomize%20overlays%20for%20their%20services.
+[sippy]: https://github.com/openshift/sippy
+[kind]: https://github.com/kubernetes-sigs/kind
+[bazelisk]: https://github.com/bazelbuild/bazelisk

--- a/github/ci/services/sippy/e2e/e2e_test.go
+++ b/github/ci/services/sippy/e2e/e2e_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"bufio"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes"
+
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/client"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/portforwarder"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/wait"
+)
+
+const (
+	testNamespace = "sippy"
+)
+
+var (
+	clientset *kubernetes.Clientset
+)
+
+func TestSippyDeployment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "sippy deployment suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	// initilize clientset
+	clientset, err = client.NewClientset()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("sippy deployment", func() {
+	It("creates a responding HTTP service", func() {
+		localPort := "8080"
+		svcPort := "8080"
+		ports := []string{fmt.Sprintf("%s:%s", localPort, svcPort)}
+
+		stopChan := make(chan struct{}, 1)
+		defer close(stopChan)
+
+		podName := "sippy-0"
+		go func() {
+			err := portforwarder.New(testNamespace, podName, ports, stopChan)
+			if err != nil {
+				panic(err)
+			}
+		}()
+
+		host := "localhost"
+		err := wait.ForPortOpen(host, localPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		url := fmt.Sprintf("http://%s:%s", host, localPort)
+		res, err := http.Get(url)
+		Expect(err).NotTo(HaveOccurred())
+
+		defer res.Body.Close()
+		scanner := bufio.NewScanner(res.Body)
+
+		expected := "CI Release kubevirt/kubevirt Health Summary"
+		found := false
+		for scanner.Scan() {
+			if strings.Contains(scanner.Text(), expected) {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue())
+		Expect(scanner.Err()).NotTo(HaveOccurred())
+	})
+})

--- a/github/ci/services/sippy/hack/deploy.sh
+++ b/github/ci/services/sippy/hack/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eo pipefail
+
+main(){
+    local environment=${1}
+
+    bazelisk run //github/ci/services/sippy:${environment}.apply
+
+    bazelisk run //github/ci/services/common/k8s/cmd/wait -- -namespace sippy -selector sippy -kind statefulset
+}
+
+main "${@}"

--- a/github/ci/services/sippy/manifests/full.yaml
+++ b/github/ci/services/sippy/manifests/full.yaml
@@ -1,0 +1,98 @@
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: sippy
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: sippy
+  namespace: sippy
+spec:
+  selector:
+    app: sippy
+  ports:
+  - port: 80
+    targetPort: 8080
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: sippy
+  namespace: sippy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sippy
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        app: sippy
+    spec:
+      containers:
+      - name: sippy-server
+        image: "quay.io/kubevirtci/sippy@sha256:2375c30f04b5cb2c56abd54e712aa7a6ffe48b0e07f1fa1962775d67489cea96"
+        resources:
+          requests:
+            memory: 800Mi
+          limits:
+            memory: 1500Mi
+        volumeMounts:
+        - mountPath: /data
+          name: sippy
+        command:
+        - /go/src/sippy/sippy
+        args:
+        - --local-data
+        - /data
+        - --dashboard
+        - kubevirt/kubevirt=kubevirt-presubmits,kubevirt-periodics=
+        - --variant
+        - kube
+        - --end-day
+        - "7"
+        - --server
+      - name: sippy-fetch
+        image: "quay.io/kubevirtci/sippy@sha256:2375c30f04b5cb2c56abd54e712aa7a6ffe48b0e07f1fa1962775d67489cea96"
+        resources:
+          requests:
+            memory: 200Mi
+          limits:
+            memory: 500Mi
+        volumeMounts:
+        - mountPath: /data
+          name: sippy
+        command:
+        - /bin/bash
+        args:
+        - -c
+        - |
+          # sleep before fetching so that if we're in some sort of fast crashloop/reschedule mode,
+          # we don't ping testgrid everytime we come back up
+          echo "Doing initial sleep before fetching testgrid data"
+          sleep 600 # 10 minutes
+          while [ true ]; do
+            echo "Fetching new testgrid data"
+            rm -rf /data/*
+            /go/src/sippy/sippy -v 4 --fetch-data /data --dashboard kubevirt/kubevirt=kubevirt-presubmits,kubevirt-periodics= --variant kube
+            echo "Done fetching data, refreshing server"
+            curl localhost:8080/refresh
+            echo "Done refreshing data, sleeping"
+            sleep 3600  # 1 hour
+          done
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      name: sippy
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 50Gi

--- a/github/ci/services/sippy/manifests/ingress.yaml
+++ b/github/ci/services/sippy/manifests/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sippy
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  tls:
+  - hosts:
+    - sippy.ci.kubevirt.io
+    secretName: sippy-tls
+  rules:
+  - host: sippy.ci.kubevirt.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: sippy
+            port:
+              number: 80

--- a/github/ci/services/sippy/overlays/testing/cluster-issuer.yaml
+++ b/github/ci/services/sippy/overlays/testing/cluster-issuer.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: nginx


### PR DESCRIPTION
I've read here https://groups.google.com/g/kubernetes-sig-testing/c/BxnXXipU42M/m/XAV53pyBAwAJ that upstream kubernetes will start using sippy https://github.com/openshift/sippy as part of their efforts for increasing CI reliability. I think it can help us as well to analyze test results from testgrid, it has a lot of nice features. Some of the links still point to openshift-related services (like openshift's ci-search) but I expect this will be changed soon. 

I've also taken the opportunity to introduce a timeout in the wait functions under `github/ci/services/common`, let me know wdyt.

/cc @dhiller @rmohr  

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>