### PR TITLE
Add hostpath-provisioner-operator repo to PROW

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/OWNERS
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/OWNERS
@@ -1,0 +1,15 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+filters:
+  .*:
+    approvers:
+    - aglitke
+    - awels
+    - mhenriks
+    reviewers:
+    - aglitke
+    - awels
+    - maya-r
+    - mhenriks
+options: {}

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -1,0 +1,123 @@
+postsubmits:
+  kubevirt/hostpath-provisioner-operator:
+  - name: push-release-hostpath-provisioner-operator-images
+    branches:
+    - release-v\d+\.\d+
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          # Only push images on tags
+          [ -z "$(git tag --points-at HEAD | head -1)" ] ||
+          TAG="$(git tag --points-at HEAD | head -1)" make push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-latest-hostpath-provisioner-operator-images
+    branches:
+    - main
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          make push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-release-hostpath-provisioner-operator-tag
+    branches:
+    - release-v\d+\.\d+
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "false"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        - name: GH_CLI_VERSION
+          value: "1.5.0"
+        - name: GITHUB_TOKEN_PATH
+          value: /etc/github/oauth
+        - name: GITHUB_REPOSITORY
+          value: kubevirt/hostpath-provisioner-operator
+        - name: GIT_USER_NAME
+          value: kubevirt-bot
+        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+        args:
+        - ./hack/release.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+      volumes:
+      - name: token
+        secret:
+          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -1,0 +1,30 @@
+presubmits:
+  kubevirt/hostpath-provisioner-operator:
+  - name: pull-hostpath-provisioner-operator-unit-test
+    cluster: prow-workloads
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "./hack/run-unit-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -1,0 +1,123 @@
+postsubmits:
+  kubevirt/hostpath-provisioner:
+  - name: push-release-hostpath-provisioner-images
+    branches:
+    - release-v\d+\.\d+
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          # Only push images on tags
+          [ -z "$(git tag --points-at HEAD | head -1)" ] ||
+          TAG="$(git tag --points-at HEAD | head -1)" make push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-latest-hostpath-provisioner-images
+    branches:
+    - main
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          make push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-release-hostpath-provisioner-tag
+    branches:
+    - release-v\d+\.\d+
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "false"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        - name: GH_CLI_VERSION
+          value: "1.5.0"
+        - name: GITHUB_TOKEN_PATH
+          value: /etc/github/oauth
+        - name: GITHUB_REPOSITORY
+          value: kubevirt/hostpath-provisioner-operator
+        - name: GIT_USER_NAME
+          value: kubevirt-bot
+        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+        args:
+        - ./hack/release.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+      volumes:
+      - name: token
+        secret:
+          secretName: oauth-token

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -86,6 +86,7 @@ tide:
     kubevirt/kubevirt-tutorial: squash
     kubevirt/community: squash
     kubevirt/hostpath-provisioner: squash
+    kubevirt/hostpath-provisioner-operator: squash
     kubevirt/katacoda-scenarios: squash
     kubevirt/demo: squash
     k8snetworkplumbingwg/ovs-cni: squash
@@ -140,6 +141,7 @@ tide:
     - kubevirt/kubevirt
     - kubevirt/containerized-data-importer
     - kubevirt/hostpath-provisioner
+    - kubevirt/hostpath-provisioner-operator
     - k8snetworkplumbingwg/ovs-cni
     - kubevirt/macvtap-cni
     - kubevirt/cluster-network-addons-operator

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -206,6 +206,13 @@ plugins:
   - lgtm
   - approve
 
+  kubevirt/hostpath-provisioner-operator:
+  - trigger
+  - release-note
+  - owners-label
+  - lgtm
+  - approve
+
   kubevirt/cluster-network-addons-operator:
   - trigger
   - owners-label
@@ -369,6 +376,7 @@ triggers:
   - kubevirt/kubevirt-tutorial
   - kubevirt/containerized-data-importer
   - kubevirt/hostpath-provisioner
+  - kubevirt/hostpath-provisioner-operator
   - kubevirt/katacoda-scenarios
   - kubevirt/common-templates
   - kubevirt/kvm-info-nfd-plugin
@@ -408,6 +416,7 @@ approve:
   - kubevirt/bridge-marker
   - kubevirt/containerized-data-importer
   - kubevirt/hostpath-provisioner
+  - kubevirt/hostpath-provisioner-operator
   - kubevirt/katacoda-scenarios
   - kubevirt/demo
   - kubevirt/cluster-network-addons-operator
@@ -447,6 +456,7 @@ lgtm:
   - kubevirt/bridge-marker
   - kubevirt/containerized-data-importer
   - kubevirt/hostpath-provisioner
+  - kubevirt/hostpath-provisioner-operator
   - kubevirt/katacoda-scenarios
   - kubevirt/demo
   - kubevirt/cluster-network-addons-operator


### PR DESCRIPTION
Added support for lgtm/approve and release for hostpath-provisioner-operator

Together with https://github.com/kubevirt/hostpath-provisioner-operator/pull/132 this should enable full PROW support for the operator.

Signed-off-by: Alexander Wels <awels@redhat.com>