### PR TITLE
Do not create HMAC secret

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -298,10 +298,6 @@ secretGenerator:
     files:
       - secret=secrets/cookie
     type: Opaque
-  - name: hmac-token
-    files:
-      - hmac=secrets/hmac-token
-    type: Opaque
   - name: github-oauth-config
     files:
       - secret=secrets/github-oauth-config

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/hmac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/hmac.yaml
@@ -1,0 +1,3 @@
+'*':
+- created_at: "0001-01-01T00:00:00Z"
+  value: BThNWMyFuvll3DLyCa2VAivt9hI+F47OWcz7tqfp

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -95,7 +95,7 @@
         - patches
         - resources
 
-    - name: patch production resources for testing usage
+    - name: prepare production resources for testing usage
       block:
         - name: patch ghproxy pvc class
           shell: |
@@ -113,3 +113,9 @@
           loop:
             - deck_deployment
             - prow_controller_manager_deployment
+        - name: create hmac secret
+          shell: |
+            kubectl create secret -n kubevirt-prow generic hmac-token --from-file=hmac={{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/resources/hmac.yaml
+          changed_when: false
+          environment:
+            KUBECONFIG: '{{ kubeconfig_path }}'

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -44,11 +44,6 @@
     content: '{{ appCookieSecret }}'
     dest: '{{ secrets_dir }}/cookie'
 
-- name: Create hmac secret
-  copy:
-    content: '{{ prowHmac }}'
-    dest: '{{ secrets_dir }}/hmac-token'
-
 - name: Create Github OAuth config secret
   copy:
     content: '{{ appOAuthConfig }}'


### PR DESCRIPTION
Now that we are using the [hmac tool](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/hmac/README.md) to handle the HMAC setup we no longer need to create the k8s secret ourselves with a plain random string, the secret is created by the tool and the contents are updated every time we reexecute it. 

The changes includes code to initialize the hmac secret on the integration testing env, where we don't call the hmac tool.

/cc @enp0s3 @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>