### PR TITLE
periodic-publish-kubevirt-flakefinder-four-weekly-report: Increase timeout to 4h

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -125,7 +125,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 5m0s
-    timeout: 3h0m0s
+    timeout: 4h0m0s
   interval: 168h
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:


### PR DESCRIPTION
Last two runs
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-publish-kubevirt-flakefinder-four-weekly-report/1454108770077511680
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-publish-kubevirt-flakefinder-four-weekly-report/1451571806946201600

seem to have timed out after 3h, so we increase the timeout to 4h.

/cc @fgimenez 