### PR TITLE
Set base branch to main for flakefinder jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -23,6 +23,7 @@ periodics:
           - --today=true
           - --report_output_child_path=kubevirt/kubevirt
           - --skip_results_before_start_of_report=false
+          - --pr_base_branch=main
         volumeMounts:
           - name: token
             mountPath: /etc/github
@@ -60,6 +61,7 @@ periodics:
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
       - --periodic_job_dir_regex=periodic-kubevirt-e2e-.*
+      - --pr_base_branch=main
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -97,6 +99,7 @@ periodics:
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
       - --periodic_job_dir_regex=periodic-kubevirt-e2e-.*
+      - --pr_base_branch=main
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -134,6 +137,7 @@ periodics:
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
       - --periodic_job_dir_regex=periodic-kubevirt-e2e-.*
+      - --pr_base_branch=main
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
Corrects the setting for the base branch for repos where the default branch has been renamed.

Fixes kubevirt/kubevirt#6043