### PR TITLE
Add configuration for GitHub webhooks reconciliation

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -236,8 +236,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        # TODO: update to latest version for hmac
-        - image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
+        - image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -289,7 +288,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
+        - image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -342,7 +341,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
+        - image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -236,6 +236,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
+        # TODO: update to latest version for hmac
         - image: quay.io/kubevirtci/prow-deploy:v20210129-a239273
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -301,7 +301,7 @@ presubmits:
       securityContext:
         runAsUser: 0
       containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210618-2e4be2d
+        - image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -522,13 +522,14 @@ managed_webhooks:
   org_repo_config:
     kubevirt:
       token_created_after: 2021-07-15T01:00:00Z
-    k8snetworkplumbingwg/kubemacpool:
-      token_created_after: 2021-07-15T01:00:00Z
-    k8snetworkplumbingwg/ovs-cni:
-      token_created_after: 2021-07-15T01:00:00Z
-    nmstate/kubernetes-nmstate:
-      token_created_after: 2021-07-15T01:00:00Z
-    nmstate/nmstate:
-      token_created_after: 2021-07-15T01:00:00Z
-    RHsyseng/rhcos-slb:
-      token_created_after: 2021-07-15T01:00:00Z
+# TODO: onboard remaining orgs and repos
+#    k8snetworkplumbingwg/kubemacpool:
+#      token_created_after: 2021-07-15T01:00:00Z
+#    k8snetworkplumbingwg/ovs-cni:
+#      token_created_after: 2021-07-15T01:00:00Z
+#    nmstate/kubernetes-nmstate:
+#      token_created_after: 2021-07-15T01:00:00Z
+#    nmstate/nmstate:
+#      token_created_after: 2021-07-15T01:00:00Z
+#    RHsyseng/rhcos-slb:
+#      token_created_after: 2021-07-15T01:00:00Z

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -521,14 +521,14 @@ managed_webhooks:
   # Config for orgs and repos that have been onboarded to this Prow instance.
   org_repo_config:
     kubevirt:
-      token_created_after: 2021-07-15T18:00:00Z
+      token_created_after: 2021-07-15T01:00:00Z
     k8snetworkplumbingwg/kubemacpool:
-      token_created_after: 2021-07-15T18:00:00Z
+      token_created_after: 2021-07-15T01:00:00Z
     k8snetworkplumbingwg/ovs-cni:
-      token_created_after: 2021-07-15T18:00:00Z
+      token_created_after: 2021-07-15T01:00:00Z
     nmstate/kubernetes-nmstate:
-      token_created_after: 2021-07-15T18:00:00Z
+      token_created_after: 2021-07-15T01:00:00Z
     nmstate/nmstate:
-      token_created_after: 2021-07-15T18:00:00Z
+      token_created_after: 2021-07-15T01:00:00Z
     RHsyseng/rhcos-slb:
-      token_created_after: 2021-07-15T18:00:00Z
+      token_created_after: 2021-07-15T01:00:00Z

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -514,3 +514,21 @@ presets:
   - name: kubevirtci-cred
     mountPath: /etc/kubevirtci-cred
     readOnly: true
+
+managed_webhooks:
+  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
+  respect_legacy_global_token: true
+  # Config for orgs and repos that have been onboarded to this Prow instance.
+  org_repo_config:
+    kubevirt:
+      token_created_after: 2021-07-15T18:00:00Z
+    k8snetworkplumbingwg/kubemacpool:
+      token_created_after: 2021-07-15T18:00:00Z
+    k8snetworkplumbingwg/ovs-cni:
+      token_created_after: 2021-07-15T18:00:00Z
+    nmstate/kubernetes-nmstate:
+      token_created_after: 2021-07-15T18:00:00Z
+    nmstate/nmstate:
+      token_created_after: 2021-07-15T18:00:00Z
+    RHsyseng/rhcos-slb:
+      token_created_after: 2021-07-15T18:00:00Z

--- a/github/ci/prow-deploy/molecule/default/molecule.yml
+++ b/github/ci/prow-deploy/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/kubevirtci/prow-deploy:v20210618-2e4be2d
+    image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
     privileged: True
     etc_hosts:
       "gcsweb.prowdeploy.ci": "127.0.0.1"

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -46,7 +46,7 @@
       --hmac-token-key=hmac \
       --hook-url https://prow.ci.kubevirt.io/hook \
       --deck-url https://prow.ci.kubevirt.io/ \
-      --dry-run=true
+      --dry-run=false
   environment:
     PROW_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/config/config.yaml"
     GITHUB_TOKEN_PATH: "{{ secrets_dir }}/oauth-token"

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -34,6 +34,25 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: bootstrap_full_config
 
+- name: Reconcile webhooks for onboarded repositories
+  shell: |
+    hmac \
+      --config-path=$PROW_CONFIG_PATH \
+      --github-token-path=$GITHUB_TOKEN_PATH \
+      --kubeconfig=$KUBECONFIG \
+      --kubeconfig-context=ibm-prow-jobs \
+      --hmac-token-secret-namespace={{ prowNamespace }} \
+      --hmac-token-secret-name=hmac-token \
+      --hmac-token-key=hmac \
+      --hook-url https://prow.ci.kubevirt.io/hook \
+      --deck-url https://prow.ci.kubevirt.io/ \
+      --dry-run=true
+  environment:
+    PROW_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/config/config.yaml"
+    GITHUB_TOKEN_PATH: "{{ secrets_dir }}/oauth-token"
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  when: reconcile_github_webhooks
+
 - name: Patch SRIOV nodes
   shell: |
     {{ project_infra_root }}/hack/patch_node.sh {{ item.name }} {{ item.capacity }}

--- a/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
+++ b/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
@@ -1,6 +1,7 @@
 testinfra_dir: /tmp/test-infra
 kubectl_exec: /usr/local/bin/kubectl
 bootstrap_full_config: true
+reconcile_github_webhooks: true
 project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/secrets/'
 components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -28,6 +28,7 @@ installerPullToken: '{}'
 coverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
 
 bootstrap_full_config: true
+reconcile_github_webhooks: false
 
 kubeconfig_path: /root/.kube/config
 

--- a/github/ci/prow-deploy/vars/workloads-production/main.yml
+++ b/github/ci/prow-deploy/vars/workloads-production/main.yml
@@ -1,6 +1,7 @@
 testinfra_dir: /tmp/test-infra
 kubectl_exec: /usr/local/bin/kubectl
 bootstrap_full_config: false
+reconcile_github_webhooks: false
 project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/workloads-production/secrets/'
 components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'


### PR DESCRIPTION
Add configuration in configs.yaml to onboard the existing orgs. Add hmac
tool execution to deploy.yaml, only being executed on the real
deployment.

/cc @rmohr @fgimenez 