### PR TITLE
Update apiVersion to v1

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/admin-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/admin-rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: admin

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: branch-protector

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: label-sync-kubevirt

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: label-sync-nmstate

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -151,7 +151,7 @@ patches:
     path: patches/JsonRFC6902/prow-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io
-      version: v1beta1
+      version: v1
       kind: Role
       namespace: default
       name: .*
@@ -179,14 +179,14 @@ patches:
     path: patches/JsonRFC6902/prow-jobs-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io
-      version: v1beta1
+      version: v1
       kind: RoleBinding
       namespace: test-pods
       name: .*
     path: patches/JsonRFC6902/prow-jobs-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io
-      version: v1beta1
+      version: v1
       kind: ClusterRoleBinding
       name: prow-rehearse
     path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
@@ -199,21 +199,21 @@ patches:
     path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io
-      version: v1beta1
+      version: v1
       kind: RoleBinding
       namespace: test-pods
       name: .*
     path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io
-      version: v1beta1
+      version: v1
       kind: RoleBinding
       namespace: default
       name: .*
     path: patches/JsonRFC6902/prow-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io
-      version: v1beta1
+      version: v1
       kind: Role
       namespace: test-pods
       name: .*
@@ -252,7 +252,7 @@ patches:
     path: patches/JsonRFC6902/prow-namespace.yaml
   - target:
       group: batch
-      version: v1beta1
+      version: v1
       kind: CronJob
       namespace: ""
       name: .*

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/StrategicMerge/prow_controller_manager_role.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/StrategicMerge/prow_controller_manager_role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: test-pods
   name: "prow-controller-manager"

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/hook-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/hook-rbac.yaml
@@ -24,7 +24,7 @@ rules:
       - update
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: kubevirt-prow-jobs
   name: "hook"

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/horologium-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/horologium-rbac.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: kubevirt-prow-jobs
   name: "horologium"
@@ -15,7 +15,7 @@ rules:
       - watch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: kubevirt-prow-jobs
   name: "horologium"


### PR DESCRIPTION
After the control-plane cluster was updated to 1.22 we started getting errors on deployment like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1446756799267999744 because of the deprecation of some apiVersions. This PR updates all of them, successful execution with these changes here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1447546373154017280

/cc @dhiller   

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>