### PR TITLE
Drop separate rook-ceph lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -986,52 +986,6 @@ periodics:
           hostPath:
             path: /dev/vfio/
             type: Directory
-- name: periodic-kubevirt-e2e-k8s-rook-ceph
-  annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cron: "0 22,10 * * *"
-  decorate: true
-  decoration_config:
-    timeout: 7h
-    grace_period: 5m
-  labels:
-    preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-shared-images: "true"
-  extra_refs:
-  - org: kubevirt
-    repo: kubevirt
-    base_ref: main
-    work_dir: true
-  skip_report: true
-  cluster: prow-workloads
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    nodeSelector:
-      type: bare-metal-external
-    containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        env:
-          - name: KUBEVIRT_QUARANTINE
-            value: "true"
-          - name: TARGET
-            value: k8s-1.20
-          - name: KUBEVIRT_STORAGE
-            value: rook-ceph
-        command:
-          - "/usr/local/bin/runner.sh"
-          - "/bin/sh"
-          - "-c"
-          - "automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"
 - name: bump-kubevirt-rpms-weekly
   cron: "15 22 * * 0"
   branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1023,48 +1023,6 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
-  - name: pull-kubevirt-e2e-k8s-1.20-rook-ceph
-    skip_branches:
-      - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    always_run: true
-    optional: false
-    skip_report: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-    cluster: prow-workloads
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-          env:
-            - name: TARGET
-              value: k8s-1.20
-            - name: KUBEVIRT_STORAGE
-              value: rook-ceph-default
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
   - name: pull-kubevirt-generate
     cluster: ibm-prow-jobs
     skip_branches:


### PR DESCRIPTION
As we are now testing rook-ceph in the sig-storage lanes we do not need
those separate jobs any more.

Examples:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5914/pull-kubevirt-e2e-k8s-1.20-sig-storage/1407998908197507072
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.21-sig-storage/1407939144176373760