### PR TITLE
Mirror images from docker.io to quay.io

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -1019,3 +1019,29 @@ postsubmits:
                 memory: "8Gi"
               limits:
                 memory: "8Gi"
+    - name: post-project-infra-mirror-images-from-docker-hub
+      always_run: false
+      run_if_changed: "hack/mirror-images.sh|hack/images_to_mirror.csv"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      cluster: ibm-prow-jobs
+      labels:
+        preset-kubevirtci-quay-credential: "true"
+        preset-docker-mirror-proxy: "true"
+      spec:
+        containers:
+        - image: quay.io/kubevirtci/bootstrap:v20211122-ca88fb4
+          command: ["/bin/sh"]
+          args:
+          - -c
+          - |
+            set -e
+
+            cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+            hack/mirror-images.sh
+          resources:
+            requests:
+              memory: "200Mi"
+            limits:
+              memory: "200Mi"

--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -1,0 +1,2 @@
+docker.io,library/registry:2.7.1,quay.io/kubevirtci
+docker.io,rook/ceph:v1.5.8,quay.io/kubevirtci

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if ! command -V skopeo; then
+    echo "skopeo required!"
+    exit 1
+fi
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+IMAGE_LIST_FILE="${BASEDIR}/images_to_mirror.csv"
+IMAGE_LIST=($(cat "${IMAGE_LIST_FILE}"))
+
+for image in "${IMAGE_LIST[@]}";
+do
+  source_registry="$(echo "$image" |cut -d',' -f1)"
+  image_in_source="$(echo "$image" |cut -d',' -f2)"
+  target_registry="$(echo "$image" |cut -d',' -f3)"
+  # since we are mirroring all images into a specific organization
+  # we cannot use full path of original image which contain user+image name.
+  # example: docker.io/user/image:v1 -> quay.io/kubevirtci/user-image:v1
+  image_in_target="${image_in_source//\//-}" # replace / with -
+
+  echo "Mirroring from $source_registry/$image_in_source to $target_registry/$image_in_target"
+  skopeo copy "docker://$source_registry/$image_in_source" "docker://$target_registry/$image_in_target" 
+done
+
+echo "DONE!"


### PR DESCRIPTION
docker.io has a pull limit and we want to consume some images from quay.io. 

This PR add a postsubmit job which mirror some specific images from docker.io to quay.io. It aims to add an automated script which will work whenever you add a new image into the list. 

**Open Points**
The list of images is not clear yet.  Please add the images as comments. 

**Notes:**
As far as I see, calico is fetched from quay.io now.  https://github.com/kubevirt/kubevirtci/blob/main/cluster-provision/k8s/1.22/extra-pre-pull-images

Signed-off-by: Erkan Erol <eerol@redhat.com>