### PR TITLE
Fix rehearse deployment

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -320,6 +320,7 @@ external_plugins:
   - name: cherrypicker
   kubevirt/project-infra:
   - name: rehearse
+    endpoint: http://prow-rehearse:9900
     events:
       - pull_request
       - issue_comment

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20210312-b3a5e0f2
+          image: docker.io/kubevirtci/rehearse:v20200923-8930f83
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-rbac.yaml
@@ -1,4 +1,9 @@
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prow-rehearse
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/prow-rehearse-deployment.yaml
@@ -1,3 +1,3 @@
 - op: add
   path: /spec/template/spec/containers/0/args/1
-  value: --jobs-namespace=kubervirt-prow-jobs
+  value: --jobs-namespace=kubevirt-prow-jobs


### PR DESCRIPTION
Required by rehearse plugin, without it the rehearse replicaset complains with:
```
Error creating: pods "rehearse-5cc657d6f6-" is forbidden: error looking up service account kubevirt-prow/prow-rehearse: serviceaccount "prow-rehearse" not found
```

/cc @oshoval @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>