### PR TITLE
Add victortoso to kubevirt members

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -168,6 +168,7 @@ orgs:
       - tomob
       - vasiliy-ul
       - vatsalparekh
+      - victortoso
       - vladikr
       - vojtechszocs
       - xpivarc


### PR DESCRIPTION
Add Victor as he's an active member of the community and he's willing to help me maintaining the [libguestfs-appliance repo](https://github.com/kubevirt/libguestfs-appliance)