### PR TITLE
Perfscale-audit binary is missing from the Perf periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1211,6 +1211,9 @@ periodics:
       - /bin/sh
       - -c
       - |
+        # Build the perfscale-audit binary
+        make bazel-build
+
         # Create k8s cluster
         make cluster-up
 


### PR DESCRIPTION
Run `make go-build` to build the binary locally in order for the test to run

Signed-off-by: Ryan Hallisey <rhallisey@nvidia.com>