### PR TITLE
Bump kubevirtci jobs to quay.io/kubevirtci/golang

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -29,7 +29,7 @@ postsubmits:
           secret:
             secretName: gcs
         containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+        - image: quay.io/kubevirtci/golang:v20210316-d295087
           env:
           - name: GIT_ASKPASS
             value: "../project-infra/hack/git-askpass.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
                       - "true"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
@@ -94,7 +94,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -121,7 +121,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -148,7 +148,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -175,7 +175,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -200,7 +200,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+        - image: quay.io/kubevirtci/golang:v20210316-d295087
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"


### PR DESCRIPTION
Switch from kubekins to our own bootstrap images based on fedora with
golang.