### PR TITLE
Make the dependency mirror tool more fault  tolerant

### DIFF
--- a/plugins/cmd/uploader/uploader.go
+++ b/plugins/cmd/uploader/uploader.go
@@ -68,7 +68,11 @@ func main() {
 
 func verify(options options, artifacts []mirror.Artifact) {
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	var opts []option.ClientOption
+	if options.dryRun {
+		opts = append(opts, option.WithoutAuthentication())
+	}
+	client, err := storage.NewClient(ctx, opts...)
 	if err != nil {
 		log.Fatalf("Failed to create new storage client: %v.\n", err)
 	}

--- a/plugins/mirror/bazel.go
+++ b/plugins/mirror/bazel.go
@@ -105,6 +105,10 @@ func WriteToBucket(dryRun bool, ctx context.Context, client *storage.Client, art
 			continue
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			log.Printf("Could not upload artifact from %s, continuing with next URL: Status Code: %v", uri, resp.StatusCode)
+			continue
+		}
 
 		log.Printf("File will be written to gs://%s/%s", bucket, reportObject.ObjectName())
 


### PR DESCRIPTION
* Check if we get a good HTTP return code
* Check if the artifact from the mirror has the expected shasum
* Add a command to verify that all mirrored dependencies have the expected shasum

Here the output after running the new verify command:
```
$ ./uploader -verify -workspace /home/rmohr/go/src/kubevirt.io/kubevirt/WORKSPACE 
true
2021/02/22 12:35:24 failed to upload llvm-libs-0__10.0.1-4.fc32.x86_64 to https://storage.googleapis.com/builddeps/2553c52dfcf5b6b8edabb89bfd3af8c4a7cecb81169a48cd7af9460ea20e108f: artifact llvm-libs-0__10.0.1-4.fc32.x86_64: expected shasum 2553c52dfcf5b6b8edabb89bfd3af8c4a7cecb81169a48cd7af9460ea20e108f, got 3bf95b81d86575587ba92ece56c9a53410b3c1da529e5d66917b460c7ba263af
2021/02/22 12:35:39 failed to upload procps-ng-0__3.3.16-2.fc32.x86_64 to https://storage.googleapis.com/builddeps/9d360e29f7a54d585853407d778b194ebe299663e83d59394ac122ae1687f61a: artifact procps-ng-0__3.3.16-2.fc32.x86_64: expected shasum 9d360e29f7a54d585853407d778b194ebe299663e83d59394ac122ae1687f61a, got 8351c0267c2cd7866ff04c04261f06cd75af9a7130aac848ca43fd047404e229
```

The two invalid artifacts shown here are already fixed.
