### PR TITLE
Temporarily disable docker proxy for prow-workloads lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -240,7 +240,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -278,7 +278,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -510,7 +510,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
+    preset-docker-mirror-proxy: "false"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt


### PR DESCRIPTION
Will prevent errors like https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.19-sig-compute&width=20&show-stale-tests= when declaring `cluster` for all the jobs I took the opportunity to start migrating some of them to prow-workloads, but I didn't realize that we still don't have docker proxy there.

/cc @brybacki @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>