### PR TITLE
Add area/monitoring label to kubevirt/kubevirt

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -311,6 +311,9 @@ repos:
       - name: area/virtctl
         color: bfd4f2
         target: both
+      - name: area/monitoring
+        color: bfd4f2
+        target: both
       - name: topic/api
         color: c5def5
         target: both


### PR DESCRIPTION
We have some people on the project which are very intested in tracking
monitoring changes for e.g. performance and scale, dashboard creation or
alerting.

This change will allow people to write `/area monitoring` to label issues and PRs.