### PR TITLE
Also copy cluster-up directory when adding new provider in kubevirtci bump

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -451,7 +451,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" -p ../kubevirtci -r kubevirtci -b minor-version-bump
+            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s" --cluster-up-dir ${PWD}/../kubevirtci/cluster-up/cluster" -p ../kubevirtci -r kubevirtci -b minor-version-bump
         volumeMounts:
         - name: token
           mountPath: /etc/github

--- a/robots/cmd/kubevirtci-bumper/main.go
+++ b/robots/cmd/kubevirtci-bumper/main.go
@@ -41,6 +41,7 @@ type options struct {
 	ensureLatestThreeMinor string
 	major                  int
 	providerDir            string
+	clusterUpDir           string
 }
 
 func (o *options) Validate() error {
@@ -73,6 +74,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.ensureLatest, "ensure-latest", false, "Ensure that we have a provider for the latest k8s release")
 	fs.StringVar(&o.ensureLatestThreeMinor, "ensure-last-three-minor-of", "", "Ensure that the last three minor releases of the given major release are up to date (e.g. v1 or 2)")
 	fs.StringVar(&o.providerDir, "k8s-provider-dir", "", "The directory of the k8s providers")
+	fs.StringVar(&o.clusterUpDir, "cluster-up-dir", "", "The directory of the cluster up configurations")
 	fs.Parse(os.Args[1:])
 	return o
 }
@@ -131,7 +133,7 @@ func main() {
 			log.Info("No release found.")
 			os.Exit(0)
 		}
-		err := kubevirtci.EnsureProviderExists(o.providerDir, releases[0])
+		err := kubevirtci.EnsureProviderExists(o.providerDir, o.clusterUpDir, releases[0])
 		if err != nil {
 			log.WithError(err).Info("Failed to ensure that a provider for the given release exists.")
 		}


### PR DESCRIPTION
The current bump will never succeed on `check-cluster-up.sh` as that tries running `make cluster-up` without the cluster-up folder for the new provider being present. This PR adds the copying of that folder and also adds the new parameter to the job definition.

/cc @rmohr  