### PR TITLE
Add check that lgtm label is missing before bumping kubevirtci

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ depending on billing alerts. See [README](limiter/README.md)
   * `robots/cmd/kubevirtci-presubmit-creator`: Creates kubevirtci presubmit job
   definitions for new providers
 
+  * `robots/cmd/labels-checker`: Checks whether a PR has certain labels
+
   * `robots/cmd/kubevirt-presubmit-requirer`: Updates kubevirt presubmit jobs
   definitions to make required jobs related to new providers
 

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -109,7 +109,7 @@ periodics:
         set -e
         cwd=$(pwd)
         cd ../project-infra
-        bazel run //robots/cmd/labels-checker:labels-checker -- --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm --github-token-path=/etc/github/oauth
+        bazel run //robots/cmd/labels-checker:labels-checker -- --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved --github-token-path=/etc/github/oauth
         cd $cwd
         ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
       volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -105,7 +105,10 @@ periodics:
         value: /etc/gcs/service-account.json
       command: ["/bin/sh", "-c"]
       args:
-      - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
+      - |
+        set -e
+        bazelisk run //robots/cmd/labels-checker:labels-checker -- --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm --github-token-path=/etc/github/oauth
+        ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -97,7 +97,7 @@ periodics:
       secret:
         secretName: gcs
     containers:
-    - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
+    - image: quay.io/kubevirt/builder:2108311443-370e711b8
       env:
       - name: GIT_ASKPASS
         value: "../project-infra/hack/git-askpass.sh"
@@ -107,7 +107,10 @@ periodics:
       args:
       - |
         set -e
-        bazelisk run //robots/cmd/labels-checker:labels-checker -- --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm --github-token-path=/etc/github/oauth
+        cwd=$(pwd)
+        cd ../project-infra
+        bazel run //robots/cmd/labels-checker:labels-checker -- --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm --github-token-path=/etc/github/oauth
+        cd $cwd
         ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
       volumeMounts:
       - name: token

--- a/robots/cmd/labels-checker/BUILD.bazel
+++ b/robots/cmd/labels-checker/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/robots/cmd/labels-checker",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/pkg/kubevirtci:go_default_library",
+        "//robots/pkg/querier:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "labels-checker",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+    ],
+)

--- a/robots/cmd/labels-checker/main.go
+++ b/robots/cmd/labels-checker/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"os"
+	"strings"
+)
+
+type options struct {
+	tokenPath           string
+	endpoint            string
+	org                 string
+	repo                string
+	author              string
+	branchName          string
+	ensureLabelsMissing string
+}
+
+func (o *options) Validate() error {
+	if o.org == "" {
+		return fmt.Errorf("org is required")
+	}
+	if o.repo == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if o.author == "" {
+		return fmt.Errorf("author is required")
+	}
+	if o.branchName == "" {
+		return fmt.Errorf("branch-name is required")
+	}
+	return nil
+}
+
+func (o *options) GetEnsureLabelsMissing() []string {
+	return strings.Split(o.ensureLabelsMissing, ",")
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.tokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
+	fs.StringVar(&o.org, "org", "", "The org for the PR.")
+	fs.StringVar(&o.repo, "repo", "", "The repo for the PR.")
+	fs.StringVar(&o.author, "author", "", "The author for the PR.")
+	fs.StringVar(&o.branchName, "branch-name", "", "The branch name for the PR.")
+	fs.StringVar(&o.ensureLabelsMissing, "ensure-labels-missing", "lgtm", "What labels have to be missing on the PR (list of comma separated labels).")
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	// TODO: Use global option from the prow config.
+	logrus.SetLevel(logrus.DebugLevel)
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		log().WithError(err).Fatal("Invalid arguments provided.")
+	}
+
+	ctx := context.Background()
+	var client *github.Client
+	if o.tokenPath == "" {
+		var err error
+		client, err = github.NewEnterpriseClient(o.endpoint, o.endpoint, nil)
+		if err != nil {
+			log().Panicln(err)
+		}
+	} else {
+		tokenBytes, err := os.ReadFile(o.tokenPath)
+		if err != nil {
+			log().Panicln(err)
+		}
+		token := string(tokenBytes)
+		token = strings.TrimSuffix(token, "\n")
+		if err != nil {
+			log().Panicln(err)
+		}
+		ts := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: token},
+		)
+		client, err = github.NewEnterpriseClient(o.endpoint, o.endpoint, oauth2.NewClient(ctx, ts))
+		if err != nil {
+			log().Panicln(err)
+		}
+	}
+
+	prs, _, err := client.PullRequests.List(ctx, o.org, o.repo, &github.PullRequestListOptions{
+		State:       "open",
+		Head:        fmt.Sprintf("%s:%s", o.author, o.branchName),
+		ListOptions: github.ListOptions{},
+	})
+	if err != nil {
+		log().WithError(err).Fatal("failed to find PR")
+	} else if len(prs) == 0 {
+		logrus.Info("No PR found")
+		os.Exit(0)
+	} else if len(prs) > 1 {
+		logrus.Fatalf("More than one PR found: %+v", prs)
+	}
+
+	if checkAnyLabelExists(prs[0], o.GetEnsureLabelsMissing()) {
+		log().Fatalf("ensureLabelsMissing failed")
+	}
+
+}
+
+func checkAnyLabelExists(prToCheck *github.PullRequest, labelsToCheck []string) bool {
+	labels := map[string]struct{}{}
+	for _, label := range prToCheck.Labels {
+		name := *label.Name
+		labels[name] = struct{}{}
+	}
+	labelsExist := false
+	for _, label := range labelsToCheck {
+		if _, exists := labels[label]; exists {
+			log().Infof("label %s exists on PR %+v", label, prToCheck)
+			labelsExist = true
+		}
+	}
+	return labelsExist
+}
+
+func log() *logrus.Entry {
+	return logrus.StandardLogger().WithField("robot", "labels-checker")
+}

