### PR TITLE
Update kubespray context to enable ansible-playbook find the right inventory configuration

### DIFF
--- a/github/ci/prow-performance-workloads/hack/deploy.sh
+++ b/github/ci/prow-performance-workloads/hack/deploy.sh
@@ -5,9 +5,11 @@ source $(dirname "$0")/common.sh
 main(){
     setup
 
-    cd ${BASE_DIR}
+    cd /kubespray
+    
+    cp -r ${BASE_DIR}/inventory/prow-performance-workloads inventory/
 
-    ansible-playbook -i inventory/prow-performance-workloads/hosts.yml  --become --become-user=root --private-key ~/.ssh/id_rsa /kubespray/cluster.yml
+    ansible-playbook -i inventory/prow-performance-workloads/hosts.yml  --become --become-user=root --private-key ~/.ssh/id_rsa cluster.yml
 }
 
 main "$@"


### PR DESCRIPTION
After deploying the performance cluster, I realized that the version of Kubernetes was wrong.

We configured the cluster to deploy Kubernetes 1.21 https://github.com/kubevirt/project-infra/blob/05413874f9fe7bfe148eb503e7489225219[…]ow-performance-workloads/group_vars/k8s_cluster/k8s-cluster.yml
But, version 1.19 has been installed....

Kubespray uses ansible-playbook to deploy the cluster, where the cluster settings are in `inventory / prow-performance-workloads` in our case.

Previously, we were running the following command:
`ansible-playbook -i inventory/prow-performance-workloads /hosts.yml --become --become-user = root --private-key ~ /.ssh/id_rsa /kubespray/cluster.yml`

In the previous command, the `inventory/prow-performance-workloads` folder is not inside the `/kubespray/inventory` folder. So I believe this is the reason why the ansible-playbook does not identify the correct inventory context.

Therefore, with PR, I'm moving `inventory/prow-performance-workloads` to the kubespray folder like the kubespray documentation recommends to do.

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>