### PR TITLE
Bump the bootstrap image to get a new skopeo version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -27,7 +27,7 @@ periodics:
         set -e
         cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
         ./build.sh
-      image: quay.io/kubevirtci/bootstrap:v20211118-96b0e0c
+      image: quay.io/kubevirtci/bootstrap:v20211122-ca88fb4
       name: ""
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
         - /bin/sh
         - -c
         - ./build.sh -b
-        image: quay.io/kubevirtci/bootstrap:v20211118-96b0e0c
+        image: quay.io/kubevirtci/bootstrap:v20211122-ca88fb4
         name: ""
         resources:
           requests:


### PR DESCRIPTION
This should unblock https://github.com/kubevirt/containerdisks/pull/1 now that #1746 is merged.