### PR TITLE
EnsureProviderExists should not touch existing

### DIFF
--- a/robots/pkg/kubevirtci/kubevirtci.go
+++ b/robots/pkg/kubevirtci/kubevirtci.go
@@ -65,7 +65,7 @@ func EnsureProviderExists(providerDir string, clusterUpDir string, release *gith
 	semver := *querier.ParseRelease(release)
 
 	for _, rel := range existing {
-		cmp := rel.Compare(&semver)
+		cmp := rel.CompareMajorMinor(&semver)
 		if cmp > 0 {
 			// not yet there
 			continue

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -262,7 +262,7 @@ var testsEnsureProviderExists = []struct {
 		},
 	},
 	{
-		name:    "expect the latest 1.16 provider to be updated from 1.16.5 to 1.16.7",
+		name:    "expect the latest 1.16 provider not to be updated from 1.16.5 to 1.16.7 (already done by ensureLatestThreeMinor)",
 		release: release("v1.16.7", true),
 		existing: []querier.SemVer{
 			newSemVer("1", "2", "1"),
@@ -271,7 +271,7 @@ var testsEnsureProviderExists = []struct {
 			newSemVer("1", "16", "5"),
 		},
 		wanted: []querier.SemVer{
-			newSemVer("1", "16", "7"),
+			newSemVer("1", "16", "5"),
 			newSemVer("1", "9", "4"),
 			newSemVer("1", "3", "2"),
 			newSemVer("1", "2", "1"),


### PR DESCRIPTION
If a provider already exists for a kubernetes version, but it has a
different revision number, we don't want to update the revision as this
does the same what ensureLatestThreeMinor does.

See https://github.com/kubevirt/kubevirtci/pull/643 as an example.