### PR TITLE
Declare cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -2,6 +2,7 @@ periodics:
   - name: periodic-publish-kubemacpool-flakefinder-weekly-report
     cron: "50 0 * * *"
     decorate: true
+    cluster: phx-prow
     annotations:
       testgrid-create-test-group: "false"
     spec:
@@ -38,6 +39,7 @@ periodics:
             secretName: gcs
   - name: periodic-publish-kubemacpool-flakefinder-daily-report
     cron: "30 0 * * *"
+    cluster: phx-prow
     annotations:
       testgrid-create-test-group: "false"
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -39,6 +40,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
+      cluster: phx-prow
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
@@ -8,6 +8,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
+    cluster: phx-prow
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -40,6 +41,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -76,6 +78,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
@@ -11,6 +11,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -40,6 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -69,6 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -97,6 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
@@ -10,6 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -39,6 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -68,6 +70,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -97,6 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
@@ -11,6 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 10m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -40,6 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -72,6 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -98,6 +101,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
@@ -10,6 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -39,6 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -72,6 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -97,6 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
+      cluster: phx-prow
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -134,6 +138,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -166,6 +171,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -194,6 +200,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -226,6 +233,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -258,6 +266,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -75,6 +76,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -106,6 +108,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -138,6 +141,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -172,6 +176,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -200,6 +205,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -232,6 +238,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -264,6 +271,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -296,6 +304,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -328,6 +337,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
+      cluster: phx-prow
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
@@ -8,6 +8,7 @@ periodics:
     timeout: 1h
     grace_period: 5m
   max_concurrency: 1
+  cluster: phx-prow
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
@@ -49,6 +50,7 @@ periodics:
     timeout: 1h
     grace_period: 5m
   max_concurrency: 1
+  cluster: phx-prow
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -41,6 +42,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -78,6 +80,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.13.yaml
@@ -12,6 +12,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -44,6 +45,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -76,6 +78,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -108,6 +111,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -140,6 +144,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -172,6 +177,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -204,6 +210,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -224,4 +231,3 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.19.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.19.yaml
@@ -17,6 +17,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -54,6 +55,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -91,6 +93,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -44,6 +45,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -76,6 +78,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -108,6 +111,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -140,6 +144,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -172,6 +177,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -204,6 +210,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -236,6 +243,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -268,6 +276,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -300,6 +309,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -332,6 +342,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -364,6 +375,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -396,6 +408,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -8,6 +8,7 @@ presubmits:
       timeout: 3h
       grace_period: 5m
     max_concurrency: 6
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -16,6 +16,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
         rehearsal.allowed: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -18,6 +18,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -19,6 +19,7 @@ periodics:
       repo: hyperconverged-cluster-operator
       base_ref: master
       work_dir: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
@@ -14,6 +14,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 6
+    cluster: phx-prow
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.15.1
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -44,6 +45,7 @@ presubmits:
       preset-kubevirtci-quay-credential: "true"
       preset-shared-images: "true"
     max_concurrency: 6
+    cluster: phx-prow
     name: pull-hyperconverged-cluster-operator-e2e-ocp-4.3
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
@@ -20,6 +20,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
     preset-shared-images: "true"
+  cluster: ibm-prow-jobs
   spec:
     containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
@@ -13,6 +13,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -17,6 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    cluster: ibm-prow-jobs
     spec:
       containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1
@@ -47,6 +48,7 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    cluster: ibm-prow-jobs
     spec:
       containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1
@@ -69,6 +71,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
@@ -12,6 +12,7 @@ periodics:
         repo: kubevirt-tutorial
         base_ref: master
         path_alias: kubevirt-tutorial
+    cluster: phx-prow
     spec:
       nodeSelector:
         region: primary

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
@@ -8,6 +8,7 @@ presubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           region: primary

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -9,6 +9,7 @@ periodics:
         repo: kubevirt.github.io
         base_ref: source
         path_alias: kubevirt.github.io
+    cluster: phx-prow
     spec:
       nodeSelector:
         region: primary

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
       decorate: true
       always_run: true
       skip_report: false
