### PR TITLE
Add kuberhealthy deployment

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -493,6 +493,63 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
+    - name: post-project-infra-kuberhealthy-deployment
+      always_run: false
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      run_if_changed: "github/ci/services/kuberhealthy.*"
+      branches:
+      - ^master$
+      labels:
+        preset-docker-mirror-proxy: "true"
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+          env:
+          - name: GITHUB_TOKEN
+            value: /etc/github/oauth
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              # install yq
+              curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+              chmod +x ./yq && mv ./yq /usr/local/bin/yq
+
+              # unencrypt secrets
+              target_dir=$(mktemp -d)
+              git clone https://kubevirt-bot:$(cat ${GITHUB_TOKEN})@github.com/kubevirt/secrets ${target_dir}
+              gpg --allow-secret-key-import --import /etc/pgp/token
+              gpg --decrypt ${target_dir}/secrets.tar.asc > secrets.tar
+              tar -xvf secrets.tar
+
+              # put in place kubeconfig
+              mkdir -p ~/.kube
+              yq r main.yml 'kubeconfig' > ~/.kube/config
+
+              ./github/ci/services/kuberhealthy/hack/deploy.sh production
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          - name: pgp-bot-key
+            mountPath: /etc/pgp
+            readOnly: true
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: pgp-bot-key
+          secret:
+            secretName: pgp-bot-key
     - name: post-project-infra-upload-testgrid-config
       run_if_changed: '^(github/ci/prow/files/jobs/.*)|(github/ci/testgrid/gen-config\.yaml)$'
       branches:

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -428,6 +428,42 @@ presubmits:
               memory: "16Gi"
             limits:
               memory: "16Gi"
+  - name: pull-project-infra-kuberhealthy-deploy-test
+    optional: false
+    run_if_changed: "github/ci/services/kuberhealthy/.*|github/ci/services/common/.*|vendor/.*|WORKSPACE"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              # install kind
+              curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.9.0/kind-linux-amd64
+              chmod +x ./kind && mv ./kind /usr/local/bin/kind
+
+              # create test cluster
+              kind create cluster
+
+              ./github/ci/services/kuberhealthy/hack/deploy.sh testing
+
+              bazelisk test //github/ci/services/kuberhealthy/e2e:go_default_test --test_output=all --test_arg=-test.v
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          resources:
+            requests:
+              memory: "16Gi"
+            limits:
+              memory: "16Gi"
   - name: pull-project-infra-check-testgrid-config
     run_if_changed: '^(github/ci/prow/files/jobs/.*)|(github/ci/testgrid/gen-config\.yaml)$'
     decorate: true

--- a/github/ci/services/ci-search/e2e/BUILD.bazel
+++ b/github/ci/services/ci-search/e2e/BUILD.bazel
@@ -4,8 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["e2e_test.go"],
     deps = [
-        "//github/ci/services/common/k8s/pkg/portforwarder:go_default_library",
-        "//github/ci/services/common/k8s/pkg/wait:go_default_library",
+        "//github/ci/services/common/k8s/pkg/check:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/github/ci/services/ci-search/e2e/e2e_test.go
+++ b/github/ci/services/ci-search/e2e/e2e_test.go
@@ -1,17 +1,12 @@
 package e2e
 
 import (
-	"bufio"
-	"fmt"
-	"net/http"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/portforwarder"
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/wait"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/check"
 )
 
 const (
@@ -25,41 +20,6 @@ func TestCISearchDeployment(t *testing.T) {
 
 var _ = Describe("ci-search deployment", func() {
 	It("creates a responding HTTP service", func() {
-		localPort := "8080"
-		svcPort := "8080"
-		ports := []string{fmt.Sprintf("%s:%s", localPort, svcPort)}
-
-		stopChan := make(chan struct{}, 1)
-		defer close(stopChan)
-
-		podName := "search-0"
-		go func() {
-			err := portforwarder.New(testNamespace, podName, ports, stopChan)
-			if err != nil {
-				panic(err)
-			}
-		}()
-
-		host := "localhost"
-		err := wait.ForPortOpen(host, localPort)
-		Expect(err).NotTo(HaveOccurred())
-
-		url := fmt.Sprintf("http://%s:%s", host, localPort)
-		res, err := http.Get(url)
-		Expect(err).NotTo(HaveOccurred())
-
-		defer res.Body.Close()
-		scanner := bufio.NewScanner(res.Body)
-
-		expected := "Search OpenShift CI"
-		found := false
-		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), expected) {
-				found = true
-				break
-			}
-		}
-		Expect(found).To(BeTrue())
-		Expect(scanner.Err()).NotTo(HaveOccurred())
+		check.HTTPService(testNamespace, "8080", "app=search", "Search OpenShift CI", "")
 	})
 })

