### PR TITLE
Fix repository on kubevirtci cdi bump

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -125,7 +125,7 @@ periodics:
     - image: quay.io/kubevirtci/pr-creator:v20210907-eaf738f
       command: ["/bin/sh", "-c"]
       args:
-      - git-pr.sh -c "./hack/bump-cdi.sh" -b bump-cdi -p $(pwd) -T main
+      - git-pr.sh -c "./hack/bump-cdi.sh" -r kubevirtci -b bump-cdi -T main -p $(pwd)
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
Thanks for spotting this! Now the pr is created against the correct repo :)

Job run here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-cdi/1468176156996931584

Resulting PR here: https://github.com/kubevirt/kubevirtci/pull/719

/cc @akalenyu @fgimenez 