### PR TITLE
Tune greenhouse to not occupy the whole disk

### DIFF
--- a/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/kustomization.yaml
@@ -3,3 +3,11 @@ kind: Component
 
 resources:
   - resources/storage.yaml
+
+patches:
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: greenhouse
+    path: patches/JsonRFC6902/deployment.yaml

--- a/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/patches/JsonRFC6902/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/patches/JsonRFC6902/deployment.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/args/1
+  value: --min-percent-blocks-free=30


### PR DESCRIPTION
After setting a hostPath PV I've verified the available space in greenhouse container `/data` mount point and it didn't actually change:
```
$ kubectl exec -ti -n kubevirt-prow greenhouse-657d5bbc47-tgmfl -- /bin/sh
/app # df
Filesystem           1K-blocks      Used Available Use% Mounted on
[...............]
/dev/sda4            1872337680 208913800 1663423880  11% /data
[...............]
```
Still the whole 1.8Tb available to be filled. According to https://kubernetes.io/docs/concepts/storage/volumes/#resources `There is no limit on how much space an emptyDir or hostPath volume can consume, and no isolation between containers or between pods.` This is expected to work at some point by requesting a certain amount of space using a resource specification, but not yet in place.

For the time being In this PR we instruct greenhouse in `prow-workloads` cluster to use at most 70% of the data disk before starting to evict blocks, this would prevent the kubelet to report disk pressure.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>