### PR TITLE
Expose job's always_run and brancher settings

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: ci-usage-exporter
-        image: quay.io/kubevirtci/ci-usage-exporter:v20210707-83c2f8c1
+        image: quay.io/kubevirtci/ci-usage-exporter:v20210713-6507c046
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: ci-usage-exporter
-        image: quay.io/kubevirtci/ci-usage-exporter:v20210713-6507c046
+        image: quay.io/kubevirtci/ci-usage-exporter:v20210713-a46682bf
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/robots/pkg/ci-usage-exporter/metrics/metrics_test.go
+++ b/robots/pkg/ci-usage-exporter/metrics/metrics_test.go
@@ -89,8 +89,9 @@ var _ = Describe("resources", func() {
 
 		bodyStr := string(body)
 		for _, expectation := range expectations {
-			expectedMetric := fmt.Sprintf(`%s{job_cluster="%s",job_name="%s",org="%s",repo="%s",type="%s"} %g`,
+			expectedMetric := fmt.Sprintf(`%s{always_run="%s",job_cluster="%s",job_name="%s",org="%s",repo="%s",type="%s"} %g`,
 				expectation.name,
+				expectation.labels["always_run"],
 				expectation.labels["job_cluster"],
 				expectation.labels["job_name"],
 				expectation.labels["org"],
@@ -140,6 +141,51 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo",
 						"type":        "presubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "false",
+					},
+				},
+			},
+		),
+		Entry("presubmit honors always run",
+			metrics.Config{
+				ProwConfig: &prowConfig.Config{
+					JobConfig: prowConfig.JobConfig{
+						PresubmitsStatic: map[string][]prowConfig.Presubmit{
+							"test-org/test-repo": {
+								{
+									AlwaysRun: true,
+									JobBase: prowConfig.JobBase{
+										Name:    "test-job",
+										Cluster: "test-cluster",
+										Spec: &v1.PodSpec{
+											Containers: []v1.Container{
+												{
+													Resources: v1.ResourceRequirements{
+														Requests: v1.ResourceList{
+															v1.ResourceMemory: quantity1,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			[]metricExpectations{
+				{
+					name:  "kubevirt_ci_job_memory_bytes",
+					value: quantityValue1,
+					labels: map[string]string{
+						"job_name":    "test-job",
+						"org":         "test-org",
+						"repo":        "test-repo",
+						"type":        "presubmit",
+						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 			},
@@ -199,6 +245,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo",
 						"type":        "presubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "false",
 					},
 				},
 				{
@@ -210,6 +257,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo",
 						"type":        "presubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "false",
 					},
 				},
 			},
@@ -271,6 +319,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo1",
 						"type":        "presubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "false",
 					},
 				},
 				{
@@ -282,6 +331,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo2",
 						"type":        "presubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "false",
 					},
 				},
 			},
@@ -324,6 +374,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo",
 						"type":        "postsubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 			},
@@ -383,6 +434,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo",
 						"type":        "postsubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 				{
@@ -394,6 +446,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo",
 						"type":        "postsubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 			},
@@ -455,6 +508,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo1",
 						"type":        "postsubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 				{
@@ -466,6 +520,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo2",
 						"type":        "postsubmit",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 			},
@@ -504,6 +559,7 @@ var _ = Describe("resources", func() {
 						"job_name":    "test-job",
 						"type":        "periodic",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 			},
@@ -559,6 +615,7 @@ var _ = Describe("resources", func() {
 						"job_name":    "test-job1",
 						"type":        "periodic",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 				{
@@ -568,6 +625,7 @@ var _ = Describe("resources", func() {
 						"job_name":    "test-job2",
 						"type":        "periodic",
 						"job_cluster": "test-cluster",
+						"always_run":  "true",
 					},
 				},
 			},
@@ -650,6 +708,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo1",
 						"type":        "presubmit",
 						"job_cluster": "test-cluster1",
+						"always_run":  "false",
 					},
 				},
 				{
@@ -661,6 +720,7 @@ var _ = Describe("resources", func() {
 						"repo":        "test-repo2",
 						"type":        "postsubmit",
 						"job_cluster": "test-cluster2",
+						"always_run":  "true",
 					},
 				},
 				{
@@ -670,6 +730,7 @@ var _ = Describe("resources", func() {
 						"job_name":    "test-job3",
 						"type":        "periodic",
 						"job_cluster": "test-cluster3",
+						"always_run":  "true",
 					},
 				},
 			},

--- a/robots/pkg/ci-usage-exporter/metrics/resources.go
+++ b/robots/pkg/ci-usage-exporter/metrics/resources.go
@@ -11,7 +11,7 @@ import (
 var memoryResources = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "kubevirt_ci_job_memory_bytes",
 	Help: "Memory used by CI job",
-}, []string{"job_name", "org", "repo", "type", "job_cluster", "always_run"})
+}, []string{"job_name", "org", "repo", "type", "job_cluster", "always_run", "branches", "skip_branches"})
 
 type resourcesExporter struct{}
 
@@ -19,7 +19,7 @@ func (r *resourcesExporter) Start(c Config) error {
 	if c.ProwConfig.PresubmitsStatic != nil {
 		for orgrepo, presubmits := range c.ProwConfig.PresubmitsStatic {
 			for _, presubmit := range presubmits {
-				if err := r.registerJobBase(orgrepo, "presubmit", presubmit.JobBase, presubmit.AlwaysRun); err != nil {
+				if err := r.registerJobBase(orgrepo, "presubmit", presubmit.AlwaysRun, presubmit.JobBase, presubmit.Brancher); err != nil {
 					return err
 				}
 			}
@@ -28,7 +28,7 @@ func (r *resourcesExporter) Start(c Config) error {
 	if c.ProwConfig.PostsubmitsStatic != nil {
 		for orgrepo, postsubmits := range c.ProwConfig.PostsubmitsStatic {
 			for _, postsubmit := range postsubmits {
-				if err := r.registerJobBase(orgrepo, "postsubmit", postsubmit.JobBase, true); err != nil {
+				if err := r.registerJobBase(orgrepo, "postsubmit", true, postsubmit.JobBase, postsubmit.Brancher); err != nil {
 					return err
 				}
 			}
@@ -36,7 +36,7 @@ func (r *resourcesExporter) Start(c Config) error {
 	}
 	if c.ProwConfig.Periodics != nil {
 		for _, periodic := range c.ProwConfig.Periodics {
-			if err := r.registerJobBase("", "periodic", periodic.JobBase, true); err != nil {
+			if err := r.registerJobBase("", "periodic", true, periodic.JobBase, prowConfig.Brancher{}); err != nil {
 				return err
 			}
 		}
@@ -56,12 +56,21 @@ func init() {
 	prometheus.Register(memoryResources)
 }
 
-func (r *resourcesExporter) registerJobBase(orgrepo, kind string, jobBase prowConfig.JobBase, alwaysRun bool) error {
+func (r *resourcesExporter) registerJobBase(orgrepo, kind string, alwaysRun bool, jobBase prowConfig.JobBase, brancher prowConfig.Brancher) error {
 	org, repo := extractOrgRepo(orgrepo)
 	for _, container := range jobBase.Spec.Containers {
 		requestedMemory := container.Resources.Requests.Memory()
 		if requestedMemory != nil {
-			memoryResources.WithLabelValues(jobBase.Name, org, repo, kind, jobBase.Cluster, strconv.FormatBool(alwaysRun)).Set(requestedMemory.ToDec().AsApproximateFloat64())
+			memoryResources.WithLabelValues(
+				jobBase.Name,
+				org,
+				repo,
+				kind,
+				jobBase.Cluster,
+				strconv.FormatBool(alwaysRun),
+				strings.Join(brancher.Branches, ","),
+				strings.Join(brancher.SkipBranches, ","),
+			).Set(requestedMemory.ToDec().AsApproximateFloat64())
 		}
 	}
 	return nil

--- a/robots/pkg/ci-usage-exporter/metrics/resources.go
+++ b/robots/pkg/ci-usage-exporter/metrics/resources.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,7 +11,7 @@ import (
 var memoryResources = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "kubevirt_ci_job_memory_bytes",
 	Help: "Memory used by CI job",
-}, []string{"job_name", "org", "repo", "type", "job_cluster"})
+}, []string{"job_name", "org", "repo", "type", "job_cluster", "always_run"})
 
 type resourcesExporter struct{}
 
@@ -18,7 +19,7 @@ func (r *resourcesExporter) Start(c Config) error {
 	if c.ProwConfig.PresubmitsStatic != nil {
 		for orgrepo, presubmits := range c.ProwConfig.PresubmitsStatic {
 			for _, presubmit := range presubmits {
-				if err := r.registerJobBase(orgrepo, "presubmit", presubmit.JobBase); err != nil {
+				if err := r.registerJobBase(orgrepo, "presubmit", presubmit.JobBase, presubmit.AlwaysRun); err != nil {
 					return err
 				}
 			}
@@ -27,7 +28,7 @@ func (r *resourcesExporter) Start(c Config) error {
 	if c.ProwConfig.PostsubmitsStatic != nil {
 		for orgrepo, postsubmits := range c.ProwConfig.PostsubmitsStatic {
 			for _, postsubmit := range postsubmits {
-				if err := r.registerJobBase(orgrepo, "postsubmit", postsubmit.JobBase); err != nil {
+				if err := r.registerJobBase(orgrepo, "postsubmit", postsubmit.JobBase, true); err != nil {
 					return err
 				}
 			}
@@ -35,7 +36,7 @@ func (r *resourcesExporter) Start(c Config) error {
 	}
 	if c.ProwConfig.Periodics != nil {
 		for _, periodic := range c.ProwConfig.Periodics {
-			if err := r.registerJobBase("", "periodic", periodic.JobBase); err != nil {
+			if err := r.registerJobBase("", "periodic", periodic.JobBase, true); err != nil {
 				return err
 			}
 		}
@@ -55,12 +56,12 @@ func init() {
 	prometheus.Register(memoryResources)
 }
 
-func (r *resourcesExporter) registerJobBase(orgrepo, kind string, jobBase prowConfig.JobBase) error {
+func (r *resourcesExporter) registerJobBase(orgrepo, kind string, jobBase prowConfig.JobBase, alwaysRun bool) error {
 	org, repo := extractOrgRepo(orgrepo)
 	for _, container := range jobBase.Spec.Containers {
 		requestedMemory := container.Resources.Requests.Memory()
 		if requestedMemory != nil {
-			memoryResources.WithLabelValues(jobBase.Name, org, repo, kind, jobBase.Cluster).Set(requestedMemory.ToDec().AsApproximateFloat64())
+			memoryResources.WithLabelValues(jobBase.Name, org, repo, kind, jobBase.Cluster, strconv.FormatBool(alwaysRun)).Set(requestedMemory.ToDec().AsApproximateFloat64())
 		}
 	}
 	return nil


### PR DESCRIPTION
This will allow us to estimate the resource utilization per full execution on each PR (taking into account only presubmit jobs that have `always_run: true` and discarding release presubmits through the brancher.branches and brancher.skip_branches settings).

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>