### PR TITLE
Bump builder image in kubevirtci bump job for new pr-creator

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -97,7 +97,7 @@ periodics:
       secret:
         secretName: gcs
     containers:
-    - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+    - image: quay.io/kubevirt/builder:2104200947-285ddf078
       env:
       - name: GIT_ASKPASS
         value: "../project-infra/hack/git-askpass.sh"


### PR DESCRIPTION
Fix an issue in the kubevirtci bump periodic: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-kubevirt/1402902817156370432.

It needs a newer build image to have a `pr-creator` available with the new `-label` flag.