### PR TITLE
Fix slack-config secret for prometheus deployment

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -677,8 +677,8 @@ postsubmits:
               extract_secret 'grafanaLDAPTOML' ./github/ci/services/prometheus-stack/secrets/production-control-plane/grafana/ldap-toml
               extract_secret 'thanosObjstoreConfig' ./github/ci/services/prometheus-stack/secrets/production-control-plane/thanos-objstore-config/thanos.yaml
               extract_secret 'thanosObjstoreConfig' ./github/ci/services/prometheus-stack/secrets/production-e2e-workloads/thanos-objstore-config/thanos.yaml
-              extract_secret 'alertmanager.slack.apiURL' ./github/ci/services/prometheus-stack/secrets/production-control-plane/slack-config/apiURL.yaml
-              extract_secret 'alertmanager.slack.apiURL' ./github/ci/services/prometheus-stack/secrets/production-e2e-workloads/slack-config/apiURL.yaml
+              extract_secret 'alertmanager.slack.apiURL' ./github/ci/services/prometheus-stack/secrets/production-control-plane/slack-config/apiURL
+              extract_secret 'alertmanager.slack.apiURL' ./github/ci/services/prometheus-stack/secrets/production-e2e-workloads/slack-config/apiURL
 
               ./github/ci/services/prometheus-stack/hack/deploy.sh production-control-plane
               ./github/ci/services/prometheus-stack/hack/deploy.sh production-e2e-workloads


### PR DESCRIPTION
This will fix the creation of the generated alertmanager configuration and will prevent these errors in the operator logs:
```
level=warn ts=2021-09-15T07:31:01.814978897Z caller=operator.go:897 component=alertmanageroperator msg="skipping alertmanagerconfig" error="key \"apiURL\" in secret \"slack-config\" not found" alertmanagerconfig=monitoring/kubevirtci namespace=monitoring alertmanager=prometheus-stack-kube-prom-alertmanager
```

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>