### PR TITLE
Change the periodic job to point to the master branch of common-templates project

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
       work_dir: true
     - org: kubevirt
       repo: common-templates
-      base_ref: containerdisk-automation
+      base_ref: master
   spec:
     nodeSelector:
       type: bare-metal-external


### PR DESCRIPTION
Change the periodic job to point to the master branch of common-templates project

Signed-off-by: Shweta Padubidri <spadubid@redhat.com>