### PR TITLE
Bump containerdisks repo to golang 1.16

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -28,6 +28,9 @@ periodics:
         set -e
         cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
         ./build.sh
+      env:
+      - name: GIMME_GO_VERSION
+        value: "1.16"
       image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -21,6 +21,9 @@ presubmits:
         - /bin/sh
         - -c
         - ./build.sh -b
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.16"
         image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
         name: ""
         resources:


### PR DESCRIPTION
Needed for https://github.com/kubevirt/containerdisks/pull/9