### PR TITLE
knmstate: Use correct project-infra branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       extra_refs:
       - org: kubevirt
         repo: project-infra
-        base_ref: main
+        base_ref: master
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"


### PR DESCRIPTION
After massive changing knmstate jobs to use main branch one of the
options got renamed incorrectly. This changes address that pointing
project-infra to master.

Closes https://github.com/nmstate/kubernetes-nmstate/issues/758