### PR TITLE
use embedded rook/ceph

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -121,7 +121,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export RANDOM_CR=true && export KUBEVIRT_STORAGE=ceph && export CDI_E2E_SKIP=Destructive && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export RANDOM_CR=true && export KUBEVIRT_STORAGE=rook-ceph-default && export CDI_E2E_SKIP=Destructive && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -348,4 +348,3 @@ presubmits:
           resources:
             requests:
               memory: "4Gi"
-


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

Merge this after https://github.com/kubevirt/containerized-data-importer/pull/1703 completes to enable new embedded rook/ceph