### PR TITLE
kubevirtci, postsubmit, Add docker proxy

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
         base_ref: master
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
+        preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
       spec:
         nodeSelector:


### PR DESCRIPTION
Since some of the images are still on docker.io
publish may fail due to docker.io rate limit.

Add the docker proxy to the job.

https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/publish-kubevirtci/1384131974548951040

```
v15: Pulling from ceph/ceph
toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

Signed-off-by: Or Shoval <oshoval@redhat.com>