### PR TITLE
kubevirt: Do not run e2e tests on documentation changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
@@ -18,6 +18,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     skip_report: true
     cluster: phx-prow
@@ -58,6 +60,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-cgroupsv2-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     cluster: phx-prow
     spec:
@@ -81,7 +85,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-e2e-k8s-1.19
@@ -97,6 +101,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       containers:
@@ -135,6 +141,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-network-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     cluster: phx-prow
     spec:
@@ -169,6 +177,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-storage-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     cluster: phx-prow
     spec:
@@ -187,7 +197,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-e2e-k8s-1.19-operator
@@ -203,6 +213,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-operator-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       containers:
@@ -224,7 +236,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-e2e-k8s-1.18
@@ -240,6 +252,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       containers:
@@ -278,6 +292,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     cluster: phx-prow
     spec:
@@ -301,7 +317,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-e2e-k8s-cnao-1.19
@@ -317,6 +333,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       containers:
@@ -334,7 +352,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-e2e-windows2016
@@ -350,6 +368,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       containers:
@@ -367,7 +387,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
@@ -385,6 +405,8 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       affinity:
@@ -450,7 +472,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-check-tests-for-flakes
@@ -464,6 +486,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     cluster: phx-prow
     spec:
@@ -482,7 +506,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.40
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
@@ -498,6 +522,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     spec:
       containers:
@@ -531,6 +557,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-test-0.40
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     optional: true
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
@@ -19,6 +19,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     skip_report: true
     spec:
@@ -42,7 +44,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: prow-workloads
@@ -59,6 +61,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-network-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -78,7 +82,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: prow-workloads
@@ -95,6 +99,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-storage-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     skip_report: true
     spec:
       containers:
@@ -132,6 +138,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-compute-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     skip_report: true
     spec:
@@ -170,6 +178,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-operator-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     skip_report: true
     spec:
@@ -210,6 +220,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-cgroupsv2-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       containers:
@@ -244,6 +256,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-nonroot-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       containers:
@@ -268,7 +282,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -285,6 +299,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -306,7 +322,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -323,6 +339,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-network-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -342,7 +360,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: prow-workloads
@@ -359,6 +377,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-storage-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -375,7 +395,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: prow-workloads
@@ -392,6 +412,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-compute-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     skip_report: true
     spec:
       containers:
@@ -412,7 +434,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -429,6 +451,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-operator-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -445,7 +469,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -462,6 +486,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -495,6 +521,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       containers:
@@ -512,7 +540,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -529,6 +557,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:
@@ -564,6 +594,8 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-nonroot-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       affinity:
@@ -626,7 +658,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
@@ -645,6 +677,8 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.17-sriov-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       affinity:
         podAntiAffinity:
@@ -705,7 +739,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -720,6 +754,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       containers:
@@ -754,6 +790,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-nonroot-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       containers:
@@ -795,6 +833,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.20-rook-ceph-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     optional: true
     spec:
       containers:
@@ -812,7 +852,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.41
     cluster: phx-prow
@@ -829,6 +869,8 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.41
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -15,6 +15,8 @@ presubmits:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -55,6 +57,8 @@ presubmits:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -95,6 +99,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -135,6 +141,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -177,6 +185,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -210,7 +220,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     cluster: prow-workloads
     decorate: true
@@ -218,6 +228,8 @@ presubmits:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -249,7 +261,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     cluster: prow-workloads
     skip_report: false
@@ -258,6 +270,8 @@ presubmits:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -289,7 +303,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: true
     cluster: prow-workloads
     skip_report: false
@@ -298,6 +312,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -329,7 +345,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     cluster: phx-prow
     skip_report: false
@@ -338,6 +354,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -379,6 +397,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
@@ -421,6 +441,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
@@ -458,7 +480,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     skip_report: false
     decorate: true
@@ -466,6 +488,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     cluster: phx-prow
     labels:
       preset-dind-enabled: "true"
@@ -500,7 +524,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     skip_report: false
     decorate: true
@@ -508,6 +532,8 @@ presubmits:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -540,7 +566,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     cluster: prow-workloads
     skip_report: false
@@ -549,6 +575,8 @@ presubmits:
       timeout: 4h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -580,7 +608,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     cluster: prow-workloads
     skip_report: false
@@ -589,6 +617,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
@@ -620,7 +650,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     skip_report: false
     decorate: true
@@ -628,6 +658,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -662,13 +694,15 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     decorate: true
     decoration_config:
       timeout: 2h
       grace_period: 5m
     max_concurrency: 1 # we have one license
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -706,6 +740,8 @@ presubmits:
       timeout: 4h
       grace_period: 30m
     max_concurrency: 10
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -783,13 +819,15 @@ presubmits:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     decorate: true
     decoration_config:
       timeout: 4h
       grace_period: 30m
     max_concurrency: 10
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -864,13 +902,15 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: true
     decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -906,6 +946,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 6
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -950,6 +992,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 6
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -979,7 +1023,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: false
     skip_report: false
     decorate: true
@@ -987,6 +1031,8 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 6
+    # The regex matches all files except these patterns: *.md, *.txt, docs/*
+    run_if_changed: '^(?:[^d]|d[^o]|do[^c]|doc[^s]|docs[^/]).*(?:[^.]txt|[^t]xt|[^x]t|[^.]md|[^m]d|[^dt])$'
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"


### PR DESCRIPTION
Added `run_if_changed` fields to e2e presubmit tests, that match all files, except documentation.

Specifically, these file patterns are ignored:
- *.md
- *.txt
- docs/*
