### PR TITLE
use main branch for containerized-data-importer

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -277,7 +277,7 @@ periodics:
     base_ref: master
   - org: kubevirt
     repo: containerized-data-importer
-    base_ref: master
+    base_ref: main
   spec:
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
containerized-data-importer repo has recently changed its default branch from master to main, without these changes we get this error in the periodic:
```
$ git fetch https://github.com/kubevirt/containerized-data-importer.git master
fatal: Couldn't find remote ref master
```
For instance here https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-kubevirt-mirror-uploader/1361934958288965632#1:build-log.txt%3A125

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>