### PR TITLE
Only deploy Prow on relevant changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -223,6 +223,7 @@ postsubmits:
                 memory: "4Gi"
     - name: post-project-infra-prow-control-plane-deployment
       always_run: false
+      run_if_changed: "github/ci/prow-deploy/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -289,7 +289,7 @@ presubmits:
               memory: "8Gi"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
-    run_if_changed: "github/ci/prow-deploy/.*|github/ci/prow-deploy/files/.*"
+    run_if_changed: "github/ci/prow-deploy/.*"
     decorate: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
We are currently redeploying prow on each merge to main, these changes restrict deployment to changes on `github/ci/prow/deploy/.*`. Also fix a redundant regexp for triggering prow-deploy tests.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>