### PR TITLE
Fix rule attr nil dereference

### DIFF
--- a/plugins/cmd/uploader/uploader.go
+++ b/plugins/cmd/uploader/uploader.go
@@ -122,6 +122,10 @@ func upload(options options, workspace *build.File, artifacts []mirror.Artifact)
 	}
 
 	mirror.RemoveStaleDownloadURLS(artifacts, targetMirrorURLPattern, http.DefaultClient)
+	err = mirror.CheckArtifactsHaveURLS(artifacts)
+	if err != nil {
+		log.Fatalf("could not update workspace items: %v", err)
+	}
 
 	err = mirror.WriteWorkspace(options.dryRun, workspace, options.workspacePath)
 	if err != nil {

--- a/plugins/cmd/uploader/uploader.go
+++ b/plugins/cmd/uploader/uploader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"regexp"
 
@@ -108,7 +109,7 @@ func upload(options options, workspace *build.File, artifacts []mirror.Artifact)
 	failed := false
 	for _, artifact := range invalid {
 		newFileUrl := mirror.GenerateFilePath(options.bucket, &artifact)
-		err := mirror.WriteToBucket(options.dryRun, ctx, client, artifact, options.bucket)
+		err := mirror.WriteToBucket(options.dryRun, ctx, client, artifact, options.bucket, http.DefaultClient)
 		if err != nil {
 			log.Printf("failed to upload %s to %s: %s", artifact.Name(), newFileUrl, err)
 			if options.continueOnError {
@@ -120,7 +121,7 @@ func upload(options options, workspace *build.File, artifacts []mirror.Artifact)
 		artifact.AppendURL(newFileUrl)
 	}
 
-	mirror.RemoveStaleDownloadURLS(artifacts, targetMirrorURLPattern)
+	mirror.RemoveStaleDownloadURLS(artifacts, targetMirrorURLPattern, http.DefaultClient)
 
 	err = mirror.WriteWorkspace(options.dryRun, workspace, options.workspacePath)
 	if err != nil {

--- a/plugins/mirror/bazel.go
+++ b/plugins/mirror/bazel.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/bazelbuild/buildtools/build"
@@ -159,6 +160,19 @@ func RemoveStaleDownloadURLS(artifacts []Artifact, ignoreURLSMatching *regexp.Re
 		artifact.RemoveURLs(notFoundUrls)
 	}
 
+}
+
+func CheckArtifactsHaveURLS(artifacts []Artifact) error {
+	artifactsWithoutURLs := []string{}
+	for _, artifact := range artifacts {
+		if len(artifact.URLs()) == 0 {
+			artifactsWithoutURLs = append(artifactsWithoutURLs, artifact.Name())
+		}
+	}
+	if len(artifactsWithoutURLs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("artifacts without urls found: '%s'", strings.Join(artifactsWithoutURLs, "', '"))
 }
 
 func getMirror(artifact Artifact, regexp *regexp.Regexp) string {

--- a/plugins/mirror/bazel_test.go
+++ b/plugins/mirror/bazel_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/bazelbuild/buildtools/build"
@@ -218,6 +219,106 @@ func TestRemoveStaleDownloadURLS(t *testing.T) {
 		RemoveStaleDownloadURLS(artifacts, regexp.MustCompile("^https://kubevirt.storage.googleapis.com/.+"), mockHTTPClient)
 		if len(artifacts[0].URLs()) != workspaceData.expectedLength {
 			t.Fatalf("'%s': expected length was %d, actual was %d, URLS: %v", workspaceData.name, workspaceData.expectedLength, len(artifacts[0].URLs()), artifacts[0].URLs())
+		}
+	}
+}
+
+type testCaseDataForForCheckArtifactsHaveURLs struct {
+	name		   string
+	data           []byte
+	expectFails    bool
+	shouldContain  []string
+}
+
+var testCasesForCheckArtifactsHaveURLs = []testCaseDataForForCheckArtifactsHaveURLs{
+	{
+		name: "has urls",
+		data: []byte(`
+rpm(
+    name = "findutils-1__4.7.0-4.fc32.x86_64",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd661",
+    urls = [
+        "https://mirror.dogado.de/fedora/linux/updates/32/Everything/x86_64/Packages/f/findutils-4.7.0-4.fc32.x86_64.rpm",
+    ],
+)
+`),
+		expectFails: false,
+	},
+	{
+		name: "has url",
+		data: []byte(`
+rpm(
+    name = "findutils-1__4.7.0-4.fc32.x86_64",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd661",
+    url = "https://mirror.dogado.de/fedora/linux/updates/32/Everything/x86_64/Packages/f/findutils-4.7.0-4.fc32.x86_64.rpm",
+)
+`),
+		expectFails: false,
+	},
+	{
+		name: "neither urls nor url",
+		data: []byte(`
+rpm(
+    name = "findutils-1__4.7.0-4.fc32.x86_64",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd661",
+)
+`),
+		expectFails: true,
+	},
+	{
+		name: "urls empty",
+		data: []byte(`
+rpm(
+    name = "findutils-1",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd661",
+    urls = [],
+)
+`),
+		expectFails: true,
+	},
+	{
+		name: "two artifacts with urls empty, both names should appear in error message",
+		data: []byte(`
+rpm(
+    name = "findutils-1",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd661",
+    urls = [],
+)
+rpm(
+    name = "findutils-2",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd662",
+    urls = [],
+)
+`),
+		expectFails: true,
+	},
+}
+
+func TestCheckArtifactsHaveURLS(t *testing.T) {
+	for _, workspaceData := range testCasesForCheckArtifactsHaveURLs {
+		file, err := build.ParseWorkspace("workspace", workspaceData.data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		artifacts, err := GetArtifacts(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = CheckArtifactsHaveURLS(artifacts)
+		if workspaceData.expectFails {
+			if err == nil {
+				t.Fatalf("'%s': expected check to fail, URLS: %v", workspaceData.name, artifacts[0].URLs())
+			}
+			for _, shouldContain := range workspaceData.shouldContain {
+				if !strings.Contains(err.Error(), shouldContain) {
+					t.Fatalf("'%s': expected error to contain %s, was: %s", workspaceData.name, shouldContain, err.Error())
+				}
+			}
+		} else if !workspaceData.expectFails {
+			if err != nil {
+				t.Fatalf("'%s': expected check not to fail, URLS: %v", workspaceData.name, artifacts[0].URLs())
+			}
 		}
 	}
 }

--- a/plugins/mirror/bazel_test.go
+++ b/plugins/mirror/bazel_test.go
@@ -145,11 +145,29 @@ rpm(
 		},
 		expectedLength: 2,
 	},
+	{
+		data: []byte(`
+rpm(
+    name = "findutils-1__4.7.0-4.fc32.x86_64",
+    sha256 = "c7e5d5de11d4c791596ca39d1587c50caba0e06f12a7c24c5d40421d291cd661",
+)
+`),
+		responses: MockResponses{
+			"https://mirror.dogado.de/fedora/linux/updates/32/Everything/x86_64/Packages/f/findutils-4.7.0-4.fc32.x86_64.rpm":
+			MockResponse{
+				resp: &http.Response{
+					StatusCode: 200,
+					Body:       http.NoBody,
+				},
+			},
+		},
+		expectedLength: 0,
+	},
 }
 
 func TestRemoveStaleDownloadURLS(t *testing.T) {
 	for _, workspaceData := range testCasesForTestRemoveStaleDownloadURLS {
-		Client = MockHTTPClient{
+		mockHTTPClient := MockHTTPClient{
 			responses: workspaceData.responses,
 		}
 		file, err := build.ParseWorkspace("workspace", workspaceData.data)
@@ -161,7 +179,7 @@ func TestRemoveStaleDownloadURLS(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		RemoveStaleDownloadURLS(artifacts, regexp.MustCompile("^https://kubevirt.storage.googleapis.com/.+"))
+		RemoveStaleDownloadURLS(artifacts, regexp.MustCompile("^https://kubevirt.storage.googleapis.com/.+"), mockHTTPClient)
 		if len(artifacts[0].URLs()) != workspaceData.expectedLength {
 			t.Fatalf("expected length was %d, actual was %d, URLS: %v", workspaceData.expectedLength, len(artifacts[0].URLs()), artifacts[0].URLs())
 		}


### PR DESCRIPTION
Basic problem was missing handling of elements who only have a `url` element, but where `urls` element is missing. In that case we replace the `url` element with a `urls` element.

Also we remove http client variable for mocking, instead introduce a function parameter.

Fixes https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/periodic-kubevirt-mirror-uploader/1384765400746561536

/cc @rmohr @fgimenez @awels  