### PR TITLE
Use unprivileged token for prow-deploy tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -365,12 +365,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-ce"
-            - |
-              cd github/ci/prow-deploy/
-              molecule test
-              tmp=$(mktemp -d)
-              docker cp instance:$ARTIFACTS $tmp
-              cp -ar $tmp/artifacts/* $ARTIFACTS
+            - "github/ci/prow-deploy/hack/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -380,22 +375,23 @@ presubmits:
             limits:
               memory: "29Gi"
           volumeMounts:
-          - name: token
-            mountPath: /etc/github
           - name: gcs
             mountPath: /etc/gcs
             readOnly: true
           - name: molecule-docker
             mountPath: /tmp/prow-deploy-molecule
+          - name: pgp-bot-key
+            mountPath: /etc/pgp
+            readOnly: true
       volumes:
-      - name: token
-        secret:
-          secretName: oauth-token
       - name: gcs
         secret:
           secretName: gcs
       - name: molecule-docker
         emptyDir: {}
+      - name: pgp-bot-key
+        secret:
+          secretName: pgp-bot-key
   - name: pull-project-infra-cert-manager-deploy-test
     optional: false
     run_if_changed: "github/ci/services/cert-manager/.*|github/ci/services/common/.*|WORKSPACE|go_third_party.bzl"

--- a/github/ci/prow-deploy/hack/test.sh
+++ b/github/ci/prow-deploy/hack/test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+main(){
+    current_dir=$(dirname "$0")
+    project_infra_root=$(readlink -f "${current_dir}/../../../..")
+
+    base_dir=${project_infra_root}/github/ci/prow-deploy
+
+    source ${project_infra_root}/hack/manage-secrets.sh
+    decrypt_secrets
+
+    mkdir -p /etc/github
+    extract_secret 'githubUnprivileged.token' /etc/github/oauth
+
+    cd ${base_dir}
+
+    molecule test
+    tmp=$(mktemp -d)
+    docker cp instance:$ARTIFACTS $tmp
+    cp -ar $tmp/artifacts/* $ARTIFACTS
+}
+
+main "${@}"


### PR DESCRIPTION
Requires https://github.com/kubevirt/secrets/pull/37

Changes to use an unprivileged gh token in prow-deploy tests to make sure that we don't interact with production components during their execution. Recently this PR https://github.com/kubevirt/kubevirt-velero-plugin/pull/10 was merged before the changes that would enable tide queries for its repo were deployed, probably during prow-deploy integration tests.

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>