### PR TITLE
Enable docker proxy and bazel cache on prow-workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -245,7 +245,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -285,7 +285,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -326,7 +326,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
   - org: kubevirt
@@ -366,7 +366,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -406,7 +406,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -446,7 +446,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -488,7 +488,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -527,7 +527,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -567,7 +567,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -610,7 +610,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
   - org: kubevirt
@@ -650,7 +650,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -690,7 +690,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt
@@ -730,7 +730,7 @@ periodics:
     grace_period: 5m
   labels:
     preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "false"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   extra_refs:
     - org: kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -247,6 +247,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -287,6 +289,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -328,6 +332,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
   - org: kubevirt
     repo: kubevirt
@@ -368,6 +374,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -408,6 +416,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -448,6 +458,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -490,6 +502,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -529,6 +543,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -569,6 +585,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -612,6 +630,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
   - org: kubevirt
     repo: kubevirt
@@ -652,6 +672,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -692,6 +714,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -732,6 +756,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
   extra_refs:
     - org: kubevirt
       repo: kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
@@ -12,10 +12,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-0.41
@@ -52,10 +52,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-network-0.41
@@ -88,10 +88,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-storage-0.41
@@ -125,10 +125,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-compute-0.41
@@ -163,10 +163,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-operator-0.41
@@ -352,10 +352,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-storage-0.41
@@ -385,10 +385,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-compute-0.41

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -17,10 +17,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -57,10 +57,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -97,10 +97,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -137,10 +137,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -178,10 +178,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -220,10 +220,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -261,10 +261,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -301,10 +301,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -341,10 +341,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -492,7 +492,7 @@ presubmits:
           resources:
             requests:
               memory: "34Gi"
-  
+
   - name: pull-kubevirt-e2e-k8s-1.19-sig-network-nonroot
     skip_branches:
       - release-\d+\.\d+
@@ -545,7 +545,6 @@ presubmits:
     optional: true
     skip_report: false
     cluster: prow-workloads
-    skip_report: false
     decorate: true
     decoration_config:
       timeout: 4h
@@ -553,10 +552,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -721,10 +720,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -761,10 +760,10 @@ presubmits:
     max_concurrency: 11
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "false"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-bazel-cache: "false"
-      preset-bazel-unnested: "false"
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
Now that greenhouse and docker-mirror-proxy are running on `prow-workloads` we can enable both on all the jobs running on that cluster.

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>