### PR TITLE
Set default branch for kubevirt/kubevirt to main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -168,7 +168,7 @@ periodics:
       - --dry-run=true
       - --token=/etc/github/oauth
       - --merged=24h
-      - --pr-base-branch=master
+      - --pr-base-branch=main
       - --org=kubevirt
       - --repo=kubevirt
       - --flake-issue-labels=triage/build-watcher,kind/bug
@@ -210,7 +210,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
     work_dir: true
   cluster: phx-prow
   reporter_config:
@@ -255,7 +255,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   cluster: prow-workloads
   reporter_config:
@@ -300,7 +300,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   cluster: prow-workloads
   reporter_config:
@@ -346,7 +346,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
     work_dir: true
   reporter_config:
     slack:
@@ -391,7 +391,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   reporter_config:
     slack:
@@ -436,7 +436,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   reporter_config:
     slack:
@@ -481,7 +481,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   reporter_config:
     slack:
@@ -527,7 +527,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   cluster: prow-workloads
   spec:
@@ -569,7 +569,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   cluster: prow-workloads
   spec:
@@ -614,7 +614,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
     work_dir: true
   reporter_config:
     slack:
@@ -659,7 +659,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   reporter_config:
     slack:
@@ -704,7 +704,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   reporter_config:
     slack:
@@ -749,7 +749,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   reporter_config:
     slack:
@@ -777,7 +777,7 @@ periodics:
         resources:
           requests:
             memory: "29Gi"
-- name: periodic-kubevirt-push-nightly-build-master
+- name: periodic-kubevirt-push-nightly-build-main
   cron: "2 1 * * *"
   decorate: true
   annotations:
@@ -794,7 +794,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       work_dir: true
   cluster: phx-prow
   spec:
@@ -859,7 +859,7 @@ periodics:
       - name: gcs
         secret:
           secretName: gcs
-- name: periodic-kubevirt-clean-nightly-build-master
+- name: periodic-kubevirt-clean-nightly-build
   cluster: ibm-prow-jobs
   cron: "2 15 */7 * *"
   decorate: true
@@ -923,7 +923,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: kubevirt
-      base_ref: master
+      base_ref: main
       path_alias: kubevirt
       workdir: true
   cluster: phx-prow
@@ -960,7 +960,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
     work_dir: true
   skip_report: true
   cluster: phx-prow
@@ -1046,7 +1046,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
     work_dir: true
   skip_report: true
   cluster: phx-prow
@@ -1079,7 +1079,7 @@ periodics:
 - name: bump-kubevirt-rpms-weekly
   cron: "15 22 * * 0"
   branches:
-  - master
+  - main
   always_run: true
   annotations:
     testgrid-create-test-group: "false"
@@ -1093,7 +1093,7 @@ periodics:
     base_ref: master
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
@@ -1118,7 +1118,7 @@ periodics:
       command:
         - /bin/bash
         - -c
-        - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies -p ../kubevirt
+        - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies -p ../kubevirt -T main
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -62,9 +62,9 @@ postsubmits:
       - name: gcs
         secret:
           secretName: gcs
-  - name: push-kubevirt-master
+  - name: push-kubevirt-main
     branches:
-    - master
+    - main
     cluster: ibm-prow-jobs
     always_run: true
     optional: false
@@ -93,7 +93,7 @@ postsubmits:
           value: /etc/github/oauth
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
-        - ./automation/postsubmit-master.sh
+        - ./automation/postsubmit-main.sh
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -116,7 +116,7 @@ postsubmits:
   - name: push-kubevirt-goveralls
     cluster: ibm-prow-jobs
     branches:
-      - master
+      - main
     annotations:
       testgrid-create-test-group: "false"
     always_run: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -83,7 +83,7 @@ periodics:
     base_ref: master
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
@@ -105,7 +105,7 @@ periodics:
         value: /etc/gcs/service-account.json
       command: ["/bin/sh", "-c"]
       args:
-      - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -b bump-kubevirtci -p ../kubevirt
+      - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -b bump-kubevirtci -p ../kubevirt -T main
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -282,7 +282,7 @@ periodics:
     workdir: true
   - org: kubevirt
     repo: kubevirt
-    base_ref: master
+    base_ref: main
   - org: kubevirt
     repo: containerized-data-importer
     base_ref: main
@@ -304,7 +304,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //plugins/cmd/uploader:uploader -- -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt -L lgtm,approved,release-note-none &&
+            hack/git-pr.sh -c "bazelisk run //plugins/cmd/uploader:uploader -- -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt -L lgtm,approved,release-note-none -T main &&
             hack/git-pr.sh -c "bazelisk run //plugins/cmd/uploader:uploader -- -workspace ${PWD}/../containerized-data-importer/WORKSPACE -dry-run=false" -p ../containerized-data-importer -r containerized-data-importer -T main -L lgtm,approved,release-note-none
         volumeMounts:
         - name: token

--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -325,6 +325,7 @@ orgs:
       kubevirt:
         allow_rebase_merge: false
         allow_squash_merge: false
+        default_branch: main
         description: Kubernetes Virtualization API and runtime in order to define and manage virtual machines.
         has_projects: true
         homepage: https://kubevirt.io


### PR DESCRIPTION
see also https://github.com/kubevirt/kubevirt/pull/5823

Can only go in after the default branch in `kubevirt/kubevirt` has been renamed.

/hold