### PR TITLE
publish libguestfs appliance only on new versions

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -34,9 +34,10 @@ periodics:
         - "-c"
         - |
           set -e
+          url=https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance
           bucket_dir="kubevirt-prow/devel/release/kubevirt/libguestfs-appliance"
           ./create-libguestfs-appliance.sh
-          gsutil cp ./output/appliance-*.tar.xz gs://$bucket_dir/
+          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version.txt).tar.xz || gsutil cp ./output/appliance-*.tar.xz gs://$bucket_dir/
           gsutil cp ./output/latest-version.txt gs://$bucket_dir/
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
The new appliance is built weekly. However, if the kernel, os and appliance are the same as the previous build, we overwrite the old appliance with a new sha. The builds that refer the old sha start failing.

Fixes: https://github.com/kubevirt/libguestfs-appliance/issues/10

Signed-off-by: Alice Frosi <afrosi@redhat.com>