### PR TITLE
Fix workloads cluster deployment

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -428,6 +428,7 @@ postsubmits:
             secretName: gcs
     - name: post-project-infra-prow-workloads-cluster-deployment
       always_run: false
+      run_if_changed: "github/ci/prow-deploy/kustom/overlays/workloads-production/.*|github/ci/prow-deploy/kustom/componenets/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/deployment.yaml
@@ -56,6 +56,7 @@ spec:
         ports:
           - name: http
             containerPort: 3128
+            protocol: TCP
         resources:
           requests:
             cpu: 300m

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/service.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/resources/service.yaml
@@ -8,3 +8,4 @@ spec:
     app: docker-mirror-proxy
   ports:
   - port: 3128
+    protocol: TCP

--- a/github/ci/prow-deploy/kustom/components/greenhouse/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/base/resources/deployment.yaml
@@ -42,8 +42,10 @@ spec:
         ports:
         - name: cache
           containerPort: 8080
+          protocol: TCP
         - name: metrics
           containerPort: 9090
+          protocol: TCP
         args:
         - --dir=/data
         - --min-percent-blocks-free=30
@@ -52,11 +54,11 @@ spec:
           mountPath: /data
         resources:
           requests:
-            cpu: 1.2
-            memory: 3Gi
+            cpu: "1.2"
+            memory: "3Gi"
           limits:
-            cpu: 1.2
-            memory: 3Gi
+            cpu: "1.2"
+            memory: "3Gi"
       volumes:
       - name: cache
         persistentVolumeClaim:

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/ingress-controller.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/ingress-controller.yaml
@@ -3551,13 +3551,16 @@ spec:
         ports:
         - name: http
           containerPort: 80
+          protocol: "TCP"
         - name: https
           containerPort: 443
-
+          protocol: "TCP"
         - name: prometheus
           containerPort: 9113
+          protocol: "TCP"
         - name: readiness-port
           containerPort: 8081
+          protocol: "TCP"
         readinessProbe:
           httpGet:
             path: /nginx-ready

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/metrics-server.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/metrics-server.yaml
@@ -135,6 +135,7 @@ spec:
         - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
         - --kubelet-use-node-status-port
         - --metric-resolution=15s
+        - --kubelet-insecure-tls
         image: k8s.gcr.io/metrics-server/metrics-server:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -12,7 +12,14 @@
 
 - name: Launch deployment
   shell: |
-    kustomize build overlays/{{ deploy_environment }} | kubectl apply --server-side --force-conflicts -f -
+    # for now cant execute "kubectl apply --server-side" reliably on
+    # "workloads-production" env (which runs k8s 1.19)
+    APPLY_OPTIONS=
+    if [ "{{deploy_environment}}" != "workloads-production" ]; then
+      APPLY_OPTIONS="--server-side --force-conflicts"
+    fi
+
+    kustomize build overlays/{{ deploy_environment }} | kubectl apply ${APPLY_OPTIONS} -f -
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
   environment:


### PR DESCRIPTION
Currently we are not continuously deploying to the workloads cluster, these changes set the job to run on relevant changes and update some of the resources to be able to be deployed there. 

They also add logic in the deployment role for not using server-side apply on the workloads cluster, which runs k8s 1.19 and doesn't work well with it. In any case, server-side apply is required only for Prow control plane because of the length of the CRDs. In any case we need to update the workloads cluster k8s version, but for now these changes will allow us to keep deploying changes there.

Tested successfully here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-workloads-cluster-deployment/1454002949243015168

/cc @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>