### PR TITLE
Reenable unnested bazel builds for e2e tests in kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -243,7 +243,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -274,7 +274,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -305,7 +305,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -336,7 +336,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -163,7 +163,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+    - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -236,7 +236,7 @@ periodics:
     preset-shared-images: "true"
   spec:
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+    - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -292,7 +292,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -327,7 +327,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
           - |
@@ -362,7 +362,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
           - |
@@ -397,7 +397,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
           - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -27,7 +27,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.20 && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -59,7 +59,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.19 && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -91,7 +91,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.18 && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -123,7 +123,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -155,7 +155,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET=k8s-1.19-cnao automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -187,7 +187,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -291,7 +291,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -323,7 +323,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -353,7 +353,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -383,7 +383,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -415,7 +415,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -443,7 +443,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -471,7 +471,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make test
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -504,7 +504,7 @@ presubmits:
         env:
         - name: COVERALLS_TOKEN_FILE
           value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -540,7 +540,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -568,7 +568,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -596,7 +596,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt" && make olm-verify
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -624,7 +624,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -60,7 +60,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -96,7 +96,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           env:
             - name: KUBEVIRT_QUARANTINE
               value: "true"
@@ -137,7 +137,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -173,7 +173,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -209,7 +209,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           env:
             - name: KUBEVIRT_QUARANTINE
               value: "true"
@@ -250,7 +250,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -286,7 +286,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           env:
             - name: KUBEVIRT_QUARANTINE
               value: "true"
@@ -326,7 +326,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -362,7 +362,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
           - name: KUBEVIRT_QUARANTINE
             value: "true"
@@ -402,7 +402,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -609,7 +609,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -645,7 +645,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -676,7 +676,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -708,7 +708,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -740,7 +740,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -772,7 +772,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -804,7 +804,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -835,7 +835,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
           - name: COVERALLS_TOKEN_FILE
             value: /root/.docker/secrets/coveralls/token
@@ -877,7 +877,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -908,7 +908,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -939,7 +939,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
           command:
             - "/usr/local/bin/runner.sh"
@@ -971,7 +971,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           # skip getting old CSVs here (no QUAY_REPOSITORY), verification might fail because of stricter rules over time; falls back to latest if not on a tag
           command:
             - "/usr/local/bin/runner.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
     preset-shared-images: "true"
   spec:
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -266,7 +266,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           env:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"
@@ -316,7 +316,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           env:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20210126-a12b6c0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -296,7 +296,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -332,7 +332,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -442,7 +442,7 @@ presets:
     preset-bazel-unnested: "true"
   env:
     - name: KUBEVIRT_RUN_UNNESTED
-      value: "false"
+      value: "true"
   volumes:
   - name: bazeluserroot
     emptyDir: {}


### PR DESCRIPTION
Last time bazel was writing into the container overlay, which cause unexpected disk pressure on nodes.
This time bazel writes to a well define emptyDir which is mounted via the bazel preset.

