### PR TITLE
Fix OVS CNI branch protection configuration

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -301,10 +301,6 @@ branch-protection:
               protect: true
             release-0.39:
               protect: true
-        ovs-cni:
-          branches:
-            master:
-              protect: true
         macvtap-cni:
           branches:
             master:
@@ -351,6 +347,10 @@ branch-protection:
     k8snetworkplumbingwg:
       repos:
         kubemacpool:
+          branches:
+            master:
+              protect: true
+        ovs-cni:
           branches:
             master:
               protect: true


### PR DESCRIPTION
Since OVS CNI was moved under NPWG GitHub organization, its branch
protection configuration must be adjusted.

Fixes: https://github.com/kubevirt/project-infra/issues/1234

Signed-off-by: Petr Horáček <phoracek@redhat.com>