### PR TITLE
Update ignored files to make harder to leak secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-github/ci/phx-prow/group_vars/all/main.yml
+github/ci/**/group_vars/all/main.yml
+github/ci/prow-deploy/vars/ibmcloud-production/secrets.yml
+github/ci/prow-deploy/vars/workloads-production/secrets.yml
 *~
 github/ci/phx-prow/inventory
 *pyc


### PR DESCRIPTION
With these changes these files will be ignored by git:
* Any `group_vars/all/main.yml` file under  `github/ci` dir, no matter where.
* Specific secret files for the `ibmcloud-production` and `workloads-production` environments used by the prow deployment jobs.

/cc @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>