### PR TITLE
Move jobs running on bare metals to prow-workloads

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
@@ -36,7 +36,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: phx-prow
+      cluster: prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
@@ -36,7 +36,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: phx-prow
+      cluster: prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
@@ -40,7 +40,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: phx-prow
+      cluster: prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: phx-prow
+      cluster: prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    cluster: phx-prow
+    cluster: prow-workloads
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -70,7 +70,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 10m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -101,7 +101,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -138,7 +138,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -171,7 +171,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -200,7 +200,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -233,7 +233,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -266,7 +266,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      cluster: phx-prow
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -138,7 +138,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -171,7 +171,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -200,7 +200,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -233,7 +233,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -266,7 +266,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -49,6 +49,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -76,7 +77,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -108,7 +109,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -141,7 +142,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -176,7 +177,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -205,7 +206,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -238,7 +239,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -271,7 +272,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -304,7 +305,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -337,7 +338,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: phx-prow
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-templates/common-templates-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
     timeout: 1h
     grace_period: 5m
   max_concurrency: 1
-  cluster: phx-prow
+  cluster: prow-workloads
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
@@ -50,7 +50,7 @@ periodics:
     timeout: 1h
     grace_period: 5m
   max_concurrency: 1
-  cluster: phx-prow
+  cluster: prow-workloads
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.13.yaml
@@ -12,7 +12,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -45,7 +45,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -78,7 +78,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -111,7 +111,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -144,7 +144,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -177,7 +177,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -210,7 +210,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.19.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.19.yaml
@@ -17,7 +17,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -55,7 +55,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
@@ -93,7 +93,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.28.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.28.yaml
@@ -12,7 +12,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -45,7 +45,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -47,7 +47,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -81,7 +81,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -115,7 +115,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -149,7 +149,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -182,7 +182,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -216,7 +216,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -250,7 +250,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       timeout: 3h
       grace_period: 5m
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -16,7 +16,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
         rehearsal.allowed: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
       repo: hyperconverged-cluster-operator
       base_ref: main
       work_dir: true
-  cluster: phx-prow
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.15.1
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -45,7 +45,7 @@ presubmits:
       preset-kubevirtci-quay-credential: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    cluster: phx-prow
+    cluster: prow-workloads
     name: pull-hyperconverged-cluster-operator-e2e-ocp-4.3
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -49,7 +49,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -212,7 +212,7 @@ periodics:
     repo: kubevirt
     base_ref: master
     work_dir: true
-  cluster: phx-prow
+  cluster: prow-workloads
   reporter_config:
     slack:
       job_states_to_report: []
@@ -796,7 +796,7 @@ periodics:
       repo: kubevirt
       base_ref: master
       work_dir: true
-  cluster: phx-prow
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -926,7 +926,7 @@ periodics:
       base_ref: master
       path_alias: kubevirt
       workdir: true
-  cluster: phx-prow
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -1049,7 +1049,7 @@ periodics:
     base_ref: master
     work_dir: true
   skip_report: true
-  cluster: phx-prow
+  cluster: prow-workloads
   reporter_config:
     slack:
       job_states_to_report: []

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
@@ -15,7 +15,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.11.0-0.13
     context: pull-kubevirt-e2e-k8s-1.11.0
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -46,7 +46,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-genie-1.11.1-0.13
     context: pull-kubevirt-e2e-k8s-genie-1.11.1
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -77,7 +77,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-k8s-multus-1.13.3-0.13
     context: pull-kubevirt-e2e-k8s-multus-1.13.3
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -108,7 +108,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-os-3.11.0-crio-0.13
     context: pull-kubevirt-e2e-os-3.11.0-crio
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -139,7 +139,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-os-3.11.0-multus-0.13
     context: pull-kubevirt-e2e-os-3.11.0-multus
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -170,7 +170,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-os-3.11.0-0.13
     context: pull-kubevirt-e2e-os-3.11.0
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -201,7 +201,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.13
     context: pull-kubevirt-e2e-windows2016
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -16,7 +16,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.13.3-0.30
     context: pull-kubevirt-e2e-k8s-1.13.3
-    cluster: phx-prow
+    cluster: prow-workloads
     optional: true
     spec:
       containers:
@@ -48,7 +48,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.14-0.30
     context: pull-kubevirt-e2e-k8s-1.14
-    cluster: phx-prow
+    cluster: prow-workloads
     optional: true
     spec:
       containers:
