### PR TITLE
Fix missing reposync in kubevirtci crio sync periodic

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -32,6 +32,8 @@ periodics:
           - "-c"
           - |
             set -e;
+            apt-get update
+            apt-get install yum-utils -y
 
             sync_crio_repo_for_version () {
               if [ -z "$1" ]


### PR DESCRIPTION
bootstrap image doesn't have reposync, let's
fix that by installing it.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>