### PR TITLE
Add vm-image-builder image and jobs to handle it

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -87,7 +87,7 @@ postsubmits:
                 memory: "1Gi"
     - name: publish-bootstrap-image
       always_run: false
-      run_if_changed: "images/.*"
+      run_if_changed: "images/bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
@@ -109,6 +109,37 @@ postsubmits:
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh bootstrap quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "1Gi"
+              limits:
+                memory: "1Gi"
+    - name: publish-golang-image
+      always_run: false
+      run_if_changed: "images/golang/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
+      spec:
+        nodeSelector:
+          type: vm
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
                 ./publish_image.sh golang quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
@@ -278,6 +309,38 @@ postsubmits:
               limits:
                 memory: "16Gi"
                 cpu: "500m"
+    - name: publish-vm-image-builder-image
+      always_run: false
+      run_if_changed: "images/vm-image-builder/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: phx-prow
+      spec:
+        nodeSelector:
+          type: vm
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
+                ./publish_image.sh vm-image-builder quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "1Gi"
+              limits:
+                memory: "1Gi"
     - name: post-project-infra-prow-control-plane-deployment
       always_run: false
       run_if_changed: "github/ci/prow-deploy/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -92,7 +92,7 @@ presubmits:
               memory: "1Gi"
   - name: build-bootstrap-image
     always_run: false
-    run_if_changed: "images/.*"
+    run_if_changed: "images/bootstrap/.*"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -109,6 +109,32 @@ presubmits:
             - "/bin/bash"
             - "-ce"
             - "cd images && ./publish_image.sh -b bootstrap quay.io kubevirtci"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
+  - name: build-golang-image
+    always_run: false
+    run_if_changed: "images/golang/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
+    spec:
+      nodeSelector:
+        type: vm
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-ce"
             - "cd images && ./publish_image.sh -b golang quay.io kubevirtci"
           # docker-in-docker needs privileged mode
           securityContext:
@@ -261,6 +287,33 @@ presubmits:
             limits:
               memory: "16Gi"
               cpu: "500m"
+  - name: build-vm-image-builder-image
+    always_run: false
+    run_if_changed: "images/bootstrap/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    cluster: phx-prow
+    spec:
+      nodeSelector:
+        type: vm
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-ce"
+            - "cd images && ./publish_image.sh -b vm-image-builder quay.io kubevirtci"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
     run_if_changed: "github/ci/prow-deploy/.*"

--- a/images/vm-image-builder/Dockerfile
+++ b/images/vm-image-builder/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/kubevirtci/bootstrap:v20210924-4c47964
+
+RUN dnf install -y \
+    cloud-utils \
+    libguestfs \
+    libguestfs-tools-c \
+    libvirt \
+    qemu-img \
+    virt-install && \
+    dnf clean all && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*


### PR DESCRIPTION
Adds image to handle creation of the images defined here https://github.com/kubevirt/kubevirtci/tree/main/cluster-provision/images/vm-image-builder I've also taken the opportunity to split the jobs that currently manage bootstrap and golang images.

/cc @dhiller @jordigilh 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>