--- a/github/ci/services/common/k8s/pkg/check/BUILD.bazel
+++ b/github/ci/services/common/k8s/pkg/check/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["check.go"],
+    importpath = "kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/check",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//github/ci/services/common/k8s/pkg/client:go_default_library",
+        "//github/ci/services/common/k8s/pkg/portforwarder:go_default_library",
+        "//github/ci/services/common/k8s/pkg/wait:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+    ],
+)

--- a/github/ci/services/common/k8s/pkg/check/check.go
+++ b/github/ci/services/common/k8s/pkg/check/check.go
@@ -1,0 +1,73 @@
+package check
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/client"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/portforwarder"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/wait"
+)
+
+var (
+	clientset *kubernetes.Clientset
+	err       error
+)
+
+func HTTPService(testNamespace, svcPort, labelSelector, expectedContent, urlPath string) {
+	if clientset == nil {
+		clientset, err = client.NewClientset()
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	localPort := "8080"
+	ports := []string{fmt.Sprintf("%s:%s", localPort, svcPort)}
+
+	stopChan := make(chan struct{}, 1)
+	defer close(stopChan)
+
+	pods, err := clientset.CoreV1().
+		Pods(testNamespace).
+		List(context.TODO(),
+			metav1.ListOptions{
+				LabelSelector: labelSelector,
+			})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(pods.Items)).To(BeNumerically(">=", 1))
+	podName := pods.Items[0].Name
+
+	go func() {
+		err := portforwarder.New(testNamespace, podName, ports, stopChan)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	host := "localhost"
+	err = wait.ForPortOpen(host, localPort)
+	Expect(err).NotTo(HaveOccurred())
+
+	url := fmt.Sprintf("http://%s:%s/%s", host, localPort, urlPath)
+	res, err := http.Get(url)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer res.Body.Close()
+	scanner := bufio.NewScanner(res.Body)
+
+	found := false
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), expectedContent) {
+			found = true
+			break
+		}
+	}
+	Expect(found).To(BeTrue())
+	Expect(scanner.Err()).NotTo(HaveOccurred())
+}

--- a/github/ci/services/kuberhealthy/BUILD.bazel
+++ b/github/ci/services/kuberhealthy/BUILD.bazel
@@ -1,0 +1,47 @@
+load("@com_adobe_rules_gitops//gitops:defs.bzl", "k8s_deploy")
+
+TEST_CLUSTER = "kind-kind"
+
+TEST_USER = "kind-kind"
+
+PRODUCTION_CLUSTER = "ibm-cluster"
+
+PRODUCTION_USER = "ibm-prow-jobs-automation"
+
+[
+    k8s_deploy(
+        name = NAME,
+        cluster = CLUSTER,
+        manifests = glob([
+            "crds/*.yaml",
+        ]),
+        namespace = "kuberhealthy",
+        user = USER,
+    )
+    for NAME, CLUSTER, USER in [
+        ("testing-crds", TEST_CLUSTER, TEST_USER),
+        ("production-crds", PRODUCTION_CLUSTER, PRODUCTION_USER),
+    ]
+]
+
+[
+    k8s_deploy(
+        name = NAME,
+        cluster = CLUSTER,
+        manifests = glob([
+            "manifests/*.yaml",
+        ]),
+        patches = glob([
+            "patches/*.yaml",
+        ]),
+        secrets_srcs = glob([
+            "secrets/%s/**/*" % NAME,
+        ]),
+        namespace = "kuberhealthy",
+        user = USER,
+    )
+    for NAME, CLUSTER, USER in [
+        ("testing", TEST_CLUSTER, TEST_USER),
+        ("production", PRODUCTION_CLUSTER, PRODUCTION_USER),
+    ]
+]

