### PR TITLE
Switch CDI to k8s 1.19/1.20

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.28.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.28.yaml
@@ -1,0 +1,68 @@
+presubmits:
+  kubevirt/containerized-data-importer:
+  - name: pull-containerized-data-importer-e2e-k8s-1.17-hpp
+    branches:
+      - release-v1.28
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    cluster: phx-prow
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=hpp && export CDI_E2E_SKIP=Destructive && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"
+  - name: pull-containerized-data-importer-e2e-k8s-1.17-ceph
+    branches:
+      - release-v1.28
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    cluster: phx-prow
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export RANDOM_CR=true && export KUBEVIRT_STORAGE=rook-ceph-default && export CDI_E2E_SKIP=Destructive && automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
               memory: "29Gi"
   - name: pull-containerized-data-importer-e2e-k8s-1.19-hpp
     skip_branches:
-      - release-v1.13
+      - release-v1.28
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -101,7 +101,7 @@ presubmits:
               memory: "29Gi"
   - name: pull-containerized-data-importer-e2e-k8s-1.19-ceph
     skip_branches:
-      - release-v1.13
+      - release-v1.28
     annotations:
       fork-per-release: "true"
     always_run: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -1,45 +1,12 @@
 presubmits:
   kubevirt/containerized-data-importer:
-  - name: pull-containerized-data-importer-e2e-k8s-1.18-hpp
+  - name: pull-containerized-data-importer-e2e-k8s-1.20-hpp
     skip_branches:
       - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: phx-prow
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && export CDI_E2E_SKIP=Destructive && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.20-hpp
-    skip_branches:
-      - release-v\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
     decorate: true
     decoration_config:
       timeout: 5h
@@ -66,46 +33,13 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.18-hpp-destructive
+  - name: pull-containerized-data-importer-e2e-k8s-1.20-hpp-destructive
     skip_branches:
       - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: phx-prow
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && export CDI_E2E_FOCUS=Destructive && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.20-hpp-destructive
-    skip_branches:
-      - release-v\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
     decorate: true
     decoration_config:
       timeout: 5h
@@ -132,46 +66,13 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.17-hpp
+  - name: pull-containerized-data-importer-e2e-k8s-1.19-hpp
     skip_branches:
       - release-v1.13
     annotations:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: phx-prow
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=hpp && export CDI_E2E_SKIP=Destructive && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.19-hpp
-    skip_branches:
-      - release-v1.13
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
     decorate: true
     decoration_config:
       timeout: 5h
@@ -198,7 +99,7 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.17-ceph
+  - name: pull-containerized-data-importer-e2e-k8s-1.19-ceph
     skip_branches:
       - release-v1.13
     annotations:
@@ -224,40 +125,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export RANDOM_CR=true && export KUBEVIRT_STORAGE=rook-ceph-default && export CDI_E2E_SKIP=Destructive && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.19-ceph
-    skip_branches:
-      - release-v1.13
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: phx-prow
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.17 && export RANDOM_CR=true && export KUBEVIRT_STORAGE=rook-ceph-default && export CDI_E2E_SKIP=Destructive && automation/test.sh"
+            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.19 && export RANDOM_CR=true && export KUBEVIRT_STORAGE=rook-ceph-default && export CDI_E2E_SKIP=Destructive && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -297,46 +165,13 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.18-upg
+  - name: pull-containerized-data-importer-e2e-k8s-1.20-upg
     skip_branches:
       - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: phx-prow
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=hpp && export MULTI_UPGRADE=true && export CDI_E2E_SKIP=Destructive && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.20-upg
-    skip_branches:
-      - release-v\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
     decorate: true
     decoration_config:
       timeout: 5h
@@ -363,46 +198,13 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.18-nfs
+  - name: pull-containerized-data-importer-e2e-k8s-1.20-nfs
     skip_branches:
       - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: phx-prow
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "ln -b /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && export TARGET=k8s-1.18 && export KUBEVIRT_STORAGE=nfs && export CDI_E2E_SKIP=Destructive && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-containerized-data-importer-e2e-k8s-1.20-nfs
-    skip_branches:
-      - release-v\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: false
-    optional: true
     decorate: true
     decoration_config:
       timeout: 5h


### PR DESCRIPTION
- Make 1.19 / 1.20 lanes required.
- Remove 1.17 / 1.18 lanes.
- Make ceph lane actually test k8s 1.20, not 1.17.
- Keep the lanes for release-v1.28, which isn't expected to support k8s-1.19 / 1.20 lanes