### PR TITLE
The release job needs golang

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+      - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt


### PR DESCRIPTION
Some `go mod` actions make golang now a requirement.

Fixes this issue: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-release-kubevirt-tag/1466160989484355584