### PR TITLE
testgrid: set transfigure image tag

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -519,7 +519,7 @@ postsubmits:
       decorate: true
       spec:
         containers:
-        - image: gcr.io/k8s-prow/transfigure
+        - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
           command:
           - /transfigure.sh
           args:

--- a/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -471,7 +471,7 @@ presubmits:
       testgrid-create-test-group: "false"
     spec:
       containers:
-      - image: gcr.io/k8s-prow/transfigure
+      - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
         command:
         - /transfigure.sh
         args:


### PR DESCRIPTION
With this our jobs will use the transfigure image built with the changes from https://github.com/kubernetes/test-infra/pull/20902, which will fix the links from the dashboards in https://testgrid.k8s.io/kubevirt to our prow instance.

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>