### PR TITLE
ssp-operator: change merge_method to 'merge'

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -105,7 +105,7 @@ tide:
     kubevirt/kubevirt-template-validator: squash
     kubevirt/kubevirt-ssp-operator: squash
     kubevirt/csi-driver: squash
-    kubevirt/ssp-operator: rebase
+    kubevirt/ssp-operator: merge
     kubevirt/must-gather: squash
     kubevirt/user-guide: squash
     kubevirt/terraform-provider-kubevirt: merge


### PR DESCRIPTION
Change the `merge_method` of the SSP operator project to `merge`.