### PR TITLE
Update pr-creator image for kubevirtci bump job to latest version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -97,7 +97,7 @@ periodics:
       secret:
         secretName: gcs
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210901-354d148
+    - image: quay.io/kubevirtci/pr-creator:v20210907-eaf738f
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json


### PR DESCRIPTION
Image used in [this run](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-kubevirt/1435030289188392960) didn't have required tool. Pushed latest image version and used that in the job.

Successful run of bump-kubevirtci here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-kubevirt/1435140650168225792

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @fgimenez 