### PR TITLE
Fix cgroupv2 jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -551,7 +551,9 @@ periodics:
       - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
         env:
           - name: TARGET
-            value: "k8s-1.20-cgroupsv2"
+            value: "k8s-1.20"
+          - name: KUBEVIRT_CGROUPV2
+            value: "true"
           - name: KUBEVIRT_E2E_SKIP
             value: "Multus|SRIOV|GPU|Macvtap|\\[sig-operator\\]"
         command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -382,7 +382,9 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-cgroupsv2
+          value: k8s-1.20
+        - name: KUBEVIRT_CGROUPV2
+          value: "true"
         - name: KUBEVIRT_E2E_SKIP
           value: Multus|SRIOV|GPU|Macvtap|\[sig-operator\]
         image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -164,8 +164,8 @@ presubmits:
           requests:
             memory: "8Gi"
   - name: check-provision-k8s-1.20-cgroupsv2
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
The PR fixes the periodic and presubmit cgroupsv2 jobs considering the approach from https://github.com/kubevirt/kubevirtci/pull/638

**NOTE**: Also (if no objections) it will mark the presubmit jobs in kubevirtci as mandatory. 