### PR TITLE
Update kubevirt e2e periodics

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -511,6 +511,7 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+    k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
   cron: "0 22,10 * * *"
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -370,6 +370,8 @@ periodics:
             value: "true"
           - name: TARGET
             value: k8s-1.19
+          - name: KUBEVIRT_E2E_SKIP
+            value: Multus|SRIOV|GPU|Macvtap|Operator
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -410,6 +412,8 @@ periodics:
             value: "true"
           - name: TARGET
             value: k8s-1.18
+          - name: KUBEVIRT_E2E_SKIP
+            value: Multus|SRIOV|GPU|Macvtap|Operator
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -450,6 +454,8 @@ periodics:
             value: "true"
           - name: TARGET
             value: k8s-1.17
+          - name: KUBEVIRT_E2E_SKIP
+            value: Multus|SRIOV|GPU|Macvtap|Operator
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -541,26 +547,24 @@ periodics:
                   - "true"
               topologyKey: kubernetes.io/hostname
       containers:
-      - image: kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         env:
           - name: KUBEVIRT_QUARANTINE
             value: "true"
-          - name: TARGET
-            value: kind-k8s-sriov-1.17.0
+          - name: "TARGET"
+            value: "kind-k8s-sriov-1.17.0"
+          - name: "GIMME_GO_VERSION"
+            value: "1.13.8"
+          - name: "KUBEVIRT_PROVIDER" # for cluster-down in the command below
+            value: "kind-k8s-sriov-1.17.0"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
         - "-c"
-        - >
-            apt update &&
-            apt install gettext-base -y &&
-            wget https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -nv -S &&
-            tar -xzf go1.13.8.linux-amd64.tar.gz -C /usr/local/ &&
-            export PATH=/usr/local/go/bin:$PATH &&
-            export KUBEVIRT_PROVIDER=kind-k8s-sriov-1.17.0 &&
-            export TARGET=kind-k8s-sriov-1.17.0;
-            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM;
-            automation/test.sh;
+        - |
+            set -e
+            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM
+            automation/test.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Aligns the kubevirt e2e periodic definitions to the presubmits:
* Adds `KUBEVIRT_E2E_SKIP` for the main provider periodics
* Updates SRIOV periodic to the latest changes, aiming to fix the failures we get https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-prev-prev-sriov&width=20

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>