### PR TITLE
Exclude private and empty repos from bumping

### DIFF
--- a/hack/bump-prow-job-images.sh
+++ b/hack/bump-prow-job-images.sh
@@ -10,7 +10,11 @@ PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
 #IMAGES=$(
 #    ( cd "$PROJECT_INFRA_ROOT/images" && find . -mindepth 1 -maxdepth 1 -type d -print ) & ( cd "$PROJECT_INFRA_ROOT/robots/cmd" && find . -mindepth 1 -maxdepth 1 -type d -print ) ;
 #)
-IMAGES=( autoowners bootstrap ci-usage-exporter flakefinder golang indexpagecreator kubekins-e2e kubevirt-infra-bootstrap kubevirt-userguide prow-deploy pr-creator release-blocker release-querier )
+# repos yet private
+#  kubekins-e2e  kubevirt-userguide
+# repos public but empty
+#  release-querier
+IMAGES=( autoowners bootstrap ci-usage-exporter flakefinder golang indexpagecreator kubevirt-infra-bootstrap prow-deploy pr-creator release-blocker )
 for image_dir in "${IMAGES[@]}"; do
     image_name="quay.io/kubevirtci/${image_dir/#\.\//}"
     if ! "$PROJECT_INFRA_ROOT/hack/update-jobs-with-latest-image.sh" "$image_name"; then

--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -9,6 +9,10 @@ fi
 
 IMAGE_NAME="$1"
 latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[]' | sort -rV | head -1)
+if [ -z "$latest_image_tag" ]; then
+    echo "Couldn't find latest_image_tag"
+    exit 1
+fi
 IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$latest_image_tag"
 
 replace_regex='s#'"$IMAGE_NAME"'(@sha256\:|:v[a-z0-9]+-).*$#'"$IMAGE_NAME_WITH_TAG"'#g'


### PR DESCRIPTION
Also add non zero exit in case of empty repository.

Fixes https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-job-image-bump/1440835968474025984

/cc @fgimenez 