### PR TITLE
Add always run disabler, fix PR branch and selection of releases for delete jobs job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -625,7 +625,43 @@ periodics:
       command: [ "/bin/sh" , "-c" ]
       args:
       - |
-        git-pr.sh -c "bazel run //robots/cmd/kubevirt remove jobs -- --job-config-path-kubevirt-presubmits=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --job-config-path-kubevirt-periodics=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml --github-token-path= --dry-run=false" -r project-infra -b copy-kubevirt-jobs -T main
+        git-pr.sh -c "bazel run //robots/cmd/kubevirt remove jobs -- --job-config-path-kubevirt-presubmits=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --job-config-path-kubevirt-periodics=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml --github-token-path= --dry-run=false" -r project-infra -b remove-kubevirt-jobs -T main
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github
+      resources:
+        requests:
+          memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token
+
+- name: periodic-kubevirt-job-always-run-disabler
+  cron: "45 0 * * *"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  cluster: prow-workloads
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20210907-eaf738f
+      env:
+      command: [ "/bin/sh" , "-c" ]
+      args:
+      - |
+        git-pr.sh -c "bazel run //robots/cmd/kubevirt remove always_run -- --job-config-path-kubevirt-presubmits=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --github-token-path= --dry-run=false" -r project-infra -b disable-kubevirt-jobs -T main
       volumeMounts:
       - name: token
         mountPath: /etc/github

--- a/robots/cmd/kubevirt/README.md
+++ b/robots/cmd/kubevirt/README.md
@@ -30,6 +30,14 @@ Commands provided
     
         bazel run //robots/cmd/kubevirt remove jobs -- --help
 
+ * **kubevirt remove always_run**
+
+    sets always_run to false on presubmit job definitions for kubevirt for unsupported kubevirtci providers
+
+    Basic usage:
+
+        bazel run //robots/cmd/kubevirt remove always_run -- --help
+
 Building
 --------
 

--- a/robots/pkg/kubevirt/cmd/copy/BUILD.bazel
+++ b/robots/pkg/kubevirt/cmd/copy/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//robots/pkg/kubevirt/prowjobconfigs:go_default_library",
+        "//robots/pkg/kubevirt/release:go_default_library",
         "//robots/pkg/querier:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
         "@com_github_google_go_github//github:go_default_library",

--- a/robots/pkg/kubevirt/cmd/copy/jobs.go
+++ b/robots/pkg/kubevirt/cmd/copy/jobs.go
@@ -103,7 +103,7 @@ func run(cmd *cobra.Command, args []string) error {
 	releases = querier.ValidReleases(releases)
 	targetRelease, sourceRelease, err := getSourceAndTargetRelease(releases)
 	if err != nil {
-		log.Log().WithError(err).Info("Cannot determine source and target release.")
+		log.Log().WithError(err).Info("Cannot determine source and target Release.")
 		return nil
 	}
 
@@ -162,7 +162,7 @@ func getSourceAndTargetRelease(releases []*github.RepositoryRelease) (targetRele
 		}
 	}
 	if sourceRelease == nil {
-		err = fmt.Errorf("no source release found")
+		err = fmt.Errorf("no source Release found")
 	}
 	return
 }

--- a/robots/pkg/kubevirt/cmd/copy/jobs_test.go
+++ b/robots/pkg/kubevirt/cmd/copy/jobs_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/release"
+
 	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/project-infra/robots/pkg/kubevirt/prowjobconfigs"
