### PR TITLE
Trying again to require HCO sanity test on push to master

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -277,7 +277,6 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - coverage/coveralls
-                  - "Sanity Checks / Sanity Checks (pull_request)"
             release-1.2:
               protect: true
               required_status_checks:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -277,7 +277,7 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - coverage/coveralls
-                  - "Sanity Checks / Sanity Checks"
+                  - "Sanity Checks / Sanity Checks (pull_request)"
             release-1.2:
               protect: true
               required_status_checks:


### PR DESCRIPTION
Trying to use the exact same text as apears in the lane:

`Sanity Checks / Sanity Checks (pull_request)`

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>