### PR TITLE
sriov, periodics, Remove redundant trap

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -717,15 +717,11 @@ periodics:
             value: "kind-k8s-sriov-1.17.0"
           - name: "GIMME_GO_VERSION"
             value: "1.13.8"
-          - name: "KUBEVIRT_PROVIDER" # for cluster-down in the command below
-            value: "kind-k8s-sriov-1.17.0"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
-        - "-c"
+        - "-ce"
         - |
-            set -e
-            trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM
             automation/test.sh
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Kubevirt automation/test.sh already has a trap
to cluster-down the kind sriov cluster,
it is enough to run it once, and the signal
will propogate first to the script.

Hence remove it from the job command.

As done on https://github.com/kubevirt/project-infra/pull/1084 for the presubmit.

Signed-off-by: Or Shoval <oshoval@redhat.com>