### PR TITLE
Ignore unknown cotexts for nmstate/kubernetes-nmstate

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -186,6 +186,10 @@ tide:
         dashboard:
           skip-unknown-contexts: true
           from-branch-protection: true
+     nmstate:
+      repos:
+        kubevirt-nmstate:
+          skip-unknown-contexts: true
 
 slack_reporter_configs:
   '*':

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -181,15 +181,15 @@ tide:
     '*': https://prow.ci.kubevirt.io/pr
   context_options:
     orgs:
-     kubevirt:
-      repos:
-        dashboard:
-          skip-unknown-contexts: true
-          from-branch-protection: true
-     nmstate:
-      repos:
-        kubevirt-nmstate:
-          skip-unknown-contexts: true
+      kubevirt:
+        repos:
+          dashboard:
+            skip-unknown-contexts: true
+            from-branch-protection: true
+      nmstate:
+        repos:
+          kubevirt-nmstate:
+            skip-unknown-contexts: true
 
 slack_reporter_configs:
   '*':


### PR DESCRIPTION
Will prevent tide being blocked because of gh actions errors

/cc @qinqon @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>