### PR TITLE
Make the arm cross compile job always run

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -785,7 +785,7 @@ presubmits:
       - release-\d+\.\d+
     annotations:
       fork-per-release: "true"
-    always_run: false
+    always_run: true
     skip_report: false
     optional: true
     decorate: true


### PR DESCRIPTION
With https://github.com/kubevirt/kubevirt/pull/5456 merged we can start running the crosscompile check on every PR. Still keeping it optional for the next 2-3 days.