### PR TITLE
Update kubevirt builder to point on quay

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -18,7 +18,7 @@ postsubmits:
       decorate: true
       spec:
         containers:
-          - image: kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab
+          - image: quay.io/kubevirt/builder:32-1.0.1
             env:
               - name: GIT_ASKPASS
                 value: /go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -282,7 +282,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: "kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab"
+      - image: "quay.io/kubevirt/builder:32-1.0.1"
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -334,7 +334,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: "kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab"
+      - image: "quay.io/kubevirt/builder:32-1.0.1"
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -377,7 +377,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: "kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab"
+      - image: "quay.io/kubevirt/builder:32-1.0.1"
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh


### PR DESCRIPTION
This commit update kubevirt builder from
docker.io to quay.io (and also updates the version).

from kubevirt/builder@sha256:e6a76ec71f2de87c3bc648bae87ab43a113540bf57da69f07f76bd0edfd500ab
to image: quay.io/kubevirt/builder:32-1.0.1

Signed-off-by: Or Shoval <oshoval@redhat.com>