### PR TITLE
Updated prow-deploy image

### DIFF
--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -1,20 +1,20 @@
-FROM quay.io/kubevirtci/bootstrap:v20210126-a12b6c0
+FROM quay.io/kubevirtci/bootstrap:v20210906-994b913
 
 RUN git clone https://github.com/kubernetes/test-infra.git && \
   cd test-infra && \
-  git checkout e88598c4a7f86e0564a2d8b46ce5f729247791e6 && \
+  git checkout 689941423e01abb85b7ca6b9e317e3d035c60098 && \
   bazelisk build //prow/cmd/config-bootstrapper && \
-  cp bazel-bin/prow/cmd/config-bootstrapper/linux_amd64_stripped/config-bootstrapper /usr/local/bin && \
+  cp bazel-bin/prow/cmd/config-bootstrapper/config-bootstrapper_/config-bootstrapper /usr/local/bin && \
+  config-bootstrapper --help && \
   bazelisk build //prow/cmd/phony && \
-  cp bazel-bin/prow/cmd/phony/linux_amd64_stripped/phony /usr/local/bin && \
+  cp bazel-bin/prow/cmd/phony/phony_/phony /usr/local/bin && \
+  phony --help && \
   bazelisk build //prow/cmd/hmac && \
-  cp bazel-bin/prow/cmd/hmac/linux_amd64_stripped/hmac /usr/local/bin && \
+  cp bazel-bin/prow/cmd/hmac/hmac_/hmac /usr/local/bin && \
+  hmac --help && \
   bazelisk clean --expunge && \
   cd .. && rm -rf test-infra && \
   rm -rf ~/.cache.bazel
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  python3-venv
 
 RUN curl -Lo ./kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.7/kustomize_v3.8.7_linux_amd64.tar.gz && \
   tar -xvf kustomize.tar.gz && \
@@ -29,10 +29,13 @@ RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0
   chmod a+x ./kind && \
   mv ./kind /usr/local/bin
 
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl" && \
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
   chmod a+x ./kubectl && \
-  mv ./kubectl /usr/local/bin
+  mv ./kubectl /google-cloud-sdk/bin/ && \
+  kubectl version --client=true
 
 COPY requirements.txt .
 
 RUN pip install -r requirements.txt
+
+RUN dnf install -y which


### PR DESCRIPTION
The main goal is shipping a more recent kubectl that allows `apply --server-side` to prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1587/pull-project-infra-prow-deploy-test/1438747463094636544#1:build-log.txt%3A552 

I've also taken the opportunity to switch the base image to the latest fedora-based bootstrap, to bump the test-infra sources from which we build several tools and to add the which package required here https://github.com/kubevirt/project-infra/blob/main/hack/patch_node.sh#L15.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>