### PR TITLE
Add mkpj.sh script

### DIFF
--- a/hack/mkpj.sh
+++ b/hack/mkpj.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#
+# Adapted from https://github.com/kubernetes/test-infra/blob/master/config/mkpj.sh
+#
+# Usage: hack/mkpj.sh --job <job-name> | kubectl -n kubevirt-prow-jobs -f
+#
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+config="${root}/github/ci/prow-deploy/files/config.yaml"
+job_config_path="${root}/github/ci/prow-deploy/files/jobs"
+
+docker pull gcr.io/k8s-prow/mkpj 1>&2 || true
+docker run -i --rm -v "${root}:${root}:z" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"


### PR DESCRIPTION
I'm having some build errors with mkpj on f35 seemingly related to the python3 version shipped, after completely cleaning up bazel cache I get:
```
Loading: 0 packages loaded
INFO: Repository py3_deps instantiated at:
  no stack (--record_rule_instantiation_callstack not enabled)
Repository rule pip_import defined at:
  /home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/python/pip.bzl:44:29: in <toplevel>
ERROR: An error occurred during the fetch of repository 'py3_deps':
   pip_import failed:  (Traceback (most recent call last):
  File "/usr/lib64/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/__main__.py", line 18, in <module>
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/subpar/runtime/support.py", line 326, in setup
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/subpar/runtime/support.py", line 157, in _setup_pkg_resources
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/__init__.py", line 77, in <module>
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/_vendor/packaging/requirements.py", line 9, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 672, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 632, in _load_backward_compatible
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/extern/__init__.py", line 43, in load_module
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/_vendor/pyparsing.py", line 943, in <module>
    
AttributeError: module 'collections' has no attribute 'MutableMapping'
)
ERROR: no such package '@py3_deps//': pip_import failed:  (Traceback (most recent call last):
  File "/usr/lib64/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/__main__.py", line 18, in <module>
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/subpar/runtime/support.py", line 326, in setup
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/subpar/runtime/support.py", line 157, in _setup_pkg_resources
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/__init__.py", line 77, in <module>
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/_vendor/packaging/requirements.py", line 9, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 672, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 632, in _load_backward_compatible
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/extern/__init__.py", line 43, in load_module
  File "/home/fgimenez/.cache/bazel/_bazel_fgimenez/c0d189b08f12465ef5319973ed87a017/external/rules_python/tools/piptool.par/piptool_deps_pypi__setuptools_38_2_4/pkg_resources/_vendor/pyparsing.py", line 943, in <module>
    
AttributeError: module 'collections' has no attribute 'MutableMapping'
)
INFO: Elapsed time: 0.343s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
ERROR: Build failed. Not running target
FAILED: Build did NOT complete successfully (0 packages loaded)
```

This script both simplifies using mkpj and prevents having to build it for each execution using mkpj in a container, adapted from https://github.com/kubernetes/test-infra/blob/master/config/mkpj.sh

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>