### PR TITLE
Symlink prow-deploy requirements.txt to the file used on CI

### DIFF
--- a/github/ci/prow-deploy/requirements.txt
+++ b/github/ci/prow-deploy/requirements.txt
@@ -1,7 +1,1 @@
-ansible == 2.10.7
-kubernetes == 11.0.0
-kubernetes-validate == 1.19.0
-molecule == 3.1.5
-molecule-docker == 0.2.4
-openshift == 0.11.2
-selinux == 0.2.1
+../../../images/prow-deploy/requirements.txt


### PR DESCRIPTION
`github/ci/prow-deploy/requirements.txt` is only used for local testing during development, it should always have the same content as the one used on CI, `images/prow-deploy/requirements.txt`

/cc @dhiller @enp0s3 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>