### PR TITLE
Fixing configuration of the functional tests cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/kubevirt-velero-plugin:
   - name: pull-kvp-unit-test
-    cluster: ibm-prow-jobs
+    cluster: phx-prow
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -23,7 +23,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "make test"
+            - "hack/run-unit-tests.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -31,7 +31,7 @@ presubmits:
             requests:
               memory: "4Gi"
   - name: pull-kvp-functional-test
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -41,12 +41,14 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 1h
+      timeout: 4h
       grace_period: 5m
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     spec:
+      nodeSelector:
+        type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
           command:
@@ -59,4 +61,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "4Gi"
+              memory: "8Gi"


### PR DESCRIPTION
In order to use KVM virtualization, the tests need to be run on a bare metal node, which is not available in ibm-prow-jobs cluster. The PR adds the nodeSelector and changes cluster to prow-workloads.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>