### PR TITLE
Add periodics to report

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+        - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -46,7 +46,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+        - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -83,7 +83,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+        - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -45,7 +45,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -81,7 +81,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -46,7 +46,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -83,7 +83,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+      - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -45,7 +45,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -80,7 +80,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -92,6 +92,7 @@ periodics:
       - --merged=24h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
+      - --periodic_job_dir_regex=periodic-kubevirt-e2e-.*
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -115,7 +116,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -46,7 +46,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -83,7 +83,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9d42d74ead8740aa35d583de280555b80b49b55cbab8d7cc77bb780da138b794
+    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/cmd/flakefinder/main.go
+++ b/robots/cmd/flakefinder/main.go
@@ -52,6 +52,7 @@ func flagOptions() options {
 	flag.StringVar(&o.repo, "repo", Repo, "GitHub org name")
 	flag.BoolVar(&o.today, "today", false, "Whether to create a report for the current day only (i.e. using data starting from report day 00:00Z till now)")
 	flag.BoolVar(&o.skipBeforeStartOfReport, "skip_results_before_start_of_report", true, "Whether to skip test results occurring before start of report")
+	flag.StringVar(&o.periodicJobDirRegex, "periodic_job_dir_regex", "", "Regular expression to use for fetching data from periodic jobs, or empty string if not wanted")
 	flag.Parse()
 	return o
 }
@@ -69,6 +70,7 @@ type options struct {
 	repo                    string
 	today                   bool
 	skipBeforeStartOfReport bool
+	periodicJobDirRegex     string
 }
 
 const MaxNumberOfReportsToLinkTo = 50
@@ -114,7 +116,10 @@ func main() {
 		log.Fatalf("Failed to create new storage client: %v.\n", err)
 	}
 
