### PR TITLE
sriov, presubmits, kubevirt, Update bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -363,21 +363,22 @@ presubmits:
                   - "true"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
+        env:
+          - name: "TARGET"
+            value: "kind-k8s-sriov-1.17.0"
+          - name: "GIMME_GO_VERSION"
+            value: "1.13.8"
+          - name: "KUBEVIRT_PROVIDER" # for cluster-down in the command below
+            value: "kind-k8s-sriov-1.17.0"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
         - "-c"
-        - >
-            apt update &&
-            apt install gettext-base -y &&
-            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
-            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
-            export PATH=/usr/local/go/bin:$PATH &&
-            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
-            export TARGET=kind-k8s-sriov-1.17.0;
-            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
-            automation/test.sh;
+        - |
+            set -e
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM
+            automation/test.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
As part of the effort to migrate project-infra images
from `docker.io` to `quay.io`,
update the bootstrap image of kubevirt sriov presubmit job
to use a newer one, which is hosted on `quay.io`.

Use a quay.io/kubevirtci/golang
in order to align kubevirt job to kubevirtci job,
and to have golang easier.
    
Since the new image doesn't have apt, but already has
`gettext-base`, update the job run command accordingly.
Remove `KUBEVIRT_PROVIDER` because `TARGET` is enough,
`KUBEVIRT_PROVIDER` will be set accordingly
by automation/test.s according to `TARGET`.

Add `set -e` in order to fail fast in case the job command
has an error, and not mask those errors.

Signed-off-by: Or Shoval <oshoval@redhat.com>