### PR TITLE
Add csv reporting for easier aggregation

### DIFF
--- a/robots/cmd/flakefinder/report.go
+++ b/robots/cmd/flakefinder/report.go
@@ -225,43 +225,61 @@ const ReportTemplate = `
 </html>
 `
 
+const ReportCSVTemplate = `"Test Name","Test Lane","Severity","Failed","Succeeded","Skipped","Jobs (JSON)"
+{{ range $testName, $results := $.Data }}{{ range $jobName, $result := $results }}"{{ $testName }}","{{ $jobName }}","{{ $result.Severity }}",{{ $result.Failed }},{{ $result.Succeeded }},{{ $result.Skipped }},{{ range $job := $result.Jobs }}"{BuildNumber: {{ $job.BuildNumber }},Severity: ""{{ $job.Severity }}"",PR: {{ $job.PR }},Job: ""{{ $job.Job }}"",},"{{ end }}
+{{ end }}{{ end }}`
+
 // WriteReportToBucket creates the actual formatted report file from the report data and writes it to the bucket
 func WriteReportToBucket(ctx context.Context, client *storage.Client, merged time.Duration, org, repo string, isDryRun bool, reportBaseData flakefinder.ReportBaseData) (err error) {
-	reportObject := client.Bucket(flakefinder.BucketName).Object(path.Join(ReportOutputPath, CreateReportFileName(reportBaseData.EndOfReport, merged)))
-	log.Printf("Report will be written to gs://%s/%s", flakefinder.BucketName, reportObject.ObjectName())
 	var reportOutputWriter *storage.Writer
+	var reportCSVOutputWriter *storage.Writer
 	if !isDryRun {
+		reportObject := client.Bucket(flakefinder.BucketName).Object(path.Join(ReportOutputPath, CreateReportFileNameWithEnding(reportBaseData.EndOfReport, merged, "html")))
+		log.Printf("Report will be written to gs://%s/%s", reportObject.BucketName(), reportObject.ObjectName())
+		reportCSVObject := client.Bucket(flakefinder.BucketName).Object(path.Join(ReportOutputPath, CreateReportFileNameWithEnding(reportBaseData.EndOfReport, merged, "csv")))
+		log.Printf("Report CSV will be written to gs://%s/%s", reportCSVObject.BucketName(), reportCSVObject.ObjectName())
 		reportOutputWriter = reportObject.NewWriter(ctx)
+		defer reportOutputWriter.Close()
+		reportCSVOutputWriter = reportCSVObject.NewWriter(ctx)
+		defer reportCSVOutputWriter.Close()
 	}
-	err = Report(reportBaseData.JobResults, reportOutputWriter, org, repo, reportBaseData.PRNumbers, isDryRun, reportBaseData.StartOfReport, reportBaseData.EndOfReport)
+	err = Report(reportBaseData.JobResults, reportOutputWriter, reportCSVOutputWriter, org, repo, reportBaseData.PRNumbers, isDryRun, reportBaseData.StartOfReport, reportBaseData.EndOfReport)
 	if err != nil {
 		return fmt.Errorf("failed on generating report: %v", err)
-	}
-	if !isDryRun {
-		err = reportOutputWriter.Close()
-		if err != nil {
-			return fmt.Errorf("failed on closing report object: %v", err)
-		}
 	}
 	return nil
 }
 
-func CreateReportFileName(reportTime time.Time, merged time.Duration) string {
-	return fmt.Sprintf(flakefinder.ReportFilePrefix+"%s-%03dh.html", reportTime.Format("2006-01-02"), int(merged.Hours()))
+func CreateReportFileNameWithEnding(reportTime time.Time, merged time.Duration, fileEnding string) string {
+	return fmt.Sprintf(flakefinder.ReportFilePrefix+"%s-%03dh.%s", reportTime.Format("2006-01-02"), int(merged.Hours()), fileEnding)
 }
 
-func Report(results []*flakefinder.JobResult, reportOutputWriter *storage.Writer, org, repo string, prNumbers []int, isDryRun bool, startOfReport, endOfReport time.Time) error {
-	parameters := flakefinder.CreateFlakeReportData(results, prNumbers, endOfReport, org, repo, startOfReport)
-	var err error
-	if !isDryRun && reportOutputWriter != nil {
-		err = flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, reportOutputWriter)
-	}
-	if isDryRun {
-		err = flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, os.Stdout)
-	}
+type CSVParams struct {
+	Data map[string]map[string]*flakefinder.Details
+}
 
