### PR TITLE
Add job to bump kubevirtci on kubevirt after new release

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -56,3 +56,55 @@ postsubmits:
           resources:
             requests:
               memory: "8Gi"
+    - name: push-kubevirtci-bump-kubevirt
+      branches:
+      - master
+      always_run: true
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      decoration_config:
+        timeout: 1h
+      max_concurrency: 1
+      extra_refs:
+      - org: kubevirt
+        repo: project-infra
+        base_ref: master
+      - org: kubevirt
+        repo: kubevirt
+        base_ref: master
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: gcs
+          secret:
+            secretName: gcs
+        containers:
+        - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+          env:
+          - name: GIT_ASKPASS
+            value: "../project-infra/hack/git-askpass.sh"
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+          command: ["/bin/sh", "-c"]
+          args:
+            - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -b bump-kubevirtci -p ../kubevirt
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          # docker-in-docker needs privileged mode
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: false
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "8Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -77,8 +77,6 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
       spec:
-        nodeSelector:
-          type: bare-metal-external
         volumes:
         - name: token
           secret:


### PR DESCRIPTION
This PR adds a job that will checkout kubevirt master, call `make bump-kubevirtci` and create a PR against kubevirt.

/cc @rmohr @fgimenez @EdDev 