### PR TITLE
macvtap-cni: rename the main branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -2,7 +2,7 @@ postsubmits:
   kubevirt/macvtap-cni:
     - name: publish-macvtap-cni
       branches:
-      - master
+      - main
       always_run: true
       annotations:
         testgrid-create-test-group: "false"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -307,7 +307,7 @@ branch-protection:
               protect: true
         macvtap-cni:
           branches:
-            master:
+            main:
               protect: true
         common-templates:
           branches:


### PR DESCRIPTION
The `macvtap-cni` repo has been renamed from `master` to `main`.
