### PR TITLE
Revert image used for rehearse job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+      - image: kubevirtci/bootstrap:v20210126-a12b6c0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"


### PR DESCRIPTION
Reverts the change introduced here https://github.com/kubevirt/project-infra/pull/1027 that causes errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1004/pull-project-infra-test-rehearse/1370413514463645697

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>