### PR TITLE
Update release-blocker

### DIFF
--- a/external-plugins/release-blocker/BUILD.bazel
+++ b/external-plugins/release-blocker/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@io_k8s_test_infra//prow/pluginhelp:go_default_library",
         "@io_k8s_test_infra//prow/pluginhelp/externalplugins:go_default_library",
         "@io_k8s_test_infra//prow/plugins:go_default_library",
+        "@io_k8s_test_infra//prow/plugins/ownersconfig:go_default_library",
         "@io_k8s_test_infra//prow/repoowners:go_default_library",
     ],
 )

--- a/external-plugins/release-blocker/server.go
+++ b/external-plugins/release-blocker/server.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"

--- a/external-plugins/release-blocker/server_test.go
+++ b/external-plugins/release-blocker/server_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
+
 	"kubevirt.io/project-infra/external-plugins/testutils"
 )
 

--- a/external-plugins/testutils/BUILD.bazel
+++ b/external-plugins/testutils/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
         "@io_k8s_test_infra//prow/github:go_default_library",
+        "@io_k8s_test_infra//prow/pkg/layeredsets:go_default_library",
+        "@io_k8s_test_infra//prow/plugins/ownersconfig:go_default_library",
         "@io_k8s_test_infra//prow/repoowners:go_default_library",
     ],
 )

--- a/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
@@ -23,6 +23,7 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
         ports:
           - name: http
             containerPort: 8888

--- a/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: release-blocker
-        image: quay.io/kubevirtci/release-blocker@sha256:503b3a00a7e4fe344601710ef58470ddb1e05c9a3d3fdcd16ba6a93921c17542
+        image: quay.io/kubevirtci/release-blocker:v20210728-c3fc6359
         imagePullPolicy: Always
         args:
         - --dry-run=false


### PR DESCRIPTION
After the recent update of the format of our HMAC secret `release-blocker` pod is failing with:

```
{"level":"debug","msg":"403 Forbidden: Invalid X-Hub-Signature","response":"403 Forbidden: Invalid X-Hub-Signature","status-code":403,"time":"2021-07-28T13:19:58Z"}
``` 

Similar to what happened with cherrypicker but in this case we need to update our code and rebuild the image.

/cc @rmohr @enp0s3 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>