### PR TITLE
Pick up docker setup from CI

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -76,11 +76,15 @@ if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
     echo "Docker in Docker enabled, initializing..."
     printf '=%.0s' {1..80}; echo
     # If we have opted in to docker in docker, start the docker daemon,
+    if [ -f "/etc/default/docker" ]; then
+        source /etc/default/docker
+    fi
     /usr/bin/dockerd \
         -p /var/run/docker.pid \
         --data-root=/docker-graph \
         --init-path /usr/libexec/docker/docker-init \
         --userland-proxy-path /usr/libexec/docker/docker-proxy \
+        ${DOCKER_OPTS} \
             >/var/log/dockerd.log 2>&1 &
     # the service can be started but the docker socket not ready, wait for ready
     WAIT_N=0


### PR DESCRIPTION
The default debian location is not by default picked up on fedora.
Changing that by explicitly sourcing it and taking DOCKER_OPTS into
account.