### PR TITLE
testgrid: width compact

### DIFF
--- a/github/ci/testgrid/default.yaml
+++ b/github/ci/testgrid/default.yaml
@@ -40,3 +40,4 @@ default_dashboard_tab:
   num_columns_recent: 10
   code_search_url_template: # The URL template to visit when searching for changelists
     url: https://github.com/kubevirt/kubevirt/compare/<start-custom-0>...<end-custom-0>
+  base_options: width=20


### PR DESCRIPTION
Standard cell width (90) view takes big amount of screen estate and not much information is available. The change switches default width to 20 (compact). 

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>