### PR TITLE
git-pr, Fix case where the summary is empty but rebase exists

### DIFF
--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -122,6 +122,10 @@ fi
 
 if [ -n "${description_command}" ]; then
     summary=$(eval "${description_command}")
+    if [ -z "$summary" ]; then
+        echo "no summary detected, exiting"
+        exit 0
+    fi
     title=$(echo "$summary" | head -1)
     body=$(echo "$summary" | sed '1,2d')
 else


### PR DESCRIPTION
In case the summary command returns empty output,
for example in case there isn't bump detected,
but the rebase do exists, the pr-creator will try
to push a rebase, and fail because the PR title field
must not be empty.

Add a condition that if the commit summary is empty,
there will be no PR created, because a pure rebase is not needed.

Signed-off-by: Or Shoval <oshoval@redhat.com>