### PR TITLE
Do not update existing KCI provider bump PR when hold label exists

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -105,7 +105,7 @@ periodics:
       args:
       - |
         set -e
-        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved --github-token-path=/etc/github/oauth; then
+        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved,hold --github-token-path=/etc/github/oauth; then
           git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
         fi
       volumeMounts:


### PR DESCRIPTION
There are some cases when the automatic bump of a new provider needs
some manual adjsutments. In that case we would like to freeze the
push to existing bump PR until we manage to fix the issues.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>