### PR TITLE
Set default branch for project-infra to main

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -41,7 +41,7 @@ This will let k8s know that only one PF is allocated (each PF is represented by 
 K8s uses these resources in order to know how many jobs can run simultaneously.
 Each SR-IOV node of the CI cluster has `prow/sriov` capacity according to the amount of it's available physical PFs.
 
-[3] https://github.com/kubevirt/project-infra/blob/master/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+[3] https://github.com/kubevirt/project-infra/blob/main/github/ci/prow/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
 
 [4] 
 ```bash

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       extra_refs:
         - org: kubevirt
           repo: project-infra
-          base_ref: master
+          base_ref: main
         - org: cncf
           repo: devstats
           base_ref: master

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -8,7 +8,7 @@ postsubmits:
       extra_refs:
         - org: kubevirt
           repo: project-infra
-          base_ref: master
+          base_ref: main
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     work_dir: true
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1090,7 +1090,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
   - org: kubevirt
     repo: kubevirt
     base_ref: master

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -80,7 +80,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
   - org: kubevirt
     repo: kubevirt
     base_ref: master

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
       extra_refs:
       - org: kubevirt
         repo: project-infra
-        base_ref: master
+        base_ref: main
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -206,7 +206,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
     work_dir: true
   cluster: phx-prow
   spec:
@@ -226,6 +226,7 @@ periodics:
       - --github-endpoint=https://api.github.com
       - --org=kubevirt
       - --repo=project-infra
+      - --pr-base-branch=main
       - --target-dir=.
       - --target-subdir=github/ci/prow-deploy/files
       - --config-subdir=jobs
@@ -278,7 +279,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
     workdir: true
   - org: kubevirt
     repo: kubevirt
@@ -334,7 +335,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
     workdir: true
   - org: kubevirt
     repo: kubevirtci
@@ -422,7 +423,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
     workdir: true
   cluster: phx-prow
   spec:
@@ -440,7 +441,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-presubmit-creator:kubevirtci-presubmit-creator -- -job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml -github-token-path= -dry-run=false" -r project-infra -b create-kubevirtci-presubmit
+            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-presubmit-creator:kubevirtci-presubmit-creator -- -job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml -github-token-path= -dry-run=false" -r project-infra -b create-kubevirtci-presubmit -T main
         volumeMounts:
         - name: token
           mountPath: /etc/github
@@ -461,7 +462,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
     workdir: true
   interval: 1h
   max_concurrency: 1
@@ -506,7 +507,7 @@ periodics:
   extra_refs:
   - org: kubevirt
     repo: project-infra
-    base_ref: master
+    base_ref: main
     workdir: true
   - org: kubernetes
     repo: test-infra
@@ -546,7 +547,7 @@ periodics:
   extra_refs:
     - org: kubevirt
       repo: project-infra
-      base_ref: master
+      base_ref: main
       workdir: true
   cluster: prow-workloads
   spec:
@@ -564,7 +565,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirt-presubmit-requirer:kubevirt-presubmit-requirer -- -job-config-path-kubevirt-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml -github-token-path= -dry-run=false" -r project-infra -b require-kubevirt-presubmits
+            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirt-presubmit-requirer:kubevirt-presubmit-requirer -- -job-config-path-kubevirt-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml -github-token-path= -dry-run=false" -r project-infra -b require-kubevirt-presubmits -T main
         volumeMounts:
           - name: token
             mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -200,7 +200,7 @@ postsubmits:
         testgrid-create-test-group: "false"
       decorate: true
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       skip_report: false
@@ -252,7 +252,7 @@ postsubmits:
         testgrid-create-test-group: "false"
       decorate: true
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       skip_report: false
@@ -409,7 +409,7 @@ postsubmits:
       decorate: true
       run_if_changed: "github/ci/services/cert-manager.*"
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       cluster: ibm-prow-jobs
@@ -461,7 +461,7 @@ postsubmits:
       decorate: true
       run_if_changed: "github/ci/services/ci-search.*"
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       cluster: ibm-prow-jobs
@@ -513,7 +513,7 @@ postsubmits:
       decorate: true
       run_if_changed: "github/ci/services/sippy.*"
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       cluster: ibm-prow-jobs
@@ -564,7 +564,7 @@ postsubmits:
       decorate: true
       run_if_changed: "github/ci/services/prometheus-stack.*"
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       cluster: ibm-prow-jobs
@@ -620,7 +620,7 @@ postsubmits:
       decorate: true
       run_if_changed: "github/ci/services/kuberhealthy.*"
       branches:
-      - ^master$
+      - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
       cluster: ibm-prow-jobs
@@ -668,7 +668,7 @@ postsubmits:
     - name: post-project-infra-update-testgrid-config
       run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$|^github/ci/testgrid/gen-config\.yaml$|^github/ci/testgrid/default\.yaml$'
       branches:
-      - master
+      - main
       annotations:
         testgrid-create-test-group: "false"
       decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     extra_refs:
     - org: kubevirt
       repo: project-infra
-      base_ref: master
+      base_ref: main
     cluster: ibm-prow-jobs
     spec:
       securityContext:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
       extra_refs:
       - org: kubevirt
         repo: project-infra
-        base_ref: master
+        base_ref: main
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -405,6 +405,7 @@ orgs:
         has_projects: true
       project-infra:
         allow_rebase_merge: false
+        default_branch: main
         description: Project infrastructure administrative tools
         has_projects: false
         has_wiki: false

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -271,7 +271,7 @@ branch-protection:
                   - continuous-integration/travis-ci/pr
         project-infra:
           branches:
-            master:
+            main:
               protect: true
         libguestfs-appliance:
           branches:

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -1,6 +1,6 @@
 # Test provisioning
 testinfra_dir: /tmp/test-infra
-project_infra_root: /workspace/repos/project-infra-master
+project_infra_root: /workspace/repos/project-infra-main
 
 kubeconfig_path: '/root/.kube/config'
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/'

--- a/github/ci/testgrid/README.md
+++ b/github/ci/testgrid/README.md
@@ -9,7 +9,7 @@ It creates a pull request each time the TestGrid configuration file in the `kube
 
 ## Adding new dashboard
 
-The dashboards' configuration is stored in the [gen-config.yaml](https://github.com/kubevirt/project-infra/tree/master/github/ci/testgrid/gen-config.yaml) file. See the example of a dashboard configuration file:
+The dashboards' configuration is stored in the [gen-config.yaml](https://github.com/kubevirt/project-infra/tree/main/github/ci/testgrid/gen-config.yaml) file. See the example of a dashboard configuration file:
 ```yaml
 dashboards:
   - name: kubevirt_presubmits


### PR DESCRIPTION
/hold

Can go in after:
- https://github.com/kubevirt/project-infra/pull/1330 has been merged (for support `--pr-base-branch` of `autoowners`)
- after the default branch of project-infra has been renamed

Eventually we need to run the config updater manually after the merge: https://github.com/kubevirt/project-infra/blob/97713878997f9f31ff029dbfb08ae11a540f1c73/github/ci/README.md#updating-prow-configuration-manually