### PR TITLE
Fix branch-protector for CDI and CNAO

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -284,7 +284,7 @@ branch-protection:
               protect: true
         containerized-data-importer:
           branches:
-            master:
+            main:
               protect: true
         hyperconverged-cluster-operator:
           branches:
@@ -304,7 +304,7 @@ branch-protection:
               protect: true
         cluster-network-addons-operator:
           branches:
-            master:
+            main:
               protect: true
             release-0.27:
               protect: true


### PR DESCRIPTION
Fixes #1383

Now that the default branch has changed in these repos we need to update branch-protector config.

/cc @dhiller @awels 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>