### PR TITLE
Add yq for managing secrets if not present

### DIFF
--- a/hack/manage-secrets.sh
+++ b/hack/manage-secrets.sh
@@ -19,6 +19,12 @@ extract_secret(){
     local key="${1}"
     local path="${2}"
 
+    if ! command -v yq >/dev/null 2>&1; then
+        curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
+            chmod a+x ./yq && \
+            mv ./yq /usr/local/bin
+    fi
+
     mkdir -p $(dirname "${path}")
     # only remove new line at the end
     yq r main.yml "${key}" | awk 'NR>1{print PREV} {PREV=$0} END{printf("%s",$0)}' > "${path}"


### PR DESCRIPTION
Will fix errors like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-performance-workloads-bootstrap-nodes/1460969308174684160 and in general will be useful for any job that is based on an external image (potentially without yq installed) and requires to decrypt secrets

/cc @marceloamaral @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>