### PR TITLE
Request to be added into kubevirt.org

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -173,6 +173,7 @@ orgs:
       - xpivarc
       - yanirq
       - yossisegev
+      - yuhaohaoyu
       - yuvalif
       - yuvalturg
       - zcahana


### PR DESCRIPTION
This is Hao Yu from IBM T. J. Watson Research Laboratory and currently working with Red Hat teams on KubeVirt and OpenShift Virtualization.