### PR TITLE
Revert "Make flaky sig-storage lanes optional (#1720)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -55,7 +55,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1624,7 +1623,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.22-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
This reverts commit 9c634b8dacbe283320422e19cb3b9a956680203e.

These lanes have been stabilized.

[All the remaining failures are QUARANTINEd tests](https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.21-sig-storage) after [kubevirt#6778](https://github.com/kubevirt/kubevirt/pull/6778) was merged.