### PR TITLE
Enable 1.20-sig-sorage presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -87,8 +87,8 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     cluster: prow-workloads
     skip_report: true
     decorate: true


### PR DESCRIPTION
Once it is enabled we need to watch for 24h the number of pending jobs in https://grafana-kubevirt-prow.apps.ovirt.org/d/Cz6zgEEGz/e2e-jobs-overview?orgId=1&refresh=2h to check if they increase too much. 

/cc @brybacki 
/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>