### PR TITLE
Add Realtime lane (manual trigger)

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1598,3 +1598,39 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.22-sig-compute-realtime
+        image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external        


### PR DESCRIPTION
Adds a new manual lane for k8s 1.22 (root) to run only the [functional tests](https://github.com/kubevirt/kubevirt/blob/280697044fcdaf163bf16b99ef4cdb6528950bb3/tests/realtime/realtime.go) for realtime use cases. This PR takes into account the changes introduced in this other [PR](https://github.com/kubevirt/kubevirt/pull/6182) (kubevirt) to the [automation/test.sh](https://github.com/kubevirt/kubevirt/blob/280697044fcdaf163bf16b99ef4cdb6528950bb3/automation/test.sh) script to tune the created cluster to support realtime VMs.

@fgimenez @vladikr @dhiller @pkliczewski can you take a look? 