### PR TITLE
Add kubevirt-velero-plugin to tide queries

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -127,6 +127,7 @@ tide:
     - kubevirt/kubectl-virt-plugin
     - kubevirt/user-guide
     - kubevirt/terraform-provider-kubevirt
+    - kubevirt/kubevirt-velero-plugin
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
With all tests passing and the right labels assigned PRs are not being merged, like https://github.com/kubevirt/kubevirt-velero-plugin/pull/10

/cc @brybacki @akalenyu @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>