### PR TITLE
Make k8s 1.22 check provision job mandatory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -233,7 +233,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -243,7 +243,6 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.22
-    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
As the k8s 1.22 provider has been merged, we now make the job to run
automatically and be required to merge.

/cc @enp0s3