### PR TITLE
Run quarantined tests in SIG e2e periodic lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -217,6 +217,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.19-sig-network"
         command:
@@ -255,6 +257,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.19-sig-storage"
         command:
@@ -293,6 +297,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.19-sig-compute"
         command:
@@ -331,6 +337,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.20-sig-network"
         command:
@@ -369,6 +377,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.20-sig-storage"
         command:
@@ -407,6 +417,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.20-sig-compute"
         command:
@@ -445,6 +457,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
           - name: TARGET
             value: "k8s-1.20"
           - name: KUBEVIRT_E2E_FOCUS
@@ -779,49 +793,6 @@ periodics:
             value: "true"
           - name: TARGET
             value: k8s-1.18
-          - name: KUBEVIRT_E2E_SKIP
-            value: Multus|SRIOV|GPU|Macvtap|Operator
-        command:
-          - "/usr/local/bin/runner.sh"
-          - "/bin/sh"
-          - "-c"
-          - "automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"
-- name: periodic-kubevirt-e2e-k8s-prev-prev
-  annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cron: "0 22,10 * * *"
-  decorate: true
-  decoration_config:
-    timeout: 7h
-    grace_period: 5m
-  labels:
-    preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-shared-images: "true"
-  extra_refs:
-  - org: kubevirt
-    repo: kubevirt
-    base_ref: master
-    work_dir: true
-  skip_report: true
-  cluster: phx-prow
-  spec:
-    nodeSelector:
-      type: bare-metal-external
-    containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        env:
-          - name: KUBEVIRT_QUARANTINE
-            value: "true"
-          - name: TARGET
-            value: k8s-1.17
           - name: KUBEVIRT_E2E_SKIP
             value: Multus|SRIOV|GPU|Macvtap|Operator
         command:


### PR DESCRIPTION
We need to run the quarantined tests in the SIG e2e periodics to know when they are stable enough to go back to the SIG e2e presubmit lanes. We were doing it for the main e2e periodic lanes (1.19 and 1.18) but not for the SIG e2e periodics.

I've also taken the opportunity to remove the 1.17 e2e periodic.

/cc @EdDev @brybacki @enp0s3 @tiraboschi @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>