### PR TITLE
Always run 1.21 provision check

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -165,8 +165,8 @@ presubmits:
           requests:
             memory: "8Gi"
   - name: check-provision-k8s-1.21
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
The minor version bump should always execute this now that this lane is part of kubevirt.

/cc @fgimenez 