### PR TITLE
Ensure that go is available for the developer build pusher

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -516,7 +516,7 @@ periodics:
         value: k8s-1.21
       - name: KUBEVIRT_E2E_FOCUS
         value: \[sig-operator\]
-      image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+      image: quay.io/kubevirtci/golang:v20210906-994b913
       name: ""
       resources:
         requests:


### PR DESCRIPTION
The build now executes `hack/publish-staging.sh` which needs golang.