--- a/github/ci/services/kuberhealthy/README.md
+++ b/github/ci/services/kuberhealthy/README.md
@@ -1,7 +1,6 @@
 # ci-search
 
-Customization and deployment of a prometheus-based monitoring stack, including
-[prometheus operator], [alertmanager], [grafana] and [loki]. It uses internally
+Customization and deployment of [Kuberhealthy]. It uses internally
 these bazel [gitops rules].
 
 ## Deployment
@@ -13,7 +12,7 @@ create [these resources](./manifests).
 
 Then, from the root of project-infra run:
 ```
-$ ./github/ci/services/prometheus-stack/hack/deploy.sh production
+$ ./github/ci/services/kuberhealthy/hack/deploy.sh production
 ```
 
 ## Tests
@@ -21,14 +20,11 @@ $ ./github/ci/services/prometheus-stack/hack/deploy.sh production
 Can be tested locally using [kind] and [bazelisk], from the root of project-infra:
 ```
 $ kind create cluster
-$ ./github/ci/services/prometheus-stack/hack/deploy.sh testing
-$ bazelisk test //github/ci/services/prometheus-stack/e2e:go_default_test --test_output=all --test_arg=-test.v
+$ ./github/ci/services/kuberhealthy/hack/deploy.sh testing
+$ bazelisk test //github/ci/services/kuberhealthy/e2e:go_default_test --test_output=all --test_arg=-test.v
 ```
 
 [gitops rules]: https://github.com/adobe/rules_gitops#:~:text=Bazel%20GitOps%20Rules,kustomize%20overlays%20for%20their%20services.
-[prometheus operator]: https://github.com/prometheus-operator/prometheus-operator
-[alertmanager]: https://prometheus.io/docs/alerting/latest/alertmanager/
-[grafana]: https://grafana.com/
-[loki]: https://grafana.com/oss/loki/
+[Kuberhealthy]: https://github.com/Comcast/kuberhealthy
 [kind]: https://github.com/kubernetes-sigs/kind
 [bazelisk]: https://github.com/bazelbuild/bazelisk

--- a/github/ci/services/kuberhealthy/README.md
+++ b/github/ci/services/kuberhealthy/README.md
@@ -1,0 +1,34 @@
+# ci-search
+
+Customization and deployment of a prometheus-based monitoring stack, including
+[prometheus operator], [alertmanager], [grafana] and [loki]. It uses internally
+these bazel [gitops rules].
+
+## Deployment
+
+You need:
+* a kubernetes configuration at `~/.kube/config` with an user allowed to
+create [these resources](./manifests).
+* [bazelisk] installed.
+
+Then, from the root of project-infra run:
+```
+$ ./github/ci/services/prometheus-stack/hack/deploy.sh production
+```
+
+## Tests
+
+Can be tested locally using [kind] and [bazelisk], from the root of project-infra:
+```
+$ kind create cluster
+$ ./github/ci/services/prometheus-stack/hack/deploy.sh testing
+$ bazelisk test //github/ci/services/prometheus-stack/e2e:go_default_test --test_output=all --test_arg=-test.v
+```
+
+[gitops rules]: https://github.com/adobe/rules_gitops#:~:text=Bazel%20GitOps%20Rules,kustomize%20overlays%20for%20their%20services.
+[prometheus operator]: https://github.com/prometheus-operator/prometheus-operator
+[alertmanager]: https://prometheus.io/docs/alerting/latest/alertmanager/
+[grafana]: https://grafana.com/
+[loki]: https://grafana.com/oss/loki/
+[kind]: https://github.com/kubernetes-sigs/kind
+[bazelisk]: https://github.com/bazelbuild/bazelisk

