### PR TITLE
Point CDI flakefinder jobs at the "main" branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -20,6 +20,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=168h
       - --report_output_child_path=kubevirt/containerized-data-importer
+      - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
       volumeMounts:
@@ -56,6 +57,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=24h
       - --report_output_child_path=kubevirt/containerized-data-importer
+      - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
       volumeMounts:
@@ -92,6 +94,7 @@ periodics:
       - --token=/etc/github/oauth
       - --merged=672h
       - --report_output_child_path=kubevirt/containerized-data-importer
+      - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
       volumeMounts:


### PR DESCRIPTION
I noticed that flakefinder hasn't reported anything for CDI in a while, including any merged PRs.
I assume this is due to the branch rename, and blindly performed this change, hopefully it's the right one.