### PR TITLE
Add optional k8s-1.20 ceph lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -835,7 +835,43 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
-  
+  - name: pull-kubevirt-e2e-k8s-1.20-rook-ceph
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: false
+    optional: true
+    skip_report: false
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+    cluster: phx-prow
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.20 && export KUBEVIRT_STORAGE=rook-ceph-default && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-e2e-k8s-1.17-rook-ceph
     skip_branches:
       - release-\d+\.\d+


### PR DESCRIPTION
The ceph lane seems like it uses an old version of kubernetes, let's add an optional lane to check if it's stable, and later switch.