### PR TITLE
Do not run optional lanes on doc changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -17,7 +17,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-sig-network
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -56,7 +59,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-sig-storage
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -95,7 +101,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-sig-compute
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -134,7 +143,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-operator
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -174,7 +186,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-rest-coverage
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -291,7 +306,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-compute
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -370,7 +388,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-cgroupsv2
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -411,7 +432,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-compute-nonroot
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -452,7 +476,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-network-nonroot
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -493,7 +520,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-storage-nonroot
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -534,7 +564,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-operator-nonroot
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -770,7 +803,10 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.19-sriov-nonroot
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -929,7 +965,10 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -990,7 +1029,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-verify-rpms
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     run_if_changed: WORKSPACE
     skip_branches:
     - release-\d+\.\d+
@@ -1022,7 +1064,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-gosec
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     skip_report: true
@@ -1144,7 +1189,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-goveralls
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1184,7 +1232,10 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-fossa
+    # WARNING: please remember to remove skip_if_only_changed if this job is
+    # set to required (optional: false)
     optional: true
+    skip_if_only_changed: "^docs/|.md$|^LICENSE$"
     skip_branches:
     - release-\d+\.\d+
     skip_report: false


### PR DESCRIPTION
According to https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#protecting-status-contexts conditionally-run jobs may or may not post a status context to GitHub, and as such, they cannot be required through the branch protection mechanism. This prevents us from not executing required jobs depending on some condition, but we can still stop running the non-required ones. This PR changes the job definition of kubevirt/kubevirt presubmits to not trigger them on docs changes.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>