### PR TITLE
Remove travis branch protection from CDI

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -270,9 +270,6 @@ branch-protection:
           branches:
             master:
               protect: true
-              required_status_checks:
-                contexts:
-                  - continuous-integration/travis-ci/pr
         hyperconverged-cluster-operator:
           branches:
             master:


### PR DESCRIPTION
travis-ci.org no longer exists so the branch protection is no longer valid. The
tests performed by travis will be replaced with matching PROW jobs.

Signed-off-by: Alexander Wels <awels@redhat.com>