### PR TITLE
Job to verify that go.mod, go.sum and vendor folders are in sync

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1010,6 +1010,38 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
+  - name: pull-kubevirt-verify-go-mod
+    cluster: ibm-prow-jobs
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    skip_report: false
+    optional: true
+    run_if_changed: ^vendor/.*|go\.mod$|go\.sum$
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-bazel-cache: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make deps-sync && hack/verify-generate.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
   - always_run: false
     annotations:
       fork-per-release: "true"


### PR DESCRIPTION
This job will trigger on vendor folder changes or if any `go.sum` or `go.mod` file was changed in a PR in kubevirt.

Requires https://github.com/kubevirt/kubevirt/pull/5808 to be merged first.