### PR TITLE
Remove new lines in retester query

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -12,20 +12,7 @@ periodics:
       - /app/robots/commenter/app.binary
       args:
       - |-
-        --query=is:pr
-        -label:do-not-merge
-        -label:do-not-merge/blocked-paths
-        -label:do-not-merge/cherry-pick-not-approved
-        -label:do-not-merge/hold
-        -label:do-not-merge/invalid-owners-file
-        -label:do-not-merge/release-note-label-needed
-        -label:do-not-merge/work-in-progress
-        label:lgtm
-        label:approved
-        status:failure
-        -label:needs-rebase
-        -label:needs-ok-to-test
-        repo:kubevirt/kubevirt
+        --query=is:pr is:open -label:do-not-merge -label:do-not-merge/blocked-paths -label:do-not-merge/cherry-pick-not-approved -label:do-not-merge/hold -label:do-not-merge/invalid-owners-file -label:do-not-merge/release-note-label-needed -label:do-not-merge/work-in-progress label:lgtm label:approved status:failure -label:needs-rebase -label:needs-ok-to-test repo:kubevirt/kubevirt
       - --token=/etc/github/oauth
       - |-
         --comment=/retest


### PR DESCRIPTION
Retester haven't been creating comments for a while, removing the new lines in the query fixes the issue. Job executed with the old query https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-retester/1416057716270436352 and with the new one right after https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-retester/1416064652709728256

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>