### PR TITLE
Set kubevirt builder image to tagged version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -18,7 +18,7 @@ postsubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/kubevirt/builder@sha256:0e2dde4051711e243dbb7be57a7c10f67a3b33bc764304e14297e324deaddee0
+          - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
             env:
               - name: GIT_ASKPASS
                 value: /go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1109,7 +1109,7 @@ periodics:
       secret:
         secretName: gcs
     containers:
-    - image: quay.io/kubevirt/builder:2103251826-514132c73
+    - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
       env:
       - name: GIT_ASKPASS
         value: "../project-infra/hack/git-askpass.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -97,7 +97,7 @@ periodics:
       secret:
         secretName: gcs
     containers:
-    - image: quay.io/kubevirt/builder:2105310929-3310f7bdd
+    - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
       env:
       - name: GIT_ASKPASS
         value: "../project-infra/hack/git-askpass.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -292,7 +292,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+      - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -345,7 +345,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+      - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -389,7 +389,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+      - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -430,7 +430,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+      - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
         env:
         - name: GIT_ASKPASS
           value: ../project-infra/hack/git-askpass.sh
@@ -517,7 +517,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+      - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
         env:
         - name: GIT_ASKPASS
           value: hack/git-askpass.sh
@@ -554,7 +554,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder@sha256:0a33ac20425efa54b357e51ba0ea6e0ca515d47f572ad078408f92870e3a1e08
+      - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
         env:
           - name: GIT_ASKPASS
             value: ../project-infra/hack/git-askpass.sh


### PR DESCRIPTION
In order to align the builder version for all jobs that occasionally
fail due to "flag provided but not defined: -labels" when using
`git-pr.sh` we align those images to use one tagged version.

See i.e.: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-kubevirt/1407252471889268736

/cc @fgimenez 