### PR TITLE
prow-deploy: use quay image for kind test cluster

### DIFF
--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -54,7 +54,7 @@
     - name: Launch cluster
       shell: |
         kind delete cluster
-        kind create cluster --config {{ kind_cluster_config }}
+        kind create cluster --config {{ kind_cluster_config }} --image quay.io/kubevirtci/kind:v1.19.1
       changed_when: false
       when: "'kubevirtci' in deploy_environment"
 

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -32,7 +32,7 @@
 
     - name: create cluster config
       copy:
-        dest: '{{ kind_cluster_config }}'
+        dest: '{{ kind.cluster_config }}'
         content: |
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4
@@ -54,7 +54,7 @@
     - name: Launch cluster
       shell: |
         kind delete cluster
-        kind create cluster --config {{ kind_cluster_config }} --image quay.io/kubevirtci/kind:v1.19.1
+        kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }}
       changed_when: false
       when: "'kubevirtci' in deploy_environment"
 

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -5,7 +5,10 @@ project_infra_root: /workspace/repos/project-infra-master
 kubeconfig_path: '/root/.kube/config'
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/'
 
-kind_cluster_config: '/workspace/cluster.yaml'
+kind:
+  cluster_config: '/workspace/cluster.yaml'
+  image_tag: v1.19.1
+
 
 node_name: node01
 


### PR DESCRIPTION
This will prevent errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/854/pull-project-infra-prow-deploy-test/1363409299254022145

/cc @dhiller @oshoval 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>