### PR TITLE
Increase time to trigger KubePodNotReady

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
@@ -27,7 +27,7 @@ spec:
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: |
         sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
-      for: 30m
+      for: 1h
       labels:
         severity: critical
         namespace: monitoring


### PR DESCRIPTION
On high usage time it is common for a job to wait in the queue 30min, these changes will prevent `KubePodNotReady` to trigger very frequently because of enqueued CI jobs.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>