### PR TITLE
Make the kubevirt sig-storage 1.19 and 1.20 lanes optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -249,6 +249,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-sig-storage
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -610,6 +611,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.19-sig-storage
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
These have flakiness, and we have the more stable 1.21 lane
required already, which should avoid introducing flakes.