### PR TITLE
Added prow-workloads overlay and deployment job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -271,6 +271,73 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
+        - image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+          - name: GIT_ASKPASS
+            value: "./hack/git-askpass.sh"
+          - name: DEPLOY_ENVIRONMENT
+            value: workloads-production
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              base_dir=github/ci/prow-deploy
+
+              source ./hack/manage-secrets.sh
+              decrypt_secrets
+
+              mkdir -p ${base_dir}/vars/${DEPLOY_ENVIRONMENT}
+              mv main.yml ${base_dir}/vars/${DEPLOY_ENVIRONMENT}/secrets.yml
+
+              # run playbook
+              cd ${base_dir}
+              cat << EOF > inventory
+              [local]
+              localhost ansible_connection=local
+              EOF
+              ANSIBLE_ROLES_PATH=$(pwd)/.. ansible-playbook -i inventory prow-deploy.yaml
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: true
+          - name: pgp-bot-key
+            mountPath: /etc/pgp
+            readOnly: true
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: pgp-bot-key
+          secret:
+            secretName: pgp-bot-key
+        - name: gcs
+          secret:
+            secretName: gcs
+    - name: post-project-infra-prow-workloads-services-deployment
+      always_run: false
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      branches:
+      # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+      - ^prow-workloads-services-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      labels:
+        preset-docker-mirror-proxy: "true"
+      skip_report: false
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
         - image: quay.io/kubespray/kubespray:v2.15.0
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -209,29 +209,14 @@ postsubmits:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
           - name: GIT_ASKPASS
-            value: "./hack/git-askpass.sh"
+            value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
           - name: DEPLOY_ENVIRONMENT
             value: ibmcloud-production
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
-            - |
-              base_dir=github/ci/prow-deploy
-
-              source ./hack/manage-secrets.sh
-              decrypt_secrets
-
-              mkdir -p ${base_dir}/vars/${DEPLOY_ENVIRONMENT}
-              mv main.yml ${base_dir}/vars/${DEPLOY_ENVIRONMENT}/secrets.yml
-
-              # run playbook
-              cd ${base_dir}
-              cat << EOF > inventory
-              [local]
-              localhost ansible_connection=local
-              EOF
-              ANSIBLE_ROLES_PATH=$(pwd)/.. ansible-playbook -i inventory prow-deploy.yaml
+            - "./github/ci/prow-deploy/hack/deploy.sh"
           resources:
             requests:
               memory: "8Gi"
@@ -276,29 +261,14 @@ postsubmits:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
           - name: GIT_ASKPASS
-            value: "./hack/git-askpass.sh"
+            value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
           - name: DEPLOY_ENVIRONMENT
             value: workloads-production
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
-            - |
-              base_dir=github/ci/prow-deploy
-
-              source ./hack/manage-secrets.sh
-              decrypt_secrets
-
-              mkdir -p ${base_dir}/vars/${DEPLOY_ENVIRONMENT}
-              mv main.yml ${base_dir}/vars/${DEPLOY_ENVIRONMENT}/secrets.yml
-
-              # run playbook
-              cd ${base_dir}
-              cat << EOF > inventory
-              [local]
-              localhost ansible_connection=local
-              EOF
-              ANSIBLE_ROLES_PATH=$(pwd)/.. ansible-playbook -i inventory prow-deploy.yaml
+            - "github/ci/prow-deploy/hack/deploy.sh"
           resources:
             requests:
               memory: "8Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -247,14 +247,13 @@ presubmits:
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
-          - name: GITHUB_TOKEN
-            value: /etc/github/oauth
+          - name: GIT_ASKPASS
+            value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
-            - "-c"
+            - "-ce"
             - |
-              set -e
               cd github/ci/prow-deploy/
               molecule test
               tmp=$(mktemp -d)

--- a/github/ci/prow-deploy/hack/deploy.sh
+++ b/github/ci/prow-deploy/hack/deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+main(){
+    current_dir=$(dirname "$0")
+    project_infra_root=$(readlink -f "${current_dir}/../../../..")
+
+    base_dir=${project_infra_root}/github/ci/prow-deploy
+
+    source ${project_infra_root}/hack/manage-secrets.sh
+    decrypt_secrets
+
+    mkdir -p ${base_dir}/vars/${DEPLOY_ENVIRONMENT}
+    mv main.yml ${base_dir}/vars/${DEPLOY_ENVIRONMENT}/secrets.yml
+
+    # run playbook
+    cd ${base_dir}
+    cat << EOF > inventory
+[local]
+localhost ansible_connection=local
+EOF
+    ANSIBLE_ROLES_PATH=$(pwd)/.. ansible-playbook -i inventory prow-deploy.yaml
+}
+
+main "${@}"

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -235,7 +235,7 @@ secretGenerator:
     type: Opaque
   - name: gcs
     files:
