### PR TITLE
Enable report of 1.20-sig-storage

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -252,7 +252,7 @@ presubmits:
     always_run: true
     optional: false
     cluster: prow-workloads
-    skip_report: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 4h
@@ -560,11 +560,14 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.19-sig-storage
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.19-sig-storage && automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
`podinfo.json` is written as part of the job report here https://github.com/kubernetes/test-infra/blob/f7e21a3c18f4f4bbc7ee170675ed53e4544a0632/prow/crier/reporters/gcs/kubernetes/reporter.go#L208 when report is disabled (`skip_report: true`) `podinfo.json` is not written and we see errors in testgrid like https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.20-sig-storage&width=90. For instance, in https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.19-sig-compute&width=5 it is clear in the `pod` row how 1.19-sig-compute was reporting a podinfo.json missing error until it `skip_report` was set to false.

These changes enable reporting of 1.20-sig-storage. I've also taken the opportunity to move environment variable definition of 1.19-sig-storage to the `env` field to align 1.20-sig-storage and 1.19

/cc @brybacki @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>