### PR TITLE
Fix binary name

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -306,7 +306,7 @@ periodics:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
         command:
-          - "/app/robots/indexpagecreator/app.binary"
+          - "/app/robots/cmd/indexpagecreator/app.binary"
         args:
           - --dry-run=false
         volumeMounts:


### PR DESCRIPTION
Job failed here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-update-flakefinder-indexpage/1389963950665240576

This PR updates the job to use the correct binary. 