### PR TITLE
Add --force-conflicts to prow-deploy kubectl apply

### DIFF
--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -12,7 +12,7 @@
 
 - name: Launch deployment
   shell: |
-    kustomize build overlays/{{ deploy_environment }} | kubectl apply --server-side -f -
+    kustomize build overlays/{{ deploy_environment }} | kubectl apply --server-side --force-conflicts -f -
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
   environment:


### PR DESCRIPTION
Forces the manager of all the potential fields that might change in the future to be server-side. Will prevent errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1441026775944531968#1:build-log.txt%3A181

/cc @enp0s3 @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>