### PR TITLE
Increase timeouts for release jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -48,7 +48,7 @@ postsubmits:
       testgrid-create-test-group: "false"
     decorate: true
     decoration_config:
-      timeout: 1h
+      timeout: 3h
       grace_period: 5m
     labels:
       preset-dind-enabled: "true"
@@ -103,7 +103,7 @@ postsubmits:
       testgrid-create-test-group: "false"
     decorate: true
     decoration_config:
-      timeout: 1h
+      timeout: 3h
       grace_period: 5m
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Currently the push-release-master runs into a timeout more than half of
the runs.

/cc @fgimenez 