### PR TITLE
updated the kube proxy metrics bind address to use 0.0.0.0

### DIFF
--- a/github/ci/prow-performance-workloads/inventory/prow-performance-workloads/group_vars/kube-proxy.yml
+++ b/github/ci/prow-performance-workloads/inventory/prow-performance-workloads/group_vars/kube-proxy.yml
@@ -100,7 +100,7 @@ kube_proxy_udp_timeout: 0s
 
 # The IP address and port for the metrics server to serve on
 # (set to 0.0.0.0 for all IPv4 interfaces and `::` for all IPv6 interfaces)
-kube_proxy_metrics_bind_address: 127.0.0.1:10249
+kube_proxy_metrics_bind_address: 0.0.0.0:10249
 
 # A string slice of values which specify the addresses to use for NodePorts.
 # Values may be valid IP blocks (e.g. 1.2.3.0/24, 1.2.3.4/32).


### PR DESCRIPTION
The default configuration in kubespray when creating a k8s cluster does not expose kube proxy metrics.
But to scrape these metrics using prometheus, we need to change the `kube_proxy_metrics_bind_address` from using localhost address to 0.0.0.0 to bind all IPv4 interfaces.

/cc @fgimenez @dhiller 

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>