### PR TITLE
Enable reporting for kubevirt release jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -7,7 +7,7 @@ postsubmits:
     cluster: ibm-prow-jobs
     always_run: true
     optional: false
-    skip_report: true
+    skip_report: false
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
@@ -68,7 +68,7 @@ postsubmits:
     cluster: ibm-prow-jobs
     always_run: true
     optional: false
-    skip_report: true
+    skip_report: false
     annotations:
       testgrid-create-test-group: "false"
     decorate: true


### PR DESCRIPTION
The jobs skipped reporting to the configured channels, so we missed notifications about their failures.

/cc @davidvossel @rmohr @fgimenez 