### PR TITLE
infra, postsubmit, Update kubevirt-infra-bootstrap to push to quay

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -40,17 +40,20 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
-        preset-project-infra-kubevirtci-docker-credential: "true"
+        preset-kubevirtci-quay-credential: "true"
       spec:
         nodeSelector:
           type: vm
         containers:
-          - image: kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
-              - "-c"
-              - "cat $DOCKER_PASSWORD | docker login --username $(<$DOCKER_USER) --password-stdin && cd images && ./publish_image.sh kubevirt-infra-bootstrap docker.io kubevirtci"
+              - "-ce"
+              - |
+                  cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io
+                  cd images
+                  ./publish_image.sh kubevirt-infra-bootstrap quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
In order to fix docker.io rate limit,
the push of kubevirt-infra-bootstrap updated to point to quay.

More changes:
1. Use yaml literal that preserves new lines.
2. Add `-e` to the bash, so in case one command fails,
it will fail the whole job command, instead having
the commands anded together in one long command.
3. Update job bootstrap image to point to quay.

Signed-off-by: Or Shoval <oshoval@redhat.com>