### PR TITLE
openshift-python-wrapper remove release-note plugin

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -333,7 +333,6 @@ plugins:
   - hold
   - lgtm
   - approve
-  - release-note
   - owners-label
   - assign
   - blunderbuss


### PR DESCRIPTION
openshift-python-wrapper remove release-note plugin