### PR TITLE
Set the number of kept packages to 2 in workloads cluster nodes

### DIFF
--- a/github/ci/prow-workloads/roles/bootstrap/tasks/main.yml
+++ b/github/ci/prow-workloads/roles/bootstrap/tasks/main.yml
@@ -95,5 +95,17 @@
   loop:
     - openvswitch
 
+- name: package maintenaince
+  block:
+    - name: set number of packages to keep by yum
+      lineinfile:
+        path: '/etc/yum.conf'
+        regexp: 'installonly_limit=.*'
+        line: 'installonly_limit=2'
+
+    - name: remove old packages kept
+      shell: |
+        dnf remove $(dnf repoquery --installonly --latest-limit=-2)
+
 - name: reboot to apply changes
   reboot:


### PR DESCRIPTION
We have had an issue in one of the nodes, the boot partition is only 256MB and yum was configured to keep files for 3 versions of the same package. This led to a situation in which a `dnf update` that introduced a new kernel was not able to put the new kernel files in place. The grub entry had been already updated and the node was not able to reboot.

These changes add tasks to set the number of packages kept by yum to 2 and also remove all the old packages leaving only the two most recent versions.

/cc @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>