--- a/github/ci/services/kuberhealthy/crds/kuberhealthy.yaml
+++ b/github/ci/services/kuberhealthy/crds/kuberhealthy.yaml
@@ -1,0 +1,66 @@
+---
+# Source: crds/khcheck.yaml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: khchecks.comcast.github.io
+spec:
+  group: comcast.github.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: khchecks
+    singular: khcheck
+    kind: KuberhealthyCheck
+    shortNames:
+      - khc
+
+---
+# Source: crds/khjob.yaml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: khjobs.comcast.github.io
+spec:
+  group: comcast.github.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: khjobs
+    singular: khjob
+    kind: KuberhealthyJob
+    shortNames:
+      - khj
+
+---
+# Source: crds/khstate.yaml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: khstates.comcast.github.io
+spec:
+  group: comcast.github.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: khstates
+    singular: khstate
+    kind: KuberhealthyState
+    shortNames:
+      - khs
+  additionalPrinterColumns:
+    - description: OK status
+      JSONPath: .spec.OK
+      name: OK
+      type: string
+    - description: Last Run
+      JSONPath: .spec.LastRun
+      name: Age LastRun
+      type: date
+    - description: Age
+      JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date

--- a/github/ci/services/kuberhealthy/e2e/BUILD.bazel
+++ b/github/ci/services/kuberhealthy/e2e/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["e2e_test.go"],
+    deps = [
+        "//github/ci/services/common/k8s/pkg/check:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/github/ci/services/kuberhealthy/e2e/e2e_test.go
+++ b/github/ci/services/kuberhealthy/e2e/e2e_test.go
@@ -1,0 +1,29 @@
+package e2e
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/check"
+)
+
+const (
+	testNamespace = "kuberhealthy"
+)
+
+func TestKuberhealthyDeployment(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "kuberhealthy deployment suite")
+}
+
+var _ = Describe("kuberhealthy deployment", func() {
+	table.DescribeTable("should deploy HTTP services",
+		func(svcPort, labelSelector, expectedContent, urlPath string) {
+			check.HTTPService(testNamespace, svcPort, labelSelector, expectedContent, urlPath)
+		},
+		table.Entry("kuberhealthy", "8080", "app=kuberhealthy", `"OK": true`, ""),
+	)
+})

--- a/github/ci/services/kuberhealthy/hack/deploy.sh
+++ b/github/ci/services/kuberhealthy/hack/deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eo pipefail
+
+main(){
+    local environment=${1}
+
+    bazelisk run //github/ci/services/kuberhealthy:${environment}-crds.apply
+
+    bazelisk run //github/ci/services/common/k8s/cmd/wait -- -selector khchecks.comcast.github.io -kind crd
+
+    bazelisk run //github/ci/services/kuberhealthy:${environment}.apply
+
+    bazelisk run //github/ci/services/common/k8s/cmd/wait -- -namespace kuberhealthy -selector kuberhealthy -kind deployment
+}
+
+main "${@}"

--- a/github/ci/services/kuberhealthy/manifests/ingress.yaml
+++ b/github/ci/services/kuberhealthy/manifests/ingress.yaml
@@ -17,6 +17,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: search
+            name: kuberhealthy
             port:
               number: 80

--- a/github/ci/services/kuberhealthy/manifests/ingress.yaml
+++ b/github/ci/services/kuberhealthy/manifests/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kuberhealthy
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+spec:
+  tls:
+  - hosts:
+    - status.ci.kubevirt.io
+    secretName: kuberhealthy-tls
+  rules:
+  - host: status.ci.kubevirt.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: search
+            port:
+              number: 80

