### PR TITLE
Add presubmit job to test PRs on qe-tools

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
@@ -1,0 +1,18 @@
+presubmits:
+  kubevirt/qe-tools:
+  - name: pull-qe-tools-make-test
+    always_run: true
+    decorate: true
+    cluster: ibm-prow-jobs
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make test
+        image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
+        args:
+        resources:
+          requests:
+            memory: "500Mi"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -113,6 +113,7 @@ tide:
     kubevirt/user-guide: squash
     kubevirt/terraform-provider-kubevirt: merge
     kubevirt/kubevirt-velero-plugin: squash
+    kubevirt/qe-tools: merge
 
   queries:
   - repos:
@@ -131,6 +132,7 @@ tide:
     - kubevirt/user-guide
     - kubevirt/terraform-provider-kubevirt
     - kubevirt/kubevirt-velero-plugin
+    - kubevirt/qe-tools
     labels:
     - lgtm
     - approved
@@ -377,6 +379,8 @@ branch-protection:
           branches:
             main:
               protect: true
+        kubevirt/qe-tools:
+          protect: true
     k8snetworkplumbingwg:
       repos:
         kubemacpool:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -343,6 +343,12 @@ plugins:
   - lgtm
   - owners-label
 
+  kubevirt/qe-tools:
+  - approve
+  - lgtm
+  - owners-label
+  - trigger
+
 external_plugins:
   libguestfs-appliance:
   - name: needs-rebase
@@ -411,6 +417,7 @@ triggers:
   - kubevirt/community
   - kubevirt/terraform-provider-kubevirt
   - kubevirt/kubevirt-velero-plugin
+  - kubevirt/qe-tools
 - repos:
   - virtblocks/virtblocks
 - repos:
@@ -455,6 +462,7 @@ approve:
   - kubevirt/user-guide
   - kubevirt/terraform-provider-kubevirt
   - kubevirt/kubevirt-velero-plugin
+  - kubevirt/qe-tools
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -497,6 +505,7 @@ lgtm:
   - kubevirt/user-guide
   - kubevirt/terraform-provider-kubevirt
   - kubevirt/kubevirt-velero-plugin
+  - kubevirt/qe-tools
   review_acts_as_lgtm: true
 
 override:


### PR DESCRIPTION
Since we disabled Travis CI we don't have any automated testing here. See https://github.com/kubevirt/qe-tools/pull/24 where we could need it.

Manual run of the job here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_qe-tools/24/pull-qe-tools-make-test/1468170849990217728

/cc @lukas-bednar @rmohr 