### PR TITLE
Add experimental presubmit lane for rest coverage tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -162,6 +162,47 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
+  - name: pull-kubevirt-e2e-k8s-1.21-rest-coverage
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      testgrid-create-test-group: "false"
+    always_run: false
+    optional: true
+    skip_report: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-shared-images: "true"
+      preset-bazel-cache: "false"
+      preset-bazel-unnested: "false"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.21
+            - name: RUN_REST_COVERAGE
+              value: "true"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "34Gi"
   - name: pull-kubevirt-e2e-k8s-1.20
     skip_branches:
       - release-\d+\.\d+


### PR DESCRIPTION
This lane is triggered manually and optional, but will report to GitHub. Required for kubevirt/kubevirt#5612

FYI @mfranczy 

/cc @fgimenez 