+      cluster: phx-prow
       spec:
         nodeSelector:
           region: primary

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -40,6 +41,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -75,6 +77,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -110,6 +113,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -145,6 +149,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -204,6 +209,7 @@ periodics:
     repo: kubevirt
     base_ref: master
     work_dir: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -241,6 +247,7 @@ periodics:
       repo: kubevirt
       base_ref: master
       work_dir: true
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -278,6 +285,7 @@ periodics:
       repo: kubevirt
       base_ref: master
       work_dir: true
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -509,6 +517,7 @@ periodics:
       repo: kubevirt
       base_ref: master
       work_dir: true
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -549,6 +558,7 @@ periodics:
       repo: kubevirt
       base_ref: master
       work_dir: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -678,6 +688,7 @@ periodics:
       base_ref: master
       path_alias: kubevirt
       workdir: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -713,6 +724,7 @@ periodics:
     base_ref: master
     work_dir: true
   skip_report: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -755,6 +767,7 @@ periodics:
     base_ref: master
     work_dir: true
   skip_report: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -797,6 +810,7 @@ periodics:
     base_ref: master
     work_dir: true
   skip_report: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -840,6 +854,7 @@ periodics:
     base_ref: master
     work_dir: true
   skip_report: true
+  cluster: phx-prow
   spec:
       nodeSelector:
         hardwareSupport: sriov-nic
@@ -922,6 +937,7 @@ periodics:
     base_ref: master
     work_dir: true
   skip_report: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -968,6 +984,7 @@ periodics:
     preset-docker-mirror: "true"
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
+  cluster: phx-prow
   spec:
     volumes:
     - name: token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
@@ -15,6 +15,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.11.0-0.13
     context: pull-kubevirt-e2e-k8s-1.11.0
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -45,6 +46,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-genie-1.11.1-0.13
     context: pull-kubevirt-e2e-k8s-genie-1.11.1
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -75,6 +77,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-k8s-multus-1.13.3-0.13
     context: pull-kubevirt-e2e-k8s-multus-1.13.3
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -105,6 +108,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-os-3.11.0-crio-0.13
     context: pull-kubevirt-e2e-os-3.11.0-crio
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -135,6 +139,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-os-3.11.0-multus-0.13
     context: pull-kubevirt-e2e-os-3.11.0-multus
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -165,6 +170,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-os-3.11.0-0.13
     context: pull-kubevirt-e2e-os-3.11.0
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -195,6 +201,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.13
     context: pull-kubevirt-e2e-windows2016
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -16,6 +16,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.13.3-0.30
     context: pull-kubevirt-e2e-k8s-1.13.3
+    cluster: phx-prow
     optional: true
     spec:
       containers:
@@ -47,6 +48,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.14-0.30
     context: pull-kubevirt-e2e-k8s-1.14
+    cluster: phx-prow
     optional: true
     spec:
       containers:
@@ -78,6 +80,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.15-ceph-0.30
     context: pull-kubevirt-e2e-k8s-1.15-ceph
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -109,6 +112,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.16-0.30
     context: pull-kubevirt-e2e-k8s-1.16
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -139,6 +143,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-k8s-1.17-0.30
     context: pull-kubevirt-e2e-k8s-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -169,6 +174,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-cnao-1.17-0.30
     context: pull-kubevirt-e2e-k8s-cnao-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -200,6 +206,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-crio-0.30
     context: pull-kubevirt-e2e-os-3.11.0-crio
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -231,6 +238,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-multus-0.30
     context: pull-kubevirt-e2e-os-3.11.0-multus
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -261,6 +269,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.30
     context: pull-kubevirt-e2e-windows2016
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -296,6 +305,7 @@ presubmits:
     context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -365,6 +375,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-k8s-1.17.0-ipv6-0.30
     context: pull-kubevirt-e2e-kind-k8s-1.17.0-ipv6
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -411,6 +422,7 @@ presubmits:
     name: pull-kubevirt-check-tests-for-flakes-0.30
     context: pull-kubevirt-check-tests-for-flakes
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -442,6 +454,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.30
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -17,6 +17,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.13.3-0.34
     context: pull-kubevirt-e2e-k8s-1.13.3
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -48,6 +49,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.14-0.34
     context: pull-kubevirt-e2e-k8s-1.14
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -80,6 +82,7 @@ presubmits:
     context: pull-kubevirt-e2e-k8s-1.16-ceph
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -114,6 +117,7 @@ presubmits:
     context: pull-kubevirt-e2e-k8s-1.19-release-0.34
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -144,6 +148,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.34
     context: pull-kubevirt-e2e-k8s-1.18
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -174,6 +179,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.34
     context: pull-kubevirt-e2e-k8s-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -204,6 +210,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.16-0.34
     context: pull-kubevirt-e2e-k8s-1.16
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -234,6 +241,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.17-0.34
     context: pull-kubevirt-e2e-k8s-cnao-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -265,6 +273,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-crio-0.34
     context: pull-kubevirt-e2e-os-3.11.0-crio
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -296,6 +305,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-multus-0.34
     context: pull-kubevirt-e2e-os-3.11.0-multus
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -326,6 +336,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.34
     context: pull-kubevirt-e2e-windows2016
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -360,6 +371,7 @@ presubmits:
     name: pull-kubevirt-e2e-kind-1.17-sriov-release-0.34
     context: pull-kubevirt-e2e-kind-1.17-sriov
     optional: true
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -430,6 +442,7 @@ presubmits:
     name: pull-kubevirt-check-tests-for-flakes-0.34
     context: pull-kubevirt-check-tests-for-flakes
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -460,6 +473,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.34
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -521,6 +535,7 @@ presubmits:
     context: pull-kubevirt-build-release-0.34
     optional: false
     skip_report: false
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -16,6 +16,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.36
     context: pull-kubevirt-e2e-k8s-1.19
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -46,6 +47,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.36
     context: pull-kubevirt-e2e-k8s-1.18
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -76,6 +78,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.36
     context: pull-kubevirt-e2e-k8s-1.17
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -106,6 +109,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.36
     context: pull-kubevirt-e2e-k8s-cnao-1.19
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -136,6 +140,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.36
     context: pull-kubevirt-e2e-windows2016
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -172,6 +177,7 @@ presubmits:
     context: pull-kubevirt-e2e-kind-1.17-sriov-release
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -242,6 +248,7 @@ presubmits:
     name: pull-kubevirt-check-tests-for-flakes-0.36
     context: pull-kubevirt-check-tests-for-flakes
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -272,6 +279,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.36
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -18,6 +18,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.37
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -48,6 +49,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.37
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -108,6 +110,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.37
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -138,6 +141,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.37
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -168,6 +172,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.37
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -202,6 +207,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-0.37
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -219,7 +225,7 @@ presubmits:
                 operator: In
                 values:
                 - "true"
