### PR TITLE
Temporariy disable bazel cache for 0.41 lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
@@ -12,7 +12,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -278,7 +277,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -455,7 +453,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 7h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"


### PR DESCRIPTION
Some of the bazel cache entries related to 0.41 jobs are missing, we get errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5971/pull-kubevirt-e2e-k8s-1.18-0.41/1435874708988891136#1:build-log.txt%3A238. 

I've temporarily disable the cache for 1.18-0.41 lane and the build process works fine here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/5971/pull-kubevirt-e2e-k8s-1.18-0.41/1435985550992478208

These are all the cache miss failures we are getting https://search.ci.kubevirt.io/?search=IOException%3A+null&maxAge=48h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job The underlying issue will be fixed when we reset the bazel cache in prow-workloads cluster. For the time being this PR disables the cache for them so that they can continue building.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>