### PR TITLE
Update flakefinder to latest version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+        - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+        - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -85,7 +85,7 @@ periodics:
         type: vm
         zone: ci
       containers:
-        - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+        - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -47,7 +47,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -84,7 +84,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -86,7 +86,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-      - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+      - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
         env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -86,7 +86,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -124,7 +124,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -48,7 +48,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -86,7 +86,7 @@ periodics:
       type: vm
       zone: ci
     containers:
-    - image: quay.io/kubevirtci/flakefinder@sha256:9871c510cde2945ae65406c8e6b153a3e573ced8b95f3eeb8ff47a6642cffdb4
+    - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 IMAGE_NAME="$1"
 
-job_dir="$(cd "$(cd "$(dirname $0)" && pwd)"'/../github/ci/prow/files/jobs' && pwd)"
+job_dir="$(readlink --canonicalize $(cd "$(cd "$(dirname $0)" && pwd)"'/../github/ci/prow-deploy/files/jobs' && pwd))"
 
 docker pull "$IMAGE_NAME"
 sha_id=$(docker images --digests "$IMAGE_NAME" | grep 'latest ' | head -1 | awk '{ print $3 }')


### PR DESCRIPTION
This updates the flakefinder jobs to use the latest version (which contains the fix to the new prow.ci.kubevirt.io). Also fixes the job directory path in the update image script.

Fixes #1516

/cc @jean-edouard 