### PR TITLE
libguestfs-appliance: periodic: notify by email on failure

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -5,7 +5,10 @@ periodics:
   # Run once a week at midnight on Sunday morning
   cron: "0 0 * * 0"
   annotations:
-    testgrid-create-test-group: "false"
+    testgrid-dashboards: kubevirt-libguestfs-appliance-periodics
+    testgrid-alert-email: afrosi@redhat.com, victortoso@redhat.com
+    testgrid-num-failures-to-alert: "1"
+    testgrid-alert-stale-results-hours: "1"
   decorate: true
   decoration_config:
     timeout: 3h

--- a/github/ci/testgrid/gen-config.yaml
+++ b/github/ci/testgrid/gen-config.yaml
@@ -1,9 +1,11 @@
 dashboards:
 - name: kubevirt-presubmits
 - name: kubevirt-periodics
+- name: kubevirt-libguestfs-appliance-periodics
 
 dashboard_groups:
 - name: kubevirt
   dashboard_names:
   - kubevirt-presubmits
   - kubevirt-periodics
+  - kubevirt-libguestfs-appliance-periodics


### PR DESCRIPTION
It'll send an email if the job fails or it stales for an hour.
Note that the last successful job took less than 10 minutes.

Signed-off-by: Victor Toso <victortoso@redhat.com>