### PR TITLE
Add sig-monitoring lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2050,3 +2050,38 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
+    optional: true
+    skip_report: true
+    run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.22-sig-monitoring
+        image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true


### PR DESCRIPTION
This PR adds a new lane for testing metrics/alerts with a real Prometheus instance.

The job in this PR will consume the changes in this PR: https://github.com/kubevirt/kubevirt/pull/6933

Signed-off-by: Erkan Erol <eerol@redhat.com>