### PR TITLE
Configuration fixes of KubeVirt Velero Plugin's CI.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
             - "make test"
           # docker-in-docker needs privileged mode
           securityContext:
-            privileged: false
+            privileged: true
           resources:
             requests:
               memory: "4Gi"
@@ -53,7 +53,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "make test-functional"
+            - "make build-builder cluster-up cluster-push-image cluster-sync test-functional CLUSTER_PREFIX='-p pull-kvp-functional-test'"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
This PR fixes configuration of KubeVirt Velero Plugin's CI.

There are two fixes:
- pull-kvp-unit-test needs to be run in priviledged mode, because it
  runs the tests inside Docker container

- pull-kvp-functional-test has cluster setup pulled from the test target
  to the job configuration (i.e. test config instead of chainging
  dependencies inside Makefile target definition).

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>