### PR TITLE
ovs-cni presubmit job, Update the bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ovs-cni/ovs-cni-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
In order to use the latest image cache proxy,
update the bootstrap image.
This change also update the bootstrap image itself
to point on quay instead of docker.io.

`preset-docker-mirror-proxy: "true"` already exists in this job.

Signed-off-by: Or Shoval <oshoval@redhat.com>