### PR TITLE
nmstate, Update bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -115,7 +115,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Update kubernetes-nmstate-e2e-handler-k8s-parallel
bootstrap image, in order to point to quay.io instead
of to docker.io which has rate limits.

It is done on a seperate PR so it will be easy to
retest it without retesting a bunch of jobs.

Signed-off-by: Or Shoval <oshoval@redhat.com>