### PR TITLE
Fix test-infra repo path.

### DIFF
--- a/github/ci/testgrid/hack/common.sh
+++ b/github/ci/testgrid/hack/common.sh
@@ -3,8 +3,8 @@
 set -euxo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-TEST_INFRA_ROOT=$(readlink -f --canonicalize ${BASEDIR}/../../kubernetes/test-infra)
-TESTGRID_CONFIG=${BASEDIR}/github/ci/testgrid/gen-config.yaml
+TEST_INFRA_ROOT=$(readlink -f --canonicalize ${BASEDIR}/../../../../../../kubernetes/test-infra)
+TESTGRID_CONFIG=$(readlink -f --canonicalize ${BASEDIR}/../gen-config.yaml)
 USER=kubevirtbot
 EMAIL=kubevirtbot@redhat.com
 


### PR DESCRIPTION
This will prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1224/pull-project-infra-check-testgrid-config/1394252628979879936

/cc @dhiller

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>