### PR TITLE
knmstate: Install go 1.16

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -281,12 +281,15 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
             securityContext:
               privileged: true
             resources:
               requests:
                 memory: "29Gi"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -20,15 +20,17 @@ presubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
             securityContext:
               privileged: true
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
               - "-c"
               - "automation/check-patch.unit-test.sh"
-
     - name: pull-kubernetes-nmstate-e2e-handler-k8s
       skip_branches:
         - release-\d+\.\d+
@@ -50,12 +52,15 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
             securityContext:
               privileged: true
             resources:
               requests:
                 memory: "29Gi"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -83,12 +88,15 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
             securityContext:
               privileged: true
             resources:
               requests:
                 memory: "29Gi"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -146,12 +154,15 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
             securityContext:
               privileged: true
             resources:
               requests:
                 memory: "29Gi"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"


### PR DESCRIPTION
The kubernetes-nmstate project has remove the go installation from the
Makefile, it's still at automation but this should be part of the CI, so
we reduce infra at the project.