### PR TITLE
Promote k6t 1.20 sig-net presubmit lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -48,10 +48,9 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     cluster: prow-workloads
-    skip_report: true
     decorate: true
     decoration_config:
       timeout: 4h


### PR DESCRIPTION
Looks like the periodic jobs for kubevirt sig-network k8s-1.20 are fine
[1], let's promote the presubmit so it's always run but not voting and
not reporting to github.

[1] https://grafana-kubevirt-prow.apps.ovirt.org/d/Cz6zgEEGz/e2e-jobs-overview?orgId=1&refresh=2h&from=now-5d&to=now&var-job_name=periodic-kubevirt-e2e-k8s-1.20-sig-network

Signed-off-by: Quique Llorente <ellorent@redhat.com>