### PR TITLE
Bump builder tag to prevent pr-creator errors

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -344,7 +344,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -388,7 +388,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -429,7 +429,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -516,7 +516,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
         env:
         - name: GIT_ASKPASS
           value: hack/git-askpass.sh


### PR DESCRIPTION
With the recent changes in `hack/git-pr.sh` we require to use the latest builder version that ships pr-creator with labels support, if not we get errors like in this build https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-bump/1393086418238050304
```
Creating PR to merge kubevirt-bot:prow-autobump into master...
+ pr-creator --github-token-path=/etc/github/oauth --org=kubevirt --repo=project-infra --branch=master '--title=Run hack/bump-prow.sh' '--match-title=Run hack/bump-prow.sh' '--body=Automatic run of "hack/bump-prow.sh". Please review' --source=kubevirt-bot:prow-autobump --labels= --confirm
flag provided but not defined: -labels
```

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>