### PR TITLE
infra, Remove docker.io preset from kubernetes-crud-ci-role

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -205,7 +205,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-docker-credential: "true"
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
In case we don't need it, lets remove it.

Signed-off-by: Or Shoval <oshoval@redhat.com>