### PR TITLE
Set KubePodNotReady alert trigger to 90m in prow-workloads

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
@@ -20,17 +20,6 @@ spec:
       labels:
         severity: critical
         namespace: monitoring
-    - alert: KubePodNotReady
-      annotations:
-        message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
-          state for longer than 30 minutes.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
-      expr: |
-        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
-      for: 1h
-      labels:
-        severity: critical
-        namespace: monitoring
     - alert: KubeDeploymentGenerationMismatch
       annotations:
         message: 'Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment

--- a/github/ci/services/prometheus-stack/manifests/rules/production-control-plane/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/production-control-plane/kubernetes-apps.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    group: kubevirtci
+  name: kubernetes-apps
+spec:
+  groups:
+  - name: kubernetes-apps
+    rules:
+    - alert: KubePodNotReady
+      annotations:
+        message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+          state for longer than 30 minutes.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: |
+        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 30m
+      labels:
+        severity: critical
+        namespace: monitoring

--- a/github/ci/services/prometheus-stack/manifests/rules/production-e2e-workloads/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/production-e2e-workloads/kubernetes-apps.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    group: kubevirtci
+  name: kubernetes-apps
+spec:
+  groups:
+  - name: kubernetes-apps
+    rules:
+    - alert: KubePodNotReady
+      annotations:
+        message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+          state for longer than 1h30m.'
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
+      expr: |
+        sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+      for: 90m
+      labels:
+        severity: critical
+        namespace: monitoring


### PR DESCRIPTION
* Creates different definitions of `KubePodNotReady` for control plane and workloads clusters.
* Sets the trigger to 90m for workloads cluster.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>