--- a/github/ci/services/kuberhealthy/manifests/kuberhealthy.yaml
+++ b/github/ci/services/kuberhealthy/manifests/kuberhealthy.yaml
@@ -1,0 +1,454 @@
+---
+# Source: kuberhealthy/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name:  kuberhealthy-pdb
+  namespace: default
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: kuberhealthy
+---
+# Source: kuberhealthy/templates/khcheck-daemonset.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: daemonset-khcheck
+  namespace: default
+---
+# Source: kuberhealthy/templates/khcheck-deployment.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deployment-sa
+  namespace: default
+---
+# Source: kuberhealthy/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuberhealthy
+  namespace: default
+---
+# Source: kuberhealthy/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuberhealthy
+data:
+  kuberhealthy.yaml: |-
+    listenAddress: ":8080" # The port for kuberhealthy to listen on for web requests
+    enableForceMaster: false # Set to true to enable local testing, forced master mode
+    logLevel: "debug" # Log level to be used
+    influxUsername: "" # Username for the InfluxDB instance
+    influxPassword: "" # Password for the InfluxDB instance
+    influxURL: "" # Address for the InfluxDB instance
+    influxDB: "http://localhost:8086" # Name of the InfluxDB database
+    enableInflux: false # Set to true to enable metric forwarding to Infux DB
+    jobCleanupDuration: 15m
+    maxCheckPods: 4
+---
+# Source: kuberhealthy/templates/clusterrole.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  name: kuberhealthy
+rules:
+  - apiGroups:
+    - apps
+    resources:
+    - daemonsets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - daemonsets
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - comcast.github.io
+    resources:
+    - khstates
+    - khchecks
+    - khjobs
+    verbs:
+    - "*"
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    - componentstatuses
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - pods/eviction
+    verbs:
+    - create
+---
+# Source: kuberhealthy/templates/clusterrole.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRole
+metadata:
+  name: kuberhealthy-daemonset-khcheck
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+---
+# Source: kuberhealthy/templates/clusterrolebinding.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  name: kuberhealthy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuberhealthy
+subjects:
+- kind: ServiceAccount
+  name: kuberhealthy
+  namespace: default
+---
+# Source: kuberhealthy/templates/clusterrolebinding.yaml
+apiVersion: "rbac.authorization.k8s.io/v1"
+kind: ClusterRoleBinding
+metadata:
+  name: kuberhealthy-daemonset-khcheck
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuberhealthy-daemonset-khcheck
+subjects:
+- kind: ServiceAccount
+  name: daemonset-khcheck
+  namespace: default
+---
+# Source: kuberhealthy/templates/khcheck-daemonset.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ds-admin
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+      - apps
+    resources:
+      - daemonsets
+      - pods
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: kuberhealthy/templates/khcheck-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deployment-service-role
+  namespace: default
+rules:
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: kuberhealthy/templates/khcheck-daemonset.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: daemonset-khcheck
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ds-admin
+subjects:
+  - kind: ServiceAccount
+    name: daemonset-khcheck
+---
+# Source: kuberhealthy/templates/khcheck-deployment.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deployment-check-rb
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: deployment-service-role
+subjects:
+  - kind: ServiceAccount
+    name: deployment-sa
+---
+# Source: kuberhealthy/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kuberhealthy
+  name: kuberhealthy
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    name: http
+    targetPort: http
+  selector:
+    app: kuberhealthy
+---
+# Source: kuberhealthy/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kuberhealthy
+  namespace: default
+  labels:
+    app: kuberhealthy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: kuberhealthy
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: kuberhealthy
+    spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            # Provide the name of the ConfigMap containing the files you want
+            # to add to the container
+            name: kuberhealthy
+      serviceAccountName: kuberhealthy
+      automountServiceAccountToken: true
+      containers:
+      - image: kuberhealthy/kuberhealthy:v2.4.0
+        command: [/app/kuberhealthy]
+        ports:
+        - containerPort: 8080
+          name: http
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+          allowPrivilegeEscalation: false
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 2
+          periodSeconds: 4
+          successThreshold: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        name: kuberhealthy
+        volumeMounts:
+          - name: config-volume
+            mountPath: /etc/config/
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        readinessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 2
+          periodSeconds: 4
+          successThreshold: 1
+          tcpSocket:
+            port: 8080
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 400m
+            memory: 300Mi
+          limits:
+            cpu: 2
+            memory: 1Gi
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 60
+---
+# Source: kuberhealthy/templates/khcheck-daemonset.yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: daemonset
+  namespace: default
+spec:
+  runInterval:  15m
+  timeout: 12m
+  podSpec:
+    securityContext:
+      runAsUser: 999
+      fsGroup: 999
+    containers:
+      - env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CHECK_POD_TIMEOUT
+            value: "10m"
+        image: kuberhealthy/daemonset-check:v3.2.5
+        imagePullPolicy: IfNotPresent
+        name: main
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+    serviceAccountName: daemonset-khcheck
+---
+# Source: kuberhealthy/templates/khcheck-deployment.yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: deployment
+  namespace: default
+spec:
+  runInterval:  10m
+  timeout: 15m
+  podSpec:
+    securityContext:
+      runAsUser: 999
+      fsGroup: 999
+    containers:
+    - name: deployment
+      image: kuberhealthy/deployment-check:v1.8.1
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: CHECK_DEPLOYMENT_REPLICAS
+          value: "4"
+        - name: CHECK_DEPLOYMENT_ROLLING_UPDATE
+          value: "true"
+        - name: CHECK_SERVICE_ACCOUNT
+          value: "default"
+      resources:
+        requests:
+          cpu: 25m
+          memory: 15Mi
+        limits:
+          cpu: 40m
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+      restartPolicy: Never
+    serviceAccountName: deployment-sa
+    terminationGracePeriodSeconds: 60
+---
+# Source: kuberhealthy/templates/khcheck-dns-internal.yaml
+apiVersion: comcast.github.io/v1
+kind: KuberhealthyCheck
+metadata:
+  name: dns-status-internal
+  namespace: default
+spec:
+  runInterval: 2m
+  timeout: 15m
+  podSpec:
+    securityContext:
+      runAsUser: 999
+      fsGroup: 999
+    containers:
+      - env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: HOSTNAME
+            value: "kubernetes.default"
+        image: kuberhealthy/dns-resolution-check:v1.4.2
+        imagePullPolicy: IfNotPresent
+        name: main
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true

