### PR TITLE
Update branch for repo config, move jobs to ibm cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -7,12 +7,10 @@ periodics:
     extra_refs:
       - org: kubevirt
         repo: kubevirt.github.io
-        base_ref: source
+        base_ref: master
         path_alias: kubevirt.github.io
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
-      nodeSelector:
-        region: primary
       containers:
         - image: docker.io/library/ruby
           env:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -4,10 +4,8 @@ presubmits:
       decorate: true
       always_run: true
       skip_report: false
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          region: primary
         containers:
           - image: docker.io/library/ruby
             env:

--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -355,7 +355,7 @@ orgs:
         homepage: https://www.kubevirt.io/
       kubevirt.github.io:
         allow_rebase_merge: false
-        default_branch: source
+        default_branch: master
         description: KubeVirt website repo, documentation at https://kubevirt.io/user-guide/
         has_projects: false
         has_wiki: false


### PR DESCRIPTION
Due to the default branch change the repo config needs to get adjusted, otherwise the peribolos job fails. See: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-org-github-config-updater/1409764248128589824#1:build-log.txt%3A150

Also we move the existing jobs away from phx-prow.

/cc @fgimenez 

FYI @mazzystr 