### PR TITLE
remove runner.sh script from jobs using kubespray image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -555,7 +555,6 @@ postsubmits:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"
           command:
-            - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
             - "./github/ci/prow-workloads/hack/deploy.sh"
@@ -606,7 +605,6 @@ postsubmits:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"
           command:
-            - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
             - "./github/ci/prow-performance-workloads/hack/bootstrap.sh"
@@ -657,7 +655,6 @@ postsubmits:
           - name: GIT_ASKPASS
             value: "./hack/git-askpass.sh"
           command:
-            - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
             - "./github/ci/prow-performance-workloads/hack/deploy.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -583,6 +583,108 @@ postsubmits:
         - name: gcs
           secret:
             secretName: gcs
+    - name: post-project-infra-prow-performance-workloads-bootstrap-nodes
+      always_run: false
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      branches:
+      # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+      - ^prow-performance-workloads-bootstrap-nodes-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      labels:
+        preset-docker-mirror-proxy: "true"
+      skip_report: false
+      cluster: ibm-prow-jobs
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
+        - image: quay.io/kubespray/kubespray:v2.15.0
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+          - name: GIT_ASKPASS
+            value: "./hack/git-askpass.sh"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "./github/ci/prow-performance-workloads/hack/bootstrap.sh"
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: true
+          - name: pgp-bot-key
+            mountPath: /etc/pgp
+            readOnly: true
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: pgp-bot-key
+          secret:
+            secretName: pgp-bot-key
+        - name: gcs
+          secret:
+            secretName: gcs
+    - name: post-project-infra-prow-performance-workload-cluster-deployment
+      always_run: false
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      branches:
+      # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+      - ^prow-performance-workload-cluster-deployment-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      labels:
+        preset-docker-mirror-proxy: "true"
+      skip_report: false
+      cluster: ibm-prow-jobs
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
+        - image: quay.io/kubespray/kubespray:v2.15.0
+          env:
+          - name: GOOGLE_APPLICATION_CREDENTIALS
+            value: /etc/gcs/service-account.json
+          - name: GIT_ASKPASS
+            value: "./hack/git-askpass.sh"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "./github/ci/prow-performance-workloads/hack/deploy.sh"
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
+          volumeMounts:
+          - name: token
+            mountPath: /etc/github
+          - name: gcs
+            mountPath: /etc/gcs
+            readOnly: true
+          - name: pgp-bot-key
+            mountPath: /etc/pgp
+            readOnly: true
+        volumes:
+        - name: token
+          secret:
+            secretName: oauth-token
+        - name: pgp-bot-key
+          secret:
+            secretName: pgp-bot-key
+        - name: gcs
+          secret:
+            secretName: gcs
     - name: post-project-infra-cert-manager-deployment
       always_run: false
       annotations:


### PR DESCRIPTION
The jobs using the kubespray image does not have the initialization script "/usr/local/bin/runner.sh" like the jobs using the other images. Then, this PR is removing the script "/usr/local/bin/runner.sh" of those jobs and calling "/bin/bash" directly.