### PR TITLE
Update Prometheus settings

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/common/kube-prometheus-stack.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/common/kube-prometheus-stack.yaml
@@ -1217,7 +1217,7 @@ spec:
     requests:
       cpu: 500m
       memory: 2Gi
-  retention: "10d"
+  retention: "4d"
   routePrefix: "/"
   serviceAccountName: prometheus-stack-kube-prom-prometheus
   serviceMonitorSelector:

--- a/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
+++ b/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
@@ -16,7 +16,7 @@ spec:
   resources:
     requests:
       cpu: 700m
-      memory: 4Gi
+      memory: 6Gi
     limits:
       cpu: 700m
-      memory: 4Gi
+      memory: 6Gi


### PR DESCRIPTION
We are ingesting more metrics now, Prometheus pod was being OOMKilled with the old settings. Also, now that Thanos is in place we don't need that much local retention (we also had issues with the PV being filled).

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>