### PR TITLE
Rename kubernetes-apps PrometheusRule and rule group for common and cluster use cases

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
@@ -4,10 +4,10 @@ kind: PrometheusRule
 metadata:
   labels:
     group: kubevirtci
-  name: kubernetes-apps
+  name: kubernetes-apps-common
 spec:
   groups:
-  - name: kubernetes-apps
+  - name: kubernetes-apps-common
     rules:
     - alert: KubePodCrashLooping
       annotations:

--- a/github/ci/services/prometheus-stack/manifests/rules/production-control-plane/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/production-control-plane/kubernetes-apps.yaml
@@ -4,10 +4,10 @@ kind: PrometheusRule
 metadata:
   labels:
     group: kubevirtci
-  name: kubernetes-apps
+  name: kubernetes-apps-cluster
 spec:
   groups:
-  - name: kubernetes-apps
+  - name: kubernetes-apps-cluster
     rules:
     - alert: KubePodNotReady
       annotations:

--- a/github/ci/services/prometheus-stack/manifests/rules/production-e2e-workloads/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/production-e2e-workloads/kubernetes-apps.yaml
@@ -4,10 +4,10 @@ kind: PrometheusRule
 metadata:
   labels:
     group: kubevirtci
-  name: kubernetes-apps
+  name: kubernetes-apps-cluster
 spec:
   groups:
-  - name: kubernetes-apps
+  - name: kubernetes-apps-cluster
     rules:
     - alert: KubePodNotReady
       annotations:


### PR DESCRIPTION
Fixes errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prometheus-stack-deployment/1443935838986571776

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>