### PR TITLE
kubevirt: Avoid using k8s-1.17 lanes for ceph, make 1.20 ceph lane mandatory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1030,7 +1030,7 @@ periodics:
           hostPath:
             path: /dev/vfio/
             type: Directory
-- name: periodic-kubevirt-e2e-k8s-prev-prev-rook-ceph
+- name: periodic-kubevirt-e2e-k8s-rook-ceph
   annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1062,7 +1062,7 @@ periodics:
           - name: KUBEVIRT_QUARANTINE
             value: "true"
           - name: TARGET
-            value: k8s-1.17
+            value: k8s-1.20
           - name: KUBEVIRT_STORAGE
             value: rook-ceph
         command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -764,11 +764,14 @@ presubmits:
         type: bare-metal-external
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+          - name: TARGET
+            value: windows2016
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-c"
-        - "export TARGET=windows2016 && automation/test.sh"
+        - "automation/test.sh"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -1045,11 +1048,16 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          env:
+            - name: TARGET
+              value: k8s-1.20
+            - name: KUBEVIRT_STORAGE
+              value: rook-ceph-default
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.20 && export KUBEVIRT_STORAGE=rook-ceph-default && automation/test.sh"
+            - "automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -975,7 +975,7 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.17-rook-ceph-nonroot
+  - name: pull-kubevirt-e2e-k8s-1.20-rook-ceph-nonroot
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -1005,7 +1005,7 @@ presubmits:
             - name: FEATURE_GATES
               value: "NonRoot"
             - name: TARGET
-              value: k8s-1.17
+              value: k8s-1.20
             - name: KUBEVIRT_STORAGE
               value: rook-ceph-default
           command:
@@ -1020,43 +1020,6 @@ presubmits:
             requests:
               memory: "29Gi"
   - name: pull-kubevirt-e2e-k8s-1.20-rook-ceph
-    skip_branches:
-      - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    always_run: false
-    optional: true
-    skip_report: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-    cluster: prow-workloads
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "export TARGET=k8s-1.20 && export KUBEVIRT_STORAGE=rook-ceph-default && automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.17-rook-ceph
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -1086,7 +1049,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.17 && export KUBEVIRT_STORAGE=rook-ceph-default && automation/test.sh"
+            - "export TARGET=k8s-1.20 && export KUBEVIRT_STORAGE=rook-ceph-default && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
We want to deprecate the 1.17 lane from kubevirtci, so let's make sure there are no remaining uses.