### PR TITLE
Flakefinder periodics:  Skip job data outside report window for periodics

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+        - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+        - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -85,7 +85,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+        - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -47,7 +47,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -84,7 +84,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -86,7 +86,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+      - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -47,7 +47,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -83,7 +83,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -120,7 +120,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -86,7 +86,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:6badf19c61f5affc77c3cc83b9df60a31b18e87cfa2affe6b179d31e87f0fdb5
+    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/pkg/flakefinder/flakefinder.go
+++ b/robots/pkg/flakefinder/flakefinder.go
@@ -237,7 +237,7 @@ func GetReportBaseData(ctx context.Context, c *github.Client, client *storage.Cl
 			if !o.periodicJobDirRegex.MatchString(periodicJobDir) {
 				continue
 			}
-			results, err := FindUnitTestFilesForPeriodicJob(ctx, client, BucketName, []string{jobDir, periodicJobDir}, startOfReport, o.skipBeforeStartOfReport)
+			results, err := FindUnitTestFilesForPeriodicJob(ctx, client, BucketName, []string{jobDir, periodicJobDir}, startOfReport, endOfReport)
 			if err != nil {
 				log.Printf("failed to load JUnit files for job %v: %v", periodicJobDir, err)
 			}


### PR DESCRIPTION
We never want to include job data that is outside the time window of
the report.
This differs from the PR based data retrieval where we
want to include all job data from a PR, even if it is before the time
window, to have the complete picture of all failures.