### PR TITLE
Add periodic job, code and simple test for kubevirt-job-copier

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -578,6 +578,48 @@ periodics:
         secret:
           secretName: oauth-token
 
+- name: periodic-kubevirt-job-copier
+  cron: "20 0 * * *"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  cluster: prow-workloads
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+    - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
+      env:
+      - name: GIT_ASKPASS
+        value: ../project-infra/hack/git-askpass.sh
+      command: [ "/bin/sh" , "-c" ]
+      args:
+      - |
+        bazel_dir=$(mktemp -d) &&
+        curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
+        chmod a+x ${bazel_dir}/bazelisk &&
+        export PATH=${PATH}:${bazel_dir} &&
+        hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirt-job-copier:kubevirt-job-copier -- -job-config-path-kubevirt-presubmits=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml -job-config-path-kubevirt-periodics=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml -github-token-path= -dry-run=false" -r project-infra -b copy-kubevirt-jobs -T main
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github
+      resources:
+        requests:
+          memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token
+
 - name: periodic-project-infra-mirror-istioctl
   cron: "25 1 * * 1"
   decorate: true

--- a/robots/cmd/kubevirt-job-copier/BUILD.bazel
+++ b/robots/cmd/kubevirt-job-copier/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/robots/cmd/kubevirt-job-copier",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "kubevirt-job-copier",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+    ],
+)