-            topologyKey: kubernetes.io/hostname            
+            topologyKey: kubernetes.io/hostname
       containers:
       - command:
         - /usr/local/bin/runner.sh
@@ -272,6 +278,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.37
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -302,6 +309,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.37
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
@@ -18,6 +18,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.38
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -48,6 +49,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.38
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -78,6 +80,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.38
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -108,6 +111,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.38
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -138,6 +142,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.38
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -168,6 +173,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.38
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -202,6 +208,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-0.38
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -272,6 +279,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.38
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -302,6 +310,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.38
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -20,6 +20,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.39
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -52,6 +53,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.39
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -84,6 +86,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.39
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -116,6 +119,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.39
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -148,6 +152,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.39
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -180,6 +185,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.39
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -214,6 +220,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-0.39
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -284,6 +291,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.39
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -316,6 +324,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.39
+    cluster: phx-prow
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
@@ -20,6 +20,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.40
     optional: true
     skip_report: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -53,6 +54,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-cgroupsv2-0.40
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -85,6 +87,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.40
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -118,6 +121,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-network-0.40
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -151,6 +155,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-storage-0.40
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -183,6 +188,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-operator-0.40
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -215,6 +221,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.40
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -248,6 +255,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.40
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -280,6 +288,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.40
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -312,6 +321,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.40
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -346,6 +356,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-0.40
+    cluster: phx-prow
     spec:
       affinity:
         podAntiAffinity:
@@ -425,6 +436,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.40
     optional: true
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -457,6 +469,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.40
+    cluster: phx-prow
     spec:
       containers:
       - command:
@@ -489,6 +502,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-test-0.40
+    cluster: phx-prow
     optional: true
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -217,6 +217,7 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -253,6 +254,7 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -300,6 +302,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -376,6 +379,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -412,6 +416,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -448,6 +453,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -483,6 +489,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -519,6 +526,7 @@ presubmits:
       preset-shared-images: "true"
       sriov-pod: "true"
       rehearsal.allowed: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic
@@ -597,6 +605,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -633,6 +642,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -10,6 +10,7 @@ periodics:
   max_concurrency: 1
   labels:
     preset-shared-images: "true"
+  cluster: phx-prow
   spec:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -86,6 +87,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+  cluster: phx-prow
   spec:
     volumes:
     - name: token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -18,6 +18,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -15,6 +15,7 @@ presubmits:
       preset-kubevirtci-installer-pull-token: "true"
       sriov-pod: "true"
       rehearsal.allowed: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         hardwareSupport: sriov-nic
