### PR TITLE
Fix testgrid update job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -617,6 +617,8 @@ postsubmits:
       run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$'
       branches:
       - master
+      labels:
+        preset-bazel-cache: "true"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -628,6 +628,9 @@ postsubmits:
       spec:
         containers:
         - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
+          env:
+          - name: GIT_ASKPASS
+            value: "./hack/git-askpass.sh"
           command:
           - github/ci/testgrid/hack/update.sh
           args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -621,6 +621,10 @@ postsubmits:
         testgrid-create-test-group: "false"
       decorate: true
       cluster: ibm-prow-jobs
+      extra_refs:
+      - org: kubernetes
+        repo: test-infra
+        base_ref: master
       spec:
         containers:
         - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -500,6 +500,8 @@ presubmits:
   - name: pull-project-infra-check-testgrid-config
     run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$'
     decorate: true
+    labels:
+      preset-bazel-cache: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: ibm-prow-jobs

--- a/github/ci/testgrid/hack/check.sh
+++ b/github/ci/testgrid/hack/check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${BASEDIR}/common.sh

--- a/github/ci/testgrid/hack/common.sh
+++ b/github/ci/testgrid/hack/common.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink -f --canonicalize ${BASEDIR}/../../../..)
 TEST_INFRA_ROOT=$(readlink -f --canonicalize ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra)
 TESTGRID_CONFIG=$(readlink -f --canonicalize ${BASEDIR}/../gen-config.yaml)
-USER=kubevirtbot
+USER=kubevirt-bot
 EMAIL=kubevirtbot@redhat.com
 
 generate_config(){
@@ -30,6 +30,7 @@ generate_config(){
 
 run_tests(){
     (
+        ${PROJECT_INFRA_ROOT}/hack/create_bazel_cache_rcs.sh
         cd ${TEST_INFRA_ROOT}
         bazel test //config/tests/... //hack:verify-spelling
     )
@@ -53,9 +54,9 @@ propose_pr(){
     title="Update TestGrid"
     git commit -m "${title}"
     echo "Pushing commit to ${USER}/project-infra:${branch}..."
-    git push -f "https://${USER}:$(cat "${token}")@github.com/${USER}/project-infra" "HEAD:${branch}"
+    git push -f "https://${USER}@github.com/${USER}/project-infra" "HEAD:${branch}"
 
-    echo "Creating PR to merge ${user}:${branch} into kubevirt/project-infra:master..."
+    echo "Creating PR to merge ${USER}:${branch} into kubevirt/project-infra:master..."
     /pr-creator \
         --github-token-path="${token}" \
         --org="kubevirt" --repo="project-infra" --branch=master \

--- a/github/ci/testgrid/hack/update.sh
+++ b/github/ci/testgrid/hack/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${BASEDIR}/common.sh

--- a/github/ci/testgrid/hack/upload.sh
+++ b/github/ci/testgrid/hack/upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -euo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${BASEDIR}/common.sh

--- a/hack/create_bazel_cache_rcs.sh
+++ b/hack/create_bazel_cache_rcs.sh
@@ -1,0 +1,1 @@
+../images/bootstrap/create_bazel_cache_rcs.sh


### PR DESCRIPTION
Changes in this PR:
* Use bazel cache, reduces execution time from 33m here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-update-testgrid-config/1395311825699999744 to 3m here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-update-testgrid-config/1395331223252897792
* Include missing kubernetes/test-infra extra_ref
* Use `GIT_ASKPASS` instead of plain token
* Reduce verbosity of scripts
* A couple of fixes related to the GitHub username

Successful execution here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-update-testgrid-config/1395331223252897792 

/cc @dhiller @rmohr 