### PR TITLE
Drop unsupported providers

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -407,7 +407,7 @@ periodics:
       secret:
         secretName: oauth-token
 - name: periodic-kubevirtci-cluster-unsupported-version-remover
-  interval: 24h
+  cron: "30 3 * * *"
   max_concurrency: 1
   annotations:
     testgrid-create-test-group: "false"
@@ -423,7 +423,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: main
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -406,6 +406,54 @@ periodics:
     - name: token
       secret:
         secretName: oauth-token
+- name: periodic-kubevirtci-cluster-unsupported-version-remover
+  interval: 24h
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
+  cluster: prow-workloads
+  spec:
+    securityContext:
+      runAsUser: 0
+    containers:
+      - image: quay.io/kubevirtci/pr-creator:v20210915-8bb373f
+        command: ["/bin/sh"]
+        args:
+          - "-c"
+          - |
+            set -e
+            TEMP_FILE=$(mktemp)
+            bazel run //robots/cmd/kubevirt check providers -- \
+              --job-config-path-kubevirt-presubmits=${PWD}/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml \
+              --job-config-path-kubevirt-periodics=${PWD}/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml \
+              --output-file=${TEMP_FILE} \
+              --overwrite=true \
+              --github-token-path= \
+              --dry-run=false
+            cat ${TEMP_FILE}
+            git-pr.sh -c "bazel run //robots/cmd/kubevirtci-bumper:kubevirtci-bumper -- -ensure-only-latest-three --k8s-provider-dir ${PWD}/../kubevirtci/cluster-provision/k8s --cluster-up-dir ${PWD}/../kubevirtci/cluster-up/cluster" -p ../kubevirtci -r kubevirtci -b remove-unsupported-versions -T main
+        volumeMounts:
+        - name: token
+          mountPath: /etc/github
+        resources:
+          requests:
+            memory: "200Mi"
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token
 - name: periodic-kubevirtci-provider-presubmit-creator
   interval: 24h
   max_concurrency: 1

--- a/robots/cmd/kubevirtci-bumper/README.md
+++ b/robots/cmd/kubevirtci-bumper/README.md
@@ -7,9 +7,7 @@ kubevirtci-bumper
 
 1. Ensuring that we have a provider for the latest minor release by copying a predecessor provider
 2. Ensuring that the last three minor releases are up-to-date
-3. Not yet implemented: Dropping unsuppored k8s providers automatically
-4. Not yet implemented: Cloning and Dropping correspnding prow jobs
-5. Not yet implemented: Create PRs agains kubevirtci and project-infra
+3. Dropping unsupported k8s providers automatically
 
 Example
 =======

--- a/robots/pkg/kubevirt/cmd/BUILD.bazel
+++ b/robots/pkg/kubevirt/cmd/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/project-infra/robots/pkg/kubevirt/cmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//robots/pkg/kubevirt/cmd/check:go_default_library",
         "//robots/pkg/kubevirt/cmd/copy:go_default_library",
         "//robots/pkg/kubevirt/cmd/flags:go_default_library",
         "//robots/pkg/kubevirt/cmd/remove:go_default_library",

--- a/robots/pkg/kubevirt/cmd/check/BUILD.bazel
+++ b/robots/pkg/kubevirt/cmd/check/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "check.go",
+        "providers.go",
+    ],
+    importpath = "kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/check",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robots/pkg/kubevirt/cmd/flags:go_default_library",
+        "//robots/pkg/kubevirt/github:go_default_library",
+        "//robots/pkg/kubevirt/log:go_default_library",
+        "//robots/pkg/kubevirt/prowjobconfigs:go_default_library",
+        "//robots/pkg/querier:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+    ],
+)

--- a/robots/pkg/kubevirt/cmd/check/check.go
+++ b/robots/pkg/kubevirt/cmd/check/check.go
@@ -12,39 +12,26 @@
  *
  */
 
-package cmd
+package check
 
 import (
 	"fmt"
 
-	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/check"
-
 	"github.com/spf13/cobra"
-
-	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/remove"
-
-	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/copy"
-	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/flags"
-	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/require"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "kubevirt",
-	Short: "kubevirt alters job definitions in project-infra for kubevirt/kubevirt repo",
+var checkCommand = &cobra.Command{
+	Use:   "check",
+	Short: "kubevirt check checks job definitions in project-infra for kubevirt/kubevirt repo",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Fprint(cmd.OutOrStderr(), cmd.UsageString())
 	},
 }
 
 func init() {
-	flags.AddPersistentFlags(rootCmd)
-
-	rootCmd.AddCommand(copy.CopyCommand())
-	rootCmd.AddCommand(require.RequireCommand())
-	rootCmd.AddCommand(remove.RemoveCommand())
-	rootCmd.AddCommand(check.CheckCommand())
+	checkCommand.AddCommand(CheckProvidersCommand())
 }
 
-func Execute() error {
-	return rootCmd.Execute()
+func CheckCommand() *cobra.Command {
+	return checkCommand
 }

--- a/robots/pkg/kubevirt/cmd/check/providers.go
+++ b/robots/pkg/kubevirt/cmd/check/providers.go
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2021 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package check
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/spf13/cobra"
+	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/flags"
+	github2 "kubevirt.io/project-infra/robots/pkg/kubevirt/github"
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/log"
+	"kubevirt.io/project-infra/robots/pkg/kubevirt/prowjobconfigs"
+	"kubevirt.io/project-infra/robots/pkg/querier"
+)
+
+const (
+	shortUse = "kubevirt check providers checks the usage of kubevirtci providers for periodic and presubmit jobs for kubevirt/kubevirt"
+)
+
+type checkProvidersOptions struct {
+	jobConfigPathKubevirtPresubmits string
+	jobConfigPathKubevirtPeriodics  string
+	outputFile                      string
+	overwrite                       bool
+	failOnUnsupported               bool
+}
+
+func (o checkProvidersOptions) Validate() error {
+	if _, err := os.Stat(o.jobConfigPathKubevirtPresubmits); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPresubmits is required: %v", err)
+	}
+	if _, err := os.Stat(o.jobConfigPathKubevirtPeriodics); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPeriodics is required: %v", err)
+	}
+	return nil
+}
+
+var checkProvidersOpts = checkProvidersOptions{}
+
+var checkProvidersCommand = &cobra.Command{
+	Use:   "providers",
+	Short: shortUse,
+	Long: fmt.Sprintf(`%s
+
+For each of the periodics and presubmits for kubevirt/kubevirt it matches the TARGET env variable value of all containers specs against the provider name pattern and records all matches.
+It then generates a list of used providers, separated in unsupported and supported ones.
+`, shortUse),
+	RunE: run,
+}
+
+const providerNamePattern = "k8s-%s.%s"
+
+var providerRegex *regexp.Regexp
+
+func CheckProvidersCommand() *cobra.Command {
+	return checkProvidersCommand
+}
+
+func init() {
+	checkProvidersCommand.PersistentFlags().StringVar(&checkProvidersOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The path to the kubevirt presubmit job definitions")
+	checkProvidersCommand.PersistentFlags().StringVar(&checkProvidersOpts.jobConfigPathKubevirtPeriodics, "job-config-path-kubevirt-periodics", "", "The path to the kubevirt periodic job definitions")
+	checkProvidersCommand.PersistentFlags().StringVar(&checkProvidersOpts.outputFile, "output-file", "", "Path to output file, if not given, a temporary file will be used")
+	checkProvidersCommand.PersistentFlags().BoolVar(&checkProvidersOpts.overwrite, "overwrite", false, "Whether to overwrite output file")
+	checkProvidersCommand.PersistentFlags().BoolVar(&checkProvidersOpts.failOnUnsupported, "fail-on-unsupported-provider-usage", true, "Whether to exit with non zero exit code in case an unsupported provider usage is detected")
+
+	providerRegex = regexp.MustCompile("(k8s-[0-9.]+)")
+}
+
+type checkProvidersUsed struct {
+	Supported   map[string][]string `json:"supported,omitempty"`
+	Unsupported map[string][]string `json:"unsupported,omitempty"`
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	err := flags.ParseFlags(cmd, args, checkProvidersOpts)
+	if err != nil {
+		return err
+	}
+
+	if checkProvidersOpts.outputFile == "" {
+		outputFile, err := os.CreateTemp("", "kubevirt-check-providers-*.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to write output: %v", err)
+		}
+		checkProvidersOpts.outputFile = outputFile.Name()
+	} else {
+		stat, err := os.Stat(checkProvidersOpts.outputFile)
+		if err != nil && err != os.ErrNotExist {
+			return fmt.Errorf("failed to write output: %v", err)
+		}
+		if stat.IsDir() {
+			return fmt.Errorf("failed to write output, file %s is a directory", checkProvidersOpts.outputFile)
+		}
+		if err == nil && !checkProvidersOpts.overwrite {
+			log.Log().Fatal(fmt.Errorf("failed to write output, file %s exists", checkProvidersOpts.outputFile))
+		}
+	}
+	log.Log().Infof("Will write output to file %s", checkProvidersOpts.outputFile)
+
+	ctx := context.Background()
+	client, err := github2.NewGitHubClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	jobConfigsToExtractFuncs := map[string]func(*config.JobConfig, map[string][]string){
+		checkProvidersOpts.jobConfigPathKubevirtPresubmits: func(jobConfig *config.JobConfig, result map[string][]string) {
+			extractUsedProvidersFromPresubmitJobs(jobConfig, result)
+		},
+		checkProvidersOpts.jobConfigPathKubevirtPeriodics: func(jobConfig *config.JobConfig, result map[string][]string) {
+			extractUsedProvidersFromPeriodicJobs(jobConfig, result)
+		},
+	}
+
+	allProviderNamesToJobNames := map[string][]string{}
+	for jobConfigPath, usedProvidersFromJobsExtractFunc := range jobConfigsToExtractFuncs {
+		jobConfig, err := config.ReadJobConfig(jobConfigPath)
+		if err != nil {
+			return fmt.Errorf("failed to read jobconfig %s: %v", jobConfigPath, err)
+		}
+		usedProvidersFromJobsExtractFunc(&jobConfig, allProviderNamesToJobNames)
+	}
+
+	releases, _, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
+	if err != nil {
+		return err
+	}
+	releases = querier.ValidReleases(releases)
+	supportedProviderVersions := querier.LastThreeMinor(1, releases)
+
+	providersUsed := checkProvidersUsed{Supported: map[string][]string{}, Unsupported: map[string][]string{}}
+	for _, supportedProviderName := range supportedProviderVersions {
+		semVer := querier.ParseRelease(supportedProviderName)
+		providerName := fmt.Sprintf(providerNamePattern, semVer.Major, semVer.Minor)
+		providersUsed.Supported[providerName] = allProviderNamesToJobNames[providerName]
+		delete(allProviderNamesToJobNames, providerName)
+	}
+	for unsupportedProviderName, jobNames := range allProviderNamesToJobNames {
+		providersUsed.Unsupported[unsupportedProviderName] = jobNames
+	}
+
+	marshalled, err := yaml.Marshal(providersUsed)
+	if err != nil {
+		return fmt.Errorf("failed to marshall output %s: %v", checkProvidersOpts.outputFile, err)
+	}
+	err = os.WriteFile(checkProvidersOpts.outputFile, marshalled, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to write output %s: %v", checkProvidersOpts.outputFile, err)
+	}
+
+	if checkProvidersOpts.failOnUnsupported && len(providersUsed.Unsupported) > 0 {
+		return fmt.Errorf("usage of unsupported providers detected: %v", providersUsed.Unsupported)
+	}
+
+	return nil
+}
+
+func extractUsedProvidersFromPeriodicJobs(jobConfig *config.JobConfig, result map[string][]string) {
+	for index := range jobConfig.Periodics {
+		appendProviderNamesToJobNames((&jobConfig.Periodics[index]).JobBase, result)
+	}
+}
+
+func extractUsedProvidersFromPresubmitJobs(jobConfig *config.JobConfig, result map[string][]string) {
+	for index := range jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig] {
+		appendProviderNamesToJobNames((&jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig][index]).JobBase, result)
+	}
+}
+
+func appendProviderNamesToJobNames(base config.JobBase, result map[string][]string) {
+	name := base.Name
+	var providerNames []string
+	for _, container := range base.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name != "TARGET" {
+				continue
+			}
+			if !providerRegex.MatchString(env.Value) {
+				continue
+			}
+			var submatches []string
+			submatches = providerRegex.FindStringSubmatch(name)
+			providerNames = append(providerNames, submatches[1])
+		}
+	}
+	for _, providerName := range providerNames {
+		if _, exists := result[providerName]; exists {
+			result[providerName] = append(result[providerName], name)
+		} else {
+			result[providerName] = []string{name}
+		}
+	}
+}

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -460,7 +460,7 @@ func TestDropUnsupportedProviders(t *testing.T) {
 			targetProviderDir := path.Join(tempDir, tt.args.providerDir)
 			err = DropUnsupportedProviders(targetProviderDir, targetClusterUpDir, tt.args.supportedReleases)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("DropUnsupportedProviders() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("DropUnsupportedProviders() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if err == nil {

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -333,4 +334,192 @@ func release(tagName string, released bool) *github.RepositoryRelease {
 		release.PublishedAt = &github.Timestamp{time.Now()}
 	}
 	return release
+}
+
+type testScenario struct {
+	dirsBefore         []string
+	clusterUpDirsAfter []string
+	providerDirsAfter  []string
+}
+
+func TestDropUnsupportedProviders(t *testing.T) {
+	type args struct {
+		scenario          testScenario
+		providerDir       string
+		clusterUpDir      string
+		supportedReleases []*github.RepositoryRelease
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "no supported releases provokes error",
+			args: args{
+				scenario: testScenario{
+					dirsBefore: []string{
+						"cluster-provision/k8s/1.19",
+						"cluster-provision/k8s/1.20",
+						"cluster-provision/k8s/1.21",
+						"cluster-up/cluster/k8s-1.19",
+						"cluster-up/cluster/k8s-1.20",
+						"cluster-up/cluster/k8s-1.21",
+					},
+				},
+				providerDir:       "cluster-provision/k8s",
+				clusterUpDir:      "cluster-up/cluster",
+				supportedReleases: []*github.RepositoryRelease{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "only supported providers left",
+			args: args{
+				scenario: testScenario{
+					dirsBefore: []string{
+						"cluster-provision/k8s/1.19",
+						"cluster-provision/k8s/1.20",
+						"cluster-provision/k8s/1.21",
+						"cluster-up/cluster/k8s-1.19",
+						"cluster-up/cluster/k8s-1.20",
+						"cluster-up/cluster/k8s-1.21",
+					},
+					providerDirsAfter: []string{
+						"1.19",
+						"1.20",
+						"1.21",
+					},
+					clusterUpDirsAfter: []string{
+						"k8s-1.19",
+						"k8s-1.20",
+						"k8s-1.21",
+					},
+				},
+				providerDir:  "cluster-provision/k8s",
+				clusterUpDir: "cluster-up/cluster",
+				supportedReleases: []*github.RepositoryRelease{
+					{
+						TagName: strPointer("v1.19.3"),
+					},
+					{
+						TagName: strPointer("v1.20.2"),
+					},
+					{
+						TagName: strPointer("v1.21.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "unsupported providers should get deleted",
+			args: args{
+				scenario: testScenario{
+					dirsBefore: []string{
+						"cluster-provision/k8s/1.19",
+						"cluster-provision/k8s/1.20",
+						"cluster-provision/k8s/1.21",
+						"cluster-up/cluster/k8s-1.19",
+						"cluster-up/cluster/k8s-1.20",
+						"cluster-up/cluster/k8s-1.21",
+					},
+					providerDirsAfter: []string{
+						"1.20",
+						"1.21",
+					},
+					clusterUpDirsAfter: []string{
+						"k8s-1.20",
+						"k8s-1.21",
+					},
+				},
+				providerDir:  "cluster-provision/k8s",
+				clusterUpDir: "cluster-up/cluster",
+				supportedReleases: []*github.RepositoryRelease{
+					{
+						TagName: strPointer("v1.20.2"),
+					},
+					{
+						TagName: strPointer("v1.21.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir, err := os.MkdirTemp("", "dropProviders-")
+			panicOnErr(err)
+			defer os.RemoveAll(tempDir)
+			for _, dir := range tt.args.scenario.dirsBefore {
+				panicOnErr(mkDirs(path.Join(tempDir, dir)))
+			}
+
+			targetClusterUpDir := path.Join(tempDir, tt.args.clusterUpDir)
+			targetProviderDir := path.Join(tempDir, tt.args.providerDir)
+			err = DropUnsupportedProviders(targetProviderDir, targetClusterUpDir, tt.args.supportedReleases)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DropUnsupportedProviders() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				checkForSuperfluousDirEntries(t, err, targetClusterUpDir, tt.args.scenario.clusterUpDirsAfter)
+				checkForRequiredDirEntries(t, targetClusterUpDir, tt.args.scenario.clusterUpDirsAfter)
+				checkForSuperfluousDirEntries(t, err, targetProviderDir, tt.args.scenario.providerDirsAfter)
+				checkForRequiredDirEntries(t, targetProviderDir, tt.args.scenario.providerDirsAfter)
+			}
+		})
+	}
+}
+
+func checkForSuperfluousDirEntries(t *testing.T, err error, pathToCheck string, listOfEntriesThatShouldExist []string) {
+	dirEntries, err := os.ReadDir(pathToCheck)
+	for _, entry := range dirEntries {
+		found := false
+		for _, clusterUpDir := range listOfEntriesThatShouldExist {
+			if clusterUpDir == entry.Name() {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("DropUnsupportedProviders() error = dir %v should not exist", entry.Name())
+		}
+	}
+}
+
+func checkForRequiredDirEntries(t *testing.T, pathToCheck string, requiredEntries []string) {
+	for _, entry := range requiredEntries {
+		pathShouldExist := path.Join(pathToCheck, entry)
+		_, err := os.Stat(pathShouldExist)
+		if os.IsNotExist(err) {
+			t.Errorf("DropUnsupportedProviders() error = dir %v should exist", pathShouldExist)
+			continue
+		}
+		panicOnErr(err)
+	}
+}
+
+func mkDirs(dir string) error {
+	_, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		parent, _ := path.Split(dir)
+		parent = strings.TrimSuffix(parent, "/")
+		err := mkDirs(parent)
+		if err != nil {
+			return err
+		}
+		return os.Mkdir(dir, 0777)
+	}
+	return nil
+}
+
+func panicOnErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func strPointer(input string) *string {
+	return &input
 }

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -461,7 +461,6 @@ func TestDropUnsupportedProviders(t *testing.T) {
 			err = DropUnsupportedProviders(targetProviderDir, targetClusterUpDir, tt.args.supportedReleases)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("DropUnsupportedProviders() error = %v, wantErr %v", err, tt.wantErr)
-				return
 			}
 			if err == nil {
 				checkForSuperfluousDirEntries(t, err, targetClusterUpDir, tt.args.scenario.clusterUpDirsAfter)


### PR DESCRIPTION
Split in three parts:
- [x] kubevirtci-bumper drops unsupported providers from kubevirtci
- [x] kubevirt checks whether unsupported providers are not used any more
- [x] create job that uses two parts above (first checking for unused unsupported provider, then dropping it)