### PR TITLE
Enable 1.20-operator presubmit to run on PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -167,10 +167,10 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
-    cluster: prow-workloads
-    skip_report: true
+    always_run: true
+    optional: false
+    cluster: phx-prow
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 7h
@@ -178,10 +178,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -289,7 +289,7 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
-  
+
   - name: pull-kubevirt-e2e-k8s-1.19
     skip_branches:
       - release-\d+\.\d+
@@ -694,7 +694,7 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
-  
+
   - name: pull-kubevirt-e2e-kind-1.17-sriov
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
Given that the migration of bare metals from `phx-prow` cluster to `prow-workloads` hasn't started yet I've taken the opportunity to configure the job to run on `phx-prow` to prevent increasing the pressure on `prow-workloads`.

We don't have manual executions of the presubmit but do have the periodic results that execute the same set of tests plus the quarantined ones, these are the latest runs:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-operator/1389606132045058048
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-operator/1389726759133384704
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-operator/1389847562520891392
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.20-operator/1389968232093323264

Only a quarantined tests has failed twice, as always it will be filtered out in the presubmit. 

/cc @tiraboschi @phoracek @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>