--- a/github/ci/services/kuberhealthy/manifests/namespace.yaml
+++ b/github/ci/services/kuberhealthy/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kuberhealthy

--- a/github/ci/services/kuberhealthy/overlays/testing/cluster-issuer.yaml
+++ b/github/ci/services/kuberhealthy/overlays/testing/cluster-issuer.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/github/ci/services/prometheus-stack/e2e/BUILD.bazel
+++ b/github/ci/services/prometheus-stack/e2e/BUILD.bazel
@@ -4,13 +4,9 @@ go_test(
     name = "go_default_test",
     srcs = ["e2e_test.go"],
     deps = [
-        "//github/ci/services/common/k8s/pkg/client:go_default_library",
-        "//github/ci/services/common/k8s/pkg/portforwarder:go_default_library",
-        "//github/ci/services/common/k8s/pkg/wait:go_default_library",
+        "//github/ci/services/common/k8s/pkg/check:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/extensions/table:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )

--- a/github/ci/services/prometheus-stack/e2e/e2e_test.go
+++ b/github/ci/services/prometheus-stack/e2e/e2e_test.go
@@ -1,30 +1,17 @@
 package e2e
 
 import (
-	"bufio"
-	"context"
-	"fmt"
-	"net/http"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/client"
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/portforwarder"
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/wait"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/check"
 )
 
 const (
 	testNamespace = "monitoring"
-)
-
-var (
-	clientset *kubernetes.Clientset
 )
 
 func TestPrometheusStackDeployment(t *testing.T) {
@@ -32,61 +19,10 @@ func TestPrometheusStackDeployment(t *testing.T) {
 	RunSpecs(t, "prometheus-stack deployment suite")
 }
 
-var _ = BeforeSuite(func() {
-	var err error
-
-	// initilize clientset
-	clientset, err = client.NewClientset()
-	Expect(err).NotTo(HaveOccurred())
-})
-
 var _ = Describe("prometheus-stack deployment", func() {
 	table.DescribeTable("should deploy HTTP services",
 		func(svcPort, labelSelector, expectedContent, urlPath string) {
-			localPort := "8080"
-			ports := []string{fmt.Sprintf("%s:%s", localPort, svcPort)}
-
-			stopChan := make(chan struct{}, 1)
-			defer close(stopChan)
-
-			pods, err := clientset.CoreV1().
-				Pods(testNamespace).
-				List(context.TODO(),
-					metav1.ListOptions{
-						LabelSelector: labelSelector,
-					})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(pods.Items)).To(Equal(1))
-			podName := pods.Items[0].Name
-
-			go func() {
-				err := portforwarder.New(testNamespace, podName, ports, stopChan)
-				if err != nil {
-					panic(err)
-				}
-			}()
-
-			host := "localhost"
-			err = wait.ForPortOpen(host, localPort)
-			Expect(err).NotTo(HaveOccurred())
-
-			url := fmt.Sprintf("http://%s:%s/%s", host, localPort, urlPath)
-			res, err := http.Get(url)
-			Expect(err).NotTo(HaveOccurred())
-
-			defer res.Body.Close()
-			scanner := bufio.NewScanner(res.Body)
-
-			found := false
-			for scanner.Scan() {
-				if strings.Contains(scanner.Text(), expectedContent) {
-					found = true
-					break
-				}
-			}
-			Expect(found).To(BeTrue())
-			Expect(scanner.Err()).NotTo(HaveOccurred())
-
+			check.HTTPService(testNamespace, svcPort, labelSelector, expectedContent, urlPath)
 		},
 		table.Entry("grafana service", "3000", "app.kubernetes.io/name=grafana", "<title>Grafana</title>", ""),
 		table.Entry("prometheus service", "9090", "app=prometheus", "<title>Prometheus Time Series Collection and Processing Server</title>", ""),

--- a/github/ci/services/sippy/e2e/BUILD.bazel
+++ b/github/ci/services/sippy/e2e/BUILD.bazel
@@ -4,8 +4,7 @@ go_test(
     name = "go_default_test",
     srcs = ["e2e_test.go"],
     deps = [
-        "//github/ci/services/common/k8s/pkg/portforwarder:go_default_library",
-        "//github/ci/services/common/k8s/pkg/wait:go_default_library",
+        "//github/ci/services/common/k8s/pkg/check:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/github/ci/services/sippy/e2e/e2e_test.go
+++ b/github/ci/services/sippy/e2e/e2e_test.go
@@ -1,17 +1,12 @@
 package e2e
 
 import (
-	"bufio"
-	"fmt"
-	"net/http"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/portforwarder"
-	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/wait"
+	"kubevirt.io/project-infra/github/ci/services/common/k8s/pkg/check"
 )
 
 const (
@@ -25,41 +20,6 @@ func TestSippyDeployment(t *testing.T) {
 
 var _ = Describe("sippy deployment", func() {
 	It("creates a responding HTTP service", func() {
-		localPort := "8080"
-		svcPort := "8080"
-		ports := []string{fmt.Sprintf("%s:%s", localPort, svcPort)}
-
-		stopChan := make(chan struct{}, 1)
-		defer close(stopChan)
-
-		podName := "sippy-0"
-		go func() {
-			err := portforwarder.New(testNamespace, podName, ports, stopChan)
-			if err != nil {
-				panic(err)
-			}
-		}()
-
-		host := "localhost"
-		err := wait.ForPortOpen(host, localPort)
-		Expect(err).NotTo(HaveOccurred())
-
-		url := fmt.Sprintf("http://%s:%s", host, localPort)
-		res, err := http.Get(url)
-		Expect(err).NotTo(HaveOccurred())
-
-		defer res.Body.Close()
-		scanner := bufio.NewScanner(res.Body)
-
-		expected := "<title>Release CI Health Dashboard</title>"
-		found := false
-		for scanner.Scan() {
-			if strings.Contains(scanner.Text(), expected) {
-				found = true
-				break
-			}
-		}
-		Expect(found).To(BeTrue())
-		Expect(scanner.Err()).NotTo(HaveOccurred())
+		check.HTTPService(testNamespace, "8080", "app=sippy", "<title>Release CI Health Dashboard</title>", "")
 	})
 })


### PR DESCRIPTION
Test and deployment code for a basic [Kuberhealthy](https://github.com/Comcast/kuberhealthy) installation. Includes 3 preconfigured synthetic checks for damonset, deployment and dns status. Includes ingress for accessing the status page at https://status.ci.kubevirt.io

I've taken the opportunity to refactor the HTTP service checks in the `github/ci/services` deployments e2e tests.

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>