### PR TITLE
Release tool enhancements and fixes

### DIFF
--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -401,10 +401,10 @@ func (r *releaseData) forkProwJobs() error {
 			return err
 		}
 
-		_, err = gitCommand("-C", r.infraDir, "pull", "origin", gitbranch)
-		if err != nil {
-			return err
-		}
+	}
+	_, err = gitCommand("-C", r.infraDir, "pull", "origin", gitbranch)
+	if err != nil {
+		return err
 	}
 
 	if _, err = os.Stat(fullJobConfig); err != nil && os.IsNotExist(err) {

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -468,21 +468,23 @@ func (r *releaseData) forkProwJobs() error {
 	return nil
 }
 
-func (r *releaseData) cutNewBranch() error {
+func (r *releaseData) cutNewBranch(skipProw bool) error {
 
-	// checkout project infra project in order to update jobs for new branch
-	err := r.checkoutProjectInfra()
-	if err != nil {
-		return err
-	}
+	if !skipProw {
+		// checkout project infra project in order to update jobs for new branch
+		err := r.checkoutProjectInfra()
+		if err != nil {
+			return err
+		}
 
-	err = r.forkProwJobs()
-	if err != nil {
-		return err
+		err = r.forkProwJobs()
+		if err != nil {
+			return err
+		}
 	}
 
 	// checkout remote branch
-	err = r.checkoutUpstream()
+	err := r.checkoutUpstream()
 	if err != nil {
 		return err
 	}
@@ -1106,6 +1108,7 @@ func main() {
 	gitEmail := flag.String("git-email", "", "git user email")
 	skipReleaseNotes := flag.Bool("skip-release-notes", false, "skip generating release notes for a tag")
 	force := flag.Bool("force", false, "force a release or release branch to occur despite blockers or other warnings")
+	skipProw := flag.Bool("skip-prow", false, "skip creating prow configs")
 	promoteRC := flag.String("promote-release-candidate", "", "The tag of an rc release that will be promoted to an official release")
 
 	autoRelease := flag.Bool("auto-release", false, "Automatically perform branch cutting an releases based on time intervals")
@@ -1204,7 +1207,7 @@ func main() {
 			log.Fatal("ERROR Branch is blocked")
 		}
 
-		err = r.cutNewBranch()
+		err = r.cutNewBranch(*skipProw)
 		if err != nil {
 			log.Fatalf("ERROR Creating Branch: %s ", err)
 		}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -402,10 +402,10 @@ func (r *releaseData) forkProwJobs() error {
 		}
 
 	}
-	_, err = gitCommand("-C", r.infraDir, "pull", "origin", gitbranch)
-	if err != nil {
-		return err
-	}
+	// ignore error here, we're just trying to make sure we've synced
+	// and pulled down any changes from the origin branch in github
+	// in case there are non local changes that need to get pulled in.
+	_, _ = gitCommand("-C", r.infraDir, "pull", "origin", gitbranch)
 
 	if _, err = os.Stat(fullJobConfig); err != nil && os.IsNotExist(err) {
 		// no job to fork for this project
@@ -455,7 +455,6 @@ func (r *releaseData) forkProwJobs() error {
 			"--title", fmt.Sprintf("Release configs for %s/%s release branch %s", r.org, r.repo, r.newBranch),
 			"--body", "adds new release configs",
 			"--source", fmt.Sprintf("kubevirt:%s", gitbranch),
-			"--labels", "lgtm,approved",
 			"--confirm",
 		)
 		bytes, err := cmd.CombinedOutput()

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -391,6 +391,7 @@ func TestCutNewBranch(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra config user.email fake-email@fake.fake]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra checkout -b fake-org_fake-repo_release-0.2_configs]", r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/kubevirt/https-project-infra pull origin fake-org_fake-repo_release-0.2_configs]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [clone https://fake-token@github.com/fake-org/fake-repo.git %s/fake-org/https-fake-repo]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -405,7 +405,7 @@ func TestCutNewBranch(t *testing.T) {
 		return "", nil
 	}
 
-	err := r.cutNewBranch()
+	err := r.cutNewBranch(false)
 	if err != nil {
 		t.Errorf("got unexpected error %s", err)
 	} else if len(expectedGitCommands) != len(seenGitCommands) {


### PR DESCRIPTION
* Removes the automatic addition of lgtm/approve labels to prow configs because the operation causes the PR to fail to post.
* Adds option to skip prow config generation, which is useful to unblock the release when pr creation fails. 
* Fixes issue where project-infra repo's release branch isn't pulled before making changes resulting in out-of-date local branch.