@@ -47,11 +49,11 @@ func Test_getSourceAndTargetRelease(t *testing.T) {
 		wantErr           error
 	}{
 		{
-			name: "has one patch release for latest",
+			name: "has one patch Release for latest",
 			args: args{
 				releases: []*github.RepositoryRelease{
-					release("v1.22.0"),
-					release("v1.21.3"),
+					release.Release("v1.22.0"),
+					release.Release("v1.21.3"),
 				},
 			},
 			wantTargetRelease: &querier.SemVer{
@@ -70,9 +72,9 @@ func Test_getSourceAndTargetRelease(t *testing.T) {
 			name: "has two patch releases for latest",
 			args: args{
 				releases: []*github.RepositoryRelease{
-					release("v1.22.1"),
-					release("v1.22.0"),
-					release("v1.21.3"),
+					release.Release("v1.22.1"),
+					release.Release("v1.22.0"),
+					release.Release("v1.21.3"),
 				},
 			},
 			wantTargetRelease: &querier.SemVer{
@@ -88,10 +90,10 @@ func Test_getSourceAndTargetRelease(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name: "has one release only, should err",
+			name: "has one Release only, should err",
 			args: args{
 				releases: []*github.RepositoryRelease{
-					release("v1.22.1"),
+					release.Release("v1.22.1"),
 				},
 			},
 			wantTargetRelease: nil,
@@ -102,8 +104,8 @@ func Test_getSourceAndTargetRelease(t *testing.T) {
 			name: "has two major same releases",
 			args: args{
 				releases: []*github.RepositoryRelease{
-					release("v1.22.1"),
-					release("v1.22.0"),
+					release.Release("v1.22.1"),
+					release.Release("v1.22.0"),
 				},
 			},
 			wantTargetRelease: &querier.SemVer{
@@ -112,7 +114,7 @@ func Test_getSourceAndTargetRelease(t *testing.T) {
 				Patch: "1",
 			},
 			wantSourceRelease: nil,
-			wantErr:           fmt.Errorf("no source release found"),
+			wantErr:           fmt.Errorf("no source Release found"),
 		},
 	}
 	for _, tt := range tests {
@@ -672,12 +674,6 @@ func panicOn(err error) {
 	}
 }
 
-func release(version string) *github.RepositoryRelease {
-	result := github.RepositoryRelease{}
-	result.TagName = &version
-	return &result
-}
-
 func semver(major, minor, patch string) *querier.SemVer {
 	return &querier.SemVer{
 		Major: major,
@@ -704,7 +700,7 @@ func Test_copyPresubmitJobsForNewProvider(t *testing.T) {
 				jobConfig: &config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
 						prowjobconfigs.OrgAndRepoForJobConfig: {
-							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
 						},
 					},
 				},
@@ -715,8 +711,8 @@ func Test_copyPresubmitJobsForNewProvider(t *testing.T) {
 			wantJobConfig: &config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
 					prowjobconfigs.OrgAndRepoForJobConfig: {
-						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
-						createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
+						createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
 					},
 				},
 			},
@@ -727,7 +723,7 @@ func Test_copyPresubmitJobsForNewProvider(t *testing.T) {
 				jobConfig: &config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
 						prowjobconfigs.OrgAndRepoForJobConfig: {
-							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher(nil, []string{"release-\\d+\\.\\d+"})),
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher(nil, []string{"Release-\\d+\\.\\d+"})),
 						},
 					},
 				},
@@ -738,8 +734,8 @@ func Test_copyPresubmitJobsForNewProvider(t *testing.T) {
 			wantJobConfig: &config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
 					prowjobconfigs.OrgAndRepoForJobConfig: {
-						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher(nil, []string{"release-\\d+\\.\\d+"})),
-						createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher(nil, []string{"release-\\d+\\.\\d+"})),
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher(nil, []string{"Release-\\d+\\.\\d+"})),
+						createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher(nil, []string{"Release-\\d+\\.\\d+"})),
 					},
 				},
 			},
@@ -750,8 +746,8 @@ func Test_copyPresubmitJobsForNewProvider(t *testing.T) {
 				jobConfig: &config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
 						prowjobconfigs.OrgAndRepoForJobConfig: {
-							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
-							createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
+							createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
+							createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
 						},
 					},
 				},
