### PR TITLE
Set K8s 1.20 sig-compute lane to run always

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -127,10 +127,10 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
+    always_run: true
     optional: true
     cluster: prow-workloads
-    skip_report: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 7h


### PR DESCRIPTION
This is a part of an effort to put 1.20 lane as mandatory.
we would like to observe the stability of the lane
and as part of it we will enable the reporting and make
it always run.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>