### PR TITLE
sriov-1.19, Readd check-up-kind-1.19-sriov lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -14,6 +14,89 @@ presubmits:
       rehearsal.allowed: "true"
       sriov-pod: "true"
     max_concurrency: 1
+    name: check-up-kind-1.19-sriov
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - |
+          trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM
+          make cluster-up
+          ./cluster-up/cluster/kind/check-cluster-up.sh
+        env:
+        - name: GIMME_GO_VERSION
+          value: 1.13.8
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.19-sriov
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: "RUN_KUBEVIRT_CONFORMANCE"
+          value: "true"
+        - name: "SONOBUOY_EXTRA_ARGS"
+          value: "--plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV"
+        image: quay.io/kubevirtci/golang:v20210316-d295087
+        name: ""
+        resources:
+          requests:
+            memory: 15Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
+  - always_run: true
+    annotations:
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-installer-pull-token: "true"
+      rehearsal.allowed: "true"
+      sriov-pod: "true"
+    max_concurrency: 1
     name: check-up-kind-1.22-sriov
     spec:
       affinity:


### PR DESCRIPTION
We still use kind-1.19-sriov on kubevirt,
let's return the lane until we fully switch to sriov-1.22,
so it will be part of the gating.

Signed-off-by: Or Shoval <oshoval@redhat.com>