### PR TITLE
Run sig-storage periodics with rook-ceph-default storage.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -271,6 +271,8 @@ periodics:
             value: "true"
           - name: TARGET
             value: "k8s-1.19-sig-storage"
+          - name: KUBEVIRT_STORAGE
+            value: rook-ceph-default
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -406,6 +408,8 @@ periodics:
             value: "true"
           - name: TARGET
             value: "k8s-1.20-sig-storage"
+          - name: KUBEVIRT_STORAGE
+            value: rook-ceph-default
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -630,6 +634,8 @@ periodics:
             value: "true"
           - name: TARGET
             value: "k8s-1.21-sig-storage"
+          - name: KUBEVIRT_STORAGE
+            value: rook-ceph-default
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
After the removal of the ceph periodic lane in #1370,
no periodics run ceph-dependent tests.

That's mostly a storage concern, let's add those to the
sig-storage lane.