### PR TITLE
Add kubevirt e2e presubmit requirer

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -548,7 +548,7 @@ periodics:
       repo: project-infra
       base_ref: master
       workdir: true
-  cluster: phx-prow
+  cluster: prow-workloads
   spec:
     securityContext:
       runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -534,3 +534,44 @@ periodics:
     - name: token
       secret:
         secretName: oauth-token
+- name: periodic-kubevirt-presubmit-requirer
+  cron: "0 1 1 * *"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+    - org: kubevirt
+      repo: project-infra
+      base_ref: master
+      workdir: true
+  cluster: phx-prow
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+        env:
+          - name: GIT_ASKPASS
+            value: ../project-infra/hack/git-askpass.sh
+        command: [ "/bin/sh" , "-c" ]
+        args:
+          - |
+            bazel_dir=$(mktemp -d) &&
+            curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
+            chmod a+x ${bazel_dir}/bazelisk &&
+            export PATH=${PATH}:${bazel_dir} &&
+            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirt-presubmit-requirer:kubevirt-presubmit-requirer -- -job-config-path-kubevirt-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml -github-token-path= -dry-run=false" -r project-infra -b require-kubevirt-presubmits
+        volumeMounts:
+          - name: token
+            mountPath: /etc/github
+        resources:
+          requests:
+            memory: "200Mi"
+    volumes:
+      - name: token
+        secret:
+          secretName: oauth-token

--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -120,11 +120,14 @@ git commit -s -m "${summary}"
 git push -f "https://${user}@github.com/${user}/${repo}.git" HEAD:"${branch}"
 
 echo "Creating PR to merge ${user}:${branch} into master..." >&2
+# TODO: fix the truncation of the summary in pr-creator
+# this is currently required as the search for existing PRs fails if the summary is too long due to
+# GitHub search being limited to 250 characters
 pr-creator \
     --github-token-path="${token}" \
     --org="${org}" --repo="${repo}" --branch="${targetbranch}" \
-    --title="${summary}" --match-title="${summary}" \
-    --body="Automatic run of \"$command\". Please review" \
+    --title="${summary}" --match-title="$(echo $summary | cut -c -150)" \
+    --body="Automatic run of \"${command}\". Please review" \
     --source="${user}":"${branch}" \
     --labels="${labels}" \
     --confirm

--- a/robots/cmd/kubevirt-presubmit-requirer/BUILD.bazel
+++ b/robots/cmd/kubevirt-presubmit-requirer/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/robots/cmd/kubevirt-presubmit-requirer",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+        "@io_k8s_test_infra//prow/apis/prowjobs/v1:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "kubevirt-presubmit-requirer",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+    ],
+)

--- a/robots/cmd/kubevirt-presubmit-requirer/main.go
+++ b/robots/cmd/kubevirt-presubmit-requirer/main.go
@@ -29,7 +29,7 @@ import (
 	"kubevirt.io/project-infra/robots/pkg/querier"
 )
 
