### PR TITLE
Add experimental lane to prevent builds on docs changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1402,3 +1402,25 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
+  - name: pull-kubevirt-test-doc-change-ignore
+    skip_branches:
+    - release-\d+\.\d+
+    always_run: false
+    optional: false
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
+    skip_report: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    max_concurrency: 11
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        command:
+        - "echo"
+        - "test-doc-change-ignore lane executed"
+        resources:
+          requests:
+            memory: "10Mi"


### PR DESCRIPTION
According to https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#requiring-jobs-for-auto-merge-through-tide looks like this combination of options should work for having required jobs that are not triggered on doc changes:

* always_run: false
* optional: false
* skip_if_only_changed: <docs_regexp>

This way the job should keep being required when run, ie. when the regexp doesn't match at least for one of the changed files. The job in this PR is an experimental lane to check if it works as expected.

/cc @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>