### PR TITLE
sriov, Enable Multi SR-IOV jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -848,8 +848,8 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      sriov-pod-multi: "true"
       rehearsal.allowed: "true"
-      sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.19-sriov
     skip_branches:
@@ -861,13 +861,6 @@ presubmits:
           - labelSelector:
               matchExpressions:
               - key: sriov-pod
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod-multi
                 operator: In
                 values:
                 - "true"
@@ -889,6 +882,9 @@ presubmits:
         resources:
           requests:
             memory: 29Gi
+            prow/sriov: "2"
+          limits:
+            prow/sriov: "2"            
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
In order to utilize the CI SR-IOV nodes better,
enable multi SR-IOV jobs mode.
This mode allows CI SR-IOV nodes to run multi jobs at a time,
according the number of PFs each machine has.

Each machine was updated to have prow/sriov resource,
with capacity according its PFs amount.

The CNI allocates 2 PFs for each job, and the job
is updated to request 2 prow/sriov,
this way k8s scheduler will know to limit how many
jobs run on the same time, instead the anti affinity
which allowed only one job at a time.

In order to return to serial mode,
rename the `sriov-pod-multi` back to `sriov-pod`.

TODO:

* Once there is ack, do it for all jobs, all must have it, in order to have the
same scheduling mode.

Signed-off-by: Or Shoval <oshoval@redhat.com>