### PR TITLE
periodics, 1.21-sig-network, remove QUARANTINE env var

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -581,8 +581,6 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
-          - name: KUBEVIRT_QUARANTINE
-            value: "true"
           - name: TARGET
             value: "k8s-1.21-sig-network"
         command:


### PR DESCRIPTION
Removing QUARANTINE env var results in skipping QUARANTINE tests.

Since those tests are flaky and quarantined we don't
need to run them in the periodic, so it will reflect the true
state of the job.

Signed-off-by: Or Shoval <oshoval@redhat.com>