### PR TITLE
Fixed providers for e2e periodics

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -365,14 +365,16 @@ periodics:
       type: bare-metal-external
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         env:
           - name: KUBEVIRT_QUARANTINE
             value: "true"
-        args:
-          - |
-            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '1p')
-            automation/test.sh
+          - name: TARGET
+            value: k8s-1.19
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -403,14 +405,16 @@ periodics:
       type: bare-metal-external
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         env:
           - name: KUBEVIRT_QUARANTINE
             value: "true"
-        args:
-          - |
-            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '2p')
-            automation/test.sh
+          - name: TARGET
+            value: k8s-1.18
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -444,11 +448,13 @@ periodics:
         env:
           - name: KUBEVIRT_QUARANTINE
             value: "true"
-        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
-        args:
-          - |
-            export TARGET=$(ls cluster-up/cluster/ | grep -E '^k8s-1\.[0-9]+$' | sort --sort=version -r | sed -n '3p')
-            automation/test.sh
+          - name: TARGET
+            value: k8s-1.17
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
The `-latest` periodic is running on 1.20 now, even though we are not using this provider its directory is under `cluster-up/cluster`, and the code to determine the target in these jobs is blindly picking it. 

With these changes we will have fixed targets for each e2e periodic that need to be updated when we include a new provider. The job names keep the same so that we don't need to update testgrid config

/cc @dhiller @enp0s3 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>