### PR TITLE
Publish a golang image together with the bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -84,6 +84,7 @@ postsubmits:
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh bootstrap quay.io kubevirtci
+                ./publish_image.sh golang quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -63,7 +63,7 @@ postsubmits:
                 memory: "1Gi"
     - name: publish-bootstrap-image
       always_run: false
-      run_if_changed: "images/bootstrap/.*"
+      run_if_changed: "images/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -104,6 +104,7 @@ presubmits:
             - "/bin/bash"
             - "-c"
             - "cd images && ./publish_image.sh -b bootstrap docker.io kubevirtci"
+            - "cd images && ./publish_image.sh -b golang docker.io kubevirtci"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -88,7 +88,7 @@ presubmits:
               memory: "1Gi"
   - name: build-bootstrap-image
     always_run: false
-    run_if_changed: "images/bootstrap/.*"
+    run_if_changed: "images/.*"
     decorate: true
     labels:
       preset-dind-enabled: "true"

--- a/images/golang/Dockerfile
+++ b/images/golang/Dockerfile
@@ -1,0 +1,10 @@
+FROM bootstrap
+
+ENV GIMME_GO_VERSION=1.15.8
+
+# Cache latest stable golang version
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN gimme 1.15.8
+
+# GIMME_GO_VERSION is not expanded, so that it can be overwritten on container start
+RUN echo 'eval $(gimme ${GIMME_GO_VERSION})' > /etc/setup.mixin.d/golang.sh

--- a/images/publish_image.sh
+++ b/images/publish_image.sh
@@ -36,7 +36,7 @@ main() {
     (
         cd "$build_target"
 
-        build_image "$full_image_name"
+        build_image "$build_target" "$full_image_name"
     )
     [[ $build_only ]] && return
     publish_image "$full_image_name"
@@ -63,8 +63,9 @@ get_image_tag() {
 }
 
 build_image() {
-    local image_name="${1:?}"
-    docker build . -t "$image_name"
+    local build_target="${1:?}"
+    local image_name="${2:?}"
+    docker build . -t "$image_name" -t "$build_target"
 }
 
 publish_image() {


### PR DESCRIPTION
The image wraps `gimme`. By default 1.15.8 will be used, but
`GIMME_GO_VERSION` can be overwritten at runtime to fetch any other
golang version. 1.15.8 is also pre-cached.

It will be published together with a new bootrap build in a postsubmit.

Follow up of #985 