### PR TITLE
Use bootstrap image for sriov and vgpu jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -760,6 +760,7 @@ presubmits:
       grace_period: 30m0s
       timeout: 4h0m0s
     labels:
+      preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
@@ -801,7 +802,7 @@ presubmits:
           value: 1.13.8
         - name: FEATURE_GATES
           value: NonRoot
-        image: quay.io/kubevirtci/golang:v20210316-d295087
+        image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         name: ""
         resources:
           requests:
@@ -845,6 +846,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-bazel-unnested: "true"
       rehearsal.allowed: "true"
       sriov-pod: "true"
     max_concurrency: 10
@@ -881,7 +883,7 @@ presubmits:
           value: kind-1.19-sriov
         - name: GIMME_GO_VERSION
           value: 1.13.8
-        image: quay.io/kubevirtci/golang:v20210316-d295087
+        image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         name: ""
         resources:
           requests:
@@ -923,6 +925,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-bazel-unnested: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-kind-1.19-vgpu
     skip_branches:
@@ -940,7 +943,7 @@ presubmits:
           value: kind-1.19-vgpu
         - name: GIMME_GO_VERSION
           value: 1.13.8
-        image: quay.io/kubevirtci/golang:v20210316-d295087
+        image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         name: ""
         resources:
           requests:


### PR DESCRIPTION
The jobs build with bazel and all jobs which use bazel should use the
bootstrap image.

Further let the jobs build unnested to not have to download the builder image which saves a few gigabyte of transfer per run.

This fixes some sandboxing issues when updating to centos8: https://github.com/kubevirt/kubevirt/pull/6177#issuecomment-914349099