### PR TITLE
Fix kubemacpool flakefinder weekly report job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -80,10 +80,8 @@ periodics:
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
+    cluster: ibm-prow-jobs
     spec:
-      nodeSelector:
-        type: vm
-        zone: ci
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20210824-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-168-g42274555c
           env:


### PR DESCRIPTION
We started getting alerts about one job in non-ready state, looking at the pod list it was in pending state, from the description:
```
$ kubectl describe pod -n kubevirt-prow-jobs b38e4b9b-124b-11ec-ba99-4ab30ff1269c 
......
Containers:
  test:
......
    Environment:
......
      JOB_NAME:                        periodic-publish-kubemacpool-flakefinder-four-weekly-report
......
Events:
  Type     Reason            Age                   From               Message
  ----     ------            ----                  ----               -------
  Warning  FailedScheduling  2m17s (x73 over 67m)  default-scheduler  0/6 nodes are available: 6 node(s) didn't match Pod's node affinity/selector.
```
Looking at the job definition it doesn't have a cluster defined and it has a node selector that doesn't match any of the nodes in the cluster. This has been probably happening for a while, after the 24h deadline period the job will be probably removed by plank. We might find other periodics with this same problem, alerts will bring these issues to the surface.

/cc @dhiller 


Signed-off-by: Federico Gimenez <fgimenez@redhat.com>