### PR TITLE
Create k6t periodic lanes for k8s-1.20 

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -303,14 +303,15 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "0 1,9,17 * * *"
+  cron: "10 4,12,20 * * *"
   decorate: true
+  cluster: prow-workloads
   decoration_config:
     timeout: 4h
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
   - org: kubevirt
@@ -340,14 +341,15 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "20 2,10,18 * * *"
+  cron: "20 5,13,21 * * *"
   decorate: true
+  cluster: prow-workloads
   decoration_config:
     timeout: 4h
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -377,14 +379,15 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "40 3,11,19 * * *"
+  cron: "30 6,14,22 * * *"
   decorate: true
+  cluster: prow-workloads
   decoration_config:
     timeout: 4h
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -416,14 +419,15 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "40 3,11,19 * * *"
+  cron: "40 7,15,23 * * *"
   decorate: true
+  cluster: prow-workloads
   decoration_config:
     timeout: 4h
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -455,14 +459,15 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "15 7,15,23 * * *"
+  cron: "50 8,16,0 * * *"
   decorate: true
+  cluster: prow-workloads
   decoration_config:
     timeout: 7h
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -478,7 +483,7 @@ periodics:
           - name: TARGET
             value: "k8s-1.20"
           - name: KUBEVIRT_E2E_SKIP
-            value: "Multus|SRIOV|GPU|Macvtap|Operator|sig-network|sig-storage|owner:@sig-compute"
+            value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]|owner:@sig-compute"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -494,7 +499,7 @@ periodics:
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cron: "15 7,15,23 * * *"
+  cron: "0 9,17,0 * * *"
   decorate: true
   decoration_config:
     timeout: 7h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -299,6 +299,197 @@ periodics:
         resources:
           requests:
             memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20-sig-network
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "0 1,9,17 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt
+    base_ref: master
+    work_dir: true
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20-sig-network"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20-sig-storage
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "20 2,10,18 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20-sig-storage"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20-sig-compute
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "40 3,11,19 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20"
+          - name: KUBEVIRT_E2E_FOCUS
+            value: "owner:@sig-compute"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20-operator
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "40 3,11,19 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20"
+          - name: KUBEVIRT_E2E_FOCUS
+            value: "Operator"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "15 7,15,23 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 7h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20"
+          - name: KUBEVIRT_E2E_SKIP
+            value: "Multus|SRIOV|GPU|Macvtap|Operator|sig-network|sig-storage|owner:@sig-compute"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
 - name: periodic-kubevirt-e2e-k8s-1.20-cgroupsv2
   annotations:
     testgrid-dashboards: kubevirt-periodics

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -8,6 +8,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: false
     optional: true
+    cluster: prow-workloads
     skip_report: true
     decorate: true
     decoration_config:
@@ -16,20 +17,189 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
+      preset-docker-mirror-proxy: "false"
       preset-shared-images: "true"
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.20
+            - name: KUBEVIRT_E2E_SKIP
+              value: "SRIOV|GPU|Operator|\\[sig-storage\\]|\\[sig-network\\]|owner:@sig-compute"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.20 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh"
+            - "automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.20-sig-network
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    cluster: prow-workloads
+    skip_report: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-shared-images: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.20-sig-network        
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.20-sig-storage
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    cluster: prow-workloads
+    skip_report: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-shared-images: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.20-sig-storage
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.20-sig-compute
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    cluster: prow-workloads
+    skip_report: true
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-shared-images: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.20
+            - name: KUBEVIRT_E2E_FOCUS
+              value: owner:@sig-compute
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.20-operator
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    cluster: prow-workloads
+    skip_report: true
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-shared-images: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.20
+            - name: KUBEVIRT_E2E_FOCUS
+              value: Operator
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
This is part of checking k8s 1.20 lanes status and try to graduate to
github reporting.

It also add counterpart presubmit jobs with `always_run: false` to run them manually at `cluster: prow-workloads`