### PR TITLE
Create pr-creator image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -246,6 +246,36 @@ postsubmits:
                 memory: "4Gi"
               limits:
                 memory: "4Gi"
+    - name: publish-pr-creator-image
+      always_run: false
+      run_if_changed: "images/pr-creator/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: prow-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
+                ./publish_image.sh pr-creator quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "4Gi"
+              limits:
+                memory: "4Gi"
     - name: post-project-infra-prow-control-plane-deployment
       always_run: false
       run_if_changed: "github/ci/prow-deploy/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -232,6 +232,33 @@ presubmits:
               memory: "4Gi"
             limits:
               memory: "4Gi"
+  - name: build-pr-creator-image
+    always_run: false
+    run_if_changed: "images/pr-creator/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    cluster: prow-workloads
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              cd images
+              ./publish_image.sh -b pr-creator quay.io kubevirtci
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+            limits:
+              memory: "4Gi"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
     run_if_changed: "github/ci/prow-deploy/.*"

--- a/images/pr-creator/Dockerfile
+++ b/images/pr-creator/Dockerfile
@@ -15,6 +15,9 @@ RUN set -x && \
     cd ./project-infra && \
     cp ./hack/git-askpass.sh hack/git-pr.sh /usr/local/bin && \
     chmod +x /usr/local/bin/git-askpass.sh /usr/local/bin/git-pr.sh && \
+    bazel build //robots/cmd/labels-checker:labels-checker && \
+    cp ./bazel-out/k8-fastbuild/bin/robots/cmd/labels-checker/labels-checker_/labels-checker /usr/local/bin && \
+    chmod +x /usr/local/bin/labels-checker && \
     cd .. && rm -rf ./project-infra
 
 ENV GIT_ASKPASS=/usr/local/bin/git-askpass.sh

--- a/images/pr-creator/Dockerfile
+++ b/images/pr-creator/Dockerfile
@@ -9,3 +9,12 @@ RUN set -x && \
     chmod +x /usr/local/bin/pr-creator && \
     bazel clean --expunge && \
     cd .. && rm -rf ./test-infra
+
+RUN set -x && \
+    git clone https://github.com/kubevirt/project-infra.git && \
+    cd ./project-infra && \
+    cp ./hack/git-askpass.sh hack/git-pr.sh /usr/local/bin && \
+    chmod +x /usr/local/bin/git-askpass.sh /usr/local/bin/git-pr.sh && \
+    cd .. && rm -rf ./project-infra
+
+ENV GIT_ASKPASS=/usr/local/bin/git-askpass.sh

--- a/images/pr-creator/Dockerfile
+++ b/images/pr-creator/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/kubevirtci/bootstrap:v20210715-d0c2b78
+
+RUN set -x && \
+    git clone https://github.com/kubernetes/test-infra.git && \
+    cd ./test-infra && \
+    git checkout 00bc5aa56077a37432ce757dbae358c56435c010 && \
+    bazel build //robots/pr-creator:pr-creator && \
+    cp ./bazel-out/k8-fastbuild/bin/robots/pr-creator/pr-creator_/pr-creator /usr/local/bin && \
+    chmod +x /usr/local/bin/pr-creator && \
+    bazel clean --expunge && \
+    cd .. && rm -rf ./test-infra


### PR DESCRIPTION
Adds an image as base for jobs using git-pr.sh. This is intended to
replace the kubevirt builder image where that image is not required to
be used.

This image is based on kubevirtci/bootstrap so it has bazel built in, which most of the jobs require.
It also has git-pr.sh and git-askpass.sh built in so we can remove the env var declaration and remove the path from the script call. 

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @fgimenez 