### PR TITLE
Relax prow-exporter probes settings and set resources

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -48,15 +48,23 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 3
-          periodSeconds: 3
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 15
         readinessProbe:
           httpGet:
             path: /healthz/ready
             port: 8081
           initialDelaySeconds: 10
-          periodSeconds: 3
-          timeoutSeconds: 600
+          periodSeconds: 30
+          timeoutSeconds: 15
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: 100m
+            memory: 500Mi
       volumes:
       - name: kubeconfig
         secret:


### PR DESCRIPTION
We have been getting alerts about prow-exporter crashlooping and being down when prometheus tried to scrape it. Looking at the resource usage and logs all seemed to be ok, in the pod description:
```
Warning  Unhealthy  1s (x391 over 3d2h)  kubelet, 10.240.128.12  Liveness probe failed: Get "http://172.17.89.68:8081/healthz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
``` 
This PR aims to prevent the pod from being restarted by the kubelet  by relaxing the probes settings. It also sets resources according to recent usage to get guaranteed QoS.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>