### PR TITLE
Do not use GIT_ASKPASS for prow-deploy-test

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -359,8 +359,8 @@ presubmits:
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
-          - name: GIT_ASKPASS
-            value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
+          - name: GITHUB_TOKEN
+            value: "/etc/github/oauth"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -383,6 +383,8 @@ presubmits:
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
+          - name: unprivileged-token
+            mountPath: /etc/github
       volumes:
       - name: gcs
         secret:
@@ -392,6 +394,9 @@ presubmits:
       - name: pgp-bot-key
         secret:
           secretName: pgp-bot-key
+      - name: unprivileged-token
+        secret:
+          secretName: unprivileged-oauth-token
   - name: pull-project-infra-cert-manager-deploy-test
     optional: false
     run_if_changed: "github/ci/services/cert-manager/.*|github/ci/services/common/.*|WORKSPACE|go_third_party.bzl"

--- a/github/ci/prow-deploy/hack/test.sh
+++ b/github/ci/prow-deploy/hack/test.sh
@@ -8,12 +8,6 @@ main(){
 
     base_dir=${project_infra_root}/github/ci/prow-deploy
 
-    source ${project_infra_root}/hack/manage-secrets.sh
-    decrypt_secrets
-
-    mkdir -p /etc/github
-    extract_secret 'githubUnprivileged.token' /etc/github/oauth
-
     cd ${base_dir}
 
     molecule test

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -23,6 +23,11 @@ secretGenerator:
     files:
       - oauth=secrets/oauth-token
     type: Opaque
+  - name: unprivileged-oauth-token
+    namespace: kubevirt-prow-jobs
+    files:
+      - oauth=secrets/unprivileged-oauth-token
+    type: Opaque
   - name: gcs
     namespace: kubevirt-prow-jobs
     files:

--- a/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/molecule/default/vars/kubevirtci-testing.yml
@@ -17,3 +17,6 @@ SRIOVNodes:
   capacity: 2
 
 ansible_python_interpreter: /usr/bin/python3
+
+githubUnprivileged:
+  token: "test"

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -21,6 +21,11 @@
     content: '{{ githubToken }}'
     dest: '{{ secrets_dir }}/oauth-token'
 
+- name: Create unprivileged github token secret
+  copy:
+    content: '{{ githubUnprivileged.token }}'
+    dest: '{{ secrets_dir }}/unprivileged-oauth-token'
+
 - name: set gcs service account
   set_fact:
     gcsServiceAccount: '{{ lookup("env", "GOOGLE_APPLICATION_CREDENTIALS") }}'


### PR DESCRIPTION
Fixes errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1701/pull-project-infra-prow-deploy-test/1455871425150717952 The `GIT_ASKPASS` definition is a leftover, now that we don't mount the github token it has started causing the job to fail.

Also added code to deploy the unprivileged github token used during tests, and changed the `pull-project-infra-prow-deploy-test` to mount and use it.

/cc @rmohr @dhiller  

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>