--- a/robots/cmd/kubevirt-job-copier/main.go
+++ b/robots/cmd/kubevirt-job-copier/main.go
@@ -1,0 +1,323 @@
+/*
+Copyright 2021 The KubeVirt Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+
+	"kubevirt.io/project-infra/robots/pkg/querier"
+)
+
+const orgAndRepoForJobConfig = "kubevirt/kubevirt"
+
+type options struct {
+	port int
+
+	dryRun bool
+
+	TokenPath                       string
+	endpoint                        string
+	jobConfigPathKubevirtPresubmits string
+	jobConfigPathKubevirtPeriodics  string
+}
+
+var cronRegex *regexp.Regexp
+
+func init() {
+	var err error
+	cronRegex, err = regexp.Compile("[0-9] [0-9]+,[0-9]+,[0-9]+ \\* \\* \\*")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (o *options) Validate() error {
+	if _, err := os.Stat(o.jobConfigPathKubevirtPresubmits); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPresubmits is required: %v", err)
+	}
+	if _, err := os.Stat(o.jobConfigPathKubevirtPeriodics); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPeriodics is required: %v", err)
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether the file should get modified or just modifications printed to stdout.")
+	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
+	fs.StringVar(&o.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The path to the kubevirt presubmit job definitions")
+	fs.StringVar(&o.jobConfigPathKubevirtPeriodics, "job-config-path-kubevirt-periodics", "", "The path to the kubevirt periodic job definitions")
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Println(fmt.Errorf("failed to parse args: %v", err))
+		os.Exit(1)
+	}
+	return o
+}
+
+func main() {
+
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.DebugLevel)
+	log := logrus.StandardLogger().WithField("robot", "kubevirt-job-copier")
+
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		log.WithError(err).Error("Invalid arguments provided.")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	var client *github.Client
+	if o.TokenPath == "" {
+		var err error
+		client, err = github.NewEnterpriseClient(o.endpoint, o.endpoint, nil)
+		if err != nil {
+			log.Panicln(err)
+		}
+	} else {
+		token, err := ioutil.ReadFile(o.TokenPath)
+		if err != nil {
+			log.Panicln(err)
+		}
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: string(token)},
+		)
+		client, err = github.NewEnterpriseClient(o.endpoint, o.endpoint, oauth2.NewClient(ctx, ts))
+		if err != nil {
+			log.Panicln(err)
+		}
+	}
+
+	releases, _, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
+	if err != nil {
+		log.Panicln(err)
+	}
+	releases = querier.ValidReleases(releases)
+	if len(releases) < 2 {
+		log.Info("No two releases found, nothing to do.")
+		os.Exit(0)
+	}
+
+	latestReleaseSemver := querier.ParseRelease(releases[0])
+	secondLatestReleaseSemver := querier.ParseRelease(releases[1])
+
+	jobConfigs := map[string]func(*config.JobConfig, *querier.SemVer, *querier.SemVer, *logrus.Entry) bool{
+		o.jobConfigPathKubevirtPresubmits: func(jobConfig *config.JobConfig, latestReleaseSemver *querier.SemVer, secondLatestReleaseSemver *querier.SemVer, log *logrus.Entry) bool { return CopyPresubmitJobsForNewProvider(jobConfig, latestReleaseSemver, secondLatestReleaseSemver, log) },
+		o.jobConfigPathKubevirtPeriodics:  func(jobConfig *config.JobConfig, latestReleaseSemver *querier.SemVer, secondLatestReleaseSemver *querier.SemVer, log *logrus.Entry) bool { return CopyPeriodicJobsForNewProvider(jobConfig, latestReleaseSemver, secondLatestReleaseSemver, log) },
+	}
+	for jobConfigPath, jobConfigCopyFunc := range jobConfigs {
+		jobConfig, err := config.ReadJobConfig(jobConfigPath)
+		if err != nil {
+			log.WithField("jobConfigPath", jobConfigPath).WithError(err).Fatal("Failed to read jobconfig")
+		}
+
+		updated := jobConfigCopyFunc(&jobConfig, latestReleaseSemver, secondLatestReleaseSemver, log)
+		if !updated && !o.dryRun {
+			log.WithField("jobConfigPath", jobConfigPath).Info(fmt.Sprintf("presubmit jobs for %v weren't modified, nothing to do.", latestReleaseSemver))
+			continue
+		}
+
+		marshalledConfig, err := yaml.Marshal(&jobConfig)
+		if err != nil {
+			log.WithField("jobConfigPath", jobConfigPath).WithError(err).Error("Failed to marshall jobconfig")
+		}
+
+		if o.dryRun {
+			_, err = os.Stdout.Write(marshalledConfig)
+			if err != nil {
+				log.WithField("jobConfigPath", jobConfigPath).WithError(err).Error("Failed to write jobconfig")
+			}
+			continue
+		}
+
+		err = ioutil.WriteFile(jobConfigPath, marshalledConfig, os.ModePerm)
+		if err != nil {
+			log.WithField("jobConfigPath", jobConfigPath).WithError(err).Error("Failed to write jobconfig")
+		}
+	}
+}
+
+var sigNames = []string{
+	"sig-network",
+	"sig-storage",
+	"sig-compute",
+	"operator",
+}
+
+func CopyPresubmitJobsForNewProvider(jobConfig *config.JobConfig, targetProviderReleaseSemver *querier.SemVer, sourceProviderReleaseSemver *querier.SemVer, log *logrus.Entry) (updated bool) {
+	allPresubmitJobs := map[string]config.Presubmit{}
+	for index := range jobConfig.PresubmitsStatic[orgAndRepoForJobConfig] {
+		job := jobConfig.PresubmitsStatic[orgAndRepoForJobConfig][index]
+		allPresubmitJobs[job.Name] = job
+	}
+
+	for _, sigName := range sigNames {
+		targetJobName := createPresubmitJobName(targetProviderReleaseSemver, sigName)
+		sourceJobName := createPresubmitJobName(sourceProviderReleaseSemver, sigName)
+
+		if _, exists := allPresubmitJobs[targetJobName]; exists {
+			log.WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Info("Target job exists, nothing to do")
+			continue
+		}
+
+		if _, exists := allPresubmitJobs[sourceJobName]; !exists {
+			log.WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Warn("Source job does not exist, can't copy job definition!")
+			continue
+		}
+
+		log.WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Info("Copying source to target job")
+
+		newJob := config.Presubmit{}
+		newJob.Annotations = make(map[string]string)
+		for k, v := range allPresubmitJobs[sourceJobName].Annotations {
+			newJob.Annotations[k] = v
+		}
+		newJob.Cluster = allPresubmitJobs[sourceJobName].Cluster
+		newJob.Decorate = allPresubmitJobs[sourceJobName].Decorate
+		newJob.DecorationConfig = allPresubmitJobs[sourceJobName].DecorationConfig.DeepCopy()
+		copy(newJob.ExtraRefs, allPresubmitJobs[sourceJobName].ExtraRefs)
+		newJob.Labels = make(map[string]string)
+		for k, v := range allPresubmitJobs[sourceJobName].Labels {
+			newJob.Labels[k] = v
+		}
+		newJob.MaxConcurrency = allPresubmitJobs[sourceJobName].MaxConcurrency
+		newJob.Spec = allPresubmitJobs[sourceJobName].Spec.DeepCopy()
+
+		newJob.AlwaysRun = false
+		for index, envVar := range newJob.Spec.Containers[0].Env {
+			if envVar.Name != "TARGET" {
+				continue
+			}
+			newEnvVar := *envVar.DeepCopy()
+			newEnvVar.Value = createTargetValue(targetProviderReleaseSemver, sigName)
+			newJob.Spec.Containers[0].Env[index] = newEnvVar
+			break
+		}
+		newJob.Name = targetJobName
+		newJob.Optional = true
+		jobConfig.PresubmitsStatic[orgAndRepoForJobConfig] = append(jobConfig.PresubmitsStatic[orgAndRepoForJobConfig], newJob)
+
+		updated = true
+	}
+
+	return
+}
+
+func CopyPeriodicJobsForNewProvider(jobConfig *config.JobConfig, targetProviderReleaseSemver *querier.SemVer, sourceProviderReleaseSemver *querier.SemVer, log *logrus.Entry) (updated bool) {
+	allPeriodicJobs := map[string]config.Periodic{}
+	for index := range jobConfig.Periodics {
+		job := jobConfig.Periodics[index]
+		allPeriodicJobs[job.Name] = job
+	}
+
+	for _, sigName := range sigNames {
+		targetJobName := createPeriodicJobName(targetProviderReleaseSemver, sigName)
+		sourceJobName := createPeriodicJobName(sourceProviderReleaseSemver, sigName)
+
+		if _, exists := allPeriodicJobs[targetJobName]; exists {
+			log.WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Info("Target job exists, nothing to do")
+			continue
+		}
+
+		if _, exists := allPeriodicJobs[sourceJobName]; !exists {
+			log.WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Warn("Source job does not exist, can't copy job definition!")
+			continue
+		}
+
+		log.WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Info("Copying source to target job")
+
+		newJob := config.Periodic{}
+		newJob.Annotations = make(map[string]string)
+		for k, v := range allPeriodicJobs[sourceJobName].Annotations {
+			newJob.Annotations[k] = v
+		}
+		newJob.Cluster = allPeriodicJobs[sourceJobName].Cluster
+		newJob.Cron = advanceCronExpression(allPeriodicJobs[sourceJobName].Cron)
+		newJob.Decorate = allPeriodicJobs[sourceJobName].Decorate
+		newJob.DecorationConfig = allPeriodicJobs[sourceJobName].DecorationConfig.DeepCopy()
+		copy(newJob.ExtraRefs, allPeriodicJobs[sourceJobName].ExtraRefs)
+		newJob.Labels = make(map[string]string)
+		for k, v := range allPeriodicJobs[sourceJobName].Labels {
+			newJob.Labels[k] = v
+		}
+		newJob.MaxConcurrency = allPeriodicJobs[sourceJobName].MaxConcurrency
+		newJob.ReporterConfig = allPeriodicJobs[sourceJobName].ReporterConfig.DeepCopy()
+		newJob.Spec = allPeriodicJobs[sourceJobName].Spec.DeepCopy()
+
+		for index, envVar := range newJob.Spec.Containers[0].Env {
+			if envVar.Name != "TARGET" {
+				continue
+			}
+			newEnvVar := *envVar.DeepCopy()
+			newEnvVar.Value = createTargetValue(targetProviderReleaseSemver, sigName)
+			newJob.Spec.Containers[0].Env[index] = newEnvVar
+			break
+		}
+		newJob.Name = targetJobName
+		jobConfig.Periodics = append(jobConfig.Periodics, newJob)
+
+		updated = true
+	}
+
+	return
+}
+
+func createPresubmitJobName(latestReleaseSemver *querier.SemVer, sigName string) string {
+	return fmt.Sprintf("pull-kubevirt-e2e-k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
+}
+
+func createPeriodicJobName(latestReleaseSemver *querier.SemVer, sigName string) string {
+	return fmt.Sprintf("periodic-kubevirt-e2e-k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
+}
+
+func createTargetValue(latestReleaseSemver *querier.SemVer, sigName string) string {
+	return fmt.Sprintf("k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
+}
+
+// advanceCronExpression advances source cron expression to +1h10m
+// cron expression must have format of i.e. "0 1,9,17 * * *" or it will panic
+func advanceCronExpression (sourceCronExpr string) string {
+	if !cronRegex.MatchString(sourceCronExpr) {
+		logrus.StandardLogger().WithField("cronRegex", cronRegex).WithField("sourceCronExpr", sourceCronExpr).Fatal("cronRegex doesn't match")
+	}
+	parts := strings.Split(sourceCronExpr, " ")
+	mins, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	mins = ( mins + 10 ) % 60
+	firstHour, err := strconv.ParseInt(strings.Split(parts[1], ",")[0], 10, 64)
+	firstHour = ( firstHour + 1 ) % 9
+	if firstHour == 0 {
+		firstHour = 1
+	}
+	return fmt.Sprintf("%d %d,%d,%d * * *", mins, firstHour, firstHour + 8, firstHour + 16)
+}

--- a/robots/cmd/kubevirt-job-copier/main_test.go
+++ b/robots/cmd/kubevirt-job-copier/main_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"fmt"
+	"github.com/google/go-github/github"
+	"kubevirt.io/project-infra/robots/pkg/querier"
+	"reflect"
+	"testing"
+)
 
 func Test_advanceCronExpression(t *testing.T) {
 	type args struct {
@@ -40,4 +46,106 @@ func Test_advanceCronExpression(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_getSourceAndTargetRelease(t *testing.T) {
+	type args struct {
+		releases []*github.RepositoryRelease
+	}
+	tests := []struct {
+		name  string
+		args  args
+		wantTargetRelease  *querier.SemVer
+		wantSourceRelease *querier.SemVer
+		wantErr error
+	}{
+		{
+			name: "has one patch release for latest",
+			args: args{
+				releases: []*github.RepositoryRelease{
+					release("v1.22.0"),
+					release("v1.21.3"),
+				},
+			},
+			wantTargetRelease: &querier.SemVer{
+				Major: "1",
+				Minor: "22",
+				Patch: "0",
+			},
+			wantSourceRelease: &querier.SemVer{
+				Major: "1",
+				Minor: "21",
+				Patch: "3",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "has two patch releases for latest",
+			args: args{
+				releases: []*github.RepositoryRelease{
+					release("v1.22.1"),
+					release("v1.22.0"),
+					release("v1.21.3"),
+				},
+			},
+			wantTargetRelease: &querier.SemVer{
+				Major: "1",
+				Minor: "22",
+				Patch: "1",
+			},
+			wantSourceRelease: &querier.SemVer{
+				Major: "1",
+				Minor: "21",
+				Patch: "3",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "has one release only, should err",
+			args: args{
+				releases: []*github.RepositoryRelease{
+					release("v1.22.1"),
+				},
+			},
+			wantTargetRelease: nil,
+			wantSourceRelease: nil,
+			wantErr: fmt.Errorf("less than two releases"),
+		},
+		{
+			name: "has two major same releases",
+			args: args{
+				releases: []*github.RepositoryRelease{
+					release("v1.22.1"),
+					release("v1.22.0"),
+				},
+			},
+			wantTargetRelease: &querier.SemVer{
+				Major: "1",
+				Minor: "22",
+				Patch: "1",
+			},
+			wantSourceRelease: nil,
+			wantErr: fmt.Errorf("no source release found"),
+		},
+	}
+		for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTargetRelease, gotSourceRelease, gotErr := getSourceAndTargetRelease(tt.args.releases)
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+				t.Errorf("getSourceAndTargetRelease() got = %v, want %v", gotErr, tt.wantErr)
+			}
+			if !reflect.DeepEqual(gotTargetRelease, tt.wantTargetRelease) {
+				t.Errorf("getSourceAndTargetRelease() got = %v, want %v", gotTargetRelease, tt.wantTargetRelease)
+			}
+			if !reflect.DeepEqual(gotSourceRelease, tt.wantSourceRelease) {
+				t.Errorf("getSourceAndTargetRelease() got1 = %v, want %v", gotSourceRelease, tt.wantSourceRelease)
+			}
+		})
+	}
+}
+
+func release(version string) *github.RepositoryRelease {
+	result := github.RepositoryRelease{}
+	result.TagName = &version
+	return &result
 }

--- a/robots/cmd/kubevirt-job-copier/main_test.go
+++ b/robots/cmd/kubevirt-job-copier/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+func Test_advanceCronExpression(t *testing.T) {
+	type args struct {
+		sourceCronExpr string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "zero one nine seventeen",
+			args: args{
+				sourceCronExpr: "0 1,9,17 * * *",
+			},
+			want: "10 2,10,18 * * *",
+		},
+		{
+			name: "fifty one nine seventeen",
+			args: args{
+				sourceCronExpr: "50 1,9,17 * * *",
+			},
+			want: "0 2,10,18 * * *",
+		},
+		{
+			name: "zero eight sixteen twentyfour",
+			args: args{
+				sourceCronExpr: "0 8,16,24 * * *",
+			},
+			want: "10 1,9,17 * * *",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := advanceCronExpression(tt.args.sourceCronExpr); got != tt.want {
+				t.Errorf("advanceCronExpression() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
kubevirt-job-copier creates new periodic and presubmit jobs in case a
new kubernetes provider gets released. It does that by copying the
existing jobs that use the currently latest kubevirt provider.

Periodics cron expressions are advanced to spread the load, presubmits
are created as optional and always_run: false. This way they are not
failing when the new provider has not landed in the kubevirt codebase
yet, but can be triggered manually when it has landed.

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @fgimenez