### PR TITLE
Move jobs scheduled on phx-prow to ibm-prow-jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -2,13 +2,10 @@ periodics:
   - name: periodic-publish-kubemacpool-flakefinder-weekly-report
     cron: "50 0 * * *"
     decorate: true
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     annotations:
       testgrid-create-test-group: "false"
     spec:
-      nodeSelector:
-        type: vm
-        zone: ci
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
           env:
@@ -39,14 +36,11 @@ periodics:
             secretName: gcs
   - name: periodic-publish-kubemacpool-flakefinder-daily-report
     cron: "30 0 * * *"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
     spec:
-      nodeSelector:
-        type: vm
-        zone: ci
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
           env:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
@@ -10,16 +10,13 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20201201-08dc4a9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
@@ -10,16 +10,13 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20201201-08dc4a9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
@@ -12,16 +12,13 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20201201-08dc4a9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
@@ -10,16 +10,13 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20201201-08dc4a9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -12,16 +12,13 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20201201-08dc4a9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -4,11 +4,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:
@@ -41,11 +38,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:
@@ -78,11 +72,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -10,11 +10,8 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
             command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -4,11 +4,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:
@@ -42,11 +39,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:
@@ -80,11 +74,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/hostpath-provisioner-operator:
   - name: pull-hostpath-provisioner-operator-unit-test
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     annotations:
       fork-per-release: "true"
     always_run: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       containers:
         - image: quay.io/kubevirtci/golang:v20210924-7b670cb
@@ -97,7 +97,7 @@ presubmits:
             requests:
               memory: "29Gi"
   - name: pull-hpp-unit-test
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     skip_branches:
       - release-\d+\.\d+
     annotations:
@@ -126,4 +126,3 @@ presubmits:
           resources:
             requests:
               memory: "4Gi"
-

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
@@ -12,10 +12,8 @@ periodics:
         repo: kubevirt-tutorial
         base_ref: main
         path_alias: kubevirt-tutorial
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
-      nodeSelector:
-        region: primary
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
           command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
@@ -8,10 +8,8 @@ presubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          region: primary
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
             command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/kubevirt-velero-plugin:
   - name: pull-kvp-unit-test
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     skip_branches:
       - release-\d+\.\d+
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   cron: 5 * * * *
   decorate: true
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
@@ -29,9 +29,6 @@ periodics:
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
-    nodeSelector:
-      type: vm
-      zone: ci
     volumes:
     - name: token
       secret:
@@ -41,7 +38,7 @@ periodics:
         secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   cron: 45 0 * * *
   decorate: true
   name: periodic-publish-kubevirt-flakefinder-weekly-report
@@ -69,9 +66,6 @@ periodics:
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
-    nodeSelector:
-      type: vm
-      zone: ci
     volumes:
     - name: token
       secret:
@@ -81,7 +75,7 @@ periodics:
         secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   cron: 25 0 * * *
   decorate: true
   name: periodic-publish-kubevirt-flakefinder-daily-report
@@ -109,9 +103,6 @@ periodics:
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
-    nodeSelector:
-      type: vm
-      zone: ci
     volumes:
     - name: token
       secret:
@@ -121,7 +112,7 @@ periodics:
         secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -152,9 +143,6 @@ periodics:
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
-    nodeSelector:
-      type: vm
-      zone: ci
     volumes:
     - name: token
       secret:
@@ -960,7 +948,7 @@ periodics:
       name: vfio
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   cron: 15 22 * * 0
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -535,7 +535,7 @@ presubmits:
     context: pull-kubevirt-build-release-0.34
     optional: false
     skip_report: false
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
@@ -683,7 +683,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.42
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     context: pull-kubevirt-e2e-kind-1.17-sriov-nonroot
     decorate: true
     decoration_config:
@@ -764,7 +764,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.42
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     context: pull-kubevirt-e2e-kind-1.17-sriov
     decorate: true
     decoration_config:
@@ -843,7 +843,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.42
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     context: pull-kubevirt-e2e-kind-1.19-sriov
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -12,11 +12,8 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
             command:
@@ -37,11 +34,8 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
             command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -16,11 +16,8 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
@@ -47,11 +47,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
       command:
@@ -85,11 +82,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
       command:
@@ -122,11 +116,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
       command:
@@ -163,11 +154,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
       command:
@@ -245,11 +233,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
       - image: quay.io/kubevirtci/indexpagecreator@sha256:43fa17a6a92b74df3474d95b102f2b675ff9570c2bef1c80f74fb72aaf7fc434
         env:
@@ -288,7 +273,7 @@ periodics:
   - org: kubevirt
     repo: containerized-data-importer
     base_ref: main
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -342,7 +327,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: main
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -386,7 +371,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: main
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -420,7 +405,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -461,7 +446,7 @@ periodics:
     workdir: true
   interval: 1h
   max_concurrency: 1
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
     containers:
     - name: peribolos

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -63,7 +63,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -95,7 +95,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -127,7 +127,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -160,7 +160,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -193,7 +193,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -225,7 +225,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -319,7 +319,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm
@@ -351,7 +351,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
         nodeSelector:
           type: vm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -3,11 +3,8 @@ presubmits:
   - name: check-prow-config
     always_run: true
     decorate: true
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
-      nodeSelector:
-        type: vm
-        zone: ci
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20200623-9f5410055c
         args:
@@ -71,7 +68,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -98,7 +95,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -125,7 +122,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -152,7 +149,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -181,7 +178,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -210,7 +207,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -295,7 +292,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -322,7 +319,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
       nodeSelector:
         type: vm
@@ -691,11 +688,8 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     max_concurrency: 1
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     spec:
-      nodeSelector:
-        type: vm
-        zone: ci
       containers:
       - name: label-sync
         image: gcr.io/k8s-prow/label_sync:v20200623-9f5410055c
@@ -722,12 +716,9 @@ presubmits:
     decoration_config:
       timeout: 1h
       grace_period: 5m
-    cluster: phx-prow
+    cluster: ibm-prow-jobs
     max_concurrency: 1
     spec:
-      nodeSelector:
-        type: vm
-        zone: ci
       containers:
       - name: label-sync
         image: gcr.io/k8s-prow/label_sync:v20200623-9f5410055c

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -4,11 +4,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:
@@ -42,11 +39,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:
@@ -80,11 +74,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: phx-prow
+  cluster: ibm-prow-jobs
   spec:
-    nodeSelector:
-      type: vm
-      zone: ci
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       env:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -16,11 +16,8 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20211004-a19e71e
             env:
@@ -57,11 +54,8 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - ^v\d+\.\d+\.\d+$
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20211004-a19e71e
             command:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
@@ -15,11 +15,8 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
@@ -15,11 +15,8 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -15,11 +15,8 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
             securityContext:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -15,11 +15,8 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: phx-prow
+      cluster: ibm-prow-jobs
       spec:
-        nodeSelector:
-          type: vm
-          zone: ci
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
             securityContext:


### PR DESCRIPTION
phx-prow cluster is being decommissioned by EOY and the jobs running there are giving a lot of connectivity issues, we need to migrate all the jobs currently running there. The end goal is having a new separate workloads cluster, it is not yet in place but for now we have already scaled up ibm-prow-jobs cluster to handle the load. 

This PR takes care of configuring all the jobs currently running on phx-prow to run on ibm-prow-jobs, it also removes the node selector settings that are only meaningful in phx-prow.

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>