### PR TITLE
Adjust resources for several components

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -70,6 +70,12 @@ patches:
       version: v1
       group: apps
       kind: Deployment
+      name: sinker
+    path: patches/JsonRFC6902/sinker_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
       name: ghproxy
     path: patches/JsonRFC6902/ghproxy_deployment.yaml
   - target:

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/sinker_deployment.yaml
@@ -3,8 +3,8 @@
   path: /spec/template/spec/containers/0/resources
   value:
     limits:
-      cpu: 500m
+      cpu: 400m
       memory: 600Mi
     requests:
-      cpu: 500m
+      cpu: 400m
       memory: 600Mi

--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -128,7 +128,13 @@ spec:
             port: 9090
             scheme: HTTP
           periodSeconds: 5
-        resources: {}
+        resources:
+          limits:
+            cpu: 100m
+            memory: 800Mi
+          requests:
+            cpu: 100m
+            memory: 800Mi
         terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         fsGroup: 65534
@@ -272,10 +278,10 @@ spec:
         resources:
           limits:
             cpu: 0.42
-            memory: 420Mi
+            memory: 1Gi
           requests:
-            cpu: 0.123
-            memory: 123Mi
+            cpu: 0.42
+            memory: 1Gi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/store

--- a/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
+++ b/github/ci/services/prometheus-stack/patches/production-control-plane/prometheus.yaml
@@ -16,7 +16,7 @@ spec:
   resources:
     requests:
       cpu: 1
-      memory: 6Gi
+      memory: 12Gi
     limits:
       cpu: 1
-      memory: 6Gi
+      memory: 12Gi


### PR DESCRIPTION
Resources adjusted according to reported usage from https://grafana.ci.kubevirt.io/d/GlXkUBGiz/kubernetes-pod-overview?orgId=1&refresh=10s

The resources are defined with matching limits and requests to:
* Force Guaranteed QoS
* Have predictable resource utilization, we won't see utilization spikes on these pods.
* The pods with these limits have the resources available, the rest of pods will need to fight for the remaining resources with the risk of being throttled on CPU and even evicted first if they use too much memory. 

/cc @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>