### PR TITLE
Include openvswitch kernel module in prow-workloads node bootstrap

### DIFF
--- a/github/ci/prow-workloads/roles/bootstrap/tasks/additional_kernel_modules.yml
+++ b/github/ci/prow-workloads/roles/bootstrap/tasks/additional_kernel_modules.yml
@@ -1,0 +1,10 @@
+---
+- name: insert module
+  shell: |
+    modprobe {{ item }}
+
+- name: make module insertion permanent
+  copy:
+    dest: /etc/modules-load.d/{{ item }}.conf
+    content: |
+      {{ item }}

--- a/github/ci/prow-workloads/roles/bootstrap/tasks/main.yml
+++ b/github/ci/prow-workloads/roles/bootstrap/tasks/main.yml
@@ -90,5 +90,19 @@
     content: |
       fs.inotify.max_user_watches=524288
 
+- name: additional kernel modules
+  block:
+    - name: insert module
+      shell: |
+        modprobe {{ item }}
+
+    - name: make module insertion permanent
+      copy:
+        dest: /etc/modules-load.d/{{ item }}.conf
+        content: |
+          {{ item }}
+  loop:
+    - openvswitch
+
 - name: reboot to apply changes
   reboot:

--- a/github/ci/prow-workloads/roles/bootstrap/tasks/main.yml
+++ b/github/ci/prow-workloads/roles/bootstrap/tasks/main.yml
@@ -91,16 +91,7 @@
       fs.inotify.max_user_watches=524288
 
 - name: additional kernel modules
-  block:
-    - name: insert module
-      shell: |
-        modprobe {{ item }}
-
-    - name: make module insertion permanent
-      copy:
-        dest: /etc/modules-load.d/{{ item }}.conf
-        content: |
-          {{ item }}
+  include_tasks: additional_kernel_modules.yml
   loop:
     - openvswitch
 


### PR DESCRIPTION
After moving jobs to prow-workloads OVS CNI test fail due to a missing openvswitch kernel module.

/cc @phoracek @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>