### PR TITLE
Add a presubmit job of hco in openshift prow into testgrid

### DIFF
--- a/github/ci/testgrid/gen-config.yaml
+++ b/github/ci/testgrid/gen-config.yaml
@@ -5,6 +5,19 @@ dashboards:
 - name: kubevirt-libguestfs-appliance-periodics
 - name: kubevirt-hyperconverged-cluster-operator-presubmits
 - name: kubevirt-hyperconverged-cluster-operator-periodics
+- name: kubevirt-hyperconverged-cluster-operator-openshift-ci-presubmits
+  dashboard_tab:
+  - name: pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-upgrade-prev-index-azure
+    test_group_name: pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-upgrade-prev-index-azure
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    open_bug_template:
+      url: https://github.com/kubevirt/hyperconverged-cluster-operator/issues/
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: https://github.com/kubevirt/hyperconverged-cluster-operator/search
+    code_search_url_template:
+      url: https://github.com/kubevirt/hyperconverged-cluster-operator/compare/<start-custom-0>...<end-custom-0>
 
 dashboard_groups:
 - name: kubevirt
@@ -15,3 +28,8 @@ dashboard_groups:
   - kubevirt-libguestfs-appliance-periodics
   - kubevirt-hyperconverged-cluster-operator-presubmits
   - kubevirt-hyperconverged-cluster-operator-periodics
+  - kubevirt-hyperconverged-cluster-operator-openshift-ci-presubmits
+
+test_groups:
+  - gcs_prefix: origin-ci-test/pr-logs/directory/pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-upgrade-prev-index-azure
+    name: pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-upgrade-prev-index-azure


### PR DESCRIPTION
We want to track jobs of hyperconverged cluster operator in kubevirt's testgrid since openshift's testgrid doesn't belong upstream projects.

This PR tries to add "pull-ci-kubevirt-hyperconverged-cluster-operator-main-hco-e2e-upgrade-prev-index-azure" into testgrid as a first example. The definition of that job stands here: https://github.com/openshift/release/blob/6f928dd345bc49fc52561e124d169bf7873f4fa0/ci-operator/jobs/kubevirt/hyperconverged-cluster-operator/kubevirt-hyperconverged-cluster-operator-main-presubmits.yaml#L922

As far as I see from other examples*, we have to add the jobs here one by one and there is no easy way to add all jobs by using an annotation. See
- https://github.com/kubernetes/test-infra/blob/master/config/testgrids/openshift/openshift-virtualization.yaml
- https://github.com/kubernetes/test-infra/blob/master/config/testgrids/jetstack/gen-config.yaml

Signed-off-by: Erkan Erol <eerol@redhat.com>