### PR TITLE
Run some quarantined tests with in-memory etcd

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -533,6 +533,8 @@ periodics:
             value: k8s-1.19
           - name: KUBEVIRT_E2E_SKIP
             value: Multus|SRIOV|GPU|Macvtap|Operator
+          - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+            value: "true"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
We suspect disk pressure might be causing apiserver panics in the
test runs: https://github.com/kubevirt/kubevirt/issues/5353

And this will reduce the disk pressure a bit.

Tunable mentioned in https://github.com/kubevirt/kubevirtci/pull/568