@@ -762,8 +758,8 @@ func Test_copyPresubmitJobsForNewProvider(t *testing.T) {
 			wantJobConfig: &config.JobConfig{
 				PresubmitsStatic: map[string][]config.Presubmit{
 					prowjobconfigs.OrgAndRepoForJobConfig: {
-						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
-						createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher([]string{"release-\\d+\\.\\d+"}, nil)),
+						createPresubmitJobForRelease(newMinorSemver("1", "37"), "sig-network", true, false, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
+						createPresubmitJobForRelease(newMinorSemver("1", "42"), "sig-network", false, true, false, createJobBrancher([]string{"Release-\\d+\\.\\d+"}, nil)),
 					},
 				},
 			},
@@ -796,7 +792,7 @@ func createPresubmitJobForRelease(semver *querier.SemVer, sigName string, always
 		Optional:  optional,
 		JobBase: config.JobBase{
 			Annotations: map[string]string{
-				"fork-per-release":    "true",
+				"fork-per-Release":    "true",
 				"testgrid-dashboards": "kubevirt-presubmits",
 			},
 			Labels: map[string]string{

--- a/robots/pkg/kubevirt/cmd/remove/BUILD.bazel
+++ b/robots/pkg/kubevirt/cmd/remove/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "always_run.go",
         "jobs.go",
         "remove.go",
     ],
@@ -13,6 +14,7 @@ go_library(
         "//robots/pkg/kubevirt/github:go_default_library",
         "//robots/pkg/kubevirt/log:go_default_library",
         "//robots/pkg/kubevirt/prowjobconfigs:go_default_library",
+        "//robots/pkg/kubevirt/release:go_default_library",
         "//robots/pkg/querier:go_default_library",
         "@com_github_google_go_github//github:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",

--- a/robots/pkg/kubevirt/cmd/remove/always_run.go
+++ b/robots/pkg/kubevirt/cmd/remove/always_run.go
@@ -106,10 +106,7 @@ func runAlwaysRunCommand(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to list releases: %v", err)
 	}
 	releases = querier.ValidReleases(releases)
-	allReleases := make([]*querier.SemVer, 0, len(releases))
-	for _, release := range releases {
-		allReleases = append(allReleases, querier.ParseRelease(release))
-	}
+	allReleases := release.AsSemVers(releases)
 	latestMinorReleases := release.GetLatestMinorReleases(allReleases)
 	if len(latestMinorReleases) < fourReleasesRequiredAtMinimum {
 		log.Log().Info("Not enough minor releases found, nothing to do.")

--- a/robots/pkg/kubevirt/cmd/remove/always_run.go
+++ b/robots/pkg/kubevirt/cmd/remove/always_run.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package remove
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/release"
+
+	"github.com/spf13/cobra"
+	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/flags"
+	kv_github "kubevirt.io/project-infra/robots/pkg/kubevirt/github"
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/log"
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/prowjobconfigs"
+	"kubevirt.io/project-infra/robots/pkg/querier"
+)
+
+type removeAlwaysRunOptions struct {
+	jobConfigPathKubevirtPresubmits string
+}
+
+func (o removeAlwaysRunOptions) Validate() error {
+	if _, err := os.Stat(o.jobConfigPathKubevirtPresubmits); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPresubmits is required: %v", err)
+	}
+	return nil
+}
+
+const (
+	shortAlwaysRunUsage = "kubevirt remove always_run sets always_run to false on presubmit job definitions for kubevirt for unsupported kubevirtci providers"
+)
+
+var removeAlwaysRunCommand = &cobra.Command{
+	Use:   "always_run",
+	Short: shortAlwaysRunUsage,
+	Long: fmt.Sprintf(`%s
+
+For each of the sigs (%s)
+it sets always_run to false on presubmit job definitions that contain
+"old" k8s versions. From kubevirt standpoint an old k8s version is one
+that is older than one of the three minor versions including the
+currently released k8s version at the time of the check.
+
+Example:
+
+* k8s 1.22 is the current stable version
+* job definitions exist for k8s 1.22, 1.21, 1.20
+* presubmits for 1.22 are to run always and are required (aka optional: false)
+* job definitions exist for 1.19 k8s version 
+
+This will lead to always_run being set to false for each of the sigs presubmit jobs for 1.19
+
+See kubevirt k8s version compatibility: https://github.com/kubevirt/kubevirt/blob/main/docs/kubernetes-compatibility.md#kubernetes-version-compatibility 
+`, shortAlwaysRunUsage, strings.Join(prowjobconfigs.SigNames, ", ")),
+	RunE: runAlwaysRunCommand,
+}
+
+var removeAlwaysRunOpts = removeAlwaysRunOptions{}
+
+func RemoveAlwaysRunCommand() *cobra.Command {
+	return removeAlwaysRunCommand
+}
+
+func init() {
+	removeAlwaysRunCommand.PersistentFlags().StringVar(&removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The directory of the kubevirt presubmit job definitions")
+}
+
+func runAlwaysRunCommand(cmd *cobra.Command, args []string) error {
+	err := flags.ParseFlags(cmd, args, removeAlwaysRunOpts)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	client, err := kv_github.NewGitHubClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	jobConfig, err := config.ReadJobConfig(removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits)
+	if err != nil {
+		return fmt.Errorf("failed to read jobconfig %s: %v", removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, err)
+	}
+
+	releases, _, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
+	if err != nil {
+		return fmt.Errorf("failed to list releases: %v", err)
+	}
+	releases = querier.ValidReleases(releases)
+	allReleases := make([]*querier.SemVer, 0, len(releases))
+	for _, release := range releases {
+		allReleases = append(allReleases, querier.ParseRelease(release))
+	}
+	latestMinorReleases := release.GetLatestMinorReleases(allReleases)
+	if len(latestMinorReleases) < fourReleasesRequiredAtMinimum {
+		log.Log().Info("Not enough minor releases found, nothing to do.")
+		return nil
+	}
+
+	targetReleaseSemver := latestMinorReleases[3]
+	log.Log().Infof("Targeting release %v", targetReleaseSemver)
+
+	updated := updatePresubmitsAlwaysRunField(&jobConfig, targetReleaseSemver)
+	if !updated && !flags.Options.DryRun {
+		log.Log().Info(fmt.Sprintf("presubmit jobs for %v weren't modified, nothing to do.", targetReleaseSemver))
+		return nil
+	}
+
+	marshalledConfig, err := yaml.Marshal(&jobConfig)
+	if err != nil {
+		return fmt.Errorf("failed to marshall jobconfig %s: %v", removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, err)
+	}
+
+	if flags.Options.DryRun {
+		_, err = os.Stdout.Write(marshalledConfig)
+		if err != nil {
+			return fmt.Errorf("failed to write jobconfig %s: %v", removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, err)
+		}
+		return nil
+	}
+
+	err = ioutil.WriteFile(removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, marshalledConfig, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to write jobconfig %s: %v", removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, err)
+	}
+	return nil
+}
+
+func updatePresubmitsAlwaysRunField(jobConfig *config.JobConfig, latestReleaseSemver *querier.SemVer) (updated bool) {
+	jobsToCheck := map[string]string{}
+	for _, sigName := range prowjobconfigs.SigNames {
+		jobsToCheck[prowjobconfigs.CreatePresubmitJobName(latestReleaseSemver, sigName)] = ""
+	}
+
+	for index := range jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig] {
+		job := &jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig][index]
+		name := job.Name
+		if _, exists := jobsToCheck[name]; !exists {
+			continue
+		}
+
+		if job.AlwaysRun {
+			job.AlwaysRun = false
+			updated = true
+		}
+	}
+
+	return
+}

--- a/robots/pkg/kubevirt/cmd/remove/jobs_test.go
+++ b/robots/pkg/kubevirt/cmd/remove/jobs_test.go
@@ -94,9 +94,9 @@ func Test_ensureLatestJobsAreRequired(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, message := ensureLatestJobsAreRequired(tt.args.jobConfigKubevirtPresubmits, tt.args.release)
+			got, message := ensureSigJobsAreRequired(tt.args.jobConfigKubevirtPresubmits, tt.args.release)
 			if got != tt.want {
-				t.Errorf("ensureLatestJobsAreRequired() = %v, want %v", got, tt.want)
+				t.Errorf("ensureSigJobsAreRequired() = %v, want %v", got, tt.want)
 			}
 			t.Logf("message: %s", message)
 		})
@@ -173,9 +173,9 @@ func Test_ensureJobsExistForReleases(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotAllJobsExist, gotMessage := ensurePresubmitJobsExistForReleases(tt.args.jobConfigKubevirtPresubmits, tt.args.requiredReleases)
+			gotAllJobsExist, gotMessage := ensureSigPresubmitJobsExistForReleases(tt.args.jobConfigKubevirtPresubmits, tt.args.requiredReleases)
 			if gotAllJobsExist != tt.wantAllJobsExist {
-				t.Errorf("ensurePresubmitJobsExistForReleases() gotAllJobsExist = %v, want %v", gotAllJobsExist, tt.wantAllJobsExist)
+				t.Errorf("ensureSigPresubmitJobsExistForReleases() gotAllJobsExist = %v, want %v", gotAllJobsExist, tt.wantAllJobsExist)
 			}
 			t.Logf("message: %s", gotMessage)
 		})
