### PR TITLE
prow-deploy: add SRIOV node patch action

### DIFF
--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -48,7 +48,7 @@
             - |
               kind: JoinConfiguration
               nodeRegistration:
-                name: node01
+                name: '{{ node_name }}'
                 kubeletExtraArgs:
                   system-reserved: memory=16Gi
     - name: Launch cluster

--- a/github/ci/prow-deploy/molecule/default/smoke_tests.yml
+++ b/github/ci/prow-deploy/molecule/default/smoke_tests.yml
@@ -39,3 +39,10 @@
       --address="http://{{ deckUrl }}/hook" \
       --hmac {{ prowHmac }}
   changed_when: false
+
+- name: verify SRIOV nodes patched
+  shell: |
+    timeout 60s bash -c "until kubectl get node {{ item.name }} -oyaml | grep prow/sriov | grep {{ item.capacity }} | wc -l | grep 2; do sleep 1; done"
+  loop: "{{ SRIOVNodes }}"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -6,3 +6,7 @@ kubeconfig_path: '/root/.kube/config'
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/'
 
 kind_cluster_config: '/workspace/cluster.yaml'
+
+SRIOVNodes:
+- name: node01
+  capacity: 2

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -7,6 +7,8 @@ secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kub
 
 kind_cluster_config: '/workspace/cluster.yaml'
 
+node_name: node01
+
 SRIOVNodes:
-- name: node01
+- name: '{{ node_name }}'
   capacity: 2

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -36,3 +36,10 @@
     PROW_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/config/config.yaml"
     PLUGIN_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/plugins/plugins.yaml"
     KUBECONFIG: "{{ kubeconfig_path }}"
+
+- name: Patch SRIOV nodes
+  shell: |
+    {{ project_infra_root }}/hack/patch_node.sh {{ item.name }} {{ item.capacity }}
+  loop: "{{ SRIOVNodes }}"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"

--- a/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
+++ b/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
@@ -7,3 +7,5 @@ kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
 
 shell_environment:
   KUBECONFIG: "{{ kubeconfig_path }}"
+
+SRIOVNodes: []


### PR DESCRIPTION
prow-deploy task for patching SRIOV nodes using the `hack/patch_node.sh` script, includes check in smoke tests.  

For now it only defines SRIOV node entries in the testing configuration, when we use the deployment code in the new control plane we need to add the actual node names and capacities in the prod config.

/cc @oshoval @dhiller  

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>