### PR TITLE
HCO: revert add lane for K8s 1.22

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -33,36 +33,3 @@ presubmits:
         resources:
           requests:
             memory: "29Gi"
-  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.22
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    cluster: prow-workloads
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20210419-444033d
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "export TARGET=k8s-1.22 && automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"


### PR DESCRIPTION
K8s 1.22 is not supported yet in kubevirt-infra-bootstrap

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>