### PR TITLE
Update pull-cdi-unit-test job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -272,7 +272,7 @@ presubmits:
             requests:
               memory: "29Gi"
   - name: pull-cdi-unit-test
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -287,7 +287,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
@@ -301,7 +300,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "4Gi"
+              memory: "8Gi"
   - name: pull-cdi-generate-verify
     cluster: ibm-prow-jobs
     skip_branches:


### PR DESCRIPTION
`pull-cdi-unit-test` has started failing recently, like here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1863/pull-cdi-unit-test/1415713420736466944 These changes aim to stabilize the execution by giving the job more memory and moving it to the workloads cluster. Given that the tests are executed with `go test` the bazel cache preset is also removed.

Successful execution here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/1863/pull-cdi-unit-test/1416013362738761728, execution time goes down from ~7m to 1m25s.

/cc @awels @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>