### PR TITLE
kind-1.19-sriov jobs: Cancel always_run

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -949,7 +949,7 @@ presubmits:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
       testgrid-dashboards: kubevirt-presubmits
-    always_run: true
+    always_run: false
     optional: true
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -84,7 +84,7 @@ presubmits:
   - name: check-up-kind-1.19-sriov
     annotations:
       k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
-    always_run: true
+    always_run: false
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
This PR chance 1.19 sriov jobs to **not** always run in order to prevent extra pressure on CI.

We will change it back once we set 1.19 sriov jobs as voting lanes.

Signed-off-by: Or Mergi <ormergi@redhat.com>