### PR TITLE
Replace docker with podman in bootstrap image

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -409,6 +409,19 @@ presets:
   - name: docker-graph
     mountPath: /docker-graph
 - labels:
+    preset-pinc-enabled: "true"
+  env:
+  - name: PODMAN_IN_CONTAINER_ENABLED
+    value: "true"
+  - name: KIND_EXPERIMENTAL_PROVIDER
+    value: "podman"
+  volumes:
+  - name: podman-data
+    emptyDir: {}
+  volumeMounts:
+  - name: podman-data
+    mountPath: /var/lib/containers
+- labels:
     preset-docker-mirror: "true"
   volumes:
   - name: docker-config
@@ -423,6 +436,10 @@ presets:
   env:
   - name: CA_CERT_FILE
     value: /etc/docker-mirror-proxy/ca.crt
+  - name: CONTAINER_HTTP_PROXY
+    value: http://docker-mirror-proxy.kubevirt-prow.svc:3128
+  - name: CONTAINER_HTTPS_PROXY
+    value: http://docker-mirror-proxy.kubevirt-prow.svc:3128
   volumes:
   - name: docker-mirror-proxy-ca-cert
     configMap:

--- a/images/bootstrap/87-podman.conflist
+++ b/images/bootstrap/87-podman.conflist
@@ -1,0 +1,61 @@
+{
+   "cniVersion": "0.4.0",
+   "name": "podman",
+   "plugins": [
+      {
+         "type": "bridge",
+         "bridge": "cni-podman0",
+         "isGateway": true,
+         "ipMasq": true,
+         "hairpinMode": true,
+         "ipam": {
+            "type": "host-local",
+            "routes": [
+               {
+                  "dst": "::/0"
+               },
+               {
+                  "dst": "0.0.0.0/0"
+               }
+            ],
+            "ranges": [
+               [
+                  {
+                     "subnet": "2001:db8:1::/64",
+                     "gateway": "2001:db8:1::1"
+                  }
+               ],
+               [
+                  {
+                     "subnet": "10.88.0.0/16",
+                     "gateway": "10.88.0.1"
+                  }
+               ]
+            ]
+         },
+         "capabilities": {
+            "ips": true
+         }
+      },
+      {
+         "type": "portmap",
+         "capabilities": {
+            "portMappings": true
+         }
+      },
+      {
+         "type": "firewall",
+         "backend": ""
+      },
+      {
+         "type": "tuning"
+      },
+      {
+         "type": "dnsname",
+         "domainName": "dns.podman",
+         "capabilities": {
+            "aliases": true
+         }
+      }
+   ]
+}

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,6 +14,35 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
+FROM fedora:34 AS builder
+
+ENV PKG_CONFIG_PATH="/usr/lib/pkgconfig"
+
+WORKDIR /app
+
+ENV GIMME_GO_VERSION=1.16.8
+
+# Cache latest stable golang version
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \
+    chmod +x /bin/gimme && \
+    mkdir -p /etc/setup.mixin.d/ && \
+    echo 'eval $(gimme ${GIMME_GO_VERSION})' > /etc/setup.mixin.d/golang.sh
+RUN . /etc/setup.mixin.d/golang.sh
+
+RUN dnf install -y \
+    git \
+    gpgme-devel \
+    libseccomp-devel.x86_64 \
+    libseccomp-devel.x86_64 \
+    make \
+    systemd-devel && \
+    git clone https://github.com/containers/podman && \
+    cd podman && \
+    . /etc/setup.mixin.d/golang.sh && \
+    dnf install -y gcc glibc-static && \
+    make install.tools && \
+    make binaries
+
 FROM fedora:34
 
 WORKDIR /workspace
@@ -70,25 +99,29 @@ RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.ta
     gcloud components install alpha beta kubectl && \
     gcloud info | tee /workspace/gcloud-info.txt
 
+#
+# BEGIN: PODMAN IN CONTAINER SETUP
+#
+
+RUN dnf -y update; dnf -y reinstall shadow-utils && \
+    dnf -y install crun podman --exclude container-selinux && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.* && \
+    ln -s /usr/bin/podman /usr/bin/docker && \
+    dnf update -y --refresh --enablerepo=updates-testing podman
+
+COPY --from=builder /app/podman/bin/podman /usr/bin/podman
+
+VOLUME /var/lib/containers
+
+COPY containers.conf /etc/containers/containers.conf
+COPY 87-podman.conflist /etc/cni/net.d/
+
+RUN chmod 644 /etc/containers/containers.conf
+
+ENV _CONTAINERS_USERNS_CONFIGURED=""
 
 #
-# BEGIN: DOCKER IN DOCKER SETUP
-#
-# Install packages
-
-RUN dnf install -y \
-        kmod \
-        procps-ng \
-        moby-engine && \
-    dnf -y clean all
-
-# Create directory for docker storage location
-# NOTE this should be mounted and persisted as a volume ideally (!)
-# We will make a fallback one now just in case
-RUN mkdir /docker-graph
-
-#
-# END: DOCKER IN DOCKER SETUP
+# END: PODMAN IN CONTAINER SETUP
 #
 
 
@@ -106,8 +139,8 @@ RUN USE_BAZEL_VERSION=4.1.0 bazel version && \
 # create mixin directories
 RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
 
-# note the runner is also responsible for making docker in docker function if
-# env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating
+# note the runner is also responsible for making podman in sontainer function if
+# env PODMAN_IN_CONTAINER_ENABLED is set and similarly responsible for generating
 # .bazelrc files if bazel remote caching is enabled
 COPY ["entrypoint.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
         "/usr/local/bin/"]

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -27,6 +27,7 @@ RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/mas
     chmod +x /bin/gimme && \
     mkdir -p /etc/setup.mixin.d/ && \
     echo 'eval $(gimme ${GIMME_GO_VERSION})' > /etc/setup.mixin.d/golang.sh
+RUN cat /etc/setup.mixin.d/golang.sh
 RUN . /etc/setup.mixin.d/golang.sh
 
 RUN dnf install -y \

--- a/images/bootstrap/containers.conf
+++ b/images/bootstrap/containers.conf
@@ -1,0 +1,15 @@
+[containers]
+netns="host"
+userns="host"
+ipcns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"
+network_cmd_options=[
+  "mtu=1450",
+  "enable_ipv6=true"
+]


### PR DESCRIPTION
Changes to start using podman in our CI instead of docker:

* Modification of the bootstrap image, replacing docker with podman. The image symlinks `/usr/bin/docker` to `/usr/bin/podman` to make the transition easier. Also changed the runner scripts to start podman as a system service and make the required setup and teardown.
* Added a new `preset-pinc-enabled` preset that sets up the env var, volume and volume mounts that will be used in podman-based jobs
* Modified docker-mirror-proxy preset to include HTTP proxy env vars that will be used by the podman process.

This PR represents the first step in the migration from docker to podman for the CI jobs, once it is merged and the bootstrap image built we need to gradually upgrade the jobs to use this new image and replace the `dind` preset with the new `pinc` preset, starting with periodics, then optional and always_run false presubmits, then required presubmits.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>