### PR TITLE
Add namespace for fossa token

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -329,6 +329,7 @@ secretGenerator:
       - token=secrets/kubevirtci-coveralls-token
     type: Opaque
   - name: kubevirtci-fossa-token
+    namespace: kubevirt-prow-jobs
     files:
       # fossaToken
       - token=secrets/kubevirtci-fossa-token

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -66,6 +66,7 @@ secretGenerator:
       - productKey=secrets/win-sysprep-001
     type: Opaque
   - name: kubevirtci-fossa-token
+    namespace: kubevirt-prow-jobs
     files:
       # fossaToken
       - token=secrets/kubevirtci-fossa-token


### PR DESCRIPTION
FOSSA token was created in kubevirt-prow namespace, jobs run in kubevirt-prow-jobs ns.

/cc @fgimenez 