### PR TITLE
Make sig-storage presubmit lanes required again

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -55,7 +55,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.21-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1624,7 +1623,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.22-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
After the latest PR to stabilize sig-storage lanes was merged https://github.com/kubevirt/kubevirt/pull/6778 we did not get any more errors in the periodics from master for non-quarantined tests:

1.22-sig-storage:

![Screenshot from 2021-11-15 09-12-14](https://user-images.githubusercontent.com/70376/141746016-9479572b-5f6f-45b6-a5b1-acc1629cc820.png)

1.21-sig-storage:

![Screenshot from 2021-11-15 09-12-54](https://user-images.githubusercontent.com/70376/141746357-a304c5ce-f621-4020-ac2b-1cfc27d750a1.png)


Also the presubmits look stable. This PR makes them required again. 

/cc @rmohr @maya-r @brybacki @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>