### PR TITLE
Remove k8s-handler-parallel lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -95,38 +95,6 @@ presubmits:
               - "-c"
               - "NMSTATE_PIN=future automation/check-patch.e2e-k8s.sh"
 
-    - name: pull-kubernetes-nmstate-e2e-handler-k8s-parallel
-      skip_branches:
-        - release-\d+\.\d+
-      annotations:
-        fork-per-release: "true"
-      always_run: true
-      optional: false
-      decorate: true
-      decoration_config:
-        timeout: 3h
-        grace_period: 5m
-      max_concurrency: 6
-      labels:
-        preset-dind-enabled: "true"
-        preset-docker-mirror-proxy: "true"
-        preset-shared-images: "true"
-      spec:
-        nodeSelector:
-          type: bare-metal-external
-        containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                memory: "29Gi"
-            command:
-              - "/usr/local/bin/runner.sh"
-              - "/bin/sh"
-              - "-c"
-              - "export NMSTATE_PARALLEL_ROLLOUT=true && automation/check-patch.e2e-k8s.sh"
-
     - name: pull-kubernetes-nmstate-docs
       cluster: ibm-prow-jobs
       skip_branches:


### PR DESCRIPTION
Since we're running the handler e2e tests by default in
parallel on 50% nodes, we don't need the parallel lane anymore.

This commit removes the parallel lane.

Depends on https://github.com/nmstate/kubernetes-nmstate/pull/717

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>