-	reportBaseData := flakefinder.GetReportBaseData(ctx, ghClient, storageClient, flakefinder.NewReportBaseDataOptions(o.prBaseBranch, o.today, o.merged, o.org, o.repo, o.skipBeforeStartOfReport))
+	reportBaseDataOptions := flakefinder.NewReportBaseDataOptions(o.prBaseBranch, o.today, o.merged, o.org, o.repo, o.skipBeforeStartOfReport)
+	reportBaseDataOptions.SetPeriodicJobDirRegex(o.periodicJobDirRegex)
+
+	reportBaseData := flakefinder.GetReportBaseData(ctx, ghClient, storageClient, reportBaseDataOptions)
 
 	err = WriteReportToBucket(ctx, storageClient, o.merged, o.org, o.repo, o.isDryRun, reportBaseData)
 	if err != nil {

--- a/robots/cmd/flakefinder/main.go
+++ b/robots/cmd/flakefinder/main.go
@@ -77,7 +77,6 @@ const Org = "kubevirt"
 const Repo = "kubevirt"
 
 var ReportOutputPath = flakefinder.ReportsPath
-var PRBaseBranch string
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -88,7 +87,6 @@ func main() {
 	}
 
 	ReportOutputPath = BuildReportOutputPath(o)
-	PRBaseBranch = o.prBaseBranch
 
 	secretAgent := &secret.Agent{}
 	if err := secretAgent.Start([]string{o.token}); err != nil {
@@ -116,7 +114,7 @@ func main() {
 		log.Fatalf("Failed to create new storage client: %v.\n", err)
 	}
 
-	reportBaseData := flakefinder.GetReportBaseData(ctx, ghClient, storageClient, flakefinder.NewReportBaseDataOptions(PRBaseBranch, o.today, o.merged, o.org, o.repo, o.skipBeforeStartOfReport))
+	reportBaseData := flakefinder.GetReportBaseData(ctx, ghClient, storageClient, flakefinder.NewReportBaseDataOptions(o.prBaseBranch, o.today, o.merged, o.org, o.repo, o.skipBeforeStartOfReport))
 
 	err = WriteReportToBucket(ctx, storageClient, o.merged, o.org, o.repo, o.isDryRun, reportBaseData)
 	if err != nil {

--- a/robots/cmd/flakefinder/report.go
+++ b/robots/cmd/flakefinder/report.go
@@ -161,7 +161,7 @@ const ReportTemplate = `
 		<table width="100%">
 			{{ range $key, $jobFailures := $.FailuresForJobs }}<tr class="unimportant">
 				<td>
-					<a href="https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/{{ $.Org }}_{{ $.Repo }}/{{.PR}}/{{.Job}}/{{.BuildNumber}}"><span title="job build number">{{.BuildNumber}}</span></a>
+					{{ if ne .PR 0 }}<a href="https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/{{ $.Org }}_{{ $.Repo }}/{{.PR}}/{{.Job}}/{{.BuildNumber}}"><span title="job build number">{{.BuildNumber}}</span></a>{{ else }}<a href="https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/{{.Job}}/{{.BuildNumber}}"><span title="job build number">{{.BuildNumber}}</span></a>{{ end }}
 				</td>
 				<td>
 					<a href="https://github.com/{{ $.Org }}/{{ $.Repo }}/pull/{{.PR}}"><span title="pr number">#{{.PR}}</span></a>
@@ -197,7 +197,7 @@ const ReportTemplate = `
                 <span class="tests_failed" title="failed tests">{{ (index $.Data $test $header).Failed }}</span>/<span class="tests_passed" title="passed tests">{{ (index $.Data $test $header).Succeeded }}</span>/<span class="tests_skipped" title="skipped tests">{{ (index $.Data $test $header).Skipped }}</span>
                 <div class="popuptext" id="targetr{{$row}}c{{$col}}">
                     {{ range $Job := (index $.Data $test $header).Jobs }}
-                    <div class="{{.Severity}} nowrap"><a href="https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/{{ $.Org }}_{{ $.Repo }}/{{.PR}}/{{.Job}}/{{.BuildNumber}}">{{.BuildNumber}}</a> (<a href="https://github.com/{{ $.Org }}/{{ $.Repo }}/pull/{{.PR}}">#{{.PR}}</a>)</div>
+                    <div class="{{.Severity}} nowrap">{{ if ne .PR 0 }}<a href="https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/{{ $.Org }}_{{ $.Repo }}/{{.PR}}/{{.Job}}/{{.BuildNumber}}">{{.BuildNumber}}</a> (<a href="https://github.com/{{ $.Org }}/{{ $.Repo }}/pull/{{.PR}}">#{{.PR}}</a>){{ else }}<a href="https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/logs/{{.Job}}/{{.BuildNumber}}">{{.BuildNumber}}</a>{{ end }}</div>
                     {{ end }}
                 </div>
             </div>

--- a/robots/pkg/flakefinder/flakefinder.go
+++ b/robots/pkg/flakefinder/flakefinder.go
@@ -230,7 +230,7 @@ func GetReportBaseData(ctx context.Context, c *github.Client, client *storage.Cl
 		jobDir := "logs"
 		periodicJobDirs, err := ListGcsObjects(ctx, client, BucketName, jobDir+"/", "/")
 		if err != nil {
-			log.Printf("failed to load periodicJobDirs for %v",  fmt.Sprintf("%s*", o.periodicJobDirRegex), fmt.Errorf("error listing gcs objects: %v", err))
+			log.Printf("failed to load periodicJobDirs for %v: %v",  fmt.Sprintf("%s*", o.periodicJobDirRegex), fmt.Errorf("error listing gcs objects: %v", err))
 		}
 
 		for _, periodicJobDir := range periodicJobDirs {


### PR DESCRIPTION
Adds periodic job data to flakefinder report. Is controlled by setting the option `periodic_job_dir_regex`. Example:

`--periodic_job_dir_regex=periodic-kubevirt-e2e-.*`

Result: 
![image](https://user-images.githubusercontent.com/809335/115739548-4e57ea00-a38e-11eb-8e48-77bd0570b534.png)

/cc @rmohr @fgimenez 

Fixes #1076