### PR TITLE
Add quarantine lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -98,8 +98,10 @@ presubmits:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
           env:
-            KUBEVIRT_QUARANTINE: true
-            TARGET: k8s-1.19
+            - name: KUBEVIRT_QUARANTINE
+              value: "true"
+            - name: TARGET
+              value: k8s-1.19
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -173,8 +175,10 @@ presubmits:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
           env:
-            KUBEVIRT_QUARANTINE: true
-            TARGET: k8s-1.18
+            - name: KUBEVIRT_QUARANTINE
+              value: "true"
+            - name: TARGET
+              value: k8s-1.18
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -248,8 +252,10 @@ presubmits:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
           env:
-            KUBEVIRT_QUARANTINE: true
-            TARGET: k8s-1.17
+            - name: KUBEVIRT_QUARANTINE
+              value: "true"
+            - name: TARGET
+              value: k8s-1.17
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -321,8 +327,10 @@ presubmits:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
         env:
-          KUBEVIRT_QUARANTINE: true
-          TARGET: k8s-1.19-cnao
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
+          - name: TARGET
+            value: k8s-1.19-cnao
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -496,8 +504,10 @@ presubmits:
       containers:
       - image: kubevirtci/bootstrap:v20201119-a5880e0
         env:
-          KUBEVIRT_QUARANTINE: true
-          TARGET: kind-k8s-sriov-1.17.0
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
+          - name: TARGET
+            value: kind-k8s-sriov-1.17.0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -80,7 +80,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: true
-    skip_report: false
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h
@@ -157,7 +157,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: true
-    skip_report: false
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h
@@ -234,7 +234,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: true
-    skip_report: false
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 7h
@@ -311,6 +311,7 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -471,6 +472,7 @@ presubmits:
     always_run: true
     optional: true
     decorate: true
+    skip_report: true
     decoration_config:
       timeout: 4h
       grace_period: 30m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -72,6 +72,45 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.19-quarantine
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: true
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+          env:
+            KUBEVIRT_QUARANTINE: true
+            TARGET: k8s-1.19
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/run-quarantined-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-e2e-k8s-1.18
     skip_branches:
       - release-\d+\.\d+
@@ -102,6 +141,45 @@ presubmits:
             - "/bin/sh"
             - "-c"
             - "export TARGET=k8s-1.18 && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.18-quarantine
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: true
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+          env:
+            KUBEVIRT_QUARANTINE: true
+            TARGET: k8s-1.18
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/run-quarantined-tests.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -144,6 +222,45 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.17-quarantine
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: true
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+          env:
+            KUBEVIRT_QUARANTINE: true
+            TARGET: k8s-1.17
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/run-quarantined-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-e2e-k8s-cnao-1.19
     skip_branches:
     - release-\d+\.\d+
@@ -173,6 +290,44 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "TARGET=k8s-1.19-cnao automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-cnao-1.19-quarantine
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        env:
+          KUBEVIRT_QUARANTINE: true
+          TARGET: k8s-1.19-cnao
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - "automation/run-quarantined-tests.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -298,7 +453,93 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
-
+  - name: pull-kubevirt-e2e-kind-1.17-sriov-quarantine
+    skip_branches:
+    - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 30m
+    max_concurrency: 10
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      sriov-pod: "true"
+      rehearsal.allowed: "true"
+    spec:
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                  - "true"
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - image: kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+          KUBEVIRT_QUARANTINE: true
+          TARGET: kind-k8s-sriov-1.17.0
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/bash"
+        - "-c"
+        - >
+            apt update &&
+            apt install gettext-base -y &&
+            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
+            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
+            export PATH=/usr/local/go/bin:$PATH &&
+            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
+            export TARGET=kind-k8s-sriov-1.17.0;
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
+            automation/run-quarantined-tests.sh;
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+        volumeMounts:
+          #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+          - name: modules
+            mountPath: /lib/modules
+            readOnly: true
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: vfio
+            mountPath: /dev/vfio/
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio/
+            type: Directory
   - name: pull-kubevirt-check-tests-for-flakes
     skip_branches:
       - release-\d+\.\d+


### PR DESCRIPTION
Adds quarantine lanes for 1.19, 1.18, 1.17, cnao-1.19 and kind-1.17-sriov to run the tests marked with the `QUARANTINE` label. Relies on the `automation/run-quarantined-tests.sh` script added here https://github.com/kubevirt/kubevirt/pull/5156 to only spin up the test cluster when there are quarantined tests for the specific provider.

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>