### PR TITLE
Move hpp(-operator) unit tests to phx-prow cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/hostpath-provisioner-operator:
   - name: pull-hostpath-provisioner-operator-unit-test
-    cluster: prow-workloads
+    cluster: phx-prow
     annotations:
       fork-per-release: "true"
     always_run: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -97,7 +97,7 @@ presubmits:
             requests:
               memory: "29Gi"
   - name: pull-hpp-unit-test
-    cluster: prow-workloads
+    cluster: phx-prow
     skip_branches:
       - release-\d+\.\d+
     annotations:


### PR DESCRIPTION
They are currently marked on prow-workloads but don't require
bm at all to run. So phx-prow is better.

Signed-off-by: Alexander Wels <awels@redhat.com>