### PR TITLE
Run all remaining storage and networking tests with cgroupv2

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -544,7 +544,49 @@ periodics:
           - name: TARGET
             value: "k8s-1.20-cgroupsv2"
           - name: KUBEVIRT_E2E_SKIP
-            value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
+            value: "Multus|SRIOV|GPU|Macvtap"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - "automation/test.sh"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "34Gi"
+- name: periodic-kubevirt-e2e-k8s-1.20-cgroupsv2-rook-ceph
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cron: "0 11,19,2 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 7h
+    grace_period: 5m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "false"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: master
+      work_dir: true
+  cluster: prow-workloads
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: "k8s-1.20-cgroupsv2"
+          - name: KUBEVIRT_E2E_SKIP
+            value: "Multus|SRIOV|GPU|Macvtap"
+          - name: KUBEVIRT_STORAGE
+            value: rook-ceph
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
586 tests passing, the remaining 156 skipped. Some important
networking and some important disk hotplug tests are part
of the skipped ones, so no 100% guarentee that we have
full cgroupsv2 support now.

This PR:
- Stops current cgroupsv2 lane from skipping sig-operate tests
- Adds another cgroupsv2-rook-ceph lane