### PR TITLE
Revert running etcd in-memory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -533,8 +533,6 @@ periodics:
             value: k8s-1.19
           - name: KUBEVIRT_E2E_SKIP
             value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]"
-          - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-            value: "true"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
The original background was a blind attempt at reducing I/O
load, we now have a better theory for the problem, and we
want to understand why this lane has more failures than the
-prev lane by reducing differences.

