### PR TITLE
new optional lane to test new rook/ceph

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -512,6 +512,42 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-test
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph-default && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-generate
     cluster: ibm-prow-jobs
     skip_branches:


### PR DESCRIPTION
Signed-off-by: Michael Henriksen <mhenriks@redhat.com>

`KUBEVIRT_STORAGE=rook-ceph-default`

Once this verified works, will remove/update existing rook/ceph lane.