### PR TITLE
We need an absolute askpass path due to directory switching

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -590,14 +590,13 @@ periodics:
         gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
         unset DOCKER_TAG # we want to publish to main
         export PULL_BASE_REF=main
+        export GIT_ASKPASS=$PWD/../project-infra/hack/git-askpass.sh
         hack/publish-staging.sh
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       image: quay.io/kubevirtci/golang:v20210906-994b913
       name: ""
       resources:


### PR DESCRIPTION
`hack/publish-staging.sh` is switching its path. If the git askpass path is not absolute, it will point to a non-existing file.