### PR TITLE
Execute prow-deploy-test in phx-prow

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -319,9 +319,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "18Gi"
+              memory: "22Gi"
             limits:
-              memory: "18Gi"
+              memory: "22Gi"
           volumeMounts:
           - name: token
             mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -291,7 +291,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: phx-prow
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -319,9 +319,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "18Gi"
             limits:
-              memory: "29Gi"
+              memory: "18Gi"
           volumeMounts:
           - name: token
             mountPath: /etc/github


### PR DESCRIPTION
The test started failing after set to execute on `prow-workloads`, moving it back to `phx-prow` to unblock PRs while investigating the root cause. Also reduced the requested memory, leftover from when the test used kubevirtci. 

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>