### PR TITLE
Fixes cron expression advancement edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ depending on billing alerts. See [README](limiter/README.md)
 
   * `robots/cmd/indexpagecreator`: Creates flakefinder index page
 
+  * `robots/cmd/kubevirt-job-copier`: Creates copies of the SIG jobs (periodic and presubmit) to enable testing kubevirt with kubevirtci
+
   * `robots/cmd/kubevirtci-bumper`: Tool to automatically bump kubevirtci providers.
   See [README](robots/kubevirtci-bumper/README.md)
 

--- a/robots/cmd/kubevirt-job-copier/main.go
+++ b/robots/cmd/kubevirt-job-copier/main.go
@@ -333,10 +333,7 @@ func advanceCronExpression (sourceCronExpr string) string {
 	}
 	mins = ( mins + 10 ) % 60
 	firstHour, err := strconv.ParseInt(strings.Split(parts[1], ",")[0], 10, 64)
-	firstHour = ( firstHour + 1 ) % 9
-	if firstHour == 0 {
-		firstHour = 1
-	}
+	firstHour = ( firstHour + 1 ) % 8
 	return fmt.Sprintf("%d %d,%d,%d * * *", mins, firstHour, firstHour + 8, firstHour + 16)
 }
 

--- a/robots/cmd/kubevirt-job-copier/main_test.go
+++ b/robots/cmd/kubevirt-job-copier/main_test.go
@@ -38,6 +38,13 @@ func Test_advanceCronExpression(t *testing.T) {
 			},
 			want: "10 1,9,17 * * *",
 		},
+		{
+			name: "zero seven fifteen twentythree",
+			args: args{
+				sourceCronExpr: "0 7,15,23 * * *",
+			},
+			want: "10 0,8,16 * * *",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes the edge case where a cron expression has the value of
"0 7,15,23 ..." which needs to result in "... 0,8,16 ..."

Also adds entry to README.md for job-copier.

/cc @fgimenez @enp0s3 