### PR TITLE
Remove status filter as PR never reaches success

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -229,7 +229,6 @@ periodics:
         author:kubevirt-bot
         repo:kubevirt/kubevirt
         base:master
-        status:success
         review:none
         "Run bazelisk run //plugins/cmd/uploader:uploader -- -workspace /home/prow/go/src/github.com/kubevirt/project-infra/../kubevirt/WORKSPACE -dry-run=false"
       - --updated=24h


### PR DESCRIPTION
This happens due to tide leaving this in pending for
overall status, which prohibits the search to find it.

/cc @rmohr @fgimenez 