### PR TITLE
Reduce the amount of required jobs as emergency measure

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: true
     skip_report: true
     decorate: true
@@ -196,8 +196,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     skip_report: false
     decorate: true
     decoration_config:
@@ -591,8 +591,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
-    optional: false
+    always_run: false
+    optional: true
     skip_report: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
The following lanes are affected:

 * k8s-1.17-rook is now set to optional and not always_run
 * k8s-1.17 is now set to optional and not always_run
 * k8s-1.20 is now set to not always_run

Most notably the following two main lanes stay enabled (together with
other smaller lanes):

 * k8s-1.18
 * k8s-1.19

This step should be revised and/or reverted within one week (Mar 15th).

Signed-off-by: Roman Mohr <rmohr@redhat.com>