### PR TITLE
Filter sig-compute on 1.19 lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -482,7 +482,7 @@ presubmits:
             - name: TARGET
               value: k8s-1.19
             - name: KUBEVIRT_E2E_SKIP
-              value: "SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]"
+              value: "SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
We are still executing sig-compute tests on 1.19 lane, IIRC they were already removed but somehow they are back.

/cc @vatsalparekh @enp0s3 @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>