### PR TITLE
Add presubmit linting jobs for kubevirt-github-io

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -23,13 +23,3 @@ presubmits:
           - image: quay.io/kubevirtci/ruby:v20210628-647402e
             command: ["/bin/sh", "-c"]
             args: ["/bin/make check_lint"]
-    - name: kubevirt-io-presubmit-spell-checker
-      decorate: true
-      always_run: true
-      skip_report: false
-      cluster: ibm-prow-jobs
-      spec:
-        containers:
-          - image: quay.io/kubevirtci/ruby:v20210628-647402e
-            command: ["/bin/sh", "-c"]
-            args: ["/bin/make check_spelling"]

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
           - image: quay.io/kubevirtci/ruby:v20210628-647402e
             command: ["/bin/sh", "-c"]
             args: ["/bin/make check_lint"]
-    - name: kubevirt-io/presubmit-spell-checker
+    - name: kubevirt-io-presubmit-spell-checker
       decorate: true
       always_run: true
       skip_report: false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -13,3 +13,23 @@ presubmits:
                 value: "true"
             command: ["/bin/sh", "-c"]
             args: ["/usr/local/bin/bundle install && bundle exec rake"]
+    - name: kubevirt-io-presubmit-markdown-linter
+      decorate: true
+      always_run: true
+      skip_report: false
+      cluster: ibm-prow-jobs
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/ruby:v20210628-647402e
+            command: ["/bin/sh", "-c"]
+            args: ["/bin/make check_lint"]
+    - name: kubevirt-io/presubmit-spell-checker
+      decorate: true
+      always_run: true
+      skip_report: false
+      cluster: ibm-prow-jobs
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/ruby:v20210628-647402e
+            command: ["/bin/sh", "-c"]
+            args: ["/bin/make check_spelling"]


### PR DESCRIPTION
Signed-off-by: Tyler Auerbeck <tauerbec@redhat.com>

@mazzystr Took an initial run at https://github.com/kubevirt/kubevirt.github.io/issues/785

This (I _think_) will add presubmit jobs to begin linting markdown files and running spell checks (in addition to the existing link checker). Please let me know if this is the appropriate place or if there is somewhere else this belongs. 