### PR TITLE
Set the bazel output base directory to a well known location

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presets.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presets.yaml
@@ -15,3 +15,9 @@ presets:
   env:
     - name: KUBEVIRT_RUN_UNNESTED
       value: "false"
+  volumes:
+  - name: bazeluserroot
+    emptyDir: {}
+  volumeMounts:
+  - name: bazeluserroot
+    mountPath: /tmp/cache/bazel

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -96,8 +96,10 @@ RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/downloa
      cd /usr/local/bin && ln -s bazelisk bazel
 
 # Cache the most commonly used bazel versions inside the image
+# and remove resulting cache directories to save a few hundred MB
 RUN USE_BAZEL_VERSION=3.4.1 bazel version && \
-  USE_BAZEL_VERSION=4.0.0 bazel version
+  USE_BAZEL_VERSION=4.0.0 bazel version && \
+  rm -rf /root/.cache/bazel
 
 # create mixin directories
 RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -16,6 +16,13 @@
 
 # generic runner script, handles DIND, bazelrc for caching, etc.
 
+# Give bazel a well defined output_user_root directory independent of the user
+# used in the image. This allows mounting an emptyDir at this location, instead
+# of writing into the container overlay.
+mkdir -p /tmp/cache/bazel
+echo "startup --output_user_root=/tmp/cache/bazel" >> "${HOME}/.bazelrc"
+echo "startup --output_user_root=/tmp/cache/bazel" >> "/etc/bazel.bazelrc"
+
 # Check if the job has opted-in to bazel remote caching and if so generate 
 # .bazelrc entries pointing to the remote cache
 export BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}


### PR DESCRIPTION
Ensure that we know which directory bazel will use as a cache
directories, independent of the user used on the prow job.

Further mounting an emptyDir at this well known location if jobs decide
to run bazel unnested.

This way bazel will not write massively into the container overlay,
which can fill up the container space pretty fast and which can also
perform bad.

Signed-off-by: Roman Mohr <rmohr@redhat.com>