### PR TITLE
hco, periodic, Update nightly build to use quay.io

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
-    preset-kubevirtci-docker-credential: "true"
+    preset-kubevirtci-quay-credential: "true"
     rehearsal.allowed: "true"
   extra_refs:
     - org: kubevirt


### PR DESCRIPTION
In order to fix docker.io rate limit,
switch to use quay.io

Depends on 
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/1206

Signed-off-by: Or Shoval <oshoval@redhat.com>