### PR TITLE
Update the image for cgroupsv2 jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -178,7 +178,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -205,7 +205,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"


### PR DESCRIPTION
Currently the image specified for cgroup v2 lanes is incorrect. Update to the proper one. Needed for https://github.com/kubevirt/kubevirtci/pull/638