### PR TITLE
Request an API repository for KubeVirt

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -497,6 +497,10 @@ orgs:
         description: Containerized Data Importer API definitions
         default_branch: main
         has_projects: true
+      api:
+        description: KubeVirt API definition
+        default_branch: main
+        has_projects: true
     teams:
       QE:
         description: ""
@@ -554,6 +558,13 @@ orgs:
           - aglitke
         repos:
           containerized-data-importer-api: admin
+      api:
+        description: ""
+        maintainers:
+          - mhenriks
+          - rmohr
+        repos:
+          api: admin
       maintainers:
         description: ""
         maintainers:


### PR DESCRIPTION
This repository will eventually repolace client-go by only exporting the
API of KubeVirt which can then be usede by client-gen.