### PR TITLE
sriov, presubmit, Add run_if_changed rule

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - name: check-up-kind-1.17-sriov
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni
-    always_run: true
+    always_run: false # only because we have run_if_changed
+    run_if_changed: "(^cluster-up/cluster/kind-k8s-sriov-1.17.0/.*)|(^cluster-up/cluster/kind/.*)"
     optional: false
     decorate: true
     decoration_config:


### PR DESCRIPTION
In order to save resources where we can,
add the `run_if_changed` rule for sriov presubmit job,
it will run only if the relevant sriov provider folders are changed.

Signed-off-by: Or Shoval <oshoval@redhat.com>