### PR TITLE
Use if for label-checker

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -105,8 +105,9 @@ periodics:
       args:
       - |
         set -e
-        labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved --github-token-path=/etc/github/oauth
-        git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
+        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved --github-token-path=/etc/github/oauth; then
+          git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
+        fi
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
Instead of just exiting with the binary status code in case of error we
use if to check what exit code the binary returned and only in case of
zero exit code enter the git-pr / bump-kubevirtci logic.

Successful execution here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-kubevirt/1435507009767084032

/cc @fgimenez 