### PR TITLE
Make 1.19 check-provision optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -93,6 +93,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.19
+    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
Make 1.19 check-provision optional in order to be able to remove it. This check is currently failing the removal of the kubevirtci provider for 1.19 which is not in use any more.

https://github.com/kubevirt/kubevirtci/pull/712#issuecomment-977474129

/cc @rmohr @fgimenez @enp0s3 