### PR TITLE
switch remaining hpp tests to golang container

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
     cluster: phx-prow
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - image: quay.io/kubevirtci/golang:v20210924-7b670cb
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -84,7 +84,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - image: quay.io/kubevirtci/golang:v20210924-7b670cb
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
Switch the remaining tests to the golang container as they use it
also.

Signed-off-by: Alexander Wels <awels@redhat.com>