### PR TITLE
Increase SRIOV PF to allocate for kubevirt SRIOV lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -255,7 +255,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false


### PR DESCRIPTION
Currently sriov-passthrough-cni allocates single PF to
the prow job pod.

In order to test Kubevirt SRIOV Live Migration it requires
a setup with two workers where each worker has SRIOV PF
in its netns.
https://github.com/kubevirt/kubevirt/pull/5238

This commit sets sriov-passthrough-cni to allocate two SRIOV PF's

