### PR TITLE
Fix push-release-kubevirt-tag quay login

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -73,7 +73,7 @@ postsubmits:
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
         - |
-          docker login --username "$(<"$QUAY_USER")" --password-stdin=true quay.io <"$QUAY_PASSWORD"
+          cat $QUAY_PASSWORD | docker login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
           ./automation/release.sh
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
This PR fixes the login to quay before running the tag release script.

/cc @davidvossel 