### PR TITLE
Automated prow bump

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -546,3 +546,43 @@ periodics:
     - name: token
       secret:
         secretName: oauth-token
+- name: periodic-project-infra-prow-bump
+  cron: "10 6 * * 5"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: master
+    workdir: true
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  cluster: ibm-prow-jobs
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+      - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+        env:
+        - name: GIT_ASKPASS
+          value: hack/git-askpass.sh
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+        resources:
+          requests:
+            memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token

--- a/hack/bump-prow.sh
+++ b/hack/bump-prow.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
+PROJECT_INFRA_MANIFESTS_ROOT=${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/base
+TEST_INFRA_ROOT=$(readlink --canonicalize ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra)
+TEST_INFRA_MANIFESTS_ROOT=${TEST_INFRA_ROOT}/config/prow/cluster
+
+copy_files(){
+    curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
+        chmod a+x ./yq && \
+        mv ./yq /usr/local/bin
+
+    local target_files=$(yq r ${PROJECT_INFRA_MANIFESTS_ROOT}/kustomization.yaml resources | grep test_infra | sed 's/^- \(.*\)/\1/')
+
+    for base_target_file in ${target_files}; do
+        local target_file_name=$(basename ${base_target_file})
+        local target_file=${PROJECT_INFRA_MANIFESTS_ROOT}/manifests/test_infra/current/${target_file_name}
+        local source_file=${TEST_INFRA_MANIFESTS_ROOT}/$(basename $target_file)
+
+        cp ${source_file} ${target_file}
+    done
+}
+
+get_latest_prow_tag(){
+    echo $(grep gcr.io/k8s-prow/ ${TEST_INFRA_MANIFESTS_ROOT}/prow_controller_manager_deployment.yaml | cut -d ':' -f 3)
+}
+
+bump_utility_images(){
+    local latest_prow_tag=$(get_latest_prow_tag)
+
+    if [ -z "${latest_prow_tag}" ]; then
+        echo "Could not find latest prow tag"
+        exit 1
+    fi
+
+    echo latest_prow_tag: $latest_prow_tag
+
+    local utility_images=(clonerefs initupload entrypoint sidecar)
+
+    for utility_image in ${utility_images[@]}; do
+        sed -i "s!${utility_image}: \"gcr.io/k8s-prow/${utility_image}:.*\"!${utility_image}: \"gcr.io/k8s-prow/${utility_image}:${latest_prow_tag}\"!" ${PROJECT_INFRA_MANIFESTS_ROOT}/configs/current/config/config.yaml
+    done
+}
+
+main(){
+    copy_files
+
+    bump_utility_images
+}
+
+main "${@}"


### PR DESCRIPTION
Sets a periodic to bump Prow every Friday. Loosely based on https://github.com/kubernetes/test-infra/blob/master/prow/bump.sh, no queries to GCloud for the tags (obtained from the manifests), no manual selection of tag to apply. 

Copies fresh manifests from test-infra, extracts the image tag from them, and updates the utility images with it. Then it creates a PR like this one https://github.com/kubevirt/project-infra/pull/1204 (without the changes that add the job and the bump script) to trigger the deployment tests on it and review. 

This is how the execution of the periodic job looks like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-bump/1390729643409018880 

/cc @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>