### PR TITLE
Add default preset with go proxy setting

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -534,6 +534,10 @@ presets:
   - name: kubevirtci-cred
     mountPath: /etc/kubevirtci-cred
     readOnly: true
+# default preset with no labels, settings common to all jobs
+- env:
+  - name: GOPROXY
+    value: "https://goproxy.io,direct"
 
 managed_webhooks:
   # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.


### PR DESCRIPTION
We have been getting a lot of errors downloading packages from the default golang proxy during the last weeks, like https://search.ci.kubevirt.io/?search=Error+in+fail%3A+failed+to+fetch&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

We are not sure if the issue is related to a connectivity issue or rate-limiting from the proxy. There is a support ticket open for more than 10 days now to determine if this is a connectivity problem on the cloud provider side, but we haven't had too much progress so far.

This PR proposes to set https://goproxy.io/ as the default proxy for all the jobs using Prow's default preset with no labels as described here https://github.com/kubernetes/test-infra/blob/master/config/jobs/README.md#job-presets If we keep getting errors downloading golang packages they will be probably related to an infrastructure problem.

/cc @rmohr @dhiller 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>