### PR TITLE
Create periodic for kubevirt/kubevirt#5922 SRIOV migration tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1094,6 +1094,97 @@ periodics:
           hostPath:
             path: /dev/vfio/
             type: Directory
+- name: periodic-kubevirt-e2e-k8s-1.19-sriov-migration
+  annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+    k8s.v1.cni.cncf.io/networks: 'multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni'
+  cron: "0,30 2,3 * * *"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+    grace_period: 30m
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: main
+      work_dir: true
+  skip_report: true
+  cluster: prow-workloads
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  spec:
+    nodeSelector:
+      hardwareSupport: sriov-nic
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+                - key: sriov-pod
+                  operator: In
+                  values:
+                    - "true"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+                - key: sriov-pod-multi
+                  operator: In
+                  values:
+                    - "true"
+            topologyKey: kubernetes.io/hostname
+    containers:
+      - image: quay.io/kubevirtci/golang:v20210316-d295087
+        env:
+          - name: KUBEVIRT_QUARANTINE
+            value: "true"
+          - name: "TARGET"
+            value: "kind-1.19-sriov"
+          - name: "GIMME_GO_VERSION"
+            value: "1.13.8"
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/bash"
+          - "-ce"
+          - |
+            pr=5922
+            branch="pr$pr"
+            git fetch origin pull/$pr/head:$branch
+            git checkout $branch
+            automation/test.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "29Gi"
+        volumeMounts:
+          #for running kind with dind (see https://github.com/kubernetes-sigs/kind/issues/303)
+          - name: modules
+            mountPath: /lib/modules
+            readOnly: true
+          - name: cgroup
+            mountPath: /sys/fs/cgroup
+          - name: vfio
+            mountPath: /dev/vfio/
+    volumes:
+      - name: modules
+        hostPath:
+          path: /lib/modules
+          type: Directory
+      - name: cgroup
+        hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+      - name: vfio
+        hostPath:
+          path: /dev/vfio/
+          type: Directory
 - name: bump-kubevirt-rpms-weekly
   cron: "15 22 * * 0"
   branches:


### PR DESCRIPTION
Following kubevirt/kubevirt#5922
There are three new tests, two of them tests
SRIOV migration abort while running.
These tests pass consistently of local env
but flaky on CI.

On the old CI cluster, SRIOV jobs were scheduled
to dedicated nodes (with SRIOV hardware) that run
SRIOV job only.
Unlike the new cluster that schedule various kind of
jobs on the SRIOV nodes in parallel.

To confirm that its the pressure on the nodes that
affects the new SRIOV migration tests stability
This commit creates periodic job to run them
on late night hours where there is less pressure
on CI.

Signed-off-by: Or Mergi <ormergi@redhat.com>