### PR TITLE
sriov, presubmit, Allocate two PFs for each job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -291,7 +291,7 @@ presubmits:
     - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
@@ -340,6 +340,7 @@ presubmits:
             export PATH=/usr/local/go/bin:$PATH &&
             export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
             export TARGET=kind-k8s-sriov-1.17.0;
+            echo bla;
             trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
             automation/test.sh;
         # docker-in-docker needs privileged mode


### PR DESCRIPTION
In order to support migration,
call the undercloud CNI twice, this way it will allocate two
sriov PFs which are needed for migration.

Signed-off-by: Or Shoval <oshoval@redhat.com>