### PR TITLE
Make nonroot lanes optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -389,6 +389,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
+    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -517,6 +518,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
+    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1633,4 +1635,4 @@ presubmits:
         securityContext:
           privileged: true
       nodeSelector:
-        type: bare-metal-external        
+        type: bare-metal-external


### PR DESCRIPTION
`test_id:3145` is a release blocker that we can't quarantine. It has started failing a lot in the nonroot lanes after https://github.com/kubevirt/kubevirt/pull/6112 was merged, see https://prow.ci.kubevirt.io/?job=pull-kubevirt-e2e-k8s-1.20-sig-compute-nonroot and https://prow.ci.kubevirt.io/?job=pull-kubevirt-e2e-k8s-1.20-operator-nonroot. These are all the recent failures of `test_id:3145` https://search.ci.kubevirt.io/?search=test_id%3A3145&maxAge=336h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

This PR makes the nonroot lanes optional to unblock the PRs pending to be merged (for instance all the non-cherrypick PRs currently ready to be merged are blocked in the nonroot lanes https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+is%3Aopen+label%3Aapproved+label%3Algtm+-label%3Ado-not-merge%2Fhold+-label%3Aneeds-rebase) 

/cc @xpivarc @davidvossel @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>