### PR TITLE
Add RedHatQE/openshift-python-wrapper to managed webhooks

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -537,3 +537,5 @@ managed_webhooks:
       token_created_after: 2021-07-16T01:00:00Z
     RHsyseng/rhcos-slb:
       token_created_after: 2021-07-16T01:00:00Z
+    RedHatQE/openshift-python-wrapper:
+      token_created_after: 2021-07-22T01:00:00Z


### PR DESCRIPTION
This will configure gh webhook on RedHatQE/openshift-python-wrapper repo, kubevirt-bot is already admin there.

/cc @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>