-const OrgAndRepoForJobConfig = "kubevirt/kubevirt"
+const orgAndRepoForJobConfig = "kubevirt/kubevirt"
 
 type options struct {
 	port int
@@ -148,8 +148,8 @@ func UpdatePresubmitsAlwaysRunAndOptionalFields(jobConfig *config.JobConfig, lat
 		createPresubmitJobName(latestReleaseSemver, "operator"): "",
 	}
 
-	for index := range jobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] {
-		job := &jobConfig.PresubmitsStatic[OrgAndRepoForJobConfig][index]
+	for index := range jobConfig.PresubmitsStatic[orgAndRepoForJobConfig] {
+		job := &jobConfig.PresubmitsStatic[orgAndRepoForJobConfig][index]
 		name := job.Name
 		if _, exists := jobsToCheck[name]; !exists {
 			continue

--- a/robots/cmd/kubevirt-presubmit-requirer/main.go
+++ b/robots/cmd/kubevirt-presubmit-requirer/main.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2021 The KubeVirt Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+
+	"kubevirt.io/project-infra/robots/pkg/querier"
+)
+
+const OrgAndRepoForJobConfig = "kubevirt/kubevirt"
+
+type options struct {
+	port int
+
+	dryRun bool
+
+	TokenPath                      string
+	endpoint                       string
+	jobConfigPathKubevirtPresubmit string
+}
+
+func (o *options) Validate() error {
+	if _, err := os.Stat(o.jobConfigPathKubevirtPresubmit); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPresubmit is required: %v", err)
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether the file should get modified or just modifications printed to stdout.")
+	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
+	fs.StringVar(&o.jobConfigPathKubevirtPresubmit, "job-config-path-kubevirt-presubmit", "", "The directory of the kubevirt presubmit job definitions")
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to parse args: %v", err))
+		os.Exit(1)
+	}
+	return o
+}
+
+func main() {
+
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.DebugLevel)
+	log := logrus.StandardLogger().WithField("robot", "kubevirt-presubmit-requirer")
+
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		log.WithError(err).Error("Invalid arguments provided.")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	var client *github.Client
+	if o.TokenPath == "" {
+		var err error
+		client, err = github.NewEnterpriseClient(o.endpoint, o.endpoint, nil)
+		if err != nil {
+			log.Panicln(err)
+		}
+	} else {
+		token, err := ioutil.ReadFile(o.TokenPath)
+		if err != nil {
+			log.Panicln(err)
+		}
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: string(token)},
+		)
+		client, err = github.NewEnterpriseClient(o.endpoint, o.endpoint, oauth2.NewClient(ctx, ts))
+		if err != nil {
+			log.Panicln(err)
+		}
+	}
+
+	jobConfig, err := config.ReadJobConfig(o.jobConfigPathKubevirtPresubmit)
+	if err != nil {
+		log.Panicln(err)
+	}
+
+	releases, _, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
+	if err != nil {
+		log.Panicln(err)
+	}
+	releases = querier.ValidReleases(releases)
+	if len(releases) == 0 {
+		log.Info("No release found, nothing to do.")
+		os.Exit(0)
+	}
+
+	latestReleaseSemver := querier.ParseRelease(releases[0])
+
+	updated := UpdatePresubmitsAlwaysRunAndOptionalFields(&jobConfig, latestReleaseSemver)
+	if !updated && !o.dryRun {
+		log.Info(fmt.Sprintf("presubmit jobs for %v weren't modified, nothing to do.", latestReleaseSemver))
+		os.Exit(0)
+	}
+
+	marshalledConfig, err := yaml.Marshal(&jobConfig)
+	if err != nil {
+		log.WithError(err).Error("Failed to marshall jobconfig")
+	}
+
+	if o.dryRun {
+		_, err = os.Stdout.Write(marshalledConfig)
+		if err != nil {
+			log.WithError(err).Error("Failed to write jobconfig")
+		}
+		os.Exit(0)
+	}
+
+	err = ioutil.WriteFile(o.jobConfigPathKubevirtPresubmit, marshalledConfig, os.ModePerm)
+	if err != nil {
+		log.WithError(err).Error("Failed to write jobconfig")
+	}
+}
+
+func UpdatePresubmitsAlwaysRunAndOptionalFields(jobConfig *config.JobConfig, latestReleaseSemver *querier.SemVer) (updated bool) {
+	jobsToCheck := map[string]string{
+		createPresubmitJobName(latestReleaseSemver, "sig-network"): "",
+		createPresubmitJobName(latestReleaseSemver, "sig-storage"): "",
+		createPresubmitJobName(latestReleaseSemver, "sig-compute"): "",
+		createPresubmitJobName(latestReleaseSemver, "operator"): "",
+	}
+
+	for index := range jobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] {
+		job := &jobConfig.PresubmitsStatic[OrgAndRepoForJobConfig][index]
+		name := job.Name
+		if _, exists := jobsToCheck[name]; !exists {
+			continue
+		}
+
+		// phase 1: always_run: false -> true
+		if !job.AlwaysRun {
+			job.AlwaysRun = true
+			updated = true
+
+			// -- fix skip_report: true -> false
+			job.SkipReport = false
+
+			continue
+		}
+
+		// phase 2: optional: true -> false
+		if job.Optional {
+			job.Optional = false
+			updated = true
+		}
+
+	}
+
+	return
+}
+
+func createPresubmitJobName(latestReleaseSemver *querier.SemVer, sigName string) string {
+	return fmt.Sprintf("pull-kubevirt-e2e-k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
+}

--- a/robots/cmd/kubevirt-presubmit-requirer/main_test.go
+++ b/robots/cmd/kubevirt-presubmit-requirer/main_test.go
@@ -23,14 +23,14 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			args: args{
 				jobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
-						OrgAndRepoForJobConfig: {},
+						orgAndRepoForJobConfig: {},
 					},
 				},
 				latestReleaseSemver: newMinorSemver("1", "37"),
 			},
 			wantNewJobConfig: config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
-					OrgAndRepoForJobConfig: {},
+					orgAndRepoForJobConfig: {},
 				},
 			},
 			wantUpdated: false,
@@ -40,7 +40,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			args: args{
 				jobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
-						OrgAndRepoForJobConfig: {
+						orgAndRepoForJobConfig: {
 							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", false, true, true),
 						},
 					},
@@ -49,7 +49,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			},
 			wantNewJobConfig: config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
-					OrgAndRepoForJobConfig: {
+					orgAndRepoForJobConfig: {
 						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", false, true, true),
 					},
 				},
@@ -61,7 +61,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			args: args{
 				jobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
-						OrgAndRepoForJobConfig: {
+						orgAndRepoForJobConfig: {
 							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-other", false, true, true),
 						},
 					},
@@ -70,7 +70,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			},
 			wantNewJobConfig: config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
-					OrgAndRepoForJobConfig: {
+					orgAndRepoForJobConfig: {
 						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-other", false, true, true),
 					},
 				},
