### PR TITLE
Increase the worker node in the cluster to accommodate all common-templates automation tests.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
@@ -34,7 +34,7 @@ periodics:
           export KUBEVIRTCI_TAG=$(curl -L https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
           export KUBEVIRTCI_GOCLI_CONTAINER=quay.io/kubevirtci/gocli:${KUBEVIRTCI_TAG}
           export KUBEVIRT_PROVIDER=k8s-1.20
-          export KUBEVIRT_NUM_NODES=2
+          export KUBEVIRT_NUM_NODES=3
           export KUBEVIRT_MEMORY_SIZE=10240M
           export KUBEVIRT_PROVIDER_EXTRA_ARGS="--registry-port 5000"
 


### PR DESCRIPTION
Increase the worker node in the cluster to accommodate all common-templates automation tests.

The old kubevirt cluster had a master node and a worker node. This cluster also creates 10 pvs in each of the nodes. The common-templates automation test for linux has 12 test cases for the different VM flavors and sizes. Each of these tests need a pv. There was a recent addition in common-templates code that specifies that the high-performance VMs only need to be placed on worker nodes. If the worker node PVs get used up before the last few high-performance VM tests are run(the PVs are bound, even after the test finishes), then there is a VM scheduling error for the last few tests. Increasing the worker node, provides another 10 PVs, that allow the tests to pass.

Signed-off-by: Shweta Padubidri <spadubid@redhat.com>