### PR TITLE
kubevirtci k8s-x.yy presubmits, Increase max_concurrency to 2

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -87,7 +87,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 3h
-    max_concurrency: 1
+    max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -115,7 +115,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 3h
-    max_concurrency: 1
+    max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -142,7 +142,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 3h
-    max_concurrency: 1
+    max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"


### PR DESCRIPTION
In order to allow more than one PR test the mandatory lanes,
increase max_concurrency to 2.

Signed-off-by: Or Shoval <oshoval@redhat.com>