### PR TITLE
Fix namespaces for secrets in kustomize

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -233,7 +233,7 @@ patches:
   - target:
       version: v1
       kind: Secret
-      namespace: ""
+      namespace: default
       name: .*
     path: patches/JsonRFC6902/prow-namespace.yaml
   - target:
@@ -270,10 +270,12 @@ configMapGenerator:
 
 secretGenerator:
   - name: oauth-token
+    namespace: kubevirt-prow-jobs
     files:
       - oauth=secrets/oauth-token
     type: Opaque
   - name: gcs
+    namespace: kubevirt-prow-jobs
     files:
       - secrets/service-account.json
     type: Opaque
@@ -294,6 +296,7 @@ secretGenerator:
       - secret=secrets/github-oauth-config
     type: Opaque
   - name: kubeconfig
+    namespace: kubevirt-prow-jobs
     files:
       - config=secrets/kubeconfig
     type: Opaque
@@ -301,6 +304,7 @@ secretGenerator:
     literals:
       - honk.txt=
   - name: kubevirtci-docker-credential
+    namespace: kubevirt-prow-jobs
     # username=dockerUser
     # password=dockerPass
     envs:
@@ -308,22 +312,26 @@ secretGenerator:
     type: Opaque
 
   - name: kubevirtci-quay-credential
+    namespace: kubevirt-prow-jobs
     # username=quayUser
     # password=quayPass
     envs:
     - secrets/kubevirtci-quay-credential
     type: Opaque
   - name: kubevirtci-installer-pull-token
+    namespace: kubevirt-prow-jobs
     files:
       # installerPullToken
       - token=secrets/kubevirtci-installer-pull-token
     type: Opaque
   - name: commenter-oauth-token
+    namespace: kubevirt-prow-jobs
     # githubCommenterToken
     files:
       - oauth=secrets/commenter-oauth-token
     type: Opaque
   - name: kubevirtci-coveralls-token
+    namespace: kubevirt-prow-jobs
     files:
       # coverallsToken
       - token=secrets/kubevirtci-coveralls-token

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -270,9 +270,17 @@ configMapGenerator:
 
 secretGenerator:
   - name: oauth-token
+    files:
+      - oauth=secrets/oauth-token
+    type: Opaque
+  - name: oauth-token
     namespace: kubevirt-prow-jobs
     files:
       - oauth=secrets/oauth-token
+    type: Opaque
+  - name: gcs
+    files:
+      - secrets/service-account.json
     type: Opaque
   - name: gcs
     namespace: kubevirt-prow-jobs
@@ -296,7 +304,6 @@ secretGenerator:
       - secret=secrets/github-oauth-config
     type: Opaque
   - name: kubeconfig
-    namespace: kubevirt-prow-jobs
     files:
       - config=secrets/kubeconfig
     type: Opaque


### PR DESCRIPTION
As the secrets for jobs in ibm-prow-jobs context need to get created
in kubevirt-prow-jobs ns we add the namespace explicitly to those.
We set the default for secrets without namespace declaration to go to
kubevirt-prow now.

Related to #1404 whose fix only works for context prow-workloads

Tested locally with kustomize, partial result:
```
....
---
apiVersion: v1
data:
  token: ""
kind: Secret
metadata:
  name: slack-token
  namespace: kubevirt-prow
type: Opaque
...
---
apiVersion: v1
data:
  honk.txt: ""
kind: Secret
metadata:
  name: unsplash-api-key
  namespace: kubevirt-prow
type: Opaque
---
...
---
apiVersion: v1
data:
  token: ""
kind: Secret
metadata:
  name: kubevirtci-fossa-token
  namespace: kubevirt-prow-jobs
type: Opaque
(END)

```