@@ -80,7 +80,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.15-ceph-0.30
     context: pull-kubevirt-e2e-k8s-1.15-ceph
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -112,7 +112,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.16-0.30
     context: pull-kubevirt-e2e-k8s-1.16
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -143,7 +143,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-k8s-1.17-0.30
     context: pull-kubevirt-e2e-k8s-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -174,7 +174,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-cnao-1.17-0.30
     context: pull-kubevirt-e2e-k8s-cnao-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -206,7 +206,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-crio-0.30
     context: pull-kubevirt-e2e-os-3.11.0-crio
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -238,7 +238,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-multus-0.30
     context: pull-kubevirt-e2e-os-3.11.0-multus
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -269,7 +269,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.30
     context: pull-kubevirt-e2e-windows2016
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -375,7 +375,7 @@ presubmits:
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-k8s-1.17.0-ipv6-0.30
     context: pull-kubevirt-e2e-kind-k8s-1.17.0-ipv6
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -422,7 +422,7 @@ presubmits:
     name: pull-kubevirt-check-tests-for-flakes-0.30
     context: pull-kubevirt-check-tests-for-flakes
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -454,7 +454,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.30
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -17,7 +17,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.13.3-0.34
     context: pull-kubevirt-e2e-k8s-1.13.3
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.14-0.34
     context: pull-kubevirt-e2e-k8s-1.14
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -82,7 +82,7 @@ presubmits:
     context: pull-kubevirt-e2e-k8s-1.16-ceph
     optional: true
     skip_report: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -117,7 +117,7 @@ presubmits:
     context: pull-kubevirt-e2e-k8s-1.19-release-0.34
     optional: true
     skip_report: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -148,7 +148,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.34
     context: pull-kubevirt-e2e-k8s-1.18
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -179,7 +179,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.34
     context: pull-kubevirt-e2e-k8s-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -210,7 +210,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.16-0.34
     context: pull-kubevirt-e2e-k8s-1.16
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -241,7 +241,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.17-0.34
     context: pull-kubevirt-e2e-k8s-cnao-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -273,7 +273,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-crio-0.34
     context: pull-kubevirt-e2e-os-3.11.0-crio
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -305,7 +305,7 @@ presubmits:
     name: pull-kubevirt-e2e-os-3.11.0-multus-0.34
     context: pull-kubevirt-e2e-os-3.11.0-multus
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -336,7 +336,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.34
     context: pull-kubevirt-e2e-windows2016
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -442,7 +442,7 @@ presubmits:
     name: pull-kubevirt-check-tests-for-flakes-0.34
     context: pull-kubevirt-check-tests-for-flakes
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -473,7 +473,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.34
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -16,7 +16,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.36
     context: pull-kubevirt-e2e-k8s-1.19
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -47,7 +47,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.36
     context: pull-kubevirt-e2e-k8s-1.18
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -78,7 +78,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.36
     context: pull-kubevirt-e2e-k8s-1.17
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -109,7 +109,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.36
     context: pull-kubevirt-e2e-k8s-cnao-1.19
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -140,7 +140,7 @@ presubmits:
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.36
     context: pull-kubevirt-e2e-windows2016
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -248,7 +248,7 @@ presubmits:
     name: pull-kubevirt-check-tests-for-flakes-0.36
     context: pull-kubevirt-check-tests-for-flakes
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -279,7 +279,7 @@ presubmits:
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.36
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -18,7 +18,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.37
     optional: true
     skip_report: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.37
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -80,6 +80,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.37
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -110,7 +111,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.37
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -141,7 +142,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.37
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -172,7 +173,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.37
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -278,7 +279,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.37
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -309,7 +310,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.37
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
@@ -18,7 +18,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.38
     optional: true
     skip_report: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -49,7 +49,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.38
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -80,7 +80,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.38
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -111,7 +111,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.38
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -142,7 +142,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.38
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -173,7 +173,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.38
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -279,7 +279,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.38
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -310,7 +310,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.38
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -20,7 +20,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.39
     optional: true
     skip_report: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -53,7 +53,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.39
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -86,7 +86,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.39
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -119,7 +119,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.39
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -152,7 +152,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.39
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -185,7 +185,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.39
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -291,7 +291,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.39
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -324,7 +324,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.39
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
@@ -20,7 +20,7 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.20-0.40
     optional: true
     skip_report: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -59,7 +59,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-cgroupsv2-0.40
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -97,7 +97,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -136,7 +136,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-network-0.40
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -170,7 +170,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-storage-0.40
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -203,7 +203,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-operator-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -240,7 +240,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.18-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -279,7 +279,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.17-0.40
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -317,7 +317,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-cnao-1.19-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -350,7 +350,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -465,7 +465,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes-0.40
     optional: true
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -498,7 +498,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -531,7 +531,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-test-0.40
-    cluster: phx-prow
+    cluster: prow-workloads
     optional: true
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
@@ -196,7 +196,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.20-cgroupsv2
     decorate: true
     decoration_config:
@@ -230,7 +230,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.19-nonroot
     decorate: true
     decoration_config:
@@ -271,7 +271,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.19
     decorate: true
     decoration_config:
@@ -309,7 +309,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.19-sig-network
     decorate: true
     decoration_config:
@@ -415,7 +415,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.19-operator
     decorate: true
     decoration_config:
@@ -448,7 +448,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.18
     decorate: true
     decoration_config:
@@ -481,7 +481,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.17
     decorate: true
     decoration_config:
@@ -515,7 +515,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -708,7 +708,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -740,7 +740,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph-nonroot
     decorate: true
     decoration_config:
@@ -781,7 +781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.20-rook-ceph
     decorate: true
     decoration_config:
@@ -815,7 +815,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: phx-prow
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.17-rook-ceph
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -330,7 +330,7 @@ presubmits:
       testgrid-dashboards: kubevirt-presubmits
     always_run: true
     optional: false
-    cluster: phx-prow
+    cluster: prow-workloads
     skip_report: false
     decorate: true
     decoration_config:
@@ -378,7 +378,7 @@ presubmits:
       timeout: 7h
       grace_period: 5m
     max_concurrency: 11
-    cluster: phx-prow
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -469,7 +469,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -553,7 +553,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -717,7 +717,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -758,7 +758,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -958,7 +958,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -995,7 +995,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -1039,7 +1039,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -1076,7 +1076,7 @@ presubmits:
       preset-shared-images: "true"
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -231,7 +231,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -264,7 +264,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -319,7 +319,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -356,7 +356,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -393,7 +393,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -430,7 +430,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -467,7 +467,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
@@ -44,7 +44,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -75,7 +75,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -107,7 +107,7 @@ presubmits:
         preset-docker-mirror: "true"
         preset-shared-images: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
@@ -44,7 +44,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -75,7 +75,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -44,7 +44,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -75,7 +75,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -106,7 +106,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -44,7 +44,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -75,7 +75,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -134,7 +134,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -81,7 +81,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -144,7 +144,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external


### PR DESCRIPTION
Continues the migration to the new workloads cluster, sets all the jobs running on bare metals to execute on `prow-workloads`.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>