### PR TITLE
Add new job and script that bump images used in prow job definitions

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -105,7 +105,7 @@ periodics:
       args:
       - |
         set -e
-        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved,hold --github-token-path=/etc/github/oauth; then
+        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
           git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
         fi
       volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -662,3 +662,43 @@ periodics:
       - name: gcs
         secret:
           secretName: gcs
+
+- name: periodic-project-infra-prow-job-image-bump
+  cron: "30 0 * * *"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  cluster: ibm-prow-jobs
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20210915-8bb373f
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      args:
+      - |
+        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,hold --github-token-path=/etc/github/oauth; then
+          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main
+        fi
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github
+      resources:
+        requests:
+          memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -689,7 +689,7 @@ periodics:
       - -c
       args:
       - |
-        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,hold --github-token-path=/etc/github/oauth; then
+        if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
           hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main
         fi
       volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -273,9 +273,11 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "4Gi"
+                memory: "16Gi"
+                cpu: "500m"
               limits:
-                memory: "4Gi"
+                memory: "16Gi"
+                cpu: "500m"
     - name: post-project-infra-prow-control-plane-deployment
       always_run: false
       run_if_changed: "github/ci/prow-deploy/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -256,9 +256,11 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "4Gi"
+              memory: "16Gi"
+              cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "16Gi"
+              cpu: "500m"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
     run_if_changed: "github/ci/prow-deploy/.*"

--- a/hack/bump-prow-job-images.sh
+++ b/hack/bump-prow-job-images.sh
@@ -15,7 +15,7 @@ for image_dir in "${IMAGES[@]}"; do
     image_name="quay.io/kubevirtci/${image_dir/#\.\//}"
     if ! "$PROJECT_INFRA_ROOT/hack/update-jobs-with-latest-image.sh" "$image_name"; then
         echo "Failed to update prow jobs using image $image_name"
-    else
-        echo "Updated prow jobs using image $image_name"
+        exit 1
     fi
+    echo "Updated prow jobs using image $image_name"
 done

--- a/hack/bump-prow-job-images.sh
+++ b/hack/bump-prow-job-images.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+set -x
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
+
+# won't work as image names differ from directory names
+#IMAGES=$(
+#    ( cd "$PROJECT_INFRA_ROOT/images" && find . -mindepth 1 -maxdepth 1 -type d -print ) & ( cd "$PROJECT_INFRA_ROOT/robots/cmd" && find . -mindepth 1 -maxdepth 1 -type d -print ) ;
+#)
+IMAGES=( autoowners bootstrap ci-usage-exporter flakefinder golang indexpagecreator kubekins-e2e kubevirt-infra-bootstrap kubevirt-userguide prow-deploy pr-creator release-blocker release-querier )
+for image_dir in "${IMAGES[@]}"; do
+    image_name="quay.io/kubevirtci/${image_dir/#\.\//}"
+    if ! "$PROJECT_INFRA_ROOT/hack/update-jobs-with-latest-image.sh" "$image_name"; then
+        echo "Failed to update prow jobs using image $image_name"
+    else
+        echo "Updated prow jobs using image $image_name"
+    fi
+done

--- a/images/pr-creator/Dockerfile
+++ b/images/pr-creator/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/kubevirtci/bootstrap:v20210715-d0c2b78
 RUN set -x && \
     git clone https://github.com/kubernetes/test-infra.git && \
     cd ./test-infra && \
-    git checkout 00bc5aa56077a37432ce757dbae358c56435c010 && \
+    git checkout f2693aba912dd40c974304caca999d45ee8dce33 && \
     bazel build //robots/pr-creator:pr-creator && \
     cp ./bazel-out/k8-fastbuild/bin/robots/pr-creator/pr-creator_/pr-creator /usr/local/bin && \
     chmod +x /usr/local/bin/pr-creator && \

--- a/images/pr-creator/Dockerfile
+++ b/images/pr-creator/Dockerfile
@@ -20,4 +20,8 @@ RUN set -x && \
     chmod +x /usr/local/bin/labels-checker && \
     cd .. && rm -rf ./project-infra
 
+RUN dnf install -y \
+        skopeo && \
+    dnf -y clean all
+
 ENV GIT_ASKPASS=/usr/local/bin/git-askpass.sh


### PR DESCRIPTION
The script `hack/bump-prow-job-images.sh` updates a list of images that are currently hardcoded. Changes required for that to work:

* update pr-creator image by adding install of skopeo to be able to fetch latest image tags
* update `hack/update-jobs-with-latest-image.sh` to use skopeo for fetching latest image tag

Created a new periodic job `periodic-project-infra-prow-job-image-bump` that runs daily to execute that script.

Example result is here: https://github.com/kubevirt/project-infra/pull/1584/commits/6268062bb2109d9e41b9707cd798e64d6a43e38a

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @fgimenez 