### PR TITLE
Create new jobs for kind-1.19-sriov provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -941,6 +941,90 @@ presubmits:
           hostPath:
             path: /dev/vfio/
             type: Directory
+
+  - name: pull-kubevirt-e2e-kind-1.19-sriov
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
+      testgrid-dashboards: kubevirt-presubmits
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+      grace_period: 30m
+    max_concurrency: 10
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      sriov-pod: "true"
+      rehearsal.allowed: "true"
+    cluster: phx-prow
+    spec:
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod-multi
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - image: quay.io/kubevirtci/golang:v20210316-d295087
+          env:
+            - name: "TARGET"
+              value: "kind-1.19-sriov"
+            - name: "GIMME_GO_VERSION"
+              value: "1.13.8"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-ce"
+            - |
+                automation/test.sh
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"
+          volumeMounts:
+            #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+            - name: vfio
+              mountPath: /dev/vfio/
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio/
+            type: Directory
+
   - name: pull-kubevirt-check-tests-for-flakes
     skip_branches:
       - release-\d+\.\d+

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -37,14 +37,95 @@ presubmits:
                       - "true"
               topologyKey: kubernetes.io/hostname
       containers:
+        - image: quay.io/kubevirtci/golang:v20210316-d295087
+          env:
+            - name: "GIMME_GO_VERSION"
+              value: "1.13.8"
+            - name: "KUBEVIRT_PROVIDER"
+              value: "kind-k8s-sriov-1.17.0"
+            - name: "KUBEVIRT_NUM_NODES"
+              value: "2"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - >
+              trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM &&
+              make cluster-up
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "15Gi"
+          volumeMounts:
+            #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+            - name: modules
+              mountPath: /lib/modules
+              readOnly: true
+            - name: cgroup
+              mountPath: /sys/fs/cgroup
+            - name: vfio
+              mountPath: /dev/vfio/
+      volumes:
+        - name: modules
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        - name: vfio
+          hostPath:
+            path: /dev/vfio/
+            type: Directory
+
+  - name: check-up-kind-1.19-sriov
+    annotations:
+      k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-installer-pull-token: "true"
+      sriov-pod: "true"
+      rehearsal.allowed: "true"
+    cluster: phx-prow
+    spec:
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod-multi
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+      containers:
       - image: quay.io/kubevirtci/golang:v20210316-d295087
         env:
         - name: "GIMME_GO_VERSION"
           value: "1.13.8"
         - name: "KUBEVIRT_PROVIDER"
-          value: "kind-k8s-sriov-1.17.0"
+          value: "kind-1.19-sriov"
         - name: "KUBEVIRT_NUM_NODES"
-          value: "2"
+          value: "3"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"


### PR DESCRIPTION
Signed-off-by: Or Mergi <ormergi@redhat.com>

Following kubevirt/kubevirtci#621, we need to test it on CI environment 
as kind-1.19-sriov going to be new provider for SRIOV lanes.

This PR adds new kubvirtci-check-up and kubvirt-pull-e2e jobs for it.