-	if err != nil {
-		return fmt.Errorf("failed to render report template: %v", err)
+func Report(results []*flakefinder.JobResult, reportOutputWriter, reportCSVOutputWriter *storage.Writer, org, repo string, prNumbers []int, isDryRun bool, startOfReport, endOfReport time.Time) error {
+	parameters := flakefinder.CreateFlakeReportData(results, prNumbers, endOfReport, org, repo, startOfReport)
+	csvParams := CSVParams{Data: parameters.Data}
+	var err error
+	if !isDryRun {
+		err = flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, reportOutputWriter)
+		if err != nil {
+			return fmt.Errorf("failed to write report: %v", err)
+		}
+		err = flakefinder.WriteTemplateToOutput(ReportCSVTemplate, csvParams, reportCSVOutputWriter)
+		if err != nil {
+			return fmt.Errorf("failed to write report csv: %v", err)
+		}
+	} else {
+		err = flakefinder.WriteTemplateToOutput(ReportTemplate, parameters, os.Stdout)
+		if err != nil {
+			return fmt.Errorf("failed to render report template: %v", err)
+		}
+		err = flakefinder.WriteTemplateToOutput(ReportCSVTemplate, csvParams, os.Stdout)
+		if err != nil {
+			return fmt.Errorf("failed to write report csv: %v", err)
+		}
 	}
 
 	return nil

--- a/robots/cmd/flakefinder/report_test.go
+++ b/robots/cmd/flakefinder/report_test.go
@@ -25,12 +25,12 @@ var _ = Describe("report.go", func() {
 	When("creates filename with date and merged as hours", func() {
 
 		It("creates a filename for week", func() {
-			fileName := CreateReportFileName(reportTime, 24*7*time.Hour)
+			fileName := CreateReportFileNameWithEnding(reportTime, 24*7*time.Hour, "html")
 			Expect(fileName).To(BeEquivalentTo("flakefinder-2019-08-23-168h.html"))
 		})
 
 		It("creates a filename for day", func() {
-			fileName := CreateReportFileName(reportTime, 24*time.Hour)
+			fileName := CreateReportFileNameWithEnding(reportTime, 24*time.Hour, "html")
 			Expect(fileName).To(BeEquivalentTo("flakefinder-2019-08-23-024h.html"))
 		})
 
@@ -195,6 +195,50 @@ var _ = Describe("report.go", func() {
 			Expect(buffer.String()).To(ContainSubstring("4217"))
 			Expect(buffer.String()).To(ContainSubstring("k8s-1.18-whatever"))
 			Expect(buffer.String()).To(ContainSubstring("k8s-1.19-whocares"))
+		})
+
+	})
+
+	When("rendering report csv", func() {
+
+		var buffer bytes.Buffer
+
+		prepareBuffer := func() {
+			buffer = bytes.Buffer{}
+			data := CSVParams{
+				Data: map[string]map[string]*flakefinder.Details{
+					"t1": {
+						"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
+							{
+								BuildNumber: 1742,
+								Severity:    "red",
+								PR:          4217,
+								Job:         "testJob",
+							}}},
+						"b": &flakefinder.Details{Failed: 5, Succeeded: 2, Skipped: 3, Severity: "yellow", Jobs: []*flakefinder.Job{}},
+					},
+					"t2": {
+						"a": &flakefinder.Details{Failed: 8, Succeeded: 2, Skipped: 4, Severity: "cyan", Jobs: []*flakefinder.Job{}},
+						"b": &flakefinder.Details{Failed: 9, Succeeded: 3, Skipped: 5, Severity: "blue", Jobs: []*flakefinder.Job{}},
+					},
+				},
+			}
+			err := flakefinder.WriteTemplateToOutput(ReportCSVTemplate, data, &buffer)
+			Expect(err).ToNot(HaveOccurred())
+			if testOptions.printTestOutput {
+				logger := log.New(os.Stdout, "reportCSV:", log.Flags())
+				logger.Printf(buffer.String())
+			}
+		}
+
+		It("contains headers", func() {
+			prepareBuffer()
+			Expect(buffer.String()).To(ContainSubstring("\"Test Name\",\"Test Lane\",\"Severity\",\"Failed\",\"Succeeded\",\"Skipped\",\"Jobs (JSON)\""))
+		})
+
+		It("contains data", func() {
+			prepareBuffer()
+			Expect(buffer.String()).To(ContainSubstring("\"t1\",\"a\",\"red\",4,1,2"))
 		})
 
 	})


### PR DESCRIPTION
Introduces an additional report in CSV format that is written and
stored besides the original html report.

Output is like this:

```
"Test Name","Test Lane","Severity","Failed","Succeeded","Skipped","Jobs (JSON)"
"t1","a","red",4,1,2,"{BuildNumber: 1742,Severity: ""red"",PR: 4217,Job: ""testJob"",},"
"t1","b","yellow",5,2,3,
"t2","a","cyan",8,2,4,
"t2","b","blue",9,3,5,
```
**Note:** according to [RFC 4180](https://tools.ietf.org/html/rfc4180) double quotes within a double quoted field value have to be escaped with another double quote

Example output: gs://kubevirt-prow/reports/flakefinder/preview/kubevirt/kubevirt/flakefinder-2021-09-05-024h.csv

Signed-off-by: dhiller@redhat.com

/cc @fgimenez 