### PR TITLE
Make arm64 crosscompile presubmit required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -786,7 +786,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     skip_report: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
The job history speaks for itself: https://prow.apps.ovirt.org/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-build-arm64. Pretty much always green and failed lanes are not related to the cross-compilation.