### PR TITLE
Remove slack reporting for kubevirt cgroupsv2 periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -598,6 +598,9 @@ periodics:
       base_ref: main
       work_dir: true
   cluster: prow-workloads
+  reporter_config:
+    slack:
+      job_states_to_report: []
   spec:
     nodeSelector:
       type: bare-metal-external


### PR DESCRIPTION
That job is still reporting to #kubevirt-ci-monitoring slack channel, which it shouldn't any more IMHO.

/cc @enp0s3 