### PR TITLE
Backport kubevirt release job to release-0.36

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -39,7 +39,7 @@ postsubmits:
         - |
           set -e
           major_minor="$(git tag --points-at HEAD | head -1 | grep -oE '[0-9]+.[0-9]+')"
-          if [ $(expr $major_minor \>\= 0.40) -eq 1 ]; then
+          if [ $(expr $major_minor \>\= 0.40) -eq 1 ] || [ $(expr $major_minor \=\= 0.36) -eq 1 ]; then
             cat $QUAY_PASSWORD | docker login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
             ./automation/release.sh
           fi


### PR DESCRIPTION
Enables the release job backported by https://github.com/kubevirt/kubevirt/pull/6837 to run.

/cc @rmohr

/hold