### PR TITLE
Update kubevirt.github.io default branch to main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     extra_refs:
       - org: kubevirt
         repo: kubevirt.github.io
-        base_ref: master
+        base_ref: main
         path_alias: kubevirt.github.io
     cluster: ibm-prow-jobs
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
@@ -1,8 +1,8 @@
 postsubmits:
   kubevirt/kubevirt.github.io:
-  - name: push-kubevirt.github.io-master-build-and-push-to-gh-pages
+  - name: push-kubevirt.github.io-main-build-and-push-to-gh-pages
     branches:
-    - ^master$
+    - ^main$
     annotations:
       testgrid-create-test-group: "false"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -364,7 +364,7 @@ orgs:
         homepage: https://www.kubevirt.io/
       kubevirt.github.io:
         allow_rebase_merge: false
-        default_branch: master
+        default_branch: main
         description: KubeVirt website repo, documentation at https://kubevirt.io/user-guide/
         has_projects: false
         has_wiki: false


### PR DESCRIPTION
Part of respectful naming initiative.

https://github.com/kubevirt/kubevirt.github.io/issues/786

Signed-off-by: cwilkers <cwilkers@redhat.com>