### PR TITLE
Bump prow-deploy image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -275,7 +275,7 @@ presubmits:
       securityContext:
         runAsUser: 0
       containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210715-d0c2b78
+        - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/molecule/default/molecule.yml
+++ b/github/ci/prow-deploy/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/kubevirtci/prow-deploy:v20210917-11ede77
+    image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
     privileged: True
     etc_hosts:
       "gcsweb.prowdeploy.ci": "127.0.0.1"


### PR DESCRIPTION
Bumps the image used in prow-deploy tests to the version created in #1614

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>