### PR TITLE
Manage operator tests using its dedicated SIG label

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -462,7 +462,7 @@ periodics:
           - name: TARGET
             value: "k8s-1.20"
           - name: KUBEVIRT_E2E_FOCUS
-            value: "Operator"
+            value: "\\[sig-operator\\]"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -502,7 +502,7 @@ periodics:
           - name: TARGET
             value: "k8s-1.20"
           - name: KUBEVIRT_E2E_SKIP
-            value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]"
+            value: "SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -542,7 +542,7 @@ periodics:
           - name: TARGET
             value: "k8s-1.20-cgroupsv2"
           - name: KUBEVIRT_E2E_SKIP
-            value: "Multus|SRIOV|GPU|Macvtap|Operator"
+            value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -751,7 +751,7 @@ periodics:
           - name: TARGET
             value: k8s-1.19
           - name: KUBEVIRT_E2E_SKIP
-            value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]"
+            value: "SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -794,7 +794,7 @@ periodics:
           - name: TARGET
             value: k8s-1.18
           - name: KUBEVIRT_E2E_SKIP
-            value: Multus|SRIOV|GPU|Macvtap|Operator
+            value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
@@ -23,12 +23,17 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-      - command:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: TARGET
+          value: "k8s-1.20"
+        - name: KUBEVIRT_E2E_SKIP
+          value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
+        command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=k8s-1.20 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - automation/test.sh
         name: ""
         resources:
           requests:
@@ -57,12 +62,17 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-      - command:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: TARGET
+          value: "k8s-1.20-cgroupsv2"
+        - name: KUBEVIRT_E2E_SKIP
+          value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
+        command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=k8s-1.20-cgroupsv2 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - automation/test.sh
         name: ""
         resources:
           requests:
@@ -90,12 +100,17 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-      - command:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: TARGET
+          value: "k8s-1.19"
+        - name: KUBEVIRT_E2E_SKIP
+          value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
+        command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=k8s-1.19 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - automation/test.sh
         name: ""
         resources:
           requests:
@@ -191,13 +206,17 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-      - command:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: TARGET
+          value: "k8s-1.19"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: "\\[sig-operator\\]"
+        command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - TARGET=k8s-1.19 KUBEVIRT_E2E_FOCUS=Operator automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        name: ""
+        - automation/test.sh
         resources:
           requests:
             memory: 34Gi
@@ -224,12 +243,17 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-      - command:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: TARGET
+          value: "k8s-1.18"
+        - name: KUBEVIRT_E2E_SKIP
+          value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
+        command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=k8s-1.18 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - automation/test.sh
         name: ""
         resources:
           requests:
@@ -258,12 +282,17 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-      - command:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: TARGET
+          value: "k8s-1.17"
+        - name: KUBEVIRT_E2E_SKIP
+          value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
+        command:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - export TARGET=k8s-1.17 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh
-        image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - automation/test.sh
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
             - name: TARGET
               value: k8s-1.20
             - name: KUBEVIRT_E2E_SKIP
-              value: "SRIOV|GPU|Operator|\\[sig-storage\\]|\\[sig-network\\]|\\[sig-compute\\]"
+              value: "SRIOV|GPU|\\[sig-operator\\]|\\[sig-storage\\]|\\[sig-network\\]|\\[sig-compute\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -191,7 +191,7 @@ presubmits:
             - name: TARGET
               value: k8s-1.20
             - name: KUBEVIRT_E2E_FOCUS
-              value: Operator
+              value: "\\[sig-operator\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -229,11 +229,16 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: "k8s-1.20-cgroupsv2"
+            - name: KUBEVIRT_E2E_SKIP
+              value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.20-cgroupsv2 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -315,7 +320,7 @@ presubmits:
             - name: TARGET
               value: k8s-1.19
             - name: KUBEVIRT_E2E_SKIP
-              value: "SRIOV|GPU|Operator|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]"
+              value: "SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -470,11 +475,16 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: "k8s-1.19"
+            - name: KUBEVIRT_E2E_FOCUS
+              value: "\\[sig-operator\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "TARGET=k8s-1.19 KUBEVIRT_E2E_FOCUS=Operator automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -507,11 +517,16 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: "k8s-1.18"
+            - name: KUBEVIRT_E2E_SKIP
+              value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.18 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -544,11 +559,16 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: "k8s-1.17"
+            - name: KUBEVIRT_E2E_SKIP
+              value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.17 KUBEVIRT_E2E_SKIP='Multus|SRIOV|GPU|Macvtap|Operator' && automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Instead of filtering based on the `Operator` string now we can use `[sig-operator]` instead.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>