### PR TITLE
Revert "Add nonroot keyword to target (#1525)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -420,7 +420,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-compute-nonroot
+          value: k8s-1.20-sig-compute
         - name: FEATURE_GATES
           value: NonRoot
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
@@ -461,7 +461,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-network-nonroot
+          value: k8s-1.20-sig-network
         - name: FEATURE_GATES
           value: NonRoot
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
@@ -502,7 +502,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-storage-nonroot
+          value: k8s-1.20-sig-storage
         - name: FEATURE_GATES
           value: NonRoot
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
@@ -542,7 +542,7 @@ presubmits:
         - ' automation/test.sh'
         env:
         - name: TARGET
-          value: k8s-1.20-nonroot
+          value: k8s-1.20
         - name: FEATURE_GATES
           value: NonRoot
         - name: KUBEVIRT_E2E_FOCUS
@@ -796,7 +796,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.19-sriov-nonroot
+          value: kind-1.19-sriov
         - name: GIMME_GO_VERSION
           value: 1.13.8
         - name: FEATURE_GATES


### PR DESCRIPTION
Non root lanes are failing with:

```
The cluster provider k8s-1.20-nonroot does not exist
```

See for example https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6361/pull-kubevirt-e2e-k8s-1.20-sig-compute-nonroot/1435140916326174720