### PR TITLE
Add headBranch support to git-pr.sh

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -401,7 +401,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s --cluster-up-dir ${PWD}/../kubevirtci/cluster-up/cluster" -s "Update minor version of KubevirtCI cluster" -p ../kubevirtci -r kubevirtci -b minor-version-bump -T main
+            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s --cluster-up-dir ${PWD}/../kubevirtci/cluster-up/cluster" -p ../kubevirtci -r kubevirtci -b minor-version-bump -T main
         volumeMounts:
         - name: token
           mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -401,7 +401,7 @@ periodics:
             curl --fail -L https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 --output ${bazel_dir}/bazelisk &&
             chmod a+x ${bazel_dir}/bazelisk &&
             export PATH=${PATH}:${bazel_dir} &&
-            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s --cluster-up-dir ${PWD}/../kubevirtci/cluster-up/cluster" -p ../kubevirtci -r kubevirtci -b minor-version-bump -T main
+            hack/git-pr.sh -c "bazelisk run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-latest --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s --cluster-up-dir ${PWD}/../kubevirtci/cluster-up/cluster" -s "Update minor version of KubevirtCI cluster" -p ../kubevirtci -r kubevirtci -b minor-version-bump -T main
         volumeMounts:
         - name: token
           mountPath: /etc/github


### PR DESCRIPTION
We are getting errors in periodic-kubevirtci-cluster-minorversion-updater, for instance https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-cluster-minorversion-updater/1432736830964371456. The job doesn't find an existing PR to update and later fails to create it bc it is already there.

Looks like GH query is failing with the truncated title here https://github.com/kubevirt/kubevirtci/pulls?q=is%3Aopen+is%3Apr+archived%3Afalse+repo%3Akubevirt%2Fkubevirtci+author%3Akubevirt-bot+in%3Atitle+Run+bazelisk+run+%2F%2Frobots%2Fcmd%2Fkubevirtci-bumper%3Akubevirtci-bumper+--+-ensure-latest+--k8s-provider-dir+%2Fhome%2Fprow%2Fgo%2Fsrc%2Fgithub.com%2Fkubevirt%2Fproject-i but not if we get a bit more of the title https://github.com/kubevirt/kubevirtci/pulls?q=is%3Aopen+is%3Apr+archived%3Afalse+repo%3Akubevirt%2Fkubevirtci+author%3Akubevirt-bot+in%3Atitle+Run+bazelisk+run+%2F%2Frobots%2Fcmd%2Fkubevirtci-bumper%3Akubevirtci-bumper+--+-ensure-latest+--k8s-provider-dir+%2Fhome%2Fprow%2Fgo%2Fsrc%2Fgithub.com%2Fkubevirt%2Fproject-infra

 Instead of depending on match-title, with these changes we use the head-branch option that looks for a specific branch from which the PR will be created.

/cc @dhiller  

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>