### PR TITLE
Do not deploy default IngressClass in ibm-prow-jobs

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
   - ../../components/docker-mirror-proxy/base
   - ../../components/greenhouse/base
   - resources/docker-mirror-proxy_pvc.yaml
-  - resources/ingress-class.yaml
   - resources/hook-rbac.yaml
   - resources/horologium-rbac.yaml
   - resources/sinker-rbac.yaml

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ingress-class.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ingress-class.yaml
@@ -1,8 +1,0 @@
-apiVersion: networking.k8s.io/v1
-kind: IngressClass
-metadata:
-  name: public-iks-k8s-nginx
-  annotations:
-    ingressclass.kubernetes.io/is-default-class: "true"
-spec:
-  controller: "k8s.io/ingress-nginx"


### PR DESCRIPTION
We no longer need to deploy the default IngressClass in ibm-prow-jobs cluster, it is deployed with different values by the managed services.

This change will fix errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1438837799989022720

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>