-      - secrets/gcs-service-account.json
+      - secrets/service-account.json
     type: Opaque
   - name: slack-token
     files:

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/kustomization.yaml
@@ -254,7 +254,7 @@ secretGenerator:
     type: Opaque
   - name: gcs
     files:
-      - secrets/gcs-service-account.json
+      - secrets/service-account.json
     type: Opaque
   - name: slack-token
     files:

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/.gitignore
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/.gitignore
@@ -1,0 +1,2 @@
+secrets/*
+configs/*

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -33,7 +33,7 @@ configMapGenerator:
 secretGenerator:
   - name: gcs
     files:
-      - secrets/gcs-service-account.json
+      - secrets/service-account.json
     type: Opaque
   - name: docker-mirror-proxy
     files:

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -5,6 +5,20 @@ kind: Kustomization
 resources:
   - resources/bootstrap.yaml
 
+patches:
+  - target:
+      version: v1
+      kind: Secret
+      namespace: ""
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: ConfigMap
+      namespace: ""
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -11,19 +11,19 @@ patches:
       kind: Secret
       namespace: ""
       name: .*
-    path: patches/JsonRFC6902/prow-namespace.yaml
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
   - target:
       version: v1
       kind: ConfigMap
       namespace: ""
       name: .*
-    path: patches/JsonRFC6902/prow-namespace.yaml
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-  - name: mirror-config
+  - name: docker-daemon-mirror-config
     files:
       - config.yaml=configs/mirror/mirror.yaml
   - name: mirror-proxy-config

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -1,0 +1,51 @@
+# Requires kustomize v3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - resources/bootstrap.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: mirror-config
+    files:
+      - config.yaml=configs/mirror/mirror.yaml
+  - name: mirror-proxy-config
+    files:
+      - configs/mirror-proxy/ca.crt
+
+secretGenerator:
+  - name: gcs
+    files:
+      - secrets/gcs-service-account.json
+    type: Opaque
+  - name: docker-mirror-proxy
+    files:
+      - ca.key=secrets/docker-proxy-ca.key
+    type: Opaque
+
+  - name: kubevirtci-docker-credential
+    # username=dockerUser
+    # password=dockerPass
+    envs:
+    - secrets/kubevirtci-docker-credential
+    type: Opaque
+
+  - name: kubevirtci-quay-credential
+    # username=quayUser
+    # password=quayPass
+    envs:
+    - secrets/kubevirtci-quay-credential
+    type: Opaque
+  - name: kubevirtci-installer-pull-token
+    files:
+      # installerPullToken
+      - token=secrets/kubevirtci-installer-pull-token
+    type: Opaque
+  - name: kubevirtci-coveralls-token
+    files:
+      # coverallsToken
+      - token=secrets/kubevirtci-coveralls-token
+    type: Opaque

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/patches/JsonRFC6902/prow-jobs-namespace.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/patches/JsonRFC6902/prow-jobs-namespace.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /metadata/namespace
-  value: kubevirt-prow
+  value: kubevirt-prow-jobs

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/patches/JsonRFC6902/prow-namespace.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/patches/JsonRFC6902/prow-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/bootstrap.yaml
@@ -1,4 +1,10 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kubernetes-prow-jobs
+  name: kubevirt-prow
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-prow-jobs

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/bootstrap.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernetes-prow-jobs

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -21,6 +21,8 @@
     kustomize build overlays/{{ deploy_environment }} | kubectl apply -f -
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
 
 - name: Bootstrap the full job config
   shell: |
@@ -36,6 +38,7 @@
     PROW_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/config/config.yaml"
     PLUGIN_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/plugins/plugins.yaml"
     KUBECONFIG: "{{ kubeconfig_path }}"
+  when: bootstrap_full_config
 
 - name: Patch SRIOV nodes
   shell: |

--- a/github/ci/prow-deploy/tasks/main.yml
+++ b/github/ci/prow-deploy/tasks/main.yml
@@ -78,11 +78,11 @@
   include_tasks: resources.yml
 
 - name: set kubectl context if needed
-  when: remoteClusterProwJobsContext is defined
+  when: remote_cluster_prow_jobs_context is defined
   block:
     - name: switch context
       shell: |
-        {{ kubectl_exec }} config use-context {{ remoteClusterProwJobsContext }}
+        {{ kubectl_exec }} config use-context {{ remote_cluster_prow_jobs_context }}
         {{ kubectl_exec }} config current-context
 
       environment:

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -18,7 +18,7 @@
 
 - name: Create github token secret
   copy:
-    src: '{{ githubToken }}'
+    content: '{{ githubToken }}'
     dest: '{{ secrets_dir }}/oauth-token'
 
 - name: set gcs service account

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: use git askpass to generate github token
-  shell: '{{ lookup("env", "GIT_ASKPASS") }}'
+  shell: '{{ project_infra_root }}/{{ lookup("env", "GIT_ASKPASS") }}'
   register: gitAskPass
 
 - name: set github token

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -32,7 +32,7 @@
 - name: Create GCS secret
   copy:
     src: '{{ gcsServiceAccount }}'
-    dest: '{{ secrets_dir }}/gcs-service-account.json'
+    dest: '{{ secrets_dir }}/service-account.json'
 
 - name: Create Slack secret
   copy:

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -4,9 +4,13 @@
     path: '{{ secrets_dir }}'
     state: directory
 
+- name: use git askpass to generate github token
+  shell: '{{ lookup("env", "GIT_ASKPASS") }}'
+  register: gitAskPass
+
 - name: set github token
   set_fact:
-    githubToken: '{{ lookup("env", "GITHUB_TOKEN") }}'
+    githubToken: '{{ gitAskPass.stdout }}'
 - name: Check GITHUB_TOKEN env var
   fail:
     msg: GITHUB_TOKEN must be set

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: use git askpass to generate github token
-  shell: '{{ project_infra_root }}/{{ lookup("env", "GIT_ASKPASS") }}'
+  local_action: command '{{ lookup("env", "GIT_ASKPASS") | default(playbook_dir + "/../../../../../hack/git-askpass.sh", true) }}'
   register: gitAskPass
 
 - name: set github token

--- a/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
+++ b/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
@@ -1,7 +1,7 @@
 testinfra_dir: /tmp/test-infra
 kubectl_exec: /usr/local/bin/kubectl
 bootstrap_full_config: true
-project_infra_root: /home/prow/go/src/github.com/fgimenez/project-infra
+project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/secrets/'
 kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
 
@@ -9,3 +9,4 @@ shell_environment:
   KUBECONFIG: "{{ kubeconfig_path }}"
 
 SRIOVNodes: []
+remote_cluster_prow_jobs_context: ibm-prow-jobs

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -26,3 +26,7 @@ masterClusterContext: kubernetes-admin@kubernetes
 installerPullToken: '{}'
 
 coverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
+
+bootstrap_full_config: true
+
+kubeconfig_path: /root/.kube/config

--- a/github/ci/prow-deploy/vars/workloads-production/main.yml
+++ b/github/ci/prow-deploy/vars/workloads-production/main.yml
@@ -1,6 +1,6 @@
 testinfra_dir: /tmp/test-infra
 kubectl_exec: /usr/local/bin/kubectl
-bootstrap_full_config: true
+bootstrap_full_config: false
 project_infra_root: /home/prow/go/src/github.com/fgimenez/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/workloads-production/secrets/'
 kubeconfig_path: '{{ secrets_dir }}/kubeconfig'

--- a/github/ci/prow-deploy/vars/workloads-production/main.yml
+++ b/github/ci/prow-deploy/vars/workloads-production/main.yml
@@ -1,0 +1,17 @@
+testinfra_dir: /tmp/test-infra
+kubectl_exec: /usr/local/bin/kubectl
+bootstrap_full_config: true
+project_infra_root: /home/prow/go/src/github.com/fgimenez/project-infra
+secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/workloads-production/secrets/'
+kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
+
+shell_environment:
+  KUBECONFIG: "{{ kubeconfig_path }}"
+
+SRIOVNodes:
+  - name: bare-metal-sriov-1
+    capacity: 2
+  - name: bare-metal-sriov-2
+    capacity: 2
+
+remote_cluster_prow_jobs_context: prow-workloads


### PR DESCRIPTION
Modifies prow-deploy to be able to deploy the new cluster components. It also adds a postsubmit to run the actual deployment on tag push.

It also includes these fixes that affect the deployment on ibm-prow:
* Fixed gcs secret file name
* Fixed project-infra root path (fgimenez -> kubevirt)
* Added kubeconfig path to Kustomize command
* Updated to use GIT_ASKPASS instead of GITHUB_TOKEN

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>