### PR TITLE
update ci-search image

### DIFF
--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -10,7 +10,7 @@ spec:
       tolerations: null
       containers:
       - name: web
-        image: registry.svc.ci.openshift.org/ci/ci-search:latest
+        image: registry.ci.openshift.org/ci/ci-search:latest
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
We were getting errors like https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1082/pull-project-infra-ci-search-deploy-test/1380153133111447552 Trying to pull ci-search image locally I get:
```
$ docker pull registry.svc.ci.openshift.org/ci/ci-search:latest
Error response from daemon: received unexpected HTTP status: 503 Service Unavailable
```
According to Ben Parees:
```
i think registry.svc.ci.openshift.org is dead.
use registry.ci.openshift.org/ci/ci-search:latest
```

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>