### PR TITLE
sig-network, Make sig-network job mandatory and always run

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -630,46 +630,6 @@ periodics:
         resources:
           requests:
             memory: "29Gi"
-- name: periodic-kubevirt-e2e-k8s-latest-cnao
-  annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cron: "0 22,10 * * *"
-  decorate: true
-  decoration_config:
-    timeout: 7h
-    grace_period: 5m
-  labels:
-    preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-shared-images: "true"
-  extra_refs:
-  - org: kubevirt
-    repo: kubevirt
-    base_ref: master
-    work_dir: true
-  skip_report: true
-  spec:
-    nodeSelector:
-      type: bare-metal-external
-    containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        env:
-          - name: KUBEVIRT_QUARANTINE
-            value: "true"
-          - name: TARGET
-            value: k8s-1.19-cnao
-        command:
-          - "/usr/local/bin/runner.sh"
-          - "/bin/sh"
-          - "-c"
-          - "automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"
 - name: periodic-kubevirt-e2e-k8s-prev-prev-sriov
   annotations:
     testgrid-dashboards: kubevirt-periodics

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -532,7 +532,7 @@ periodics:
           - name: TARGET
             value: k8s-1.19
           - name: KUBEVIRT_E2E_SKIP
-            value: Multus|SRIOV|GPU|Macvtap|Operator
+            value: "SRIOV|GPU|Operator|\\[sig-network\\]"
           - name: KUBEVIRT_WITH_ETC_IN_MEMORY
             value: "true"
         command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -97,11 +97,16 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.19
+            - name: KUBEVIRT_E2E_SKIP
+              value: "SRIOV|GPU|Operator|\\[sig-network\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.19 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -114,12 +119,12 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     skip_report: false
     decorate: true
     decoration_config:
-      timeout: 7h
+      timeout: 4h
       grace_period: 5m
     max_concurrency: 11
     labels:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -293,41 +293,6 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
-  - name: pull-kubevirt-e2e-k8s-cnao-1.19
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 11
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "TARGET=k8s-1.19-cnao automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "34Gi"
   - name: pull-kubevirt-e2e-windows2016
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
This PR makes the `sig-network` job mandatory and always run.
It also removes sig-network tests from
`pull-kubevirt-e2e-k8s-1.19` job,
and from k8s-1.19 periodic job (note its name is `periodic-kubevirt-e2e-k8s-latest`).

It removes CNAO jobs, since `sig-network` runs all the tests that are needed now anyway,
see https://github.com/kubevirt/kubevirt/pull/5354 which moved the `VMIlifecycle` networking tests
to `sig-network`.

No test run duplication needed, and it will ease running
`sig-network` group isolated.

The job was tested periodically for a week, each 8 hours [1],
23 runs, all passed, beside two which are not due to the `sig-network`
tests problems [2] [3].
It's stable enough for this change.

Reduce timeout from 7h to 4h for `pull-kubevirt-e2e-k8s-1.19-sig-network`.

[1] https://prow.apps.ovirt.org/job-history/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-network
[2] https://prow.apps.ovirt.org/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-network/1373786699879944192
Failed due to https://github.com/kubevirt/kubevirt/issues/5285
[3] https://prow.apps.ovirt.org/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-network/1374149087418388482#1:build-log.txt%3A49
Failed due to general quay connectivity error.

Signed-off-by: Or Shoval <oshoval@redhat.com>