### PR TITLE
Bump bootstrap image to fc34

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:32
+FROM fedora:34
 
 WORKDIR /workspace
 RUN mkdir -p /workspace


### PR DESCRIPTION
fc32 is EOL for quite some time and newer versions of some tools are
needed.