### PR TITLE
Don't error CDI job if no tag is found.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
         - |
           cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
           # Only push images on tags
-          [ -n "$(git tag --points-at HEAD | head -1)" ] &&
+          [ -z "$(git tag --points-at HEAD | head -1)" ] ||
           DOCKER_TAG="$(git tag --points-at HEAD | head -1)" make bazel-push-images
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Right now the command fails if the tag is not found. This reverses
the logic so that the second part of the || is not executed but
the result is success instead.

Signed-off-by: Alexander Wels <awels@redhat.com>