### PR TITLE
Fix periodic-kubevirt-mirror-uploader: add missing dependency

### DIFF
--- a/plugins/cmd/uploader/BUILD.bazel
+++ b/plugins/cmd/uploader/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//plugins/mirror:go_default_library",
         "//vendor/cloud.google.com/go/storage:go_default_library",
         "//vendor/github.com/bazelbuild/buildtools/build:go_default_library",
+        "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Failing job: https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-kubevirt-mirror-uploader/1366283426084163584