### PR TITLE
Use golang image for push-kubevirt-main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -127,7 +127,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+      - image: quay.io/kubevirtci/golang:v20210906-994b913
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt


### PR DESCRIPTION
Build fails due to missing go. Example:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-kubevirt-main/1462923819416031232

/cc @rmohr 