### PR TITLE
Sync cri-o version 1.21

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -25,7 +25,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.20"
+            value: "1.20,1.21"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
Adding 1.21 version to be synced with GCP.


Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>