### PR TITLE
Include local manifests in bump-prow script

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,6 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        # TODO before upgrade check back whether https://github.com/kubernetes/test-infra/issues/18074 is fixed
         image: gcr.io/k8s-prow/cherrypicker:v20210722-64d720b97e
         imagePullPolicy: Always
         args:

--- a/hack/bump-prow.sh
+++ b/hack/bump-prow.sh
@@ -44,6 +44,12 @@ bump_exporter(){
     sed -i "s!image: gcr.io/k8s-prow/exporter:.*!image: gcr.io/k8s-prow/exporter:${latest_prow_tag}!" ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
 }
 
+bump_base_manifests_local_images(){
+    local latest_prow_tag=$1
+
+    find ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/base/manifests/local -type f -name '*.yaml' | xargs sed -i "s!image: gcr.io/k8s-prow/\(.*\):.*!image: gcr.io/k8s-prow/\\1:${latest_prow_tag}!"
+}
+
 main(){
     copy_files
 
@@ -57,6 +63,7 @@ main(){
 
     bump_utility_images "${latest_prow_tag}"
     bump_exporter "${latest_prow_tag}"
+    bump_base_manifests_local_images "${latest_prow_tag}"
 }
 
 main "${@}"


### PR DESCRIPTION
This will update images for branchprotector, label_sync, and cherrypicker. Also removed TODO comment about this issue already closed https://github.com/kubernetes/test-infra/pull/18077

/cc @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>