### PR TITLE
Pull in the unversioned python binary explicitly

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf install -y dnf-plugins-core && \
     patch \
     protobuf-compiler \
     python3-devel \
+    python-unversioned-command \
     redhat-rpm-config \
     rsync \
     rsync-daemon \


### PR DESCRIPTION
Some dependencies either changed in the bootstrap image or something
changed in fedora.

This ensures that we always have the python binary present.

Without this explicit `/usr/bin/python` binary present, bazel can not detect python and fails with something like this:


```
ERROR: no such package '@pip_deps//': pip_import failed:  (src/main/tools/process-wrapper-legacy.cc:75: "execvp(python, ...)": No such file or directory
```