### PR TITLE
kubevirt push nightly: fix error handling

### DIFF
--- a/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -173,34 +173,39 @@ periodics:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - >
-          set -e;
-          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io;
-          export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)";
-          make;
-          counter=3;
+        - |
+          set -e
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+          export DOCKER_TAG="$(date +%Y%m%d)_$(git show -s --format=%h)"
+          make
+          counter=3
+          retval=0
           while [ $counter -gt 0 ]; do
-              set +e;
-              make push;
-              retval=$?;
-              set -e;
+              set +e
+              make push
+              retval=$?
+              set -e
               if [ $retval -eq 0 ]; then
-                  break;
-              fi;
-              set +e;
-              counter=$(expr $counter - 1);
-              set -e;
-              sleep 120;
-          done;
-          make build-functests;
-          git show -s --format=%H > _out/commit;
-          build_date="$(date +%Y%m%d)";
-          echo ${build_date} > _out/build_date;
-          bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}";
-          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/;
-          gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/;
-          gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/;
-          gsutil cp ./_out/commit gs://$bucket_dir/commit;
+                  break
+              fi
+              set +e
+              counter=$(expr $counter - 1)
+              set -e
+              sleep 120
+          done
+          if [ $retval -ne 0 ]; then
+              echo "push failed!"
+              exit 1
+          fi
+          make build-functests
+          git show -s --format=%H > _out/commit
+          build_date="$(date +%Y%m%d)"
+          echo ${build_date} > _out/build_date
+          bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
+          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/
+          gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/
+          gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/
+          gsutil cp ./_out/commit gs://$bucket_dir/commit
           gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
In case the push does not succeed after the maximum number of retries
check the retval to be non zero and exit in that case.

Occurred on [periodic-kubevirt-push-nightly-build-master job run](https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-master/1364742725022257152).

Cause of the failure was a nonexisting image repository on quay, although I found the 429 error code slightly misleading :)

I have created the missing repo and have started a job instance of said job manually: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-master/1364879739231145984

/cc @fgimenez @thetechnick @davidvossel 