### PR TITLE
knmstate: Don't call publish on release

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -16,6 +16,9 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+      branches:
+        - main
+        - release*
       cluster: ibm-prow-jobs
       spec:
         containers:


### PR DESCRIPTION
Publish has to be called on merged to main or release branches and
Release has to be called on tagging with semVer.