### PR TITLE
Several Prow deployment fixes

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -3,6 +3,7 @@ plank:
   job_url_prefix_config:
     '*':  https://prow.apps.ovirt.org/view/gcs/
   pod_pending_timeout: 60m
+  pod_unscheduled_timeout: 24h
   default_decoration_configs:
     '*':
       timeout: 2h

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/deck_deployment.yaml
@@ -1,6 +1,6 @@
 # Removes deprecated  --redirect-http-to=
 - op: remove
-  path: /spec/template/spec/containers/0/args/3
+  path: /spec/template/spec/containers/0/args/2
 - op: remove
   path: /spec/template/spec/containers/0/livenessProbe
 - op: remove


### PR DESCRIPTION
* Deck: actually removes deprecated `--redirect-http-to=` instead of `--oauth-url`
* Plank: defines `pod_unscheduled_timeout`, after the change introduced here https://github.com/kubernetes/test-infra/pull/20582/files#diff-88e6b42a331a7aa9260f9a830961e3ba3c77e0e6d781465378b510d7abc1517cR1633 job pods were killed after 5min if they were not already scheduled, like here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5428/pull-kubevirt-e2e-k8s-1.20-sig-network/1386672796477689856

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>