### PR TITLE
Add missing extra_refs to make periodics work for 1.22

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1251,6 +1251,10 @@ periodics:
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
   labels:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
@@ -1293,6 +1297,10 @@ periodics:
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
   labels:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
@@ -1335,6 +1343,10 @@ periodics:
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
   labels:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
@@ -1377,6 +1389,10 @@ periodics:
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
   labels:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"


### PR DESCRIPTION
Adds the [`extra_refs`](https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md#what-the-test-container-can-expect) that are missing to make the periodics run.