### PR TITLE
infra, Replace bootstrap image part 2

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -208,7 +208,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -240,7 +240,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -304,7 +304,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -336,7 +336,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
           type: vm
           zone: ci
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -53,7 +53,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -84,7 +84,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: kubevirtci/bootstrap:v20201119-a5880e0
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
Since this change need to be tested on CI,
and its resource extensive, we are doing it in batches.

Update bootstrap image from `kubevirtci/bootstrap:v20201119-a5880e0`
to `quay.io/kubevirtci/bootstrap:v20210311-09ebaa2`
(Part of those, since there are many)

Signed-off-by: Or Shoval <oshoval@redhat.com>