### PR TITLE
Add sriov lane requirements

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -48,7 +48,9 @@ RUN dnf install -y dnf-plugins-core && \
     rsync \
     rsync-daemon \
     sudo \
-    wget && \
+    wget \
+    gettext \
+    iproute &&\
   dnf -y clean all
 
 # Install gcloud


### PR DESCRIPTION
SRIOV lane installs `gettext` via `apt` and it fails on the bootstrap image due to the missing `ip` binary which is part of `iproute`.