### PR TITLE
Change check-provision job and automation to use prow-workloads

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -234,7 +234,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    cluster: phx-prow
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s

--- a/robots/cmd/kubevirtci-presubmit-creator/main.go
+++ b/robots/cmd/kubevirtci-presubmit-creator/main.go
@@ -180,7 +180,7 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 				"preset-dind-enabled":  "true",
 				"preset-docker-mirror-proxy": "true",
 			},
-			Cluster: "phx-prow",
+			Cluster: "prow-workloads",
 			Spec: &v1.PodSpec{
 				NodeSelector: map[string]string{
 					"type": "bare-metal-external",


### PR DESCRIPTION
The phx-prow can not be used for the provision check any more. This changes the latest job to use prow-workloads, also it changes the automation code that creates new jobs to use prow-workloads.

/cc @enp0s3 