### PR TITLE
Increase Prometheus CPU resources in control plane

### DIFF
--- a/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
+++ b/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
@@ -16,7 +16,7 @@ spec:
   resources:
     requests:
       cpu: 1
-      memory: 12Gi
+      memory: 6Gi
     limits:
       cpu: 1
-      memory: 12Gi
+      memory: 6Gi

--- a/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
+++ b/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
@@ -15,8 +15,8 @@ spec:
       name: thanos-objstore-config
   resources:
     requests:
-      cpu: 700m
-      memory: 6Gi
+      cpu: 1
+      memory: 12Gi
     limits:
-      cpu: 700m
-      memory: 6Gi
+      cpu: 1
+      memory: 12Gi


### PR DESCRIPTION
Prometheus pod is still being OOMKilled in ibm-prow-jobs cluster, this leads to these gaps in metrics:

![Screenshot from 2021-07-19 15-26-27](https://user-images.githubusercontent.com/70376/126167385-dd32abac-3ac3-4cfd-aee3-1e4b060e739e.png)

These changes give it resources according to the recorded resource utilization:

![Screenshot from 2021-07-19 15-35-17](https://user-images.githubusercontent.com/70376/126168493-44b06121-efb5-4e43-8a8c-10e476ca9d20.png) 

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>