### PR TITLE
Do not send slack notifications for batch jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -598,6 +598,9 @@ periodics:
       base_ref: main
       work_dir: true
   cluster: prow-workloads
+  reporter_config:
+    slack:
+      job_states_to_report: []
   spec:
     nodeSelector:
       type: bare-metal-external
@@ -1346,7 +1349,7 @@ periodics:
             # Push and deploy kubevirt
             make cluster-sync
 
-            FUNC_TEST_ARGS="--noColor --seed=42" make perftest            
+            FUNC_TEST_ARGS="--noColor --seed=42" make perftest
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -598,9 +598,6 @@ periodics:
       base_ref: main
       work_dir: true
   cluster: prow-workloads
-  reporter_config:
-    slack:
-      job_states_to_report: []
   spec:
     nodeSelector:
       type: bare-metal-external

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -185,7 +185,6 @@ slack_reporter_configs:
     job_types_to_report:
       - postsubmit
       - periodic
-      - batch
     job_states_to_report:
       - failure
       - error


### PR DESCRIPTION
We are receiving eventually error messages from presubmit jobs as batch like this one https://coreos.slack.com/archives/CTFN306KC/p1627981181003300, I've also added changes to prevent slack notifications of batch jobs by default.

/cc @rmohr @dhiller 