### PR TITLE
hco, Remove preset-docker-mirror-proxy

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -9,7 +9,6 @@ postsubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
       spec:
         nodeSelector:


### PR DESCRIPTION
Since current proxy version cause problems
when pushing big layers to quay.io,
remove it for the time being.

Signed-off-by: Or Shoval <oshoval@redhat.com>