### PR TITLE
Target prow-autobump PR to main branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -524,7 +524,7 @@ periodics:
         command: ["/bin/sh"]
         args:
           - "-c"
-          - hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra
+          - hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main
         volumeMounts:
         - name: token
           mountPath: /etc/github


### PR DESCRIPTION
Change required after the change of the default project-infra branch to main, will prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-bump/1408306601693024256#1:build-log.txt%3A333 Successful execution with the change in this PR here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-bump/1408325247156883456

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>