### PR TITLE
rhcos-slb, Adding presubmits lane for main branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/RHsyseng/rhcos-slb/rhcos-slb-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/RHsyseng/rhcos-slb/rhcos-slb-presubmits.yaml
@@ -1,0 +1,33 @@
+---
+presubmits:
+  RHsyseng/rhcos-slb:
+    - name: pull-rhcos-slb-ci-network-tests-main
+      annotations:
+        fork-per-release: "true"
+      always_run: false
+      optional: true
+      decorate: true
+      cluster: prow-workloads
+      decoration_config:
+        timeout: 30m
+        grace_period: 5m
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20210706-a5d2c6b
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "4Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "tests/setup.sh && tests/test-coreos.sh"

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -317,6 +317,10 @@ plugins:
   - lgtm
   - owners-label
 
+  RHsyseng/rhcos-slb:
+  - trigger
+  - override
+
 external_plugins:
   libguestfs-appliance:
   - name: needs-rebase


### PR DESCRIPTION
Following the [added](https://github.com/RHsyseng/rhcos-slb/pull/24) ci test script on [rhcos-slb repo](https://github.com/RHsyseng/rhcos-slb), we would like to add am optional prow lane for it