### PR TITLE
sig-network, k8s-1.19, Move presubmit job to new CI cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -683,7 +683,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
New CI cluster is now ready for k8s-1.19 sig-network.
The missing ipv6 docker gateway was added.

Signed-off-by: Or Shoval <oshoval@redhat.com>