### PR TITLE
Increase timeout for fourweekly report to avoid timeouts

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -123,6 +123,9 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 3h0m0s
   interval: 168h
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:


### PR DESCRIPTION
The job has passed the two hour mark a couple times already. Therefore
we increase the timeout to three hours.

/cc @fgimenez 