### PR TITLE
build multiarch bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -83,12 +83,15 @@ postsubmits:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
-    - name: publish-bootstrap-image
+    - name: publish-multiarch-bootstrap-image
       always_run: false
       run_if_changed: "images/golang/.*|images/bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
@@ -104,16 +107,16 @@ postsubmits:
               - |
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
-                ./publish_image.sh bootstrap quay.io kubevirtci
-                ./publish_image.sh golang quay.io kubevirtci
+                ./publish_multiarch_image.sh bootstrap quay.io kubevirtci
+                ./publish_multiarch_image.sh -l golang quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
               requests:
-                memory: "1Gi"
+                memory: "8Gi"
               limits:
-                memory: "1Gi"
+                memory: "8Gi"
     - name: publish-kubekins-e2e-image
       always_run: false
       run_if_changed: "images/kubekins-e2e/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -85,10 +85,13 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
-  - name: build-bootstrap-image
+  - name: build-multiarch-bootstrap-image
     always_run: false
     run_if_changed: "images/bootstrap/.*|images/golang/.*"
     decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -103,16 +106,16 @@ presubmits:
             - "-ce"
             - |
               cd images
-              ./publish_image.sh -b bootstrap quay.io kubevirtci
-              ./publish_image.sh -b golang quay.io kubevirtci
+              ./publish_multiarch_image.sh -b bootstrap quay.io kubevirtci
+              ./publish_multiarch_image.sh -b -l golang quay.io kubevirtci
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
             requests:
-              memory: "1Gi"
+              memory: "8Gi"
             limits:
-              memory: "1Gi"
+              memory: "8Gi"
   - name: build-kubekins-e2e-image
     always_run: false
     run_if_changed: "images/kubekins-e2e/.*"

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -93,7 +93,8 @@ RUN mkdir /docker-graph
 #
 
 # Cache the most commonly used bazel versions in the container
-RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && \
+ARG ARCH
+RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-${ARCH} && \
      chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
      cd /usr/local/bin && ln -s bazelisk bazel
 

--- a/images/golang/Dockerfile
+++ b/images/golang/Dockerfile
@@ -1,4 +1,5 @@
-FROM bootstrap
+ARG ARCH
+FROM bootstrap-$ARCH
 
 ENV GIMME_GO_VERSION=1.17.8
 

--- a/images/publish_multiarch_image.sh
+++ b/images/publish_multiarch_image.sh
@@ -1,0 +1,121 @@
+#!/bin/bash -xe
+archs=(amd64 arm64)
+
+main() {
+    local build_only local_base_image
+    local_base_image=false
+    while getopts "blh" opt; do
+        case "$opt" in
+            b)
+                build_only=true
+                ;;
+            l)
+                local_base_image=true
+                ;;
+            h)
+                help
+                exit 0
+                ;;
+            *)
+                echo "Invalid argument: $opt"
+                help
+                exit 1
+        esac
+    done
+    shift $((OPTIND-1))
+    local build_target="${1:?}"
+    local registry="${2:?}"
+    local registry_org="${3:?}"
+    local full_image_name image_tag base_image
+
+    image_tag="$(get_image_tag)"
+    full_image_name="$(
+        get_full_image_name \
+            "$registry" \
+            "$registry_org" \
+            "${build_target##*/}" \
+            "$image_tag"
+    )"
+
+    (
+        cd "$build_target"
+	base_image="$(get_base_image)"
+
+        build_image $local_base_image "$build_target" "$full_image_name" "$base_image"
+    )
+    [[ $build_only ]] && return
+    publish_image "$full_image_name"
+    publish_manifest "$full_image_name"
+}
+
+help() {
+    cat <<EOF
+    Usage:
+        ./publish_multiarch_image.sh [OPTIONS] BUILD_TARGET REGISTRY REGISTRY_ORG
+
+    Build and publish multiarch infra images.
+
+    OPTIONS
+        -h  Show this help message and exit.
+        -b  Only build the image and exit. Do not publish the built image.
+        -l  Use local base image
+EOF
+}
+
+get_base_image() {
+    name="$(cat Dockerfile |grep FROM|awk '{print $2}')"
+    echo "${name}"
+}
+
+get_image_tag() {
+    local current_commit today
+    current_commit="$(git rev-parse HEAD)"
+    today="$(date +%Y%m%d)"
+    echo "v${today}-${current_commit:0:7}"
+}
+
+build_image() {
+    local local_base_image=${1:?}
+    local build_target="${2:?}"
+    local image_name="${3:?}"
+    local base_image="${4:?}"
+    # add qemu-user-static
+    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    # build multi-arch images
+    for arch in ${archs[*]};do
+        if [[ $local_base_image == false ]]; then
+	    docker pull --platform="linux/${arch}" ${base_image}
+        fi
+        docker build --platform="linux/${arch}" --build-arg ARCH=${arch} --build-arg IMAGE_ARG=${build_target} . -t "${image_name}-${arch}" -t "${build_target}-${arch}"
+    done
+}
+
+publish_image() {
+    local full_image_name="${1:?}"
+    for arch in ${archs[*]};do
+        docker push "${full_image_name}-${arch}"
+    done
+}
+
+publish_manifest() {
+    export DOCKER_CLI_EXPERIMENTAL="enabled"
+    local amend
+    local full_image_name="${1:?}"
+    amend=""
+    for arch in ${archs[*]};do
+        amend+=" --amend ${full_image_name}-${arch}"
+    done
+    docker manifest create ${full_image_name} ${amend}
+    docker manifest push --purge ${full_image_name}
+}
+
+get_full_image_name() {
+    local registry="${1:?}"
+    local registry_org="${2:?}"
+    local image_name="${3:?}"
+    local tag="${4:?}"
+
+    echo "${registry}/${registry_org}/${image_name}:${tag}"
+}
+
+main "$@"


### PR DESCRIPTION
build bootstrap image for amd64 and arm64
New Dockerfile for bootstrap has `ARG ARCH` which is not acquired in the build-bootstrap-image test, so the test would always fail.