### PR TITLE
sriov, Update the style of the sriov CNI annotation

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -279,7 +279,7 @@ presubmits:
         type: bare-metal-external
   - always_run: false
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     branches:
     - release-0.30
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -344,7 +344,7 @@ presubmits:
         type: bare-metal-external
   - always_run: false
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     branches:
     - release-0.34
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -154,7 +154,7 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     branches:
     - release-0.36
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -186,7 +186,7 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     branches:
     - release-0.37
     context: pull-kubevirt-e2e-kind-1.17-sriov

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
@@ -186,7 +186,7 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     branches:
     - release-0.38
     context: pull-kubevirt-e2e-kind-1.17-sriov

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -198,7 +198,7 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     branches:
     - release-0.39
     context: pull-kubevirt-e2e-kind-1.17-sriov

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -383,7 +383,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
@@ -467,7 +467,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubevirt/kubevirtci:
   - name: check-up-kind-1.17-sriov
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: '[{"interface":"net1","name":"sriov-passthrough-cni","namespace":"multus-cni-ns"}]'
     always_run: true
     optional: false
     decorate: true


### PR DESCRIPTION
In order to support running the CNI twice once needed,
update the style of the undercloud sriov CNI so it would
be able to indicate two CNI instances should be run,
and as a result allocate two PFs (for migration).
Otherwise, calling the annotation twice using the old style,
would result in dedupe of the annotation and the
undercloud CNI would run only once.

There is no logical effect beside having it suitable for
running the CNI twice.
Tested on CI with one and two CNI calls.

See cni-plugins/sriov-passthrough-cni/README.md
for more info.

Signed-off-by: Or Shoval <oshoval@redhat.com>