### PR TITLE
Make sure to use Python3 in prow-deploy

### DIFF
--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -15,3 +15,5 @@ node_name: node01
 SRIOVNodes:
 - name: '{{ node_name }}'
   capacity: 2
+
+ansible_python_interpreter: /usr/bin/python3

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -1,9 +1,3 @@
-- name: install pip dependencies
-  pip:
-    name:
-      - kubernetes==11.0.0
-      - openshift==0.11.2
-
 - name: launch config rendering
   shell: |
     ./render-environment-configs.sh {{ deploy_environment }}

--- a/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
+++ b/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
@@ -11,3 +11,4 @@ shell_environment:
 
 SRIOVNodes: []
 remote_cluster_prow_jobs_context: ibm-prow-jobs
+ansible_python_interpreter: /usr/bin/python3

--- a/github/ci/prow-deploy/vars/workloads-production/main.yml
+++ b/github/ci/prow-deploy/vars/workloads-production/main.yml
@@ -16,3 +16,4 @@ SRIOVNodes:
     capacity: 2
 
 remote_cluster_prow_jobs_context: prow-workloads
+ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
prow-deploy image already ships kubernetes and openshift modules, but installed with the python3 interpreter. We needed to install them again in the test execution because the interpreter used was python2.7. Now this python version is deprecated and the pip installation during the test started failing like here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1380/pull-project-infra-prow-deploy-test/1408335642642878464

With these changes we make sure that python3 is used both for testing and deployment. The pip installation during testing is no longer needed, we use the modules installed in the image.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>