### PR TITLE
Set cpu requests for docker-mirror-proxy

### DIFF
--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
@@ -56,8 +56,10 @@ spec:
             containerPort: 3128
         resources:
           requests:
+            cpu: 300m
             memory: 3Gi
           limits:
+            cpu: 300m
             memory: 3Gi
       volumes:
       - name: ca-public

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/hostpath/patches/JsonRFC6902/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/hostpath/patches/JsonRFC6902/deployment.yaml
@@ -22,3 +22,10 @@
   value:
     name: storage
     mountPath: /docker_mirror_cache
+# set cpu resources
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: "700m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "700m"


### PR DESCRIPTION
We are getting connectivity errors in ibm-prow-workloads cluster to quay: `Get https://quay.io/v2/: net/http: request canceled (Client.Timeout exceeded while awaiting headers)`. Quay status page looks fine and we are able to connect to it without problems from other clusters. The issue seems related to docker-mirror-proxy in ibm-prow-jobs, looking at the resource usage seems like it hasn't been able to report the `up` metric around times when there was a spike in cpu usage. These changes set the cpu requests and limits a bit above the highest usage value we have recorded in the last 7 days:

![Screenshot from 2021-06-18 13-58-42](https://user-images.githubusercontent.com/70376/122557693-69b53d80-d03d-11eb-857d-a6ecf79f1bb3.png)
 
/hold
Changes are already deployed, will check for a while if the errors are gone before proposing this PR for review.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>