@@ -82,7 +82,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			args: args{
 				jobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
-						OrgAndRepoForJobConfig: {
+						orgAndRepoForJobConfig: {
 							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", false, true, true),
 						},
 					},
@@ -91,7 +91,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			},
 			wantNewJobConfig: config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
-					OrgAndRepoForJobConfig: {
+					orgAndRepoForJobConfig: {
 						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, true, false),
 					},
 				},
@@ -103,7 +103,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			args: args{
 				jobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
-						OrgAndRepoForJobConfig: {
+						orgAndRepoForJobConfig: {
 							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, true, false),
 						},
 					},
@@ -112,7 +112,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			},
 			wantNewJobConfig: config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
-					OrgAndRepoForJobConfig: {
+					orgAndRepoForJobConfig: {
 						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false),
 					},
 				},
@@ -124,7 +124,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			args: args{
 				jobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
-						OrgAndRepoForJobConfig: {
+						orgAndRepoForJobConfig: {
 							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false),
 						},
 					},
@@ -133,7 +133,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 			},
 			wantNewJobConfig: config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
-					OrgAndRepoForJobConfig: {
+					orgAndRepoForJobConfig: {
 						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false),
 					},
 				},

--- a/robots/cmd/kubevirt-presubmit-requirer/main_test.go
+++ b/robots/cmd/kubevirt-presubmit-requirer/main_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"k8s.io/test-infra/prow/config"
+	"kubevirt.io/project-infra/robots/pkg/querier"
+	"reflect"
+	"testing"
+)
+
+func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
+	type args struct {
+		jobConfig           config.JobConfig
+		latestReleaseSemver *querier.SemVer
+	}
+	tests := []struct {
+		name             string
+		args             args
+		wantNewJobConfig config.JobConfig
+		wantUpdated    	 bool
+	}{
+		{
+			name: "no job exists",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {},
+				},
+			},
+			wantUpdated: false,
+		},
+		{
+			name: "different k8s release job exists",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", false, true, true),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "42"),
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", false, true, true),
+					},
+				},
+			},
+			wantUpdated: false,
+		},
+		{
+			name: "different sig job exists",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-other", false, true, true),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-other", false, true, true),
+					},
+				},
+			},
+			wantUpdated: false,
+		},
+		{
+			name: "sig-network job exists, always_run = false",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", false, true, true),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, true, false),
+					},
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "sig-network job exists, always_run = true",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, true, false),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false),
+					},
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "sig-network job exists, always_run = true, optional = false",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false),
+					},
+				},
+			},
+			wantUpdated: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updated := UpdatePresubmitsAlwaysRunAndOptionalFields(&tt.args.jobConfig, tt.args.latestReleaseSemver)
+			if updated != tt.wantUpdated {
+				t.Errorf("UpdatePresubmitsAlwaysRunAndOptionalFields() updated = %v, want %v", updated, tt.wantUpdated)
+			}
+			if !reflect.DeepEqual(tt.args.jobConfig, tt.wantNewJobConfig) {
+				presubmit := tt.args.jobConfig.PresubmitsStatic["kubevirt/kubevirt"][0]
+				t.Errorf("UpdatePresubmitsAlwaysRunAndOptionalFields() tt.args.jobConfig = %v, want %v\n\tAlwaysRun: %v, Optional: %v, SkipReport: %v, ", tt.args.jobConfig, tt.wantNewJobConfig, presubmit.AlwaysRun, presubmit.Optional, presubmit.SkipReport)
+			}
+		})
+	}
+}
+
+func newMinorSemver(major, minor string) *querier.SemVer {
+	return &querier.SemVer{
+		Major: major,
+		Minor: minor,
+		Patch: "0",
+	}
+}
+
+func createPresubmitJobForRelease(semver *querier.SemVer, sigName string, alwaysRun, optional, skipReport bool) config.Presubmit {
+	res := config.Presubmit{
+		AlwaysRun: alwaysRun,
+		Optional:  optional,
+		JobBase: config.JobBase{
+			Name:           createPresubmitJobName(semver, sigName),
+		},
+		Reporter: config.Reporter{
+			SkipReport: skipReport,
+		},
+	}
+	return res
+}


### PR DESCRIPTION
Adds a job that converges the kubevirt e2e lanes for latest
provider into being required for merge.

Phase 1: make the lane run always (fix skip_report: false to make it
report)
Phase 2: make the lane required (by setting optional to false)

The job runs at the 1st of every month. This should have the
effect of making the new lanes run always after around three weeks
and be required after two months (in case the PRs get merged in
time).

Example of the file changes here (**Note: you need to load the diff manually, as the serialization has reordered the fields**): https://github.com/kubevirt/project-infra/pull/1297/files#diff-26f7cd0389085c1da47f919a02c4dbeca5ddd96ca00d8e49c0862f698475aaf9R3

Signed-off-by: Daniel Hiller <dhiller@redhat.com>