@@ -90,6 +91,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -117,6 +119,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -144,6 +147,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -170,6 +174,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -196,6 +201,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -222,6 +228,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -248,6 +255,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -273,6 +281,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -12,6 +12,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -36,6 +37,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -46,6 +47,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -18,6 +18,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -16,6 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ovs-cni/ovs-cni-presubmits.yaml
@@ -17,6 +17,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
+  cluster: phx-prow
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20200623-9f5410055c
@@ -45,6 +46,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -82,6 +84,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -118,6 +121,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -158,6 +162,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -198,6 +203,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -255,6 +261,7 @@ periodics:
     repo: project-infra
     base_ref: master
     work_dir: true
+  cluster: phx-prow
   spec:
     containers:
     - image: quay.io/kubevirtci/autoowners@sha256:c40b91c8452aba2c2966facd054dad1a8f9a55a9f34779c7afd3ece0da8e3633
@@ -289,6 +296,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
+  cluster: phx-prow
   spec:
     nodeSelector:
       type: vm
@@ -331,6 +339,7 @@ periodics:
   - org: kubevirt
     repo: containerized-data-importer
     base_ref: main
+  cluster: phx-prow
   spec:
     securityContext:
       runAsUser: 0
@@ -383,6 +392,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: master
+  cluster: phx-prow
   spec:
     securityContext:
       runAsUser: 0
@@ -426,6 +436,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: master
+  cluster: phx-prow
   spec:
     securityContext:
       runAsUser: 0
@@ -466,6 +477,7 @@ periodics:
     workdir: true
   interval: 1h
   max_concurrency: 1
+  cluster: phx-prow
   spec:
     containers:
     - name: peribolos

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -41,6 +41,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -72,6 +73,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -105,6 +107,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -137,6 +140,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -168,6 +172,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
       spec:
         nodeSelector:
           type: vm
@@ -200,6 +205,7 @@ postsubmits:
       labels:
         preset-docker-mirror-proxy: "true"
       skip_report: false
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -252,6 +258,7 @@ postsubmits:
       labels:
         preset-docker-mirror-proxy: "true"
       skip_report: false
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -304,6 +311,7 @@ postsubmits:
       labels:
         preset-docker-mirror-proxy: "true"
       skip_report: false
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -353,6 +361,7 @@ postsubmits:
       - ^master$
       labels:
         preset-docker-mirror-proxy: "true"
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -403,6 +412,7 @@ postsubmits:
       - ^master$
       labels:
         preset-docker-mirror-proxy: "true"
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -454,6 +464,7 @@ postsubmits:
       - ^master$
       labels:
         preset-docker-mirror-proxy: "true"
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -504,6 +515,7 @@ postsubmits:
       - ^master$
       labels:
         preset-docker-mirror-proxy: "true"
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -558,6 +570,7 @@ postsubmits:
       - ^master$
       labels:
         preset-docker-mirror-proxy: "true"
+      cluster: ibm-prow-jobs
       spec:
         securityContext:
           runAsUser: 0
@@ -606,6 +619,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
+      cluster: ibm-prow-jobs
       spec:
         containers:
         - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: check-prow-config
     always_run: true
     decorate: true
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -25,6 +26,7 @@ presubmits:
     run_if_changed: robots/.*
     optional: false
     decorate: true
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -88,6 +90,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -114,6 +117,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -141,6 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -169,6 +174,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -197,6 +203,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -224,6 +231,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -256,6 +264,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -310,6 +319,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -346,6 +356,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -382,6 +393,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -418,6 +430,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -454,6 +467,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -488,6 +502,7 @@ presubmits:
     decorate: true
     annotations:
       testgrid-create-test-group: "false"
+    cluster: ibm-prow-jobs
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
@@ -510,6 +525,7 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     max_concurrency: 1
+    cluster: ibm-prow-jobs
     spec:
       containers:
       - name: peribolos
@@ -547,6 +563,7 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     max_concurrency: 1
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: vm
@@ -577,6 +594,7 @@ presubmits:
     decoration_config:
       timeout: 1h
       grace_period: 5m
+    cluster: phx-prow
     max_concurrency: 1
     spec:
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
     - org: kubevirt
       repo: project-infra
       base_ref: master
+    cluster: ibm-prow-jobs
     spec:
       securityContext:
         runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
After migrating prow control plane to ibm cluster the default context is now ibm-prow-jobs. We have jobs that don't define the cluster where they should run, and now prow is trying to schedule them on the ibm cluster, if these jobs have any kind of node selector that is not available on the ibm cluster (like e2e jobs that require type=bare-metal-external) the jobs are not being scheduled and remain in pending state until they error.

This PR defines the cluster property for every job that didn't have it defined:
* For jobs with any nodeSelector it sets cluster to phx-prow
* For jobs without nodeSelector it sets cluster to ibm-prow-jobs

/cc @rmohr 
/cc @dhiller 