### PR TITLE
Set periodic-kubevirtci-bump-kubevirt to run every 12h

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -70,7 +70,7 @@ periodics:
         secret:
           secretName: gcs
 - name: periodic-kubevirtci-bump-kubevirt
-  interval: 24h
+  cron: "0 */12 * * *"
   annotations:
     testgrid-create-test-group: "false"
   decorate: true


### PR DESCRIPTION
Sets the job schedule with cron instead of interval, which depends on the time when the job was executed for the last time.

/cc @oshoval @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>