### PR TITLE
Fix project_infra_root for workloads-production overlay

### DIFF
--- a/github/ci/prow-deploy/vars/workloads-production/main.yml
+++ b/github/ci/prow-deploy/vars/workloads-production/main.yml
@@ -1,7 +1,7 @@
 testinfra_dir: /tmp/test-infra
 kubectl_exec: /usr/local/bin/kubectl
 bootstrap_full_config: false
-project_infra_root: /home/prow/go/src/github.com/fgimenez/project-infra
+project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/workloads-production/secrets/'
 components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
 kubeconfig_path: '{{ secrets_dir }}/kubeconfig'


### PR DESCRIPTION
Probably a leftover of local testing, it will prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-workloads-cluster-deployment/1400104330970796032

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>