--- a/robots/cmd/labels-checker/main_test.go
+++ b/robots/cmd/labels-checker/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"github.com/google/go-github/github"
+	"testing"
+)
+
+func Test_checkAnyLabelExists(t *testing.T) {
+	type args struct {
+		prToCheck     *github.PullRequest
+		labelsToCheck []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "does not have any label to check",
+			args: args{
+				prToCheck:     &github.PullRequest{
+					Labels:              []*github.Label{
+						label("whatever"),
+						label("else"),
+						label("kind/enhancement"),
+						label("release-note-none"),
+					},
+				},
+				labelsToCheck: []string{
+					"lgtm",
+					"approved",
+					"kind/bug",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "has two of three labels to check",
+			args: args{
+				prToCheck:     &github.PullRequest{
+					Labels:              []*github.Label{
+						label("lgtm"),
+						label("approved"),
+						label("needs-rebase"),
+						label("release-note-none"),
+					},
+				},
+				labelsToCheck: []string{
+					"lgtm",
+					"approved",
+					"kind/bug",
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkAnyLabelExists(tt.args.prToCheck, tt.args.labelsToCheck); got != tt.want {
+				t.Errorf("checkAnyLabelExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func label(labelText string) *github.Label {
+	return &github.Label{
+		Name: &labelText,
+	}
+}

--- a/robots/cmd/labels-checker/main_test.go
+++ b/robots/cmd/labels-checker/main_test.go
@@ -1,8 +1,27 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2021 Red Hat, Inc.
+ *
+ */
 package main
 
 import (
-	"github.com/google/go-github/github"
 	"testing"
+
+	"github.com/google/go-github/github"
 )
 
 func Test_checkAnyLabelExists(t *testing.T) {
@@ -18,8 +37,8 @@ func Test_checkAnyLabelExists(t *testing.T) {
 		{
 			name: "does not have any label to check",
 			args: args{
-				prToCheck:     &github.PullRequest{
-					Labels:              []*github.Label{
+				prToCheck: &github.PullRequest{
+					Labels: []*github.Label{
 						label("whatever"),
 						label("else"),
 						label("kind/enhancement"),
@@ -37,8 +56,8 @@ func Test_checkAnyLabelExists(t *testing.T) {
 		{
 			name: "has two of three labels to check",
 			args: args{
-				prToCheck:     &github.PullRequest{
-					Labels:              []*github.Label{
+				prToCheck: &github.PullRequest{
+					Labels: []*github.Label{
 						label("lgtm"),
 						label("approved"),
 						label("needs-rebase"),
@@ -49,6 +68,23 @@ func Test_checkAnyLabelExists(t *testing.T) {
 					"lgtm",
 					"approved",
 					"kind/bug",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "has one out of three labels to check",
+			args: args{
+				prToCheck: &github.PullRequest{
+					Labels: []*github.Label{
+						label("lgtm"),
+						label("approved"),
+						label("needs-rebase"),
+						label("release-note-none"),
+					},
+				},
+				labelsToCheck: []string{
+					"approved",
 				},
 			},
 			want: true,


### PR DESCRIPTION
Adds some code that checks whether certain labels are missing and fails
with non zero exit code if they are not.

Changes the bump-kubevirtci job to use that code to ensure lgtm
label is missing on PR.

Example why this is needed: See also kubevirt/kubevirt#6238
There we can see that the existing PR is force pushed again and again and therefore fails to get merged.

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @enp0s3 @fgimenez 