### PR TITLE
Remove branch section from nmstate job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
@@ -1,8 +1,6 @@
 presubmits:
   nmstate/nmstate:
     - name: pull-nmstate-integ_tier1-k8s
-      branches:
-        - base
       annotations:
         fork-per-release: "true"
       always_run: true


### PR DESCRIPTION
Prow by default run on all branches, that's good enoough also this is
maybe preventing running PRs.

Signed-off-by: Quique Llorente <ellorent@redhat.com>