### PR TITLE
fix libguestfs appliance periodic job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -13,6 +13,11 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+  extra_refs:
+   - org: kubevirt
+     repo: libguestfs-appliance
+     base_ref: main
+     work_dir: true
   cluster: ibm-prow-jobs
   spec:
     containers:


### PR DESCRIPTION
Add extra_refs to fetch the libguestfs-appliance repository.

Signed-off-by: Alice Frosi <afrosi@redhat.com>