### PR TITLE
Fix 1.22 periodic for kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1416,7 +1416,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.22-operator
+        value: k8s-1.22
       - name: KUBEVIRT_E2E_FOCUS
         value: \[sig-operator\]
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913


### PR DESCRIPTION
Change the TARGET value for k8s-1.22 periodic for operator, which fixes this problem: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-operator/1440108636092239872#1:build-log.txt%3A38

/cc @fgimenez @stu-gott 