### PR TITLE
Publish conformance yaml on developer builds of kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -202,7 +202,7 @@ periodics:
           build_date="$(date +%Y%m%d)"
           echo ${build_date} > _out/build_date
           bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
-          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/
+          gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
           gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/
           gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/
           gsutil cp ./_out/commit gs://$bucket_dir/commit


### PR DESCRIPTION
Publish conformance yaml to allow for instance for kubevirtci during cluster provision running latest conformance tests from kubevirt.