### PR TITLE
Allow ghproxy to run on any node

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -55,6 +55,12 @@ patches:
       name: prow-controller-manager
     path: patches/JsonRFC6902/prow_controller_manager_deployment.yaml
   - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: ghproxy
+    path: patches/JsonRFC6902/ghproxy_deployment.yaml
+  - target:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/ghproxy_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/ghproxy_deployment.yaml
@@ -1,0 +1,6 @@
+---
+# allow ghproxy to be scheduled on any node
+- op: remove
+  path: /spec/template/spec/tolerations
+- op: remove
+  path: /spec/template/spec/nodeSelector

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/bootstrap.yaml
@@ -13,11 +13,8 @@ kind: Node
 metadata:
   name: node01
   labels:
-    type: vm
-    zone: ci
     role: ingress-controller
     ci.kubevirt.io/cachenode: 'true'
-    dedicated: ghproxy
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
These changes remove the restriction to run ghproxy on a specific node that comes from upstream prow manifests here https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/ghproxy.yaml#L71-L78 (note the `run on our dedicated node` comment).

According to the doc https://github.com/kubernetes/test-infra/tree/master/ghproxy there's no specific requirement to run ghproxy in isolation and we now run prow control plane on a cluster with proper dynamic PV provisioning.

/cc @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>