### PR TITLE
Add periodic-kubevirt-e2e-k8s-1.20-cgroupsv2 job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -299,6 +299,45 @@ periodics:
         resources:
           requests:
             memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20-cgroupsv2
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "15 7,15,23 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 7h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20-cgroupsv2"
+          - name: KUBEVIRT_E2E_SKIP
+            value: "Multus|SRIOV|GPU|Macvtap|Operator"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
 - name: periodic-kubevirt-push-nightly-build-master
   cron: "2 1 * * *"
   decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: false
     optional: true
-    skip_report: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
The job is supposed to run e2e tests on k8s 1.20 cluster with cgroupv2 enabled on the nodes.

Copied from `periodic-kubevirt-e2e-k8s-1.19-sig-network` with the following changes:
- job name, command to run, env
- timeout: 4h -> 7h
- `cron: "15 7,15,23 * * *"`

Additionally the PR enables status report for cgroupv2 presubmit job.

Needed for https://github.com/kubevirt/kubevirt/pull/4907