### PR TITLE
Remove apt command usage from SRIOV check-up job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -37,20 +37,20 @@ presubmits:
               topologyKey: kubernetes.io/hostname
       containers:
       - image: quay.io/kubevirtci/golang:v20210316-d295087
+        env:
+        - name: "GIMME_GO_VERSION"
+          value: "1.13.8"
+        - name: "KUBEVIRT_PROVIDER"
+          value: "kind-k8s-sriov-1.17.0"
+        - name: "KUBEVIRT_NUM_NODES"
+          value: "2"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
         - "-c"
         - >
-            apt update &&
-            apt install gettext-base -y &&
-            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
-            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
-            export PATH=/usr/local/go/bin:$PATH &&
-            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
-            export KUBEVIRT_NUM_NODES=2;
-            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
-            make cluster-up;
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM &&
+            make cluster-up
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
The bootstrap image this job uses is fedora based and
does not have 'apt' package manager.
The job report is finished successfully, but it actually had an error that the trap didn't catch 
causing the job to deploy the default cluster k8s-1.18 instead.
https://prow.apps.ovirt.org/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/559/check-up-kind-1.17-sriov/1372225414985945088

This PR removes the usage of apt and adjust the trap to catch such errors.
Also make use of `GIMME_GO_VERSION` env var to get golang binaries