### PR TITLE
Bump bootstrap image used in nmstate publish job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
           type: vm
           zone: ci
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20211004-a19e71e
             env:
             - name: GIT_ASKPASS
               value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"


### PR DESCRIPTION
This will be automated soon (https://github.com/kubevirt/project-infra/pull/1616/files#diff-657f2447d4813480e447b9dad795932f8dd1b9e03df940df35d5fdfb1da98344R25), for now it will fix errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubernetes-nmstate/1445309051528286208#1:build-log.txt%3A82

/cc @qinqon @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>