### PR TITLE
Fix prow-deploy test

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -291,7 +291,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: phx-prow
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -319,9 +319,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "22Gi"
+              memory: "29Gi"
             limits:
-              memory: "22Gi"
+              memory: "29Gi"
           volumeMounts:
           - name: token
             mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -310,10 +310,8 @@ presubmits:
             - "-ce"
             - |
               cd github/ci/prow-deploy/
-              molecule test
-              tmp=$(mktemp -d)
-              docker cp instance:$ARTIFACTS $tmp
-              cp -ar $tmp/artifacts/* $ARTIFACTS
+              molecule test || true
+              sleep 3600
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -311,7 +311,9 @@ presubmits:
             - |
               cd github/ci/prow-deploy/
               molecule test || true
-              sleep 3600
+              tmp=$(mktemp -d)
+              docker cp instance:$ARTIFACTS $tmp
+              cp -ar $tmp/artifacts/* $ARTIFACTS
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -307,7 +307,7 @@ presubmits:
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
-            - "-ce"
+            - "-c"
             - |
               cd github/ci/prow-deploy/
               molecule test || true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -319,9 +319,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "22Gi"
             limits:
-              memory: "29Gi"
+              memory: "22Gi"
           volumeMounts:
           - name: token
             mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -298,7 +298,7 @@ presubmits:
       securityContext:
         runAsUser: 0
       containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
+        - image: quay.io/kubevirtci/prow-deploy:v20210618-2e4be2d
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -307,10 +307,10 @@ presubmits:
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
-            - "-c"
+            - "-ce"
             - |
               cd github/ci/prow-deploy/
-              molecule test || true
+              molecule test
               tmp=$(mktemp -d)
               docker cp instance:$ARTIFACTS $tmp
               cp -ar $tmp/artifacts/* $ARTIFACTS

--- a/github/ci/prow-deploy/molecule/default/cleanup.yml
+++ b/github/ci/prow-deploy/molecule/default/cleanup.yml
@@ -14,3 +14,4 @@
       vars:
         main_actions:
           - cleanup
+      ignore_errors: yes

--- a/github/ci/prow-deploy/molecule/default/collect.yml
+++ b/github/ci/prow-deploy/molecule/default/collect.yml
@@ -34,15 +34,18 @@
 - name: Describe all in a single yaml.
   shell: |
     {{ kubectl_prow }} get all -o yaml > {{ artifacts_dir }}/get_all.yaml
+  ignore_errors: yes
 
 - name: Compress yaml
   archive:
     path: "{{ artifacts_dir }}/get_all.yaml"
     remove: yes
+  ignore_errors: yes
 
 - name: collect opened port
   shell: |
     ss -ntpa > {{ artifacts_dir }}/host-netstat.txt
+  ignore_errors: yes
 
 # Putting relevant data in a hierarchy
 - name: include resource collection tasks
@@ -51,6 +54,7 @@
   loop_control:
     loop_var: resource
     label: "{{ resource.key }}"
+  ignore_errors: yes
 
 - name: collect kind logs
   shell: |

--- a/github/ci/prow-deploy/molecule/default/collect.yml
+++ b/github/ci/prow-deploy/molecule/default/collect.yml
@@ -51,3 +51,7 @@
   loop_control:
     loop_var: resource
     label: "{{ resource.key }}"
+
+- name: collect kind logs
+  shell: |
+    kind export logs {{ artifacts_dir }}

--- a/github/ci/prow-deploy/molecule/default/molecule.yml
+++ b/github/ci/prow-deploy/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
+    image: quay.io/kubevirtci/prow-deploy:v20210618-2e4be2d
     privileged: True
     etc_hosts:
       "gcsweb.prowdeploy.ci": "127.0.0.1"

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -30,35 +30,39 @@
         /usr/local/bin/start_dind.sh
       changed_when: false
 
-    - name: create cluster config
-      copy:
-        dest: '{{ kind.cluster_config }}'
-        content: |
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          nodes:
-          - role: control-plane
-          - role: worker
-            extraPortMappings:
-            - containerPort: 80
-              hostPort: 80
-            - containerPort: 443
-              hostPort: 443
-            kubeadmConfigPatches:
-            - |
-              kind: JoinConfiguration
-              nodeRegistration:
-                name: '{{ node_name }}'
-                kubeletExtraArgs:
-                  system-reserved: memory=16Gi
-                  node-labels: "ingress-ready=true"
-    - name: Launch cluster
-      shell: |
-        kind delete cluster
-        kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }} --retain
-      changed_when: false
-      when: "'kubevirtci' in deploy_environment"
-
+    - name: Create cluster
+      block:
+        - name: create cluster config
+          copy:
+            dest: '{{ kind.cluster_config }}'
+            content: |
+              kind: Cluster
+              apiVersion: kind.x-k8s.io/v1alpha4
+              nodes:
+              - role: control-plane
+              - role: worker
+                extraPortMappings:
+                - containerPort: 80
+                  hostPort: 80
+                - containerPort: 443
+                  hostPort: 443
+                kubeadmConfigPatches:
+                - |
+                  kind: JoinConfiguration
+                  nodeRegistration:
+                    name: '{{ node_name }}'
+                    kubeletExtraArgs:
+                      system-reserved: memory=16Gi
+                      node-labels: "ingress-ready=true"
+        - name: Launch cluster
+          shell: |
+            kind delete cluster
+            kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }} --retain
+          changed_when: false
+          when: "'kubevirtci' in deploy_environment"
+      always:
+        - name: collect deployment information
+          include_tasks: collect.yml
     - name: bootstrap cluster
       shell: |
         kubectl apply -f '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/resources/bootstrap.yaml'

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -55,7 +55,7 @@
     - name: Launch cluster
       shell: |
         kind delete cluster
-        kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }}
+        kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }} --verbosity 4
       changed_when: false
       when: "'kubevirtci' in deploy_environment"
 

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -55,7 +55,7 @@
     - name: Launch cluster
       shell: |
         kind delete cluster
-        kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }} --verbosity 4
+        kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }} --retain
       changed_when: false
       when: "'kubevirtci' in deploy_environment"
 

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -60,7 +60,7 @@
             kind create cluster --config {{ kind.cluster_config }} --image quay.io/kubevirtci/kind:{{ kind.image_tag }} --retain
           changed_when: false
           when: "'kubevirtci' in deploy_environment"
-      always:
+      rescue:
         - name: collect deployment information
           include_tasks: collect.yml
     - name: bootstrap cluster

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -7,7 +7,7 @@ secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kub
 components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
 kind:
   cluster_config: '/workspace/cluster.yaml'
-  image_tag: v1.19.1
+  image_tag: v1.21.1
 
 
 node_name: node01


### PR DESCRIPTION
Changes to prevent errors when running in `prow-workloads` cluster include:
* Use a more recent kubevirtci/prow-deploy image with kind v0.11.1 as suggested here https://github.com/kubernetes-sigs/kind/issues/2316#issuecomment-864182778, built with the changes in #1350 
* Bump kindest/node image used by kind (pointing to our quay mirror).
* Collect kind logs in case of cluster creation failure.

Additionally, all the executions with the new kind have taken less than 7min, previously it was taking ~10min.

Successful execution here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1341/rehearsal-pull-project-infra-prow-deploy-test/1405963755489071104 

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>