### PR TITLE
kubevirt-presubmits: Add sig-storage k8s 1.19 job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -149,6 +149,42 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.19-sig-storage
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210302-4c35b4e
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.19-sig-storage && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-e2e-k8s-1.18
     skip_branches:
       - release-\d+\.\d+


### PR DESCRIPTION
The purpose of this job is to allow running a more
focused group of tests, in isolation from the other tests,
owned by the sig-storage.

This lane would always run, but won't be a gating.
It will run only the tests that are marked with sig-network

The differences between this new lane and the official k8s-1.19
```
always_run: false
optional: true
```
The TARGET has suffix `-sig-storage`

After testing we will make it always_run true,
since there is no rehearsal on k8s-1.19 we need this lane first merged.
Corresponding Kubevirt PR https://github.com/kubevirt/kubevirt/pull/5212

I have based my work on https://github.com/kubevirt/project-infra/pull/1007 (including text for commit and PR)

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>