### PR TITLE
Add remaining repos to managed webhooks configuration

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -522,14 +522,13 @@ managed_webhooks:
   org_repo_config:
     kubevirt:
       token_created_after: 2021-07-15T01:00:00Z
-# TODO: onboard remaining orgs and repos
-#    k8snetworkplumbingwg/kubemacpool:
-#      token_created_after: 2021-07-15T01:00:00Z
-#    k8snetworkplumbingwg/ovs-cni:
-#      token_created_after: 2021-07-15T01:00:00Z
-#    nmstate/kubernetes-nmstate:
-#      token_created_after: 2021-07-15T01:00:00Z
-#    nmstate/nmstate:
-#      token_created_after: 2021-07-15T01:00:00Z
-#    RHsyseng/rhcos-slb:
-#      token_created_after: 2021-07-15T01:00:00Z
+    k8snetworkplumbingwg/kubemacpool:
+      token_created_after: 2021-07-16T01:00:00Z
+    k8snetworkplumbingwg/ovs-cni:
+      token_created_after: 2021-07-16T01:00:00Z
+    nmstate/kubernetes-nmstate:
+      token_created_after: 2021-07-16T01:00:00Z
+    nmstate/nmstate:
+      token_created_after: 2021-07-16T01:00:00Z
+    RHsyseng/rhcos-slb:
+      token_created_after: 2021-07-16T01:00:00Z


### PR DESCRIPTION
This is the configuration to add the remaining repositories that are onboarded to KubeVirt CI to also have managed their GitHub webhook by KubeVirt Prow instance. 

/cc @phoracek @stu-gott @fgimenez 