### PR TITLE
Add ingress controller to prow-workloads

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - resources/bootstrap.yaml
+  - resources/ingress-controller.yaml
   - ../../components/docker-mirror-proxy/base
   - ../../components/greenhouse/base
 

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/ingress-controller.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/ingress-controller.yaml
@@ -1,0 +1,3619 @@
+---
+---
+# Source: crds/appprotect.f5.com_aplogconfs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: aplogconfs.appprotect.f5.com
+spec:
+  group: appprotect.f5.com
+  names:
+    kind: APLogConf
+    listKind: APLogConfList
+    plural: aplogconfs
+    singular: aplogconf
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: APLogConf is the Schema for the APLogConfs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: APLogConfSpec defines the desired state of APLogConf
+              properties:
+                content:
+                  properties:
+                    format:
+                      enum:
+                        - splunk
+                        - arcsight
+                        - default
+                        - user-defined
+                      type: string
+                    format_string:
+                      type: string
+                    max_message_size:
+                      pattern: ^([1-9]|[1-5][0-9]|6[0-4])k$
+                      type: string
+                    max_request_size:
+                      pattern: ^([1-9]|[1-9][0-9]|[1-9][0-9]{2}|1[0-9]{3}|20[1-3][0-9]|204[1-8]|any)$
+                      type: string
+                  type: object
+                filter:
+                  properties:
+                    request_type:
+                      enum:
+                        - all
+                        - illegal
+                        - blocked
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+
+---
+# Source: crds/appprotect.f5.com_appolicies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: appolicies.appprotect.f5.com
+spec:
+  group: appprotect.f5.com
+  names:
+    kind: APPolicy
+    listKind: APPolicyList
+    plural: appolicies
+    singular: appolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: APPolicyConfig is the Schema for the APPolicyconfigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: APPolicySpec defines the desired state of APPolicy
+              properties:
+                modifications:
+                  items:
+                    properties:
+                      action:
+                        type: string
+                      description:
+                        type: string
+                      entity:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      entityChanges:
+                        properties:
+                          type:
+                            type: string
+                        type: object
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                modificationsReference:
+                  properties:
+                    link:
+                      pattern: ^http
+                      type: string
+                  type: object
+                policy:
+                  description: Defines the App Protect policy
+                  properties:
+                    applicationLanguage:
+                      enum:
+                        - iso-8859-10
+                        - iso-8859-6
+                        - windows-1255
+                        - auto-detect
+                        - koi8-r
+                        - gb18030
+                        - iso-8859-8
+                        - windows-1250
+                        - iso-8859-9
+                        - windows-1252
+                        - iso-8859-16
+                        - gb2312
+                        - iso-8859-2
+                        - iso-8859-5
+                        - windows-1257
+                        - windows-1256
+                        - iso-8859-13
+                        - windows-874
+                        - windows-1253
+                        - iso-8859-3
+                        - euc-jp
+                        - utf-8
+                        - gbk
+                        - windows-1251
+                        - big5
+                        - iso-8859-1
+                        - shift_jis
+                        - euc-kr
+                        - iso-8859-4
+                        - iso-8859-7
+                        - iso-8859-15
+                      type: string
+                    blocking-settings:
+                      properties:
+                        evasions:
+                          items:
+                            properties:
+                              description:
+                                enum:
+                                  - '%u decoding'
+                                  - Apache whitespace
+                                  - Bad unescape
+                                  - Bare byte decoding
+                                  - Directory traversals
+                                  - IIS backslashes
+                                  - IIS Unicode codepoints
+                                  - Multiple decoding
+                                type: string
+                              enabled:
+                                type: boolean
+                              maxDecodingPasses:
+                                type: integer
+                            type: object
+                          type: array
+                        http-protocols:
+                          items:
+                            properties:
+                              description:
+                                enum:
+                                  - Unescaped space in URL
+                                  - Unparsable request content
+                                  - Several Content-Length headers
+                                  - 'POST request with Content-Length: 0'
+                                  - Null in request
+                                  - No Host header in HTTP/1.1 request
+                                  - Multiple host headers
+                                  - Host header contains IP address
+                                  - High ASCII characters in headers
+                                  - Header name with no header value
+                                  - CRLF characters before request start
+                                  - Content length should be a positive number
+                                  - Chunked request with Content-Length header
+                                  - Check maximum number of parameters
+                                  - Check maximum number of headers
+                                  - Body in GET or HEAD requests
+                                  - Bad multipart/form-data request parsing
+                                  - Bad multipart parameters parsing
+                                  - Bad HTTP version
+                                  - Bad host header value
+                                type: string
+                              enabled:
+                                type: boolean
+                              maxHeaders:
+                                type: integer
+                              maxParams:
+                                type: integer
+                            type: object
+                          type: array
+                        violations:
+                          items:
+                            properties:
+                              alarm:
+                                type: boolean
+                              block:
+                                type: boolean
+                              description:
+                                type: string
+                              name:
+                                enum:
+                                  - VIOL_PARAMETER_VALUE_BASE64
+                                  - VIOL_MANDATORY_HEADER
+                                  - VIOL_HEADER_REPEATED
+                                  - VIOL_ASM_COOKIE_MODIFIED
+                                  - VIOL_BLACKLISTED_IP
+                                  - VIOL_COOKIE_EXPIRED
+                                  - VIOL_COOKIE_LENGTH
+                                  - VIOL_COOKIE_MALFORMED
+                                  - VIOL_COOKIE_MODIFIED
+                                  - VIOL_DATA_GUARD
+                                  - VIOL_ENCODING
+                                  - VIOL_EVASION
+                                  - VIOL_FILETYPE
+                                  - VIOL_FILE_UPLOAD
+                                  - VIOL_FILE_UPLOAD_IN_BODY
+                                  - VIOL_HEADER_LENGTH
+                                  - VIOL_HEADER_METACHAR
+                                  - VIOL_HTTP_PROTOCOL
+                                  - VIOL_HTTP_RESPONSE_STATUS
+                                  - VIOL_JSON_FORMAT
+                                  - VIOL_JSON_MALFORMED
+                                  - VIOL_JSON_SCHEMA
+                                  - VIOL_MANDATORY_PARAMETER
+                                  - VIOL_MANDATORY_REQUEST_BODY
+                                  - VIOL_METHOD
+                                  - VIOL_PARAMETER
+                                  - VIOL_PARAMETER_DATA_TYPE
+                                  - VIOL_PARAMETER_EMPTY_VALUE
+                                  - VIOL_PARAMETER_LOCATION
+                                  - VIOL_PARAMETER_MULTIPART_NULL_VALUE
+                                  - VIOL_PARAMETER_NAME_METACHAR
+                                  - VIOL_PARAMETER_NUMERIC_VALUE
+                                  - VIOL_PARAMETER_REPEATED
+                                  - VIOL_PARAMETER_STATIC_VALUE
+                                  - VIOL_PARAMETER_VALUE_LENGTH
+                                  - VIOL_PARAMETER_VALUE_METACHAR
+                                  - VIOL_POST_DATA_LENGTH
+                                  - VIOL_QUERY_STRING_LENGTH
+                                  - VIOL_RATING_THREAT
+                                  - VIOL_RATING_NEED_EXAMINATION
+                                  - VIOL_REQUEST_MAX_LENGTH
+                                  - VIOL_REQUEST_LENGTH
+                                  - VIOL_THREAT_CAMPAIGN
+                                  - VIOL_URL
+                                  - VIOL_URL_CONTENT_TYPE
+                                  - VIOL_URL_LENGTH
+                                  - VIOL_URL_METACHAR
+                                  - VIOL_XML_FORMAT
+                                  - VIOL_XML_MALFORMED
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    blockingSettingReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    bot-defense:
+                      properties:
+                        mitigations:
+                          properties:
+                            anomalies:
+                              items:
+                                properties:
+                                  action:
+                                    enum:
+                                      - alarm
+                                      - block
+                                      - default
+                                      - detect
+                                      - ignore
+                                    type: string
+                                  name:
+                                    type: string
+                                  scoreThreshold:
+                                    pattern: '[0-9]|[1-9][0-9]|1[0-4][0-9]|150|default'
+                                    type: string
+                                type: object
+                              type: array
+                            classes:
+                              items:
+                                properties:
+                                  action:
+                                    enum:
+                                      - alarm
+                                      - block
+                                      - detect
+                                      - ignore
+                                    type: string
+                                  name:
+                                    enum:
+                                      - malicious-bot
+                                      - suspicious-browser
+                                      - trusted-bot
+                                      - untrusted-bot
+                                    type: string
+                                type: object
+                              type: array
+                            signatures:
+                              items:
+                                properties:
+                                  action:
+                                    enum:
+                                      - alarm
+                                      - block
+                                      - detect
+                                      - ignore
+                                    type: string
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        settings:
+                          properties:
+                            isEnabled:
+                              type: boolean
+                          type: object
+                      type: object
+                    caseInsensitive:
+                      type: boolean
+                    character-sets:
+                      items:
+                        properties:
+                          characterSet:
+                            items:
+                              properties:
+                                isAllowed:
+                                  type: boolean
+                                metachar:
+                                  type: string
+                              type: object
+                            type: array
+                          characterSetType:
+                            enum:
+                              - gwt-content
+                              - header
+                              - json-content
+                              - parameter-name
+                              - parameter-value
+                              - plain-text-content
+                              - url
+                              - xml-content
+                            type: string
+                        type: object
+                      type: array
+                    characterSetReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    cookie-settings:
+                      properties:
+                        maximumCookieHeaderLength:
+                          pattern: any|\d+
+                          type: string
+                      type: object
+                    cookieReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    cookieSettingsReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    cookies:
+                      items:
+                        properties:
+                          accessibleOnlyThroughTheHttpProtocol:
+                            type: boolean
+                          attackSignaturesCheck:
+                            type: boolean
+                          decodeValueAsBase64:
+                            enum:
+                              - enabled
+                              - disabled
+                              - required
+                            type: string
+                          enforcementType:
+                            type: string
+                          insertSameSiteAttribute:
+                            enum:
+                              - lax
+                              - none
+                              - none-value
+                              - strict
+                            type: string
+                          name:
+                            type: string
+                          securedOverHttpsConnection:
+                            type: boolean
+                          signatureOverrides:
+                            items:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                signatureId:
+                                  type: integer
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          type:
+                            enum:
+                              - explicit
+                              - wildcard
+                            type: string
+                        type: object
+                      type: array
+                    data-guard:
+                      properties:
+                        creditCardNumbers:
+                          type: boolean
+                        enabled:
+                          type: boolean
+                        enforcementMode:
+                          enum:
+                            - ignore-urls-in-list
+                            - enforce-urls-in-list
+                          type: string
+                        enforcementUrls:
+                          items:
+                            type: string
+                          type: array
+                        lastCcnDigitsToExpose:
+                          type: integer
+                        lastSsnDigitsToExpose:
+                          type: integer
+                        maskData:
+                          type: boolean
+                        usSocialSecurityNumbers:
+                          type: boolean
+                      type: object
+                    dataGuardReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    description:
+                      type: string
+                    enablePassiveMode:
+                      type: boolean
+                    enforcementMode:
+                      enum:
+                        - transparent
+                        - blocking
+                      type: string
+                    filetypeReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    filetypes:
+                      items:
+                        properties:
+                          allowed:
+                            type: boolean
+                          checkPostDataLength:
+                            type: boolean
+                          checkQueryStringLength:
+                            type: boolean
+                          checkRequestLength:
+                            type: boolean
+                          checkUrlLength:
+                            type: boolean
+                          name:
+                            type: string
+                          postDataLength:
+                            type: integer
+                          queryStringLength:
+                            type: integer
+                          requestLength:
+                            type: integer
+                          responseCheck:
+                            type: boolean
+                          type:
+                            enum:
+                              - explicit
+                              - wildcard
+                            type: string
+                          urlLength:
+                            type: integer
+                        type: object
+                      type: array
+                    fullPath:
+                      type: string
+                    general:
+                      properties:
+                        allowedResponseCodes:
+                          items:
+                            format: int32
+                            maximum: 999
+                            minimum: 100
+                            type: integer
+                          type: array
+                        customXffHeaders:
+                          items:
+                            type: string
+                          type: array
+                        maskCreditCardNumbersInRequest:
+                          type: boolean
+                        trustXff:
+                          type: boolean
+                      type: object
+                    generalReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    header-settings:
+                      properties:
+                        maximumHttpHeaderLength:
+                          pattern: any|\d+
+                          type: string
+                      type: object
+                    headerReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    headerSettingsReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    headers:
+                      items:
+                        properties:
+                          base64Decoding:
+                            type: boolean
+                          checkSignatures:
+                            type: boolean
+                          decodeValueAsBase64:
+                            enum:
+                              - enabled
+                              - disabled
+                              - required
+                            type: string
+                          htmlNormalization:
+                            type: boolean
+                          mandatory:
+                            type: boolean
+                          maskValueInLogs:
+                            type: boolean
+                          name:
+                            type: string
+                          normalizationViolations:
+                            type: boolean
+                          percentDecoding:
+                            type: boolean
+                          type:
+                            enum:
+                              - explicit
+                              - wildcard
+                            type: string
+                          urlNormalization:
+                            type: boolean
+                        type: object
+                      type: array
+                    json-profiles:
+                      items:
+                        properties:
+                          attackSignaturesCheck:
+                            type: boolean
+                          defenseAttributes:
+                            properties:
+                              maximumArrayLength:
+                                pattern: any|\d+
+                                type: string
+                              maximumStructureDepth:
+                                pattern: any|\d+
+                                type: string
+                              maximumTotalLengthOfJSONData:
+                                pattern: any|\d+
+                                type: string
+                              maximumValueLength:
+                                pattern: any|\d+
+                                type: string
+                              tolerateJSONParsingWarnings:
+                                type: boolean
+                            type: object
+                          description:
+                            type: string
+                          hasValidationFiles:
+                            type: boolean
+                          metacharOverrides:
+                            items:
+                              properties:
+                                isAllowed:
+                                  type: boolean
+                                metachar:
+                                  type: string
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          signatureOverrides:
+                            items:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                signatureId:
+                                  type: integer
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          validationFiles:
+                            items:
+                              properties:
+                                importUrl:
+                                  type: string
+                                isPrimary:
+                                  type: boolean
+                                jsonValidationFile:
+                                  properties:
+                                    contents:
+                                      type: string
+                                    fileName:
+                                      type: string
+                                    isBase64:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                    json-validation-files:
+                      items:
+                        properties:
+                          contents:
+                            type: string
+                          fileName:
+                            type: string
+                          isBase64:
+                            type: boolean
+                        type: object
+                      type: array
+                    jsonProfileReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    jsonValidationFileReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    methodReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    methods:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                    name:
+                      type: string
+                    open-api-files:
+                      items:
+                        properties:
+                          link:
+                            pattern: ^http
+                            type: string
+                        type: object
+                      type: array
+                    parameterReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    parameters:
+                      items:
+                        properties:
+                          allowEmptyValue:
+                            type: boolean
+                          allowRepeatedParameterName:
+                            type: boolean
+                          arraySerializationFormat:
+                            enum:
+                              - csv
+                              - form
+                              - label
+                              - matrix
+                              - multi
+                              - multipart
+                              - pipe
+                              - ssv
+                              - tsv
+                            type: string
+                          attackSignaturesCheck:
+                            type: boolean
+                          checkMaxValue:
+                            type: boolean
+                          checkMaxValueLength:
+                            type: boolean
+                          checkMetachars:
+                            type: boolean
+                          checkMinValue:
+                            type: boolean
+                          checkMinValueLength:
+                            type: boolean
+                          checkMultipleOfValue:
+                            type: boolean
+                          contentProfile:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          dataType:
+                            enum:
+                              - alpha-numeric
+                              - binary
+                              - boolean
+                              - decimal
+                              - email
+                              - integer
+                              - none
+                              - phone
+                            type: string
+                          decodeValueAsBase64:
+                            enum:
+                              - enabled
+                              - disabled
+                              - required
+                            type: string
+                          disallowFileUploadOfExecutables:
+                            type: boolean
+                          enableRegularExpression:
+                            type: boolean
+                          exclusiveMax:
+                            type: boolean
+                          exclusiveMin:
+                            type: boolean
+                          isCookie:
+                            type: boolean
+                          isHeader:
+                            type: boolean
+                          level:
+                            enum:
+                              - global
+                              - url
+                            type: string
+                          maximumLength:
+                            type: integer
+                          metacharsOnParameterValueCheck:
+                            type: boolean
+                          minimumLength:
+                            type: integer
+                          name:
+                            type: string
+                          nameMetacharOverrides:
+                            items:
+                              properties:
+                                isAllowed:
+                                  type: boolean
+                                metachar:
+                                  type: string
+                              type: object
+                            type: array
+                          objectSerializationStyle:
+                            type: string
+                          parameterEnumValues:
+                            items:
+                              type: string
+                            type: array
+                          parameterLocation:
+                            enum:
+                              - any
+                              - cookie
+                              - form-data
+                              - header
+                              - path
+                              - query
+                            type: string
+                          regularExpression:
+                            type: string
+                          sensitiveParameter:
+                            type: boolean
+                          signatureOverrides:
+                            items:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                signatureId:
+                                  type: integer
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          staticValues:
+                            type: string
+                          type:
+                            enum:
+                              - explicit
+                              - wildcard
+                            type: string
+                          valueMetacharOverrides:
+                            items:
+                              properties:
+                                isAllowed:
+                                  type: boolean
+                                metachar:
+                                  type: string
+                              type: object
+                            type: array
+                          valueType:
+                            enum:
+                              - array
+                              - auto-detect
+                              - dynamic-content
+                              - dynamic-parameter-name
+                              - ignore
+                              - json
+                              - object
+                              - openapi-array
+                              - static-content
+                              - user-input
+                              - xml
+                            type: string
+                        type: object
+                      type: array
+                    response-pages:
+                      items:
+                        properties:
+                          ajaxActionType:
+                            enum:
+                              - alert-popup
+                              - custom
+                              - redirect
+                            type: string
+                          ajaxCustomContent:
+                            type: string
+                          ajaxEnabled:
+                            type: boolean
+                          ajaxPopupMessage:
+                            type: string
+                          ajaxRedirectUrl:
+                            type: string
+                          responseActionType:
+                            enum:
+                              - custom
+                              - default
+                              - erase-cookies
+                              - redirect
+                              - soap-fault
+                            type: string
+                          responseContent:
+                            type: string
+                          responseHeader:
+                            type: string
+                          responsePageType:
+                            enum:
+                              - ajax
+                              - ajax-login
+                              - captcha
+                              - captcha-fail
+                              - default
+                              - failed-login-honeypot
+                              - failed-login-honeypot-ajax
+                              - hijack
+                              - leaked-credentials
+                              - leaked-credentials-ajax
+                              - mobile
+                              - persistent-flow
+                              - xml
+                            type: string
+                          responseRedirectUrl:
+                            type: string
+                        type: object
+                      type: array
+                    responsePageReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    sensitive-parameters:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                    sensitiveParameterReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    server-technologies:
+                      items:
+                        properties:
+                          serverTechnologyName:
+                            enum:
+                              - Jenkins
+                              - SharePoint
+                              - Oracle Application Server
+                              - Python
+                              - Oracle Identity Manager
+                              - Spring Boot
+                              - CouchDB
+                              - SQLite
+                              - Handlebars
+                              - Mustache
+                              - Prototype
+                              - Zend
+                              - Redis
+                              - Underscore.js
+                              - Ember.js
+                              - ZURB Foundation
+                              - ef.js
+                              - Vue.js
+                              - UIKit
+                              - TYPO3 CMS
+                              - RequireJS
+                              - React
+                              - MooTools
+                              - Laravel
+                              - GraphQL
+                              - Google Web Toolkit
+                              - Express.js
+                              - CodeIgniter
+                              - Backbone.js
+                              - AngularJS
+                              - JavaScript
+                              - Nginx
+                              - Jetty
+                              - Joomla
+                              - JavaServer Faces (JSF)
+                              - Ruby
+                              - MongoDB
+                              - Django
+                              - Node.js
+                              - Citrix
+                              - JBoss
+                              - Elasticsearch
+                              - Apache Struts
+                              - XML
+                              - PostgreSQL
+                              - IBM DB2
+                              - Sybase/ASE
+                              - CGI
+                              - Proxy Servers
+                              - SSI (Server Side Includes)
+                              - Cisco
+                              - Novell
+                              - Macromedia JRun
+                              - BEA Systems WebLogic Server
+                              - Lotus Domino
+                              - MySQL
+                              - Oracle
+                              - Microsoft SQL Server
+                              - PHP
+                              - Outlook Web Access
+                              - Apache/NCSA HTTP Server
+                              - Apache Tomcat
+                              - WordPress
+                              - Macromedia ColdFusion
+                              - Unix/Linux
+                              - Microsoft Windows
+                              - ASP.NET
+                              - Front Page Server Extensions (FPSE)
+                              - IIS
+                              - WebDAV
+                              - ASP
+                              - Java Servlets/JSP
+                              - jQuery
+                            type: string
+                        type: object
+                      type: array
+                    serverTechnologyReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    signature-requirements:
+                      items:
+                        properties:
+                          tag:
+                            type: string
+                        type: object
+                      type: array
+                    signature-sets:
+                      items:
+                        properties:
+                          alarm:
+                            type: boolean
+                          block:
+                            type: boolean
+                          name:
+                            type: string
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      type: array
+                    signature-settings:
+                      properties:
+                        attackSignatureFalsePositiveMode:
+                          enum:
+                            - detect
+                            - detect-and-allow
+                            - disabled
+                          type: string
+                        minimumAccuracyForAutoAddedSignatures:
+                          enum:
+                            - high
+                            - low
+                            - medium
+                          type: string
+                      type: object
+                    signatureReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    signatureSetReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    signatureSettingReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    signatures:
+                      items:
+                        properties:
+                          enabled:
+                            type: boolean
+                          name:
+                            type: string
+                          signatureId:
+                            type: integer
+                          tag:
+                            type: string
+                        type: object
+                      type: array
+                    softwareVersion:
+                      type: string
+                    template:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    threat-campaigns:
+                      items:
+                        properties:
+                          isEnabled:
+                            type: boolean
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                    threatCampaignReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    urlReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    urls:
+                      items:
+                        properties:
+                          attackSignaturesCheck:
+                            type: boolean
+                          description:
+                            type: string
+                          disallowFileUploadOfExecutables:
+                            type: boolean
+                          isAllowed:
+                            type: boolean
+                          mandatoryBody:
+                            type: boolean
+                          metacharOverrides:
+                            items:
+                              properties:
+                                isAllowed:
+                                  type: boolean
+                                metachar:
+                                  type: string
+                              type: object
+                            type: array
+                          metacharsOnUrlCheck:
+                            type: boolean
+                          method:
+                            enum:
+                              - ACL
+                              - BCOPY
+                              - BDELETE
+                              - BMOVE
+                              - BPROPFIND
+                              - BPROPPATCH
+                              - CHECKIN
+                              - CHECKOUT
+                              - CONNECT
+                              - COPY
+                              - DELETE
+                              - GET
+                              - HEAD
+                              - LINK
+                              - LOCK
+                              - MERGE
+                              - MKCOL
+                              - MKWORKSPACE
+                              - MOVE
+                              - NOTIFY
+                              - OPTIONS
+                              - PATCH
+                              - POLL
+                              - POST
+                              - PROPFIND
+                              - PROPPATCH
+                              - PUT
+                              - REPORT
+                              - RPC_IN_DATA
+                              - RPC_OUT_DATA
+                              - SEARCH
+                              - SUBSCRIBE
+                              - TRACE
+                              - TRACK
+                              - UNLINK
+                              - UNLOCK
+                              - UNSUBSCRIBE
+                              - VERSION_CONTROL
+                              - X-MS-ENUMATTS
+                              - '*'
+                            type: string
+                          methodOverrides:
+                            items:
+                              properties:
+                                allowed:
+                                  type: boolean
+                                method:
+                                  enum:
+                                    - ACL
+                                    - BCOPY
+                                    - BDELETE
+                                    - BMOVE
+                                    - BPROPFIND
+                                    - BPROPPATCH
+                                    - CHECKIN
+                                    - CHECKOUT
+                                    - CONNECT
+                                    - COPY
+                                    - DELETE
+                                    - GET
+                                    - HEAD
+                                    - LINK
+                                    - LOCK
+                                    - MERGE
+                                    - MKCOL
+                                    - MKWORKSPACE
+                                    - MOVE
+                                    - NOTIFY
+                                    - OPTIONS
+                                    - PATCH
+                                    - POLL
+                                    - POST
+                                    - PROPFIND
+                                    - PROPPATCH
+                                    - PUT
+                                    - REPORT
+                                    - RPC_IN_DATA
+                                    - RPC_OUT_DATA
+                                    - SEARCH
+                                    - SUBSCRIBE
+                                    - TRACE
+                                    - TRACK
+                                    - UNLINK
+                                    - UNLOCK
+                                    - UNSUBSCRIBE
+                                    - VERSION_CONTROL
+                                    - X-MS-ENUMATTS
+                                  type: string
+                              type: object
+                            type: array
+                          methodsOverrideOnUrlCheck:
+                            type: boolean
+                          name:
+                            type: string
+                          positionalParameters:
+                            items:
+                              properties:
+                                parameter:
+                                  properties:
+                                    allowEmptyValue:
+                                      type: boolean
+                                    allowRepeatedParameterName:
+                                      type: boolean
+                                    arraySerializationFormat:
+                                      enum:
+                                        - csv
+                                        - form
+                                        - label
+                                        - matrix
+                                        - multi
+                                        - multipart
+                                        - pipe
+                                        - ssv
+                                        - tsv
+                                      type: string
+                                    attackSignaturesCheck:
+                                      type: boolean
+                                    checkMaxValue:
+                                      type: boolean
+                                    checkMaxValueLength:
+                                      type: boolean
+                                    checkMetachars:
+                                      type: boolean
+                                    checkMinValue:
+                                      type: boolean
+                                    checkMinValueLength:
+                                      type: boolean
+                                    checkMultipleOfValue:
+                                      type: boolean
+                                    contentProfile:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    dataType:
+                                      enum:
+                                        - alpha-numeric
+                                        - binary
+                                        - boolean
+                                        - decimal
+                                        - email
+                                        - integer
+                                        - none
+                                        - phone
+                                      type: string
+                                    decodeValueAsBase64:
+                                      enum:
+                                        - enabled
+                                        - disabled
+                                        - required
+                                      type: string
+                                    disallowFileUploadOfExecutables:
+                                      type: boolean
+                                    enableRegularExpression:
+                                      type: boolean
+                                    exclusiveMax:
+                                      type: boolean
+                                    exclusiveMin:
+                                      type: boolean
+                                    isCookie:
+                                      type: boolean
+                                    isHeader:
+                                      type: boolean
+                                    level:
+                                      enum:
+                                        - global
+                                        - url
+                                      type: string
+                                    maximumLength:
+                                      type: integer
+                                    metacharsOnParameterValueCheck:
+                                      type: boolean
+                                    minimumLength:
+                                      type: integer
+                                    name:
+                                      type: string
+                                    nameMetacharOverrides:
+                                      items:
+                                        properties:
+                                          isAllowed:
+                                            type: boolean
+                                          metachar:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    objectSerializationStyle:
+                                      type: string
+                                    parameterEnumValues:
+                                      items:
+                                        type: string
+                                      type: array
+                                    parameterLocation:
+                                      enum:
+                                        - any
+                                        - cookie
+                                        - form-data
+                                        - header
+                                        - path
+                                        - query
+                                      type: string
+                                    regularExpression:
+                                      type: string
+                                    sensitiveParameter:
+                                      type: boolean
+                                    signatureOverrides:
+                                      items:
+                                        properties:
+                                          enabled:
+                                            type: boolean
+                                          name:
+                                            type: string
+                                          signatureId:
+                                            type: integer
+                                          tag:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    staticValues:
+                                      type: string
+                                    type:
+                                      enum:
+                                        - explicit
+                                        - wildcard
+                                      type: string
+                                    valueMetacharOverrides:
+                                      items:
+                                        properties:
+                                          isAllowed:
+                                            type: boolean
+                                          metachar:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    valueType:
+                                      enum:
+                                        - array
+                                        - auto-detect
+                                        - dynamic-content
+                                        - dynamic-parameter-name
+                                        - ignore
+                                        - json
+                                        - object
+                                        - openapi-array
+                                        - static-content
+                                        - user-input
+                                        - xml
+                                      type: string
+                                  type: object
+                                urlSegmentIndex:
+                                  type: integer
+                              type: object
+                            type: array
+                          protocol:
+                            enum:
+                              - http
+                              - https
+                            type: string
+                          signatureOverrides:
+                            items:
+                              properties:
+                                enabled:
+                                  type: boolean
+                                name:
+                                  type: string
+                                signatureId:
+                                  type: integer
+                                tag:
+                                  type: string
+                              type: object
+                            type: array
+                          type:
+                            enum:
+                              - explicit
+                              - wildcard
+                            type: string
+                          urlContentProfiles:
+                            items:
+                              properties:
+                                headerName:
+                                  type: string
+                                headerOrder:
+                                  type: string
+                                headerValue:
+                                  type: string
+                                name:
+                                  type: string
+                                type:
+                                  enum:
+                                    - apply-content-signatures
+                                    - apply-value-and-content-signatures
+                                    - disallow
+                                    - do-nothing
+                                    - form-data
+                                    - gwt
+                                    - json
+                                    - xml
+                                  type: string
+                              type: object
+                            type: array
+                          wildcardOrder:
+                            type: integer
+                        type: object
+                      type: array
+                    whitelist-ips:
+                      items:
+                        properties:
+                          blockRequests:
+                            enum:
+                              - always
+                              - never
+                              - policy-default
+                            type: string
+                          ipAddress:
+                            pattern: '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
+                            type: string
+                          ipMask:
+                            pattern: '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
+                            type: string
+                        type: object
+                      type: array
+                    whitelistIpReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    xml-profiles:
+                      items:
+                        properties:
+                          attackSignaturesCheck:
+                            type: boolean
+                          defenseAttributes:
+                            properties:
+                              allowCDATA:
+                                type: boolean
+                              allowDTDs:
+                                type: boolean
+                              allowExternalReferences:
+                                type: boolean
+                              allowProcessingInstructions:
+                                type: boolean
+                              maximumAttributeValueLength:
+                                pattern: any|\d+
+                                type: string
+                              maximumAttributesPerElement:
+                                pattern: any|\d+
+                                type: string
+                              maximumChildrenPerElement:
+                                pattern: any|\d+
+                                type: string
+                              maximumDocumentDepth:
+                                pattern: any|\d+
+                                type: string
+                              maximumDocumentSize:
+                                pattern: any|\d+
+                                type: string
+                              maximumElements:
+                                pattern: any|\d+
+                                type: string
+                              maximumNSDeclarations:
+                                pattern: any|\d+
+                                type: string
+                              maximumNameLength:
+                                pattern: any|\d+
+                                type: string
+                              maximumNamespaceLength:
+                                pattern: any|\d+
+                                type: string
+                              tolerateCloseTagShorthand:
+                                type: boolean
+                              tolerateLeadingWhiteSpace:
+                                type: boolean
+                              tolerateNumericNames:
+                                type: boolean
+                            type: object
+                          description:
+                            type: string
+                          enableWss:
+                            type: boolean
+                          followSchemaLinks:
+                            type: boolean
+                          name:
+                            type: string
+                        type: object
+                      type: array
+                    xml-validation-files:
+                      items:
+                        properties:
+                          contents:
+                            type: string
+                          fileName:
+                            type: string
+                          isBase64:
+                            type: boolean
+                        type: object
+                      type: array
+                    xmlProfileReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                    xmlValidationFileReference:
+                      properties:
+                        link:
+                          pattern: ^http
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+
+---
+# Source: crds/appprotect.f5.com_apusersigs.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: apusersigs.appprotect.f5.com
+spec:
+  group: appprotect.f5.com
+  names:
+    kind: APUserSig
+    listKind: APUserSigList
+    plural: apusersigs
+    singular: apusersig
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: APUserSig is the Schema for the apusersigs API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: APUserSigSpec defines the desired state of APUserSig
+              properties:
+                properties:
+                  type: string
+                signatures:
+                  items:
+                    properties:
+                      accuracy:
+                        enum:
+                          - high
+                          - medium
+                          - low
+                        type: string
+                      attackType:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      description:
+                        type: string
+                      name:
+                        type: string
+                      references:
+                        properties:
+                          type:
+                            enum:
+                              - bugtraq
+                              - cve
+                              - nessus
+                              - url
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      risk:
+                        enum:
+                          - high
+                          - medium
+                          - low
+                        type: string
+                      rule:
+                        type: string
+                      signatureType:
+                        enum:
+                          - request
+                          - response
+                        type: string
+                      systems:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                tag:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+
+---
+# Source: crds/k8s.nginx.org_globalconfigurations.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: globalconfigurations.k8s.nginx.org
+spec:
+  group: k8s.nginx.org
+  names:
+    kind: GlobalConfiguration
+    listKind: GlobalConfigurationList
+    plural: globalconfigurations
+    shortNames:
+      - gc
+    singular: globalconfiguration
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GlobalConfiguration defines the GlobalConfiguration resource.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GlobalConfigurationSpec is the spec of the GlobalConfiguration resource.
+              type: object
+              properties:
+                listeners:
+                  type: array
+                  items:
+                    description: Listener defines a listener.
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/k8s.nginx.org_policies.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: policies.k8s.nginx.org
+spec:
+  group: k8s.nginx.org
+  names:
+    kind: Policy
+    listKind: PolicyList
+    plural: policies
+    shortNames:
+      - pol
+    singular: policy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Current state of the Policy. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PolicySpec is the spec of the Policy resource. The spec includes multiple fields, where each field represents a different policy. Only one policy (field) is allowed.
+              type: object
+              properties:
+                accessControl:
+                  description: 'AccessControl defines an access policy based on the source IP of a request. policy status: production-ready'
+                  type: object
+                  properties:
+                    allow:
+                      type: array
+                      items:
+                        type: string
+                    deny:
+                      type: array
+                      items:
+                        type: string
+                egressMTLS:
+                  description: 'EgressMTLS defines an Egress MTLS policy. policy status: preview'
+                  type: object
+                  properties:
+                    ciphers:
+                      type: string
+                    protocols:
+                      type: string
+                    serverName:
+                      type: boolean
+                    sessionReuse:
+                      type: boolean
+                    sslName:
+                      type: string
+                    tlsSecret:
+                      type: string
+                    trustedCertSecret:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                    verifyServer:
+                      type: boolean
+                ingressMTLS:
+                  description: 'IngressMTLS defines an Ingress MTLS policy. policy status: preview'
+                  type: object
+                  properties:
+                    clientCertSecret:
+                      type: string
+                    verifyClient:
+                      type: string
+                    verifyDepth:
+                      type: integer
+                jwt:
+                  description: 'JWTAuth holds JWT authentication configuration. policy status: preview'
+                  type: object
+                  properties:
+                    realm:
+                      type: string
+                    secret:
+                      type: string
+                    token:
+                      type: string
+                oidc:
+                  description: OIDC defines an Open ID Connect policy.
+                  type: object
+                  properties:
+                    authEndpoint:
+                      type: string
+                    clientID:
+                      type: string
+                    clientSecret:
+                      type: string
+                    jwksURI:
+                      type: string
+                    redirectURI:
+                      type: string
+                    scope:
+                      type: string
+                    tokenEndpoint:
+                      type: string
+                rateLimit:
+                  description: 'RateLimit defines a rate limit policy. policy status: preview'
+                  type: object
+                  properties:
+                    burst:
+                      type: integer
+                    delay:
+                      type: integer
+                    dryRun:
+                      type: boolean
+                    key:
+                      type: string
+                    logLevel:
+                      type: string
+                    noDelay:
+                      type: boolean
+                    rate:
+                      type: string
+                    rejectCode:
+                      type: integer
+                    zoneSize:
+                      type: string
+                waf:
+                  description: 'WAF defines an WAF policy. policy status: preview'
+                  type: object
+                  properties:
+                    apPolicy:
+                      type: string
+                    enable:
+                      type: boolean
+                    securityLog:
+                      description: SecurityLog defines the security log of a WAF policy.
+                      type: object
+                      properties:
+                        apLogConf:
+                          type: string
+                        enable:
+                          type: boolean
+                        logDest:
+                          type: string
+            status:
+              description: PolicyStatus is the status of the policy resource
+              type: object
+              properties:
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/k8s.nginx.org_transportservers.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: transportservers.k8s.nginx.org
+spec:
+  group: k8s.nginx.org
+  names:
+    kind: TransportServer
+    listKind: TransportServerList
+    plural: transportservers
+    shortNames:
+      - ts
+    singular: transportserver
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Current state of the TransportServer. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: TransportServer defines the TransportServer resource.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TransportServerSpec is the spec of the TransportServer resource.
+              type: object
+              properties:
+                action:
+                  description: Action defines an action.
+                  type: object
+                  properties:
+                    pass:
+                      type: string
+                host:
+                  type: string
+                ingressClassName:
+                  type: string
+                listener:
+                  description: TransportServerListener defines a listener for a TransportServer.
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    protocol:
+                      type: string
+                serverSnippets:
+                  type: string
+                sessionParameters:
+                  description: SessionParameters defines session parameters.
+                  type: object
+                  properties:
+                    timeout:
+                      type: string
+                upstreamParameters:
+                  description: UpstreamParameters defines parameters for an upstream.
+                  type: object
+                  properties:
+                    connectTimeout:
+                      type: string
+                    nextUpstream:
+                      type: boolean
+                    nextUpstreamTimeout:
+                      type: string
+                    nextUpstreamTries:
+                      type: integer
+                    udpRequests:
+                      type: integer
+                    udpResponses:
+                      type: integer
+                upstreams:
+                  type: array
+                  items:
+                    description: Upstream defines an upstream.
+                    type: object
+                    properties:
+                      failTimeout:
+                        type: string
+                      healthCheck:
+                        description: HealthCheck defines the parameters for active Upstream HealthChecks.
+                        type: object
+                        properties:
+                          enable:
+                            type: boolean
+                          fails:
+                            type: integer
+                          interval:
+                            type: string
+                          jitter:
+                            type: string
+                          passes:
+                            type: integer
+                          port:
+                            type: integer
+                          timeout:
+                            type: string
+                      maxFails:
+                        type: integer
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                      service:
+                        type: string
+            status:
+              description: TransportServerStatus defines the status for the TransportServer resource.
+              type: object
+              properties:
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/k8s.nginx.org_virtualserverroutes.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: virtualserverroutes.k8s.nginx.org
+spec:
+  group: k8s.nginx.org
+  names:
+    kind: VirtualServerRoute
+    listKind: VirtualServerRouteList
+    plural: virtualserverroutes
+    shortNames:
+      - vsr
+    singular: virtualserverroute
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Current state of the VirtualServerRoute. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.host
+          name: Host
+          type: string
+        - jsonPath: .status.externalEndpoints[*].ip
+          name: IP
+          type: string
+        - jsonPath: .status.externalEndpoints[*].ports
+          name: Ports
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VirtualServerRoute defines the VirtualServerRoute resource.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VirtualServerRouteSpec is the spec of the VirtualServerRoute resource.
+              type: object
+              properties:
+                host:
+                  type: string
+                ingressClassName:
+                  type: string
+                subroutes:
+                  type: array
+                  items:
+                    description: Route defines a route.
+                    type: object
+                    properties:
+                      action:
+                        description: Action defines an action.
+                        type: object
+                        properties:
+                          pass:
+                            type: string
+                          proxy:
+                            description: ActionProxy defines a proxy in an Action.
+                            type: object
+                            properties:
+                              requestHeaders:
+                                description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                type: object
+                                properties:
+                                  pass:
+                                    type: boolean
+                                  set:
+                                    type: array
+                                    items:
+                                      description: Header defines an HTTP Header.
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                              responseHeaders:
+                                description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                type: object
+                                properties:
+                                  add:
+                                    type: array
+                                    items:
+                                      description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                      type: object
+                                      properties:
+                                        always:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  hide:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ignore:
+                                    type: array
+                                    items:
+                                      type: string
+                                  pass:
+                                    type: array
+                                    items:
+                                      type: string
+                              rewritePath:
+                                type: string
+                              upstream:
+                                type: string
+                          redirect:
+                            description: ActionRedirect defines a redirect in an Action.
+                            type: object
+                            properties:
+                              code:
+                                type: integer
+                              url:
+                                type: string
+                          return:
+                            description: ActionReturn defines a return in an Action.
+                            type: object
+                            properties:
+                              body:
+                                type: string
+                              code:
+                                type: integer
+                              type:
+                                type: string
+                      errorPages:
+                        type: array
+                        items:
+                          description: ErrorPage defines an ErrorPage in a Route.
+                          type: object
+                          properties:
+                            codes:
+                              type: array
+                              items:
+                                type: integer
+                            redirect:
+                              description: ErrorPageRedirect defines a redirect for an ErrorPage.
+                              type: object
+                              properties:
+                                code:
+                                  type: integer
+                                url:
+                                  type: string
+                            return:
+                              description: ErrorPageReturn defines a return for an ErrorPage.
+                              type: object
+                              properties:
+                                body:
+                                  type: string
+                                code:
+                                  type: integer
+                                headers:
+                                  type: array
+                                  items:
+                                    description: Header defines an HTTP Header.
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                type:
+                                  type: string
+                      location-snippets:
+                        type: string
+                      matches:
+                        type: array
+                        items:
+                          description: Match defines a match.
+                          type: object
+                          properties:
+                            action:
+                              description: Action defines an action.
+                              type: object
+                              properties:
+                                pass:
+                                  type: string
+                                proxy:
+                                  description: ActionProxy defines a proxy in an Action.
+                                  type: object
+                                  properties:
+                                    requestHeaders:
+                                      description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        pass:
+                                          type: boolean
+                                        set:
+                                          type: array
+                                          items:
+                                            description: Header defines an HTTP Header.
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                    responseHeaders:
+                                      description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        add:
+                                          type: array
+                                          items:
+                                            description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                            type: object
+                                            properties:
+                                              always:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                        hide:
+                                          type: array
+                                          items:
+                                            type: string
+                                        ignore:
+                                          type: array
+                                          items:
+                                            type: string
+                                        pass:
+                                          type: array
+                                          items:
+                                            type: string
+                                    rewritePath:
+                                      type: string
+                                    upstream:
+                                      type: string
+                                redirect:
+                                  description: ActionRedirect defines a redirect in an Action.
+                                  type: object
+                                  properties:
+                                    code:
+                                      type: integer
+                                    url:
+                                      type: string
+                                return:
+                                  description: ActionReturn defines a return in an Action.
+                                  type: object
+                                  properties:
+                                    body:
+                                      type: string
+                                    code:
+                                      type: integer
+                                    type:
+                                      type: string
+                            conditions:
+                              type: array
+                              items:
+                                description: Condition defines a condition in a MatchRule.
+                                type: object
+                                properties:
+                                  argument:
+                                    type: string
+                                  cookie:
+                                    type: string
+                                  header:
+                                    type: string
+                                  value:
+                                    type: string
+                                  variable:
+                                    type: string
+                            splits:
+                              type: array
+                              items:
+                                description: Split defines a split.
+                                type: object
+                                properties:
+                                  action:
+                                    description: Action defines an action.
+                                    type: object
+                                    properties:
+                                      pass:
+                                        type: string
+                                      proxy:
+                                        description: ActionProxy defines a proxy in an Action.
+                                        type: object
+                                        properties:
+                                          requestHeaders:
+                                            description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                            type: object
+                                            properties:
+                                              pass:
+                                                type: boolean
+                                              set:
+                                                type: array
+                                                items:
+                                                  description: Header defines an HTTP Header.
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                          responseHeaders:
+                                            description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                            type: object
+                                            properties:
+                                              add:
+                                                type: array
+                                                items:
+                                                  description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                                  type: object
+                                                  properties:
+                                                    always:
+                                                      type: boolean
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                              hide:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              ignore:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              pass:
+                                                type: array
+                                                items:
+                                                  type: string
+                                          rewritePath:
+                                            type: string
+                                          upstream:
+                                            type: string
+                                      redirect:
+                                        description: ActionRedirect defines a redirect in an Action.
+                                        type: object
+                                        properties:
+                                          code:
+                                            type: integer
+                                          url:
+                                            type: string
+                                      return:
+                                        description: ActionReturn defines a return in an Action.
+                                        type: object
+                                        properties:
+                                          body:
+                                            type: string
+                                          code:
+                                            type: integer
+                                          type:
+                                            type: string
+                                  weight:
+                                    type: integer
+                      path:
+                        type: string
+                      policies:
+                        type: array
+                        items:
+                          description: PolicyReference references a policy by name and an optional namespace.
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                      route:
+                        type: string
+                      splits:
+                        type: array
+                        items:
+                          description: Split defines a split.
+                          type: object
+                          properties:
+                            action:
+                              description: Action defines an action.
+                              type: object
+                              properties:
+                                pass:
+                                  type: string
+                                proxy:
+                                  description: ActionProxy defines a proxy in an Action.
+                                  type: object
+                                  properties:
+                                    requestHeaders:
+                                      description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        pass:
+                                          type: boolean
+                                        set:
+                                          type: array
+                                          items:
+                                            description: Header defines an HTTP Header.
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                    responseHeaders:
+                                      description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        add:
+                                          type: array
+                                          items:
+                                            description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                            type: object
+                                            properties:
+                                              always:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                        hide:
+                                          type: array
+                                          items:
+                                            type: string
+                                        ignore:
+                                          type: array
+                                          items:
+                                            type: string
+                                        pass:
+                                          type: array
+                                          items:
+                                            type: string
+                                    rewritePath:
+                                      type: string
+                                    upstream:
+                                      type: string
+                                redirect:
+                                  description: ActionRedirect defines a redirect in an Action.
+                                  type: object
+                                  properties:
+                                    code:
+                                      type: integer
+                                    url:
+                                      type: string
+                                return:
+                                  description: ActionReturn defines a return in an Action.
+                                  type: object
+                                  properties:
+                                    body:
+                                      type: string
+                                    code:
+                                      type: integer
+                                    type:
+                                      type: string
+                            weight:
+                              type: integer
+                upstreams:
+                  type: array
+                  items:
+                    description: Upstream defines an upstream.
+                    type: object
+                    properties:
+                      buffer-size:
+                        type: string
+                      buffering:
+                        type: boolean
+                      buffers:
+                        description: UpstreamBuffers defines Buffer Configuration for an Upstream.
+                        type: object
+                        properties:
+                          number:
+                            type: integer
+                          size:
+                            type: string
+                      client-max-body-size:
+                        type: string
+                      connect-timeout:
+                        type: string
+                      fail-timeout:
+                        type: string
+                      healthCheck:
+                        description: HealthCheck defines the parameters for active Upstream HealthChecks.
+                        type: object
+                        properties:
+                          connect-timeout:
+                            type: string
+                          enable:
+                            type: boolean
+                          fails:
+                            type: integer
+                          headers:
+                            type: array
+                            items:
+                              description: Header defines an HTTP Header.
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          interval:
+                            type: string
+                          jitter:
+                            type: string
+                          passes:
+                            type: integer
+                          path:
+                            type: string
+                          port:
+                            type: integer
+                          read-timeout:
+                            type: string
+                          send-timeout:
+                            type: string
+                          statusMatch:
+                            type: string
+                          tls:
+                            description: UpstreamTLS defines a TLS configuration for an Upstream.
+                            type: object
+                            properties:
+                              enable:
+                                type: boolean
+                      keepalive:
+                        type: integer
+                      lb-method:
+                        type: string
+                      max-conns:
+                        type: integer
+                      max-fails:
+                        type: integer
+                      name:
+                        type: string
+                      next-upstream:
+                        type: string
+                      next-upstream-timeout:
+                        type: string
+                      next-upstream-tries:
+                        type: integer
+                      port:
+                        type: integer
+                      queue:
+                        description: UpstreamQueue defines Queue Configuration for an Upstream.
+                        type: object
+                        properties:
+                          size:
+                            type: integer
+                          timeout:
+                            type: string
+                      read-timeout:
+                        type: string
+                      send-timeout:
+                        type: string
+                      service:
+                        type: string
+                      sessionCookie:
+                        description: SessionCookie defines the parameters for session persistence.
+                        type: object
+                        properties:
+                          domain:
+                            type: string
+                          enable:
+                            type: boolean
+                          expires:
+                            type: string
+                          httpOnly:
+                            type: boolean
+                          name:
+                            type: string
+                          path:
+                            type: string
+                          secure:
+                            type: boolean
+                      slow-start:
+                        type: string
+                      subselector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      tls:
+                        description: UpstreamTLS defines a TLS configuration for an Upstream.
+                        type: object
+                        properties:
+                          enable:
+                            type: boolean
+                      use-cluster-ip:
+                        type: boolean
+            status:
+              description: VirtualServerRouteStatus defines the status for the VirtualServerRoute resource.
+              type: object
+              properties:
+                externalEndpoints:
+                  type: array
+                  items:
+                    description: ExternalEndpoint defines the IP and ports used to connect to this resource.
+                    type: object
+                    properties:
+                      ip:
+                        type: string
+                      ports:
+                        type: string
+                message:
+                  type: string
+                reason:
+                  type: string
+                referencedBy:
+                  type: string
+                state:
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+# Source: crds/k8s.nginx.org_virtualservers.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: virtualservers.k8s.nginx.org
+spec:
+  group: k8s.nginx.org
+  names:
+    kind: VirtualServer
+    listKind: VirtualServerList
+    plural: virtualservers
+    shortNames:
+      - vs
+    singular: virtualserver
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Current state of the VirtualServer. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.host
+          name: Host
+          type: string
+        - jsonPath: .status.externalEndpoints[*].ip
+          name: IP
+          type: string
+        - jsonPath: .status.externalEndpoints[*].ports
+          name: Ports
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VirtualServer defines the VirtualServer resource.
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VirtualServerSpec is the spec of the VirtualServer resource.
+              type: object
+              properties:
+                host:
+                  type: string
+                http-snippets:
+                  type: string
+                ingressClassName:
+                  type: string
+                policies:
+                  type: array
+                  items:
+                    description: PolicyReference references a policy by name and an optional namespace.
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                routes:
+                  type: array
+                  items:
+                    description: Route defines a route.
+                    type: object
+                    properties:
+                      action:
+                        description: Action defines an action.
+                        type: object
+                        properties:
+                          pass:
+                            type: string
+                          proxy:
+                            description: ActionProxy defines a proxy in an Action.
+                            type: object
+                            properties:
+                              requestHeaders:
+                                description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                type: object
+                                properties:
+                                  pass:
+                                    type: boolean
+                                  set:
+                                    type: array
+                                    items:
+                                      description: Header defines an HTTP Header.
+                                      type: object
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                              responseHeaders:
+                                description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                type: object
+                                properties:
+                                  add:
+                                    type: array
+                                    items:
+                                      description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                      type: object
+                                      properties:
+                                        always:
+                                          type: boolean
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                  hide:
+                                    type: array
+                                    items:
+                                      type: string
+                                  ignore:
+                                    type: array
+                                    items:
+                                      type: string
+                                  pass:
+                                    type: array
+                                    items:
+                                      type: string
+                              rewritePath:
+                                type: string
+                              upstream:
+                                type: string
+                          redirect:
+                            description: ActionRedirect defines a redirect in an Action.
+                            type: object
+                            properties:
+                              code:
+                                type: integer
+                              url:
+                                type: string
+                          return:
+                            description: ActionReturn defines a return in an Action.
+                            type: object
+                            properties:
+                              body:
+                                type: string
+                              code:
+                                type: integer
+                              type:
+                                type: string
+                      errorPages:
+                        type: array
+                        items:
+                          description: ErrorPage defines an ErrorPage in a Route.
+                          type: object
+                          properties:
+                            codes:
+                              type: array
+                              items:
+                                type: integer
+                            redirect:
+                              description: ErrorPageRedirect defines a redirect for an ErrorPage.
+                              type: object
+                              properties:
+                                code:
+                                  type: integer
+                                url:
+                                  type: string
+                            return:
+                              description: ErrorPageReturn defines a return for an ErrorPage.
+                              type: object
+                              properties:
+                                body:
+                                  type: string
+                                code:
+                                  type: integer
+                                headers:
+                                  type: array
+                                  items:
+                                    description: Header defines an HTTP Header.
+                                    type: object
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                type:
+                                  type: string
+                      location-snippets:
+                        type: string
+                      matches:
+                        type: array
+                        items:
+                          description: Match defines a match.
+                          type: object
+                          properties:
+                            action:
+                              description: Action defines an action.
+                              type: object
+                              properties:
+                                pass:
+                                  type: string
+                                proxy:
+                                  description: ActionProxy defines a proxy in an Action.
+                                  type: object
+                                  properties:
+                                    requestHeaders:
+                                      description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        pass:
+                                          type: boolean
+                                        set:
+                                          type: array
+                                          items:
+                                            description: Header defines an HTTP Header.
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                    responseHeaders:
+                                      description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        add:
+                                          type: array
+                                          items:
+                                            description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                            type: object
+                                            properties:
+                                              always:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                        hide:
+                                          type: array
+                                          items:
+                                            type: string
+                                        ignore:
+                                          type: array
+                                          items:
+                                            type: string
+                                        pass:
+                                          type: array
+                                          items:
+                                            type: string
+                                    rewritePath:
+                                      type: string
+                                    upstream:
+                                      type: string
+                                redirect:
+                                  description: ActionRedirect defines a redirect in an Action.
+                                  type: object
+                                  properties:
+                                    code:
+                                      type: integer
+                                    url:
+                                      type: string
+                                return:
+                                  description: ActionReturn defines a return in an Action.
+                                  type: object
+                                  properties:
+                                    body:
+                                      type: string
+                                    code:
+                                      type: integer
+                                    type:
+                                      type: string
+                            conditions:
+                              type: array
+                              items:
+                                description: Condition defines a condition in a MatchRule.
+                                type: object
+                                properties:
+                                  argument:
+                                    type: string
+                                  cookie:
+                                    type: string
+                                  header:
+                                    type: string
+                                  value:
+                                    type: string
+                                  variable:
+                                    type: string
+                            splits:
+                              type: array
+                              items:
+                                description: Split defines a split.
+                                type: object
+                                properties:
+                                  action:
+                                    description: Action defines an action.
+                                    type: object
+                                    properties:
+                                      pass:
+                                        type: string
+                                      proxy:
+                                        description: ActionProxy defines a proxy in an Action.
+                                        type: object
+                                        properties:
+                                          requestHeaders:
+                                            description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                            type: object
+                                            properties:
+                                              pass:
+                                                type: boolean
+                                              set:
+                                                type: array
+                                                items:
+                                                  description: Header defines an HTTP Header.
+                                                  type: object
+                                                  properties:
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                          responseHeaders:
+                                            description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                            type: object
+                                            properties:
+                                              add:
+                                                type: array
+                                                items:
+                                                  description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                                  type: object
+                                                  properties:
+                                                    always:
+                                                      type: boolean
+                                                    name:
+                                                      type: string
+                                                    value:
+                                                      type: string
+                                              hide:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              ignore:
+                                                type: array
+                                                items:
+                                                  type: string
+                                              pass:
+                                                type: array
+                                                items:
+                                                  type: string
+                                          rewritePath:
+                                            type: string
+                                          upstream:
+                                            type: string
+                                      redirect:
+                                        description: ActionRedirect defines a redirect in an Action.
+                                        type: object
+                                        properties:
+                                          code:
+                                            type: integer
+                                          url:
+                                            type: string
+                                      return:
+                                        description: ActionReturn defines a return in an Action.
+                                        type: object
+                                        properties:
+                                          body:
+                                            type: string
+                                          code:
+                                            type: integer
+                                          type:
+                                            type: string
+                                  weight:
+                                    type: integer
+                      path:
+                        type: string
+                      policies:
+                        type: array
+                        items:
+                          description: PolicyReference references a policy by name and an optional namespace.
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                      route:
+                        type: string
+                      splits:
+                        type: array
+                        items:
+                          description: Split defines a split.
+                          type: object
+                          properties:
+                            action:
+                              description: Action defines an action.
+                              type: object
+                              properties:
+                                pass:
+                                  type: string
+                                proxy:
+                                  description: ActionProxy defines a proxy in an Action.
+                                  type: object
+                                  properties:
+                                    requestHeaders:
+                                      description: ProxyRequestHeaders defines the request headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        pass:
+                                          type: boolean
+                                        set:
+                                          type: array
+                                          items:
+                                            description: Header defines an HTTP Header.
+                                            type: object
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                    responseHeaders:
+                                      description: ProxyResponseHeaders defines the response headers manipulation in an ActionProxy.
+                                      type: object
+                                      properties:
+                                        add:
+                                          type: array
+                                          items:
+                                            description: AddHeader defines an HTTP Header with an optional Always field to use with the add_header NGINX directive.
+                                            type: object
+                                            properties:
+                                              always:
+                                                type: boolean
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                        hide:
+                                          type: array
+                                          items:
+                                            type: string
+                                        ignore:
+                                          type: array
+                                          items:
+                                            type: string
+                                        pass:
+                                          type: array
+                                          items:
+                                            type: string
+                                    rewritePath:
+                                      type: string
+                                    upstream:
+                                      type: string
+                                redirect:
+                                  description: ActionRedirect defines a redirect in an Action.
+                                  type: object
+                                  properties:
+                                    code:
+                                      type: integer
+                                    url:
+                                      type: string
+                                return:
+                                  description: ActionReturn defines a return in an Action.
+                                  type: object
+                                  properties:
+                                    body:
+                                      type: string
+                                    code:
+                                      type: integer
+                                    type:
+                                      type: string
+                            weight:
+                              type: integer
+                server-snippets:
+                  type: string
+                tls:
+                  description: TLS defines TLS configuration for a VirtualServer.
+                  type: object
+                  properties:
+                    redirect:
+                      description: TLSRedirect defines a redirect for a TLS.
+                      type: object
+                      properties:
+                        basedOn:
+                          type: string
+                        code:
+                          type: integer
+                        enable:
+                          type: boolean
+                    secret:
+                      type: string
+                upstreams:
+                  type: array
+                  items:
+                    description: Upstream defines an upstream.
+                    type: object
+                    properties:
+                      buffer-size:
+                        type: string
+                      buffering:
+                        type: boolean
+                      buffers:
+                        description: UpstreamBuffers defines Buffer Configuration for an Upstream.
+                        type: object
+                        properties:
+                          number:
+                            type: integer
+                          size:
+                            type: string
+                      client-max-body-size:
+                        type: string
+                      connect-timeout:
+                        type: string
+                      fail-timeout:
+                        type: string
+                      healthCheck:
+                        description: HealthCheck defines the parameters for active Upstream HealthChecks.
+                        type: object
+                        properties:
+                          connect-timeout:
+                            type: string
+                          enable:
+                            type: boolean
+                          fails:
+                            type: integer
+                          headers:
+                            type: array
+                            items:
+                              description: Header defines an HTTP Header.
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          interval:
+                            type: string
+                          jitter:
+                            type: string
+                          passes:
+                            type: integer
+                          path:
+                            type: string
+                          port:
+                            type: integer
+                          read-timeout:
+                            type: string
+                          send-timeout:
+                            type: string
+                          statusMatch:
+                            type: string
+                          tls:
+                            description: UpstreamTLS defines a TLS configuration for an Upstream.
+                            type: object
+                            properties:
+                              enable:
+                                type: boolean
+                      keepalive:
+                        type: integer
+                      lb-method:
+                        type: string
+                      max-conns:
+                        type: integer
+                      max-fails:
+                        type: integer
+                      name:
+                        type: string
+                      next-upstream:
+                        type: string
+                      next-upstream-timeout:
+                        type: string
+                      next-upstream-tries:
+                        type: integer
+                      port:
+                        type: integer
+                      queue:
+                        description: UpstreamQueue defines Queue Configuration for an Upstream.
+                        type: object
+                        properties:
+                          size:
+                            type: integer
+                          timeout:
+                            type: string
+                      read-timeout:
+                        type: string
+                      send-timeout:
+                        type: string
+                      service:
+                        type: string
+                      sessionCookie:
+                        description: SessionCookie defines the parameters for session persistence.
+                        type: object
+                        properties:
+                          domain:
+                            type: string
+                          enable:
+                            type: boolean
+                          expires:
+                            type: string
+                          httpOnly:
+                            type: boolean
+                          name:
+                            type: string
+                          path:
+                            type: string
+                          secure:
+                            type: boolean
+                      slow-start:
+                        type: string
+                      subselector:
+                        type: object
+                        additionalProperties:
+                          type: string
+                      tls:
+                        description: UpstreamTLS defines a TLS configuration for an Upstream.
+                        type: object
+                        properties:
+                          enable:
+                            type: boolean
+                      use-cluster-ip:
+                        type: boolean
+            status:
+              description: VirtualServerStatus defines the status for the VirtualServer resource.
+              type: object
+              properties:
+                externalEndpoints:
+                  type: array
+                  items:
+                    description: ExternalEndpoint defines the IP and ports used to connect to this resource.
+                    type: object
+                    properties:
+                      ip:
+                        type: string
+                      ports:
+                        type: string
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+# Source: nginx-ingress/templates/controller-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-controller-nginx-ingress
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+---
+# Source: nginx-ingress/templates/controller-secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nginx-ingress-controller-nginx-ingress-default-server-tls
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+type: kubernetes.io/tls
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN2akNDQWFZQ0NRREFPRjl0THNhWFhEQU5CZ2txaGtpRzl3MEJBUXNGQURBaE1SOHdIUVlEVlFRRERCWk8KUjBsT1dFbHVaM0psYzNORGIyNTBjbTlzYkdWeU1CNFhEVEU0TURreE1qRTRNRE16TlZvWERUSXpNRGt4TVRFNApNRE16TlZvd0lURWZNQjBHQTFVRUF3d1dUa2RKVGxoSmJtZHlaWE56UTI5dWRISnZiR3hsY2pDQ0FTSXdEUVlKCktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUwvN2hIUEtFWGRMdjNyaUM3QlBrMTNpWkt5eTlyQ08KR2xZUXYyK2EzUDF0azIrS3YwVGF5aGRCbDRrcnNUcTZzZm8vWUk1Y2Vhbkw4WGM3U1pyQkVRYm9EN2REbWs1Qgo4eDZLS2xHWU5IWlg0Rm5UZ0VPaStlM2ptTFFxRlBSY1kzVnNPazFFeUZBL0JnWlJVbkNHZUtGeERSN0tQdGhyCmtqSXVuektURXUyaDU4Tlp0S21ScUJHdDEwcTNRYzhZT3ExM2FnbmovUWRjc0ZYYTJnMjB1K1lYZDdoZ3krZksKWk4vVUkxQUQ0YzZyM1lma1ZWUmVHd1lxQVp1WXN2V0RKbW1GNWRwdEMzN011cDBPRUxVTExSakZJOTZXNXIwSAo1TmdPc25NWFJNV1hYVlpiNWRxT3R0SmRtS3FhZ25TZ1JQQVpQN2MwQjFQU2FqYzZjNGZRVXpNQ0F3RUFBVEFOCkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWpLb2tRdGRPcEsrTzhibWVPc3lySmdJSXJycVFVY2ZOUitjb0hZVUoKdGhrYnhITFMzR3VBTWI5dm15VExPY2xxeC9aYzJPblEwMEJCLzlTb0swcitFZ1U2UlVrRWtWcitTTFA3NTdUWgozZWI4dmdPdEduMS9ienM3bzNBaS9kclkrcUI5Q2k1S3lPc3FHTG1US2xFaUtOYkcyR1ZyTWxjS0ZYQU80YTY3Cklnc1hzYktNbTQwV1U3cG9mcGltU1ZmaXFSdkV5YmN3N0NYODF6cFErUyt1eHRYK2VBZ3V0NHh3VlI5d2IyVXYKelhuZk9HbWhWNThDd1dIQnNKa0kxNXhaa2VUWXdSN0diaEFMSkZUUkk3dkhvQXprTWIzbjAxQjQyWjNrN3RXNQpJUDFmTlpIOFUvOWxiUHNoT21FRFZkdjF5ZytVRVJxbStGSis2R0oxeFJGcGZnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBdi91RWM4b1JkMHUvZXVJTHNFK1RYZUprckxMMnNJNGFWaEMvYjVyYy9XMlRiNHEvClJOcktGMEdYaVN1eE9ycXgrajlnamx4NXFjdnhkenRKbXNFUkJ1Z1B0ME9hVGtIekhvb3FVWmcwZGxmZ1dkT0EKUTZMNTdlT1l0Q29VOUZ4amRXdzZUVVRJVUQ4R0JsRlNjSVo0b1hFTkhzbysyR3VTTWk2Zk1wTVM3YUhudzFtMApxWkdvRWEzWFNyZEJ6eGc2clhkcUNlUDlCMXl3VmRyYURiUzc1aGQzdUdETDU4cGszOVFqVUFQaHpxdmRoK1JWClZGNGJCaW9CbTVpeTlZTW1hWVhsMm0wTGZzeTZuUTRRdFFzdEdNVWozcGJtdlFmazJBNnljeGRFeFpkZFZsdmwKMm82MjBsMllxcHFDZEtCRThCay90elFIVTlKcU56cHpoOUJUTXdJREFRQUJBb0lCQVFDZklHbXowOHhRVmorNwpLZnZJUXQwQ0YzR2MxNld6eDhVNml4MHg4Mm15d1kxUUNlL3BzWE9LZlRxT1h1SENyUlp5TnUvZ2IvUUQ4bUFOCmxOMjRZTWl0TWRJODg5TEZoTkp3QU5OODJDeTczckM5bzVvUDlkazAvYzRIbjAzSkVYNzZ5QjgzQm9rR1FvYksKMjhMNk0rdHUzUmFqNjd6Vmc2d2szaEhrU0pXSzBwV1YrSjdrUkRWYmhDYUZhNk5nMUZNRWxhTlozVDhhUUtyQgpDUDNDeEFTdjYxWTk5TEI4KzNXWVFIK3NYaTVGM01pYVNBZ1BkQUk3WEh1dXFET1lvMU5PL0JoSGt1aVg2QnRtCnorNTZud2pZMy8yUytSRmNBc3JMTnIwMDJZZi9oY0IraVlDNzVWYmcydVd6WTY3TWdOTGQ5VW9RU3BDRkYrVm4KM0cyUnhybnhBb0dCQU40U3M0ZVlPU2huMVpQQjdhTUZsY0k2RHR2S2ErTGZTTXFyY2pOZjJlSEpZNnhubmxKdgpGenpGL2RiVWVTbWxSekR0WkdlcXZXaHFISy9iTjIyeWJhOU1WMDlRQ0JFTk5jNmtWajJTVHpUWkJVbEx4QzYrCk93Z0wyZHhKendWelU0VC84ajdHalRUN05BZVpFS2FvRHFyRG5BYWkyaW5oZU1JVWZHRXFGKzJyQW9HQkFOMVAKK0tZL0lsS3RWRzRKSklQNzBjUis3RmpyeXJpY05iWCtQVzUvOXFHaWxnY2grZ3l4b25BWlBpd2NpeDN3QVpGdwpaZC96ZFB2aTBkWEppc1BSZjRMazg5b2pCUmpiRmRmc2l5UmJYbyt3TFU4NUhRU2NGMnN5aUFPaTVBRHdVU0FkCm45YWFweUNweEFkREtERHdObit3ZFhtaTZ0OHRpSFRkK3RoVDhkaVpBb0dCQUt6Wis1bG9OOTBtYlF4VVh5YUwKMjFSUm9tMGJjcndsTmVCaWNFSmlzaEhYa2xpSVVxZ3hSZklNM2hhUVRUcklKZENFaHFsV01aV0xPb2I2NTNyZgo3aFlMSXM1ZUtka3o0aFRVdnpldm9TMHVXcm9CV2xOVHlGanIrSWhKZnZUc0hpOGdsU3FkbXgySkJhZUFVWUNXCndNdlQ4NmNLclNyNkQrZG8wS05FZzFsL0FvR0FlMkFVdHVFbFNqLzBmRzgrV3hHc1RFV1JqclRNUzRSUjhRWXQKeXdjdFA4aDZxTGxKUTRCWGxQU05rMXZLTmtOUkxIb2pZT2pCQTViYjhibXNVU1BlV09NNENoaFJ4QnlHbmR2eAphYkJDRkFwY0IvbEg4d1R0alVZYlN5T294ZGt5OEp0ek90ajJhS0FiZHd6NlArWDZDODhjZmxYVFo5MWpYL3RMCjF3TmRKS2tDZ1lCbyt0UzB5TzJ2SWFmK2UwSkN5TGhzVDQ5cTN3Zis2QWVqWGx2WDJ1VnRYejN5QTZnbXo5aCsKcDNlK2JMRUxwb3B0WFhNdUFRR0xhUkcrYlNNcjR5dERYbE5ZSndUeThXczNKY3dlSTdqZVp2b0ZpbmNvVlVIMwphdmxoTUVCRGYxSjltSDB5cDBwWUNaS2ROdHNvZEZtQktzVEtQMjJhTmtsVVhCS3gyZzR6cFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
+---
+# Source: nginx-ingress/templates/controller-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-ingress-controller-nginx-ingress
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+data:
+---
+# Source: nginx-ingress/templates/controller-leader-election-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-ingress-controller-nginx-ingress-leader-election
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+---
+# Source: nginx-ingress/templates/rbac.yaml
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nginx-ingress-controller-nginx-ingress
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - k8s.nginx.org
+  resources:
+  - virtualservers
+  - virtualserverroutes
+  - globalconfigurations
+  - transportservers
+  - policies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - k8s.nginx.org
+  resources:
+  - virtualservers/status
+  - virtualserverroutes/status
+  - policies/status
+  - transportservers/status
+  verbs:
+  - update
+---
+# Source: nginx-ingress/templates/rbac.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nginx-ingress-controller-nginx-ingress
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: nginx-ingress-controller-nginx-ingress
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: nginx-ingress-controller-nginx-ingress
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: nginx-ingress/templates/controller-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-ingress-controller-nginx-ingress
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+spec:
+  externalTrafficPolicy: Local
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+    nodePort: 30080
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: https
+    nodePort: 30443
+  selector:
+    app:  nginx-ingress-controller-nginx-ingress
+---
+# Source: nginx-ingress/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller-nginx-ingress
+  namespace: default
+  labels:
+    app.kubernetes.io/name: nginx-ingress-controller-nginx-ingress
+    helm.sh/chart: nginx-ingress-0.9.3
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: nginx-ingress-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-ingress-controller-nginx-ingress
+  template:
+    metadata:
+      labels:
+        app: nginx-ingress-controller-nginx-ingress
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+    spec:
+      serviceAccountName: nginx-ingress-controller-nginx-ingress
+      hostNetwork: false
+      containers:
+      - image: "nginx/nginx-ingress:1.11.3"
+        name: nginx-ingress-controller-nginx-ingress
+        imagePullPolicy: "IfNotPresent"
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+
+        - name: prometheus
+          containerPort: 9113
+        - name: readiness-port
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /nginx-ready
+            port: readiness-port
+          periodSeconds: 1
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: true
+          runAsUser: 101 #nginx
+          capabilities:
+            drop:
+            - ALL
+            add:
+            - NET_BIND_SERVICE
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        args:
+          - -nginx-plus=false
+          - -nginx-reload-timeout=0
+          - -enable-app-protect=false
+          - -nginx-configmaps=$(POD_NAMESPACE)/nginx-ingress-controller-nginx-ingress
+          - -default-server-tls-secret=$(POD_NAMESPACE)/nginx-ingress-controller-nginx-ingress-default-server-tls
+          - -ingress-class=nginx
+          - -health-status=false
+          - -health-status-uri=/nginx-health
+          - -nginx-debug=false
+          - -v=1
+          - -nginx-status=true
+          - -nginx-status-port=8080
+          - -nginx-status-allow-cidrs=127.0.0.1
+          - -report-ingress-status
+          - -external-service=nginx-ingress-controller-nginx-ingress
+          - -enable-leader-election=true
+          - -leader-election-lock-name=nginx-ingress-controller-nginx-ingress-leader-election
+          - -enable-prometheus-metrics=true
+          - -prometheus-metrics-listen-port=9113
+          - -enable-custom-resources=true
+          - -enable-tls-passthrough=false
+          - -enable-snippets=false
+          - -enable-preview-policies=false
+          - -ready-status=true
+          - -ready-status-port=8081
+          - -enable-latency-metrics=false
+---
+# Source: nginx-ingress/templates/controller-ingress-class.yaml
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: nginx
+spec:
+  controller: nginx.org/ingress-controller


### PR DESCRIPTION
Required for accessing services in the prow-workloads cluster. 

The manifests come from upstream verbatim except for a change in the service type, from `LoadBalancer` to `NodePort` (with 30080 and 30443 as the `nodePorts` for HTTP and HTTPS respectively). This is needed for being able to receive incoming requests in the self-managed cluster.

/cc @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>