### PR TITLE
Use git-pr script in TestGrid update job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -629,14 +629,14 @@ postsubmits:
         base_ref: master
       spec:
         containers:
-        - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
+        - image: gcr.io/k8s-prow/transfigure:v20210526-84965e233e
           env:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"
-          command:
-          - github/ci/testgrid/hack/update.sh
+          command: ["/bin/sh"]
           args:
-          - /etc/github/oauth
+          - "-c"
+          - hack/git-pr.sh -c "github/ci/testgrid/hack/update.sh" -b update-testgrid-config -r project-infra
           securityContext:
             runAsUser: 0
           resources:
@@ -652,7 +652,7 @@ postsubmits:
           secret:
             secretName: oauth-token
     - name: post-project-infra-upload-testgrid-config
-      run_if_changed: '^github/ci/testgrid/gen-config\.yaml$'
+      run_if_changed: '^github/ci/testgrid/config\.yaml$'
       branches:
       - master
       annotations:

--- a/github/ci/testgrid/hack/update.sh
+++ b/github/ci/testgrid/hack/update.sh
@@ -6,16 +6,12 @@ BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${BASEDIR}/common.sh
 
 main(){
+    # make transfigure image pr-creator available in the path
+    ln -s /pr-creator /usr/local/bin/pr-creator
+
     generate_config "${@}"
 
-    if git diff --cached --quiet --exit-code; then
-        echo "No changes in testgrid config. Aborting no-op bump"
-        exit 0
-    fi
-
     run_tests "${@}"
-
-    propose_pr "${@}"
 }
 
 main "${@}"


### PR DESCRIPTION
* Refactor to use `hack/git-pr.sh` for creating the PRs with modified testgrid configs.
* Fix in the config creation, do not overwrite the base config at `github/ci/testgrid/gen-config.yaml`

PR successfully created here https://github.com/kubevirt/project-infra/pull/1260 the diff includes the changes in this PR too besides the new testgrid config, will be fixed once this PR is merged. 

/cc @dhiller  

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>