### PR TITLE
Add post submit to hostpath-provisioner and unit tests runner

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -102,7 +102,7 @@ postsubmits:
         - name: GITHUB_TOKEN_PATH
           value: /etc/github/oauth
         - name: GITHUB_REPOSITORY
-          value: kubevirt/hostpath-provisioner-operator
+          value: kubevirt/hostpath-provisioner
         - name: GIT_USER_NAME
           value: kubevirt-bot
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -96,3 +96,34 @@ presubmits:
           resources:
             requests:
               memory: "29Gi"
+  - name: pull-hpp-unit-test
+    cluster: prow-workloads
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make test"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+


### PR DESCRIPTION
To support migrating from travis, we can make releases using PROW and run unit tests. https://github.com/kubevirt/hostpath-provisioner/pull/74 supports removal of travis and adds release scripts called here.

Signed-off-by: Alexander Wels <awels@redhat.com>