### PR TITLE
Fix python toolchain definition for Bazel.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,30 @@
+# See https://github.com/bazelbuild/rules_python/blob/main/docs/python.md#py_runtime_pair
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+
+py_runtime(
+    name = "py2_runtime",
+    interpreter_path = "/usr/bin/python2",
+    python_version = "PY2",
+)
+
+py_runtime(
+    name = "py3_runtime",
+    interpreter_path = "/usr/bin/python3",
+    python_version = "PY3",
+)
+
+py_runtime_pair(
+    name = "py_runtime_pair",
+    py2_runtime = ":py2_runtime",
+    py3_runtime = ":py3_runtime",
+)
+
+toolchain(
+    name = "py_toolchain",
+    toolchain = "py_runtime_pair",
+    toolchain_type = "@rules_python//python:toolchain_type",
+)
+
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix kubevirt.io/project-infra

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,3 +122,5 @@ rules_gitops_repositories()
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
+
+register_toolchains("//:py_toolchain")

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210126-a12b6c0
+          - image: quay.io/kubevirtci/bootstrap:v20210715-d0c2b78
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -39,7 +39,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210126-a12b6c0
+          - image: quay.io/kubevirtci/bootstrap:v20210715-d0c2b78
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -767,7 +767,7 @@ postsubmits:
         preset-bazel-cache: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210126-a12b6c0
+          - image: quay.io/kubevirtci/bootstrap:v20210715-d0c2b78
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"


### PR DESCRIPTION
Properly defines the Python toolchain to be used by Bazel when there are two of them available as described here https://github.com/bazelbuild/rules_python/blob/main/docs/python.md#py_runtime_pair  

Fixes errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-release-blocker-image/1420410039285321728 and allows us to use recent fedora-based bootstrap images for jobs that require a python toolchain, like those using rules_docker. Example of successful execution with `quay.io/kubevirtci/bootstrap:v20210715-d0c2b78` https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-release-blocker-image/1425368122788941824

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>