### PR TITLE
Fix branch-protector config for ovs-cni

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -301,10 +301,6 @@ branch-protection:
               protect: true
             release-0.39:
               protect: true
-        ovs-cni:
-          branches:
-            master:
-              protect: true
         macvtap-cni:
           branches:
             master:
@@ -351,6 +347,10 @@ branch-protection:
     k8snetworkplumbingwg:
       repos:
         kubemacpool:
+          branches:
+            master:
+              protect: true
+        ovs-cni:
           branches:
             master:
               protect: true


### PR DESCRIPTION
branch-protector is failing with:
```
{"component":"branchprotector","error":"update kubevirt: update ovs-cni: update master from protected=true: get current branch protection: getting branch protection 404: Not Found","file ":"prow/cmd/branchprotector/protect.go:143","func":"main.main","level":"error","msg":"0","severity":"error","time":"2021-05-18T06:14:04Z"}
{"component":"branchprotector","file":"prow/cmd/branchprotector/protect.go:145","func":"main.main","level":"fatal","msg":"Encountered 1 errors protecting branches","severity":"fatal","ti  me":"2021-05-18T06:14:04Z"}  
```

/cc @phoracek 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>