### PR TITLE
Move bootstrap from docker io to quay.io

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
@@ -19,7 +19,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -77,7 +77,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
@@ -19,7 +19,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -77,7 +77,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
@@ -19,7 +19,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -48,7 +48,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -76,7 +76,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -106,7 +106,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
@@ -19,7 +19,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -48,7 +48,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -76,7 +76,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -106,7 +106,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -138,7 +138,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -170,7 +170,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -234,7 +234,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -266,7 +266,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -146,7 +146,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -176,7 +176,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -208,7 +208,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -240,7 +240,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -304,7 +304,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -336,7 +336,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -52,7 +52,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -84,7 +84,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -116,7 +116,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -148,7 +148,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -180,7 +180,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -212,7 +212,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: kubevirtci/bootstrap:v20201119-a5880e0
+    - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
@@ -24,7 +24,7 @@ postsubmits:
           secret:
             secretName: gcs
         containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -80,7 +80,7 @@ presubmits:
           secret:
             secretName: gcs
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
       nodeSelector:
         region: primary
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -498,7 +498,7 @@ periodics:
                   - "true"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
           - name: KUBEVIRT_QUARANTINE
             value: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -56,7 +56,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -111,7 +111,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
@@ -22,7 +22,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.11.0 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -52,7 +52,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-genie-1.11.1 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -82,7 +82,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-multus-1.13.3 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -112,7 +112,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0-crio && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -142,7 +142,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0-multus && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -172,7 +172,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -202,7 +202,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -24,7 +24,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.13.3 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -55,7 +55,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.14 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -86,7 +86,7 @@ presubmits:
         - -c
         - export TARGET=k8s-1.15 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph'
           && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -116,7 +116,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.16 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -146,7 +146,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -176,7 +176,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET=k8s-1.17-cnao automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -207,7 +207,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0-crio && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -238,7 +238,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0-multus && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -268,7 +268,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -321,7 +321,7 @@ presubmits:
         - -c
         - |
           apt update && apt install gettext-base -y && wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz && tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ && export PATH=/usr/local/go/bin:$PATH && export TARGET=kind-k8s-sriov-1.17.0 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -372,7 +372,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=kind-k8s-1.17.0-ipv6 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -418,7 +418,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -449,7 +449,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -24,7 +24,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.13.3 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -55,7 +55,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.14 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -88,7 +88,7 @@ presubmits:
         - -c
         - export TARGET=k8s-1.16 && export KUBEVIRT_PROVIDER_EXTRA_ARGS='--enable-ceph'
           && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -121,7 +121,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.19 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -151,7 +151,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.18 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -181,7 +181,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -211,7 +211,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.16 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -241,7 +241,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET=k8s-1.17-cnao automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -272,7 +272,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0-crio && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -303,7 +303,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=os-3.11.0-multus && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -333,7 +333,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -385,7 +385,7 @@ presubmits:
         - -c
         - |
           apt update && apt install gettext-base -y && wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz && tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ && export PATH=/usr/local/go/bin:$PATH && export TARGET=kind-k8s-sriov-1.17.0 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -437,7 +437,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -467,7 +467,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -497,7 +497,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -528,7 +528,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -556,7 +556,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make test
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -588,7 +588,7 @@ presubmits:
         env:
         - name: COVERALLS_TOKEN_FILE
           value: /root/.docker/secrets/coveralls/token
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -624,7 +624,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -652,7 +652,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -681,7 +681,7 @@ presubmits:
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt"
           && make olm-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -709,7 +709,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -23,7 +23,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.19 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -53,7 +53,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.18 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -83,7 +83,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -113,7 +113,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET=k8s-1.19-cnao automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -143,7 +143,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -197,7 +197,7 @@ presubmits:
         - -c
         - |
           apt update && apt install gettext-base -y && wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S && tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ && export PATH=/usr/local/go/bin:$PATH && export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 && export TARGET=kind-k8s-sriov-1.17.0; trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM; automation/test.sh;
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -249,7 +249,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -279,7 +279,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -309,7 +309,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -341,7 +341,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -369,7 +369,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -397,7 +397,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make test
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -431,7 +431,7 @@ presubmits:
         env:
         - name: COVERALLS_TOKEN_FILE
           value: /root/.docker/secrets/coveralls/token
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -467,7 +467,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -495,7 +495,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -524,7 +524,7 @@ presubmits:
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt"
           && make olm-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -552,7 +552,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -25,7 +25,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.20 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -55,7 +55,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.19 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -85,7 +85,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.18 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -115,7 +115,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -145,7 +145,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET=k8s-1.19-cnao automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -175,7 +175,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -227,7 +227,7 @@ presubmits:
         - -c
         - |
           apt update && apt install gettext-base -y && wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S && tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ && export PATH=/usr/local/go/bin:$PATH && export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 && export TARGET=kind-k8s-sriov-1.17.0; trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM; automation/test.sh;
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -279,7 +279,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -309,7 +309,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -339,7 +339,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -369,7 +369,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -401,7 +401,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -429,7 +429,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -457,7 +457,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make test
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -490,7 +490,7 @@ presubmits:
         env:
         - name: COVERALLS_TOKEN_FILE
           value: /root/.docker/secrets/coveralls/token
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -526,7 +526,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -554,7 +554,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -582,7 +582,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt" && make olm-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -610,7 +610,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
@@ -25,7 +25,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.20 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -55,7 +55,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.19 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -85,7 +85,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.18 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -115,7 +115,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -145,7 +145,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET=k8s-1.19-cnao automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -175,7 +175,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=windows2016 && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -227,7 +227,7 @@ presubmits:
         - -c
         - |
           apt update && apt install gettext-base -y && wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S && tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ && export PATH=/usr/local/go/bin:$PATH && export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 && export TARGET=kind-k8s-sriov-1.17.0; trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM; automation/test.sh;
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -279,7 +279,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -309,7 +309,7 @@ presubmits:
         - /bin/sh
         - -c
         - export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph && automation/test.sh
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -339,7 +339,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -369,7 +369,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -401,7 +401,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -429,7 +429,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -457,7 +457,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make test
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -490,7 +490,7 @@ presubmits:
         env:
         - name: COVERALLS_TOKEN_FILE
           value: /root/.docker/secrets/coveralls/token
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -526,7 +526,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -554,7 +554,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -582,7 +582,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt" && make olm-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:
@@ -610,7 +610,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -239,7 +239,7 @@ presubmits:
         - -c
         - |
           apt update && apt install gettext-base -y && wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S && tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ && export PATH=/usr/local/go/bin:$PATH && export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 && export TARGET=kind-k8s-sriov-1.17.0; trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM; automation/test.sh;
-        image: kubevirtci/bootstrap:v20201119-a5880e0
+        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -291,7 +291,7 @@ presubmits:
                   - "true"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -41,7 +41,7 @@ postsubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             command:
@@ -50,7 +50,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -53,7 +53,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -22,7 +22,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -53,7 +53,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -84,7 +84,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -20,7 +20,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -49,7 +49,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -78,7 +78,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -45,7 +45,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -73,7 +73,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -106,7 +106,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -138,7 +138,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -169,7 +169,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -99,7 +99,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -126,7 +126,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -154,7 +154,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -182,7 +182,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -210,7 +210,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -21,7 +21,7 @@ postsubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             env:
             - name: GIT_ASKPASS
               value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
@@ -61,7 +61,7 @@ postsubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -47,7 +47,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -107,7 +107,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -47,7 +47,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -77,7 +77,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -135,7 +135,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -115,7 +115,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -177,7 +177,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
This commit update specific bootstrap from
docker.io to quay.io (and also updates the version).

from kubevirtci/bootstrap:v20201119-a5880e0
to quay.io/kubevirtci/bootstrap:v20210311-09ebaa2

Signed-off-by: Or Shoval <oshoval@redhat.com>