### PR TITLE
Add lgtm,approved labels on release tool config forks

### DIFF
--- a/releng/release-tool/Dockerfile.release-tool-base
+++ b/releng/release-tool/Dockerfile.release-tool-base
@@ -16,10 +16,9 @@ RUN set -x && \
     cd / && \
     export GO111MODULE=on && \
     source /etc/profile.d/gimme.sh && \
-    # we need https://github.com/kubernetes/test-infra/pull/20535 merged
-    git clone https://github.com/rmohr/test-infra.git && \
+    git clone https://github.com/kubernetes/test-infra.git && \
     cd /test-infra && \
-    git checkout a398e0a4d605a5a523e96f5c6fb44859eaeb7d42 && \
+    git checkout 1f3edddfe487b7df5714dbd9de3b2ed6e691485e && \
     cd /test-infra/robots/pr-creator && \
     go install && \
     cd /test-infra/releng/config-forker && \

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -455,6 +455,7 @@ func (r *releaseData) forkProwJobs() error {
 			"--title", fmt.Sprintf("Release configs for %s/%s release branch %s", r.org, r.repo, r.newBranch),
 			"--body", "adds new release configs",
 			"--source", fmt.Sprintf("kubevirt:%s", gitbranch),
+			"--labels", "lgtm,approved",
 			"--confirm",
 		)
 		bytes, err := cmd.CombinedOutput()


### PR DESCRIPTION
Automatically approve forked ci configs when doing a kubevirt release.