### PR TITLE
Authenticate to gcloud to perform testgrid config upload

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -498,7 +498,7 @@ presubmits:
             limits:
               memory: "16Gi"
   - name: pull-project-infra-check-testgrid-config
-    run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$'
+    run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$|^github/ci/testgrid/gen-config\.yaml$'
     decorate: true
     labels:
       preset-bazel-cache: "true"

--- a/github/ci/testgrid/hack/common.sh
+++ b/github/ci/testgrid/hack/common.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink -f --canonicalize ${BASEDIR}/../../../..)
-TEST_INFRA_ROOT=$(readlink -f --canonicalize ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra)
+if [ -d ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra ]; then
+    TEST_INFRA_ROOT=$(readlink -f --canonicalize ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra)
+fi
 TESTGRID_GEN_CONFIG=$(readlink -f --canonicalize ${BASEDIR}/../gen-config.yaml)
 TESTGRID_CONFIG=$(readlink -f --canonicalize ${BASEDIR}/../config.yaml)
 USER=kubevirt-bot
@@ -48,5 +50,6 @@ ensure_git_config() {
 }
 
 upload_config(){
+    gcloud auth activate-service-account --key-file=/etc/gcs/service-account.json
     gsutil cp ${TESTGRID_CONFIG} gs://kubevirt-prow/testgrid/config.yaml
 }


### PR DESCRIPTION
Includes a couple of fixes too:
* Run testgrid config checks when `github/ci/testgrid/gen-config.yaml` (the root config) is changed.
* Do not initialize `TEST_INFRA_ROOT` env var when test-infra repo is present.

Successful execution of `post-project-infra-upload-testgrid-config` with these changes here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-upload-testgrid-config/1399387941830135808

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>