### PR TITLE
Allow mixins for layering funcitonality on top of the bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -99,6 +99,9 @@ RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/downloa
 RUN USE_BAZEL_VERSION=3.4.1 bazel version && \
   USE_BAZEL_VERSION=4.0.0 bazel version
 
+# create mixin directories
+RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
+
 # note the runner is also responsible for making docker in docker function if
 # env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating
 # .bazelrc files if bazel remote caching is enabled

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -118,11 +118,17 @@ fi
 SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
 export SOURCE_DATE_EPOCH
 
+# run setup mixins
+for file in $(find /etc/setup.mixin.d/ -maxdepth 1 -name '*.sh' -print -quit); do source $file; done
+
 # actually start bootstrap and the job
 set -o xtrace
 "$@"
 EXIT_VALUE=$?
 set +o xtrace
+
+# run teardown mixins
+for file in $(find /etc/teardown.mixin.d/ -maxdepth 1 -name '*.sh' -print -quit); do source $file; done
 
 # cleanup after job
 if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then


### PR DESCRIPTION
These mixin entrypoints allow layered containers to bring in additional setup and teardown code, avoiding the need to wrap the `runner.sh` script.

One example is for instance a layered golang container:


```
FROM quay.io/kubevirtci/bootstrap:latest

# Cache latest stable golang version
RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
RUN gimme 1.15.8

RUN echo 'eval $(gimme 1.15.8)' > /etc/setup.mixin.d/golang.sh
```

Similar things can very often be achived by putting code into profile files or similar places, but they very often depend on the execution shell or other assumptions on how one enters a container. This way injection can be done in a well-defined way.