### PR TITLE
Update autoowners to latest version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -208,10 +208,10 @@ periodics:
     repo: project-infra
     base_ref: master
     work_dir: true
-  cluster: phx-prow
+  cluster: prow-workloads
   spec:
     containers:
-    - image: quay.io/kubevirtci/autoowners@sha256:c40b91c8452aba2c2966facd054dad1a8f9a55a9f34779c7afd3ece0da8e3633
+    - image: quay.io/kubevirtci/autoowners@sha256:538278fcafba229ab38f0f112955a237ee69f842adaf7f480cac8f385dcdb924
       env:
       - name: GIT_ASKPASS
         value: "./hack/git-askpass.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -221,9 +221,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "1Gi"
+                memory: "4Gi"
               limits:
-                memory: "1Gi"
+                memory: "4Gi"
     - name: post-project-infra-prow-control-plane-deployment
       always_run: false
       annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -206,8 +206,6 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       cluster: prow-workloads
       spec:
-        nodeSelector:
-          type: vm
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
             command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -194,6 +194,38 @@ postsubmits:
                 memory: "8Gi"
               limits:
                 memory: "8Gi"
+    - name: publish-autoowners-image
+      always_run: false
+      run_if_changed: "images/autoowners/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: vm
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
+                ./publish_image.sh autoowners quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "1Gi"
+              limits:
+                memory: "1Gi"
     - name: post-project-infra-prow-control-plane-deployment
       always_run: false
       annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -234,8 +234,6 @@ presubmits:
       preset-kubevirtci-quay-credential: "true"
     cluster: prow-workloads
     spec:
-      nodeSelector:
-        type: vm
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -248,9 +248,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "1Gi"
+              memory: "4Gi"
             limits:
-              memory: "1Gi"
+              memory: "4Gi"
   - name: kubernetes-crud-ci-role
     always_run: false
     run_if_changed: "github/ci/kubernetes-crud/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -224,6 +224,35 @@ presubmits:
               memory: "8Gi"
             limits:
               memory: "8Gi"
+  - name: build-autoowners-image
+    always_run: false
+    run_if_changed: "images/autoowners/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    cluster: prow-workloads
+    spec:
+      nodeSelector:
+        type: vm
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              cd images
+              ./publish_image.sh -b autoowners quay.io kubevirtci
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
   - name: kubernetes-crud-ci-role
     always_run: false
     run_if_changed: "github/ci/kubernetes-crud/.*"

--- a/images/autoowners/Dockerfile
+++ b/images/autoowners/Dockerfile
@@ -1,13 +1,11 @@
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /go/src/github.com/openshift/ci-tools/
 RUN mkdir -p /go/src/github.com/openshift/ && \
     cd /go/src/github.com/openshift/ && \
     git clone https://github.com/openshift/ci-tools.git && \
     cd ci-tools/ && \
-    export GOPROXY=off && \
-    export GOFLAGS=-mod=vendor && \
-    env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/autoowners ./cmd/autoowners/...
+    env GOPROXY=off GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/autoowners ./cmd/autoowners/...
 
 FROM gcr.io/k8s-prow/git:v20200605-44f6c96
 


### PR DESCRIPTION
In order for autoowners to support the [`--pr-base-branch argument`](https://github.com/openshift/ci-tools/pull/2056) we
update the image to the latest version. This is a change required ahead
of renaming the default branch for project-infra.

Also we create jobs to automate autoowners image build and push.

Signed-off-by: Daniel Hiller <dhiller@redhat.com>