### PR TITLE
hco, Use k8s-1.19 for pull-hyperconverged-cluster-operator-e2e-k8s

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubevirt/hyperconverged-cluster-operator:
-  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
+  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.19
     skip_branches:
     - release-\d+\.\d+
     annotations:
@@ -25,7 +25,7 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "export TARGET=k8s-1.17 && automation/test.sh"
+        - "export TARGET=k8s-1.19 && automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
K8s-1.19 is more stable, hence use it once kubevirtci
is bumped in HCO.

Depends on https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1195

Signed-off-by: Or Shoval <oshoval@redhat.com>