### PR TITLE
Bump kubespray in prow-performance deployment jobs.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -582,7 +582,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubespray/kubespray:v2.15.0
+        - image: quay.io/kubespray/kubespray:v2.17.1
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -632,7 +632,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubespray/kubespray:v2.15.0
+        - image: quay.io/kubespray/kubespray:v2.17.1
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json


### PR DESCRIPTION
In order to be able to install k8s 1.21.3 we need to bump kubespray, there are dictionaries with the digests of the images to download indexed by k8s versions like https://github.com/kubernetes-sigs/kubespray/blob/b7ae4a2cfde75b7f110c756438c77b2103cc4761/roles/download/defaults/main.yml#L191-L215 and 1.21.3 is not present in kubespray v2.15.0 (the version the jobs are currently using)

Succesful execution here https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-performance-workload-cluster-deployment/1463901223005458432 (using secrets from https://github.com/kubevirt/secrets/pull/41)

/cc @marceloamaral @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>