@@ -306,11 +306,11 @@ func Test_deletePeriodicJobsForRelease(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := deletePeriodicJobsForRelease(tt.args.jobConfig, tt.args.release); got != tt.wantUpdated {
-				t.Errorf("deletePeriodicJobsForRelease() = %v, want %v", got, tt.wantUpdated)
+			if got := deleteSigPeriodicJobsForRelease(tt.args.jobConfig, tt.args.release); got != tt.wantUpdated {
+				t.Errorf("deleteSigPeriodicJobsForRelease() = %v, want %v", got, tt.wantUpdated)
 			}
 			if tt.wantUpdated && !reflect.DeepEqual(tt.args.jobConfig, tt.wantJobConfig) {
-				t.Errorf("deletePeriodicJobsForRelease() = %v", deep.Equal(tt.args.jobConfig, tt.wantJobConfig))
+				t.Errorf("deleteSigPeriodicJobsForRelease() = %v", deep.Equal(tt.args.jobConfig, tt.wantJobConfig))
 			}
 		})
 	}
@@ -434,11 +434,11 @@ func Test_deletePresubmitJobsForRelease(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := deletePresubmitJobsForRelease(tt.args.jobConfig, tt.args.targetRelease); got != tt.wantUpdated {
-				t.Errorf("deletePresubmitJobsForRelease() = %v, wantUpdated %v", got, tt.wantUpdated)
+			if got := deleteSigPresubmitJobsForRelease(tt.args.jobConfig, tt.args.targetRelease); got != tt.wantUpdated {
+				t.Errorf("deleteSigPresubmitJobsForRelease() = %v, wantUpdated %v", got, tt.wantUpdated)
 			}
 			if tt.wantUpdated && !reflect.DeepEqual(tt.args.jobConfig, tt.wantJobConfig) {
-				t.Errorf("deletePresubmitJobsForRelease() = %v", deep.Equal(tt.args.jobConfig, tt.wantJobConfig))
+				t.Errorf("deleteSigPresubmitJobsForRelease() = %v", deep.Equal(tt.args.jobConfig, tt.wantJobConfig))
 			}
 		})
 	}

--- a/robots/pkg/kubevirt/cmd/remove/remove.go
+++ b/robots/pkg/kubevirt/cmd/remove/remove.go
@@ -22,14 +22,14 @@ import (
 
 var removeCommand = &cobra.Command{
 	Use:   "remove",
-	Short: "kubevirt remove removes old job definitions in project-infra for kubevirt/kubevirt repo",
+	Short: "kubevirt remove phases out old job definitions in project-infra for kubevirt/kubevirt repo",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
 	},
 }
 
 func init() {
-	removeCommand.AddCommand(RemoveJobsCommand())
+	removeCommand.AddCommand(RemoveJobsCommand(), RemoveAlwaysRunCommand())
 }
 
 func RemoveCommand() *cobra.Command {

--- a/robots/pkg/kubevirt/release/BUILD.bazel
+++ b/robots/pkg/kubevirt/release/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["release.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/kubevirt/release",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["release_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//robots/pkg/querier:go_default_library"],
+)

--- a/robots/pkg/kubevirt/release/release.go
+++ b/robots/pkg/kubevirt/release/release.go
@@ -36,3 +36,11 @@ func Release(version string) *github.RepositoryRelease {
 	result.TagName = &version
 	return &result
 }
+
+func AsSemVers(releases []*github.RepositoryRelease) []*querier.SemVer {
+	semVers := make([]*querier.SemVer, 0, len(releases))
+	for _, theRelease := range releases {
+		semVers = append(semVers, querier.ParseRelease(theRelease))
+	}
+	return semVers
+}

--- a/robots/pkg/kubevirt/release/release.go
+++ b/robots/pkg/kubevirt/release/release.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package release
+
+import (
+	"github.com/google/go-github/github"
+
+	"kubevirt.io/project-infra/robots/pkg/querier"
+)
+
+// GetLatestMinorReleases returns the list of all latest minor releases in descending order.
+// Input is expected to be a list of all releases sorted descending
+func GetLatestMinorReleases(releases []*querier.SemVer) (latestMinorReleases []*querier.SemVer) {
+	for _, release := range releases {
+		if len(latestMinorReleases) == 0 || release.Major < latestMinorReleases[len(latestMinorReleases)-1].Major || release.Minor < latestMinorReleases[len(latestMinorReleases)-1].Minor {
+			latestMinorReleases = append(latestMinorReleases, release)
+		}
+	}
+	return
+}
+
+func Release(version string) *github.RepositoryRelease {
+	result := github.RepositoryRelease{}
+	result.TagName = &version
+	return &result
+}

--- a/robots/pkg/kubevirt/release/release_test.go
+++ b/robots/pkg/kubevirt/release/release_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package release
+
+import (
+	"reflect"
+	"testing"
+
+	"kubevirt.io/project-infra/robots/pkg/querier"
+)
+
+func Test_getLatestMinorReleases(t *testing.T) {
+	type args struct {
+		releases []*querier.SemVer
+	}
+	tests := []struct {
+		name                    string
+		args                    args
+		wantLatestMinorReleases []*querier.SemVer
+	}{
+		{
+			name: "empty list",
+			args: args{
+				releases: nil,
+			},
+			wantLatestMinorReleases: nil,
+		},
+		{
+			name: "two elements, same minor",
+			args: args{
+				releases: []*querier.SemVer{
+					{"1", "17", "42"},
+					{"1", "17", "37"},
+				},
+			},
+			wantLatestMinorReleases: []*querier.SemVer{
+				{"1", "17", "42"},
+			},
+		},
+		{
+			name: "five elements, three minors",
+			args: args{
+				releases: []*querier.SemVer{
+					{"1", "17", "42"},
+					{"1", "17", "37"},
+					{"1", "16", "4"},
+					{"1", "16", "3"},
+					{"1", "15", "1"},
+				},
+			},
+			wantLatestMinorReleases: []*querier.SemVer{
+				{"1", "17", "42"},
+				{"1", "16", "4"},
+				{"1", "15", "1"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotLatestMinorReleases := GetLatestMinorReleases(tt.args.releases); !reflect.DeepEqual(gotLatestMinorReleases, tt.wantLatestMinorReleases) {
+				t.Errorf("GetLatestMinorReleases() = %v, want %v", gotLatestMinorReleases, tt.wantLatestMinorReleases)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the automation to disable `always_run` on kubevirt sig presubmit jobs for unsupported k8s providers.

Also fixes the selection of the releases to only contain differing minor releases. The unfiltered list contains all patch release versions, while we need to consider only the latest patch version per minor version.

Finally fixes the branch name for the delete job prowjob, which was the same as the job it was copied from.

/cc @fgimenez 