### PR TITLE
Allow one unavailable pod in several deployments

### DIFF
--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,6 +9,9 @@ spec:
     matchLabels:
       app: docker-mirror-proxy
   replicas: 1
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/ghproxy_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/ghproxy_deployment.yaml
@@ -4,3 +4,8 @@
   path: /spec/template/spec/tolerations
 - op: remove
   path: /spec/template/spec/nodeSelector
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxUnavailable: 1


### PR DESCRIPTION
We are having a issues with the docker-mirror-proxy and ghproxy deployments, the new pods are blocked in `ContainerCreating` status bc the old pods have the associated volume attached and the new one can't attach it in exclusive mode.

These changes aim to improve automation (no need to manually scale down and up the deployment to unblock de rollout) at the cost of non zero-downtime deployments. In case it is required to replace the pod it might happen that after the old pod is down and before the new pod is up the service provided by it could be unavailable.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>