### PR TITLE
CNV-13187: Create fedora-realtime container image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -57,3 +57,36 @@ postsubmits:
           resources:
             requests:
               memory: "8Gi"
+
+    - name: publish-fedora-realtime-container-image
+      annotations:
+        testgrid-create-test-group: "false"
+      always_run: false
+      run_if_changed: "cluster-provision/images/vm-image-builder/fedora-realtime/.*"
+      decorate: true
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-kubevirtci-quay-credential: "true"        
+      cluster: prow-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/vm-image-builder:v20210928-7fbacd6
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-ce"
+              - |
+                cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io
+                /usr/sbin/libvirtd > /var/log/libvirt/libvirtd.log 2>&1 &
+                /usr/sbin/virtlogd > /var/log/libvirt/virtlogd.log 2>&1 &
+                ./cluster-provision/images/vm-image-builder/create-containerdisk.sh fedora-realtime
+                ./cluster-provision/images/vm-image-builder/publish-containerdisk.sh fedora-realtime quay.io/kubevirt/fedora-realtime-container-disk:v$(date +%Y%m%d)-$(git rev-parse --short HEAD)
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "2Gi"
+              limits:
+                memory: "2Gi"


### PR DESCRIPTION
The purpose of this PR is to add the job that builds the fedora-realtime-container-disk image configured to run with the real time kernel and tune packages. This image is to be used as part of the functional tests to validate the VMI realtime knobs implemented in this [PR](https://github.com/kubevirt/kubevirt/pull/6182) to add support for low latency workloads that run in real time.

This PR depends on this other [PR](https://github.com/kubevirt/kubevirtci/pull/665) from kubevirtci that contains the scripts to build the VM at runtime.

In short order, there are 3 PRs aimed at improving the support for realtime workloads by exposing new knobs in the VM schema targeted at reducing the CPU latency in the running workload:
* Kubevirt: https://github.com/kubevirt/kubevirt/pull/6182
* KubevirtCI: https://github.com/kubevirt/kubevirtci/pull/665
* project-infra: This one.


Please review @dhiller 