### PR TITLE
Fix adding the latest kubevirtci provider

### DIFF
--- a/robots/pkg/kubevirtci/kubevirtci.go
+++ b/robots/pkg/kubevirtci/kubevirtci.go
@@ -75,13 +75,16 @@ func EnsureProviderExists(providerDir string, release *github.RepositoryRelease)
 		// First smaller existing provider. Copy the provider.
 		sourceDir := filepath.Join(providerDir, fmt.Sprintf("%s.%s", rel.Major, rel.Minor))
 		targetDir := filepath.Join(providerDir, fmt.Sprintf("%s.%s", semver.Major, semver.Minor))
-		// proper recursive copy of dirs is complicated, let `cp` do that.
-		err := exec.Command("cp", "-a", sourceDir, targetDir).Run()
-		if err != nil {
-			return err
+
+		if _, err := os.Stat(targetDir); os.IsNotExist(err) {
+			// proper recursive copy of dirs is complicated, let `cp` do that.
+			err := exec.Command("cp", "-a", sourceDir, targetDir).Run()
+			if err != nil {
+				return err
+			}
+			logrus.Infof("Added provider %s.%s with version %v", semver.Major, semver.Minor, semver.String())
+			// Bump the new provider to the right version
 		}
-		logrus.Infof("Added provider %s.%s with version %v", semver.Major, semver.Minor, semver.String())
-		// Bump the new provider to the right version
 		err = bumpRelease(providerDir, release)
 		if err != nil {
 			return err

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -94,7 +94,7 @@ func createProviderEnv(dir string, releases []querier.SemVer) {
 func createRelease(dir string, semver querier.SemVer) {
 	path := filepath.Join(dir, fmt.Sprintf("%s.%s", semver.Major, semver.Minor))
 	err := os.Mkdir(path, os.ModePerm)
-	if err != nil {
+	if err != nil && !os.IsExist(err) {
 		panic(err)
 	}
 	err = ioutil.WriteFile(filepath.Join(path, "version"), []byte(fmt.Sprintf("%s.%s.%s", semver.Major, semver.Minor, semver.Patch)), os.ModePerm)
@@ -169,6 +169,7 @@ func TestEnsureProviderExists(t *testing.T) {
 		wantErr  bool
 	}{
 		{
+			name:    "expect a v1.10 provider to be added",
 			release: release("v1.10.3", true),
 			existing: []querier.SemVer{
 				newSemVer("1", "2", "1"),
@@ -179,6 +180,22 @@ func TestEnsureProviderExists(t *testing.T) {
 			wanted: []querier.SemVer{
 				newSemVer("1", "16", "5"),
 				newSemVer("1", "10", "3"),
+				newSemVer("1", "9", "4"),
+				newSemVer("1", "3", "2"),
+				newSemVer("1", "2", "1"),
+			},
+		},
+		{
+			name:    "expect the latest 1.16 provider to be updated from 1.16.5 to 1.16.7",
+			release: release("v1.16.7", true),
+			existing: []querier.SemVer{
+				newSemVer("1", "2", "1"),
+				newSemVer("1", "3", "2"),
+				newSemVer("1", "9", "4"),
+				newSemVer("1", "16", "5"),
+			},
+			wanted: []querier.SemVer{
+				newSemVer("1", "16", "7"),
 				newSemVer("1", "9", "4"),
 				newSemVer("1", "3", "2"),
 				newSemVer("1", "2", "1"),


### PR DESCRIPTION
Ensure that we properly detect if the latest k8s version provider
already exists, and in that case only bump to the latest minor version
if necessary, instead of copying the n-1th release into a subdirectory
of the latest existing provider.

Fixes a wrong copy operation like in this PR: https://github.com/kubevirt/kubevirtci/pull/547