### PR TITLE
Update bootstrap images to point to quay

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -99,7 +99,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -126,7 +126,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -154,7 +154,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -182,7 +182,7 @@ presubmits:
       nodeSelector:
         type: vm
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -369,7 +369,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -405,7 +405,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -441,7 +441,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: kubevirtci/bootstrap:v20210112-b29dfd7
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -177,7 +177,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
This commit updates few more boostrap images
that are hosted on docker.io to point to quay.io
It also updates their version.

Images that were updated
`kubevirtci/bootstrap:v20210112-b29dfd7`
`kubevirtci/bootstrap:v20201119-a5880e0`

updated to
`quay.io/kubevirtci/bootstrap:v20210311-09ebaa2`

Signed-off-by: Or Shoval <oshoval@redhat.com>