### PR TITLE
Fix bazel cache on ibm-prow-jobs

### DIFF
--- a/github/ci/prow-deploy/kustom/components/greenhouse/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/base/resources/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           containerPort: 9090
         args:
         - --dir=/data
-        - --min-percent-blocks-free=3
+        - --min-percent-blocks-free=30
         volumeMounts:
         - name: cache
           mountPath: /data

--- a/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/kustomization.yaml
@@ -3,11 +3,3 @@ kind: Component
 
 resources:
   - resources/storage.yaml
-
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: greenhouse
-    path: patches/JsonRFC6902/deployment.yaml

--- a/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/patches/JsonRFC6902/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/hostpath/patches/JsonRFC6902/deployment.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/template/spec/containers/0/args/1
-  value: --min-percent-blocks-free=30

--- a/github/ci/prow-deploy/kustom/components/greenhouse/pv/resources/pvc.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/pv/resources/pvc.yaml
@@ -1,3 +1,4 @@
+---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -8,4 +9,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 450Gi
+      storage: 700Gi


### PR DESCRIPTION
When alerts were enabled we started getting an alert about an estimation of bazel's disk being filled within 4 days. Turns out that because of how bazel handles the cache, writing and evicting entries, this is normal behavior and the alert would be flapping forever, triggering when new entries are written and resolving when old entries are evicted.

To prevent that behavior in this PR:
* the configuration of bazel in ibm-prow-jobs is aligned to what we have in prow-workloads, leaving 30% of the volume to have enough room to grow and sink the cache.
* the defined PV is increased to 700Gb.

/cc @dhiller   

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>