### PR TITLE
Adapt TestGrid config managment to Config Merger

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -614,7 +614,7 @@ postsubmits:
           secret:
             secretName: pgp-bot-key
     - name: post-project-infra-update-testgrid-config
-      run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
+      run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$'
       branches:
       - master
       annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -613,8 +613,8 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-    - name: post-project-infra-upload-testgrid-config
-      run_if_changed: '^(github/ci/prow-deploy/files/jobs/.*)|(github/ci/testgrid/gen-config\.yaml)$'
+    - name: post-project-infra-update-testgrid-config
+      run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
       branches:
       - master
       annotations:
@@ -625,18 +625,16 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
           command:
-          - /transfigure.sh
+          - github/ci/testgrid/hack/update.sh
           args:
           - /etc/github/oauth
-          - github/ci/prow-deploy/files/config.yaml
-          - github/ci/prow-deploy/files/jobs
-          - github/ci/testgrid/gen-config.yaml
-          - kubevirt
-          - test-infra
-          - kubevirt-bot
-          - rmohr+kubebot@redhat.com
           securityContext:
             runAsUser: 0
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
           volumeMounts:
           - name: token
             mountPath: /etc/github
@@ -644,3 +642,33 @@ postsubmits:
         - name: token
           secret:
             secretName: oauth-token
+    - name: post-project-infra-upload-testgrid-config
+      run_if_changed: '^github/ci/testgrid/gen-config\.yaml$'
+      branches:
+      - master
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      cluster: ibm-prow-jobs
+      spec:
+        containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+          command:
+          - github/ci/testgrid/hack/upload.sh
+          securityContext:
+            runAsUser: 0
+          resources:
+            requests:
+              memory: "200Mi"
+            limits:
+              memory: "200Mi"
+          volumeMounts:
+          - name: gcs
+            mountPath: /etc/gcs
+        volumes:
+        - name: gcs
+          secret:
+            secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -498,24 +498,27 @@ presubmits:
             limits:
               memory: "16Gi"
   - name: pull-project-infra-check-testgrid-config
-    run_if_changed: '^(github/ci/prow-deploy/files/jobs/.*)|(github/ci/testgrid/gen-config\.yaml)$'
+    run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$'
     decorate: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: ibm-prow-jobs
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
         command:
-        - /transfigure.sh
-        args:
-        - test
-        - github/ci/prow-deploy/files/config.yaml
-        - github/ci/prow-deploy/files/jobs
-        - github/ci/testgrid/gen-config.yaml
-        - kubevirt
+        - github/ci/testgrid/hack/check.sh
         securityContext:
           runAsUser: 0
+        resources:
+          requests:
+            memory: "8Gi"
+          limits:
+            memory: "8Gi"
   - name: pull-kubevirt-org-github-config-updater
     run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
     annotations:

--- a/github/ci/testgrid/hack/check.sh
+++ b/github/ci/testgrid/hack/check.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source ${BASEDIR}/common.sh
+
+main(){
+    generate_config "${@}"
+
+    if git diff --cached --quiet --exit-code; then
+        echo "No changes in testgrid config. Aborting no-op bump"
+        exit 0
+    fi
+
+    run_tests "${@}"
+}
+
+main "${@}"

--- a/github/ci/testgrid/hack/common.sh
+++ b/github/ci/testgrid/hack/common.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+TEST_INFRA_ROOT=$(readlink -f --canonicalize ${BASEDIR}/../../kubernetes/test-infra)
+TESTGRID_CONFIG=${BASEDIR}/github/ci/testgrid/gen-config.yaml
+USER=kubevirtbot
+EMAIL=kubevirtbot@redhat.com
+
+generate_config(){
+    local prow_config=${BASEDIR}/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+    local job_config=${BASEDIR}/github/ci/prow-deploy/files/jobs
+    local testgrid_dir=${TEST_INFRA_ROOT}/config/testgrids
+    local testgrid_subdir=kubevirt
+
+    /configurator \
+        --prow-config "${prow_config}" \
+        --prow-job-config "${job_config}" \
+        --output-yaml \
+        --yaml "${TESTGRID_CONFIG}" \
+        --oneshot \
+        --output "${testgrid_dir}/${testgrid_subdir}/gen-config.yaml"
+
+    cp "${testgrid_dir}/${testgrid_subdir}/gen-config.yaml" "${TESTGRID_CONFIG}"
+
+    git add --all
+}
+
+run_tests(){
+    (
+        cd ${TEST_INFRA_ROOT}
+        bazel test //config/tests/... //hack:verify-spelling
+    )
+}
+
+ensure_git_config() {
+    echo "Checking Git Config"
+    git config user.name ${USER}
+    git config user.email ${EMAIL}
+
+    git config user.name &>/dev/null && git config user.email &>/dev/null && return 0
+    echo "ERROR: git config user.name, user.email unset. No defaults provided" >&2
+    return 1
+}
+
+propose_pr(){
+    local token=${1}
+    local branch=update-testgrid-config
+
+    ensure_git_config
+    title="Update TestGrid"
+    git commit -m "${title}"
+    echo "Pushing commit to ${USER}/project-infra:${branch}..."
+    git push -f "https://${USER}:$(cat "${token}")@github.com/${USER}/project-infra" "HEAD:${branch}"
+
+    echo "Creating PR to merge ${user}:${branch} into kubevirt/project-infra:master..."
+    /pr-creator \
+        --github-token-path="${token}" \
+        --org="kubevirt" --repo="project-infra" --branch=master \
+        --title="${title}" --head-branch="${branch}" \
+        --body="TestGrid config updated by configurator, please review." \
+        --source="${USER}:${branch}" \
+        --confirm
+}
+
+upload_config(){
+    gsutil cp ${TESTGRID_CONFIG} gs://kubevirt-prow/testgrid/gen-config.yaml
+}

--- a/github/ci/testgrid/hack/update.sh
+++ b/github/ci/testgrid/hack/update.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source ${BASEDIR}/common.sh
+
+main(){
+    generate_config "${@}"
+
+    if git diff --cached --quiet --exit-code; then
+        echo "No changes in testgrid config. Aborting no-op bump"
+        exit 0
+    fi
+
+    run_tests "${@}"
+
+    propose_pr "${@}"
+}
+
+main "${@}"

--- a/github/ci/testgrid/hack/upload.sh
+++ b/github/ci/testgrid/hack/upload.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source ${BASEDIR}/common.sh
+
+main(){
+    upload_config "${@}"
+}
+
+main "${@}"


### PR DESCRIPTION
Updates to use Config Merger instead of transfigure for TestGrid config management. 

Until now with transfigure every time we merged changes in our jobs config, the new testgrid config was generated and PR was issued in k8s/test-infra with the relevant changes. With Config Merger, we first instruct TestGrid to read our config from a GCS bucket and then we can manage that config without requiring merging changes in k8s/test-infra. Config Merger configuration on test-infra side is described here https://github.com/GoogleCloudPlatform/testgrid/tree/master/cmd/config_merger and this is an example of the steps required to migrate to use Config Merger https://github.com/GoogleCloudPlatform/oss-test-infra/issues/832

These changes remove the old transfigure jobs and add 3 new jobs:
* testgrid config check presubmit: when there are changes on job configs we generate the new testgrid config and check that it is ok.
* testgrid update postsumit: after merging changes in jobs configs we we generate the new testgrid config, check that it is ok and propose a PR to update it in project-infra.
* testgrid upload postsubmit: after merging changes in testgrid config, the new testgrid config file is uploaded to GCS.

/cc @dhiller

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>