### PR TITLE
Fix prow deployment

### DIFF
--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
@@ -38,8 +38,6 @@ spec:
           value: "1200s"
         - name: PROXY_READ_TIMEOUT
           value: "1200s"
-        - name: PROXY_CONNECT_TIMEOUT
-          value: "1200s"
         - name: PROXY_SEND_TIMEOUT
           value: "1200s"
         volumeMounts:

--- a/github/ci/prow-deploy/molecule/default/Dockerfile.j2
+++ b/github/ci/prow-deploy/molecule/default/Dockerfile.j2
@@ -4,7 +4,18 @@ RUN printf '#!/bin/bash\n\
 echo "Docker in Docker enabled, initializing..."\n\
 printf '=%.0s' {1..80}; echo\n\
 # If we have opted in to docker in docker, start the docker daemon,\n\
-service docker start\n\
+(\n\
+    if [ -f "/etc/default/docker" ]; then\n\
+        source /etc/default/docker\n\
+    fi\n\
+    /usr/bin/dockerd \
+        -p /var/run/docker.pid \
+        --data-root=/docker-graph \
+        --init-path /usr/libexec/docker/docker-init \
+        --userland-proxy-path /usr/libexec/docker/docker-proxy \
+        ${DOCKER_OPTS} \
+            >/var/log/dockerd.log 2>&1 &\n\
+)\n\
 # the service can be started but the docker socket not ready, wait for ready\n\
 WAIT_N=0\n\
 MAX_WAIT=5\n\

--- a/github/ci/prow-deploy/molecule/default/molecule.yml
+++ b/github/ci/prow-deploy/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
+    image: quay.io/kubevirtci/prow-deploy:v20210917-11ede77
     privileged: True
     etc_hosts:
       "gcsweb.prowdeploy.ci": "127.0.0.1"

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -12,7 +12,7 @@
 
 - name: Launch deployment
   shell: |
-    kustomize build overlays/{{ deploy_environment }} | kubectl apply -f -
+    kustomize build overlays/{{ deploy_environment }} | kubectl apply --server-side -f -
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
   environment:


### PR DESCRIPTION
* Use image from https://github.com/kubevirt/project-infra/pull/1590 and update docker service start in the container to work with it
* Use `kubectl apply --server-side` to prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1587/pull-project-infra-prow-deploy-test/1438747463094636544#1:build-log.txt%3A552
* Remove duplicated env value in mirror-proxy deployment (unnoticed before. now causes error)

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>