### PR TITLE
Add 1.19-sig-compute presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -356,6 +356,46 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.19-sig-compute
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: false
+    cluster: prow-workloads
+    skip_report: true
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-shared-images: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.19-sig-compute
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-e2e-k8s-1.19-operator
     skip_branches:
       - release-\d+\.\d+

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -268,7 +268,7 @@ presubmits:
             - name: TARGET
               value: k8s-1.19
             - name: KUBEVIRT_E2E_SKIP
-              value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]"
+              value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
kubevirt/kubevirt's 1.19-sig-compute presubmit was missing, this PR adds it as required.

/cc @vatsalparekh 
/cc @dhiller 