### PR TITLE
Switch hpp operator to use golang container

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+      - image: quay.io/kubevirtci/golang:v20210924-7b670cb
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt
@@ -57,7 +57,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+      - image: quay.io/kubevirtci/golang:v20210924-7b670cb
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt
@@ -93,7 +93,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+      - image: quay.io/kubevirtci/golang:v20210924-7b670cb
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - image: quay.io/kubevirtci/golang:v20210924-7b670cb
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
The hpp operator scripts are very similar to hpp and thus
should be using the golang container as well for testing
and releases.

Signed-off-by: Alexander Wels <awels@redhat.com>