### PR TITLE
NMO: Remove e2e from presubmits, clean postsubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -60,7 +60,7 @@ postsubmits:
           - "-c"
           - |
             cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
-            export IMAGE_TAG="$(git tag --points-at HEAD | head -1)" && export OPERATOR_VERSION_NEXT="${IMAGE_TAG#v}" && make container-build container-push
+            VERSION=${$(git tag --points-at HEAD | head -1)#v} make container-build container-push
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -1,40 +1,5 @@
 presubmits:
   kubevirt/node-maintenance-operator:
-  - name: pull-node-maintenance-operator-e2e-k8s-1.18
-    skip_branches:
-    - release-\d+\.\d+
-    - release-v\d+\.\d+\.\d+
-    - stable-v\d+\.\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    cluster: prow-workloads
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
-        command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - "export TARGET=k8s-1.18 && automation/test.sh"
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "29Gi"
   - name: pull-node-maintenance-operator-check
     cluster: ibm-prow-jobs
     skip_branches:


### PR DESCRIPTION
We run e2e in OpenshiftCI only now