### PR TITLE
Update Prometheus settings

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/common/kube-prometheus-stack.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/common/kube-prometheus-stack.yaml
@@ -1217,7 +1217,7 @@ spec:
     requests:
       cpu: 500m
       memory: 2Gi
-  retention: "4d"
+  retention: "2d"
   routePrefix: "/"
   serviceAccountName: prometheus-stack-kube-prom-prometheus
   serviceMonitorSelector:
@@ -1251,7 +1251,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 50Gi
+            storage: 60Gi
   additionalScrapeConfigs:
     name: prometheus-stack-kube-prom-prometheus-scrape-confg
     key: additional-scrape-configs.yaml


### PR DESCRIPTION
We still had issues with the Prometheus PV being filled, these changes make the retention even lower (no need to retain a lot of data given that now Thanos is in place) and increase a bit the PV size.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>