### PR TITLE
Bump kind in prow-deploy file

### DIFF
--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_lin
   chmod a+x ./yq && \
   mv ./yq /usr/local/bin
 
-RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.9.0/kind-linux-amd64 && \
+RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64 && \
   chmod a+x ./kind && \
   mv ./kind /usr/local/bin
 


### PR DESCRIPTION
Suggested in https://github.com/kubernetes-sigs/kind/issues/2316#issuecomment-864182778 to prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1341/rehearsal-pull-project-infra-prow-deploy-test/1405885064394313728

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>