### PR TITLE
Make flaky sig-storage lanes optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -55,6 +55,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-sig-storage
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1623,6 +1624,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.22-sig-storage
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
1.21-sig-storage and 1.22-sig-storage lanes are extremely flaky since ~4 Nov. There are some ongoing efforts to stabilize them but they haven't improved the situation so far and the merge queue has already more than 10 PRs blocked because of this https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+is%3Aopen+label%3Aapproved+label%3Algtm+-label%3Ado-not-merge%2Fhold+-label%3Aneeds-rebase The average retests to merge is above 6 and the average time to merge is above one day now.

This PR proposes to make these two lanes temporarily optional until we understand the root cause of the issue and we prepare a proper fix.

/cc @maya-r @brybacki @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>