### PR TITLE
Disable peribolos team fixes for presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -504,9 +504,9 @@ presubmits:
         - --github-token-path=/etc/github/oauth
         - --fix-org=true
         - --fix-org-members=true
-        - --fix-teams=true
-        - --fix-team-members=true
-        - --fix-team-repos=true
+        - --fix-teams=false
+        - --fix-team-members=false
+        - --fix-team-repos=false
         - --fix-repos=true
         - --confirm=false
         volumeMounts:


### PR DESCRIPTION
Due to a bug peribolos seems to fail on creation of a team in dry-run mode. Therefore we disable the fix-teams switches for the presubmit.

See #990 
See https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/990/pull-kubevirt-org-github-config-updater/1366785736094781440

/cc @fgimenez 