### PR TITLE
Remove fdupont-redhat from org

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -61,7 +61,6 @@ orgs:
       - enp0s3
       - erkanerol
       - ezrasilvera
-      - fdupont-redhat
       - fedepaol
       - fromanirh
       - gabrielecerami


### PR DESCRIPTION
Account seems to have gotten deleted, peribolos complains on that:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-org-github-config-updater/1461391744753995776#1:build-log.txt%3A8

/cc @rmohr @fgimenez 