### PR TITLE
infra, Replace bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -146,7 +146,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -176,7 +176,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -80,7 +80,7 @@ presubmits:
           secret:
             secretName: gcs
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -22,7 +22,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Since this change need to be tested on CI,
and its resource extensive, we are doing it in batches.

Update bootstrap image from `kubevirtci/bootstrap:v20201119-a5880e0`
to `quay.io/kubevirtci/bootstrap:v20210311-09ebaa2`
(Part of those, since there are many)

Signed-off-by: Or Shoval <oshoval@redhat.com>