### PR TITLE
Make operator job required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -150,8 +150,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     skip_report: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
I missed on my review that the job was not `required`. The operator job needs to be required. Otherwise we would not run them at all.