### PR TITLE
sig-storage, enable to always run

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -532,7 +532,7 @@ periodics:
           - name: TARGET
             value: k8s-1.19
           - name: KUBEVIRT_E2E_SKIP
-            value: "SRIOV|GPU|Operator|\\[sig-network\\]"
+            value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]"
           - name: KUBEVIRT_WITH_ETC_IN_MEMORY
             value: "true"
         command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -157,6 +157,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: false
     optional: true
+    cluster: prow-workloads
     skip_report: false
     decorate: true
     decoration_config:
@@ -165,10 +166,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
+      preset-docker-mirror-proxy: "false"
       preset-shared-images: "true"
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -101,7 +101,7 @@ presubmits:
             - name: TARGET
               value: k8s-1.19
             - name: KUBEVIRT_E2E_SKIP
-              value: "SRIOV|GPU|Operator|\\[sig-network\\]"
+              value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -155,8 +155,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     cluster: prow-workloads
     skip_report: false
     decorate: true


### PR DESCRIPTION
The sig-storage lane should be actually run on all PRs so we can compare it's behavior to other lanes (with all tests). 
In the near future we want to remove sig-storage tests from main 1.19 lane and from periodic job. 

It takes about 30 minutes to finish on average. 

No failure (not counting single image fetch problem) since creating a periodic job with this lane: https://prow.apps.ovirt.org/job-history/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.19-sig-storage

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>