### PR TITLE
Update prometheus' ci-health target

### DIFF
--- a/github/ci/services/prometheus-stack/secrets/production-control-plane/prometheus-stack-kube-prom-prometheus-scrape-confg/additional-scrape-configs.yaml
+++ b/github/ci/services/prometheus-stack/secrets/production-control-plane/prometheus-stack-kube-prom-prometheus-scrape-confg/additional-scrape-configs.yaml
@@ -2,4 +2,4 @@
   metrics_path: /ci-health/output/metrics
   static_configs:
   - targets:
-    - fgimenez.github.io
+    - kubevirt.io


### PR DESCRIPTION
After https://github.com/fgimenez/ci-health has been transferred to https://github.com/kubevirt/ci-health we need to update the prometheus target to scrape metrics from that repo.

/cc @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>