### PR TITLE
infra, presubmit, Update build jobs to use quay.io

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-docker-credential: "true"
+      preset-kubevirtci-quay-credential: "true"
     spec:
       nodeSelector:
         type: vm
@@ -77,8 +77,8 @@ presubmits:
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
-            - "-c"
-            - "cd images && ./publish_image.sh -b kubevirt-infra-bootstrap docker.io kubevirtci"
+            - "-ce"
+            - "cd images && ./publish_image.sh -b kubevirt-infra-bootstrap quay.io kubevirtci"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -94,7 +94,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-docker-credential: "true"
+      preset-kubevirtci-quay-credential: "true"
     spec:
       nodeSelector:
         type: vm
@@ -103,9 +103,9 @@ presubmits:
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
-            - "-c"
-            - "cd images && ./publish_image.sh -b bootstrap docker.io kubevirtci"
-            - "cd images && ./publish_image.sh -b golang docker.io kubevirtci"
+            - "-ce"
+            - "cd images && ./publish_image.sh -b bootstrap quay.io kubevirtci"
+            - "cd images && ./publish_image.sh -b golang quay.io kubevirtci"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
In order to fix docker.io rate limit,
update builder jobs to use quay.io instead.

Signed-off-by: Or Shoval <oshoval@redhat.com>