### PR TITLE
Run unit tests for kubevirt unnested

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1186,9 +1186,9 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -1196,7 +1196,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make test"
+            - "make test"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
 * Adding the unnested label will run bazel directly, resulting in not
   downloading the builder image.
 * /etc/bazelrc files will now be automatically be picked up, since in
   the unnested build they are now at a well known place for bazel to
   look at.
 * Stop request docker-in-docker to be started

Signed-off-by: Roman Mohr <rmohr@redhat.com>