### PR TITLE
Set pushgateway resources

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -68,6 +68,12 @@ patches:
       name: ghproxy
     path: patches/JsonRFC6902/ghproxy_deployment.yaml
   - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: pushgateway
+    path: patches/JsonRFC6902/pushgateway_deployment.yaml
+  - target:
       group: rbac.authorization.k8s.io
       version: v1
       kind: Role

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/pushgateway_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/pushgateway_deployment.yaml
@@ -1,0 +1,10 @@
+# sets resources
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 1000m
+      memory: 1Gi


### PR DESCRIPTION
We were losing some prow-related metrics during periods of high load, pushwateway was requesting more CPU than available and was evicted in some cases.

These changes set resources for pushgateway above the highest usage it had during the last 2 days https://grafana.ci.kubevirt.io/d/GlXkUBGiz/kubernetes-pod-overview?orgId=1&refresh=10s&var-namespace=kubevirt-prow&var-pod=pushgateway-64f6547bb7-gx9tv&var-container=All&from=now-2d&to=now It also fixes the QoS to Guaranteed (same memory and CPU requests and limits) to mitigate further issues.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>