### PR TITLE
k8s-1.22-ipv6: Add kubevirtci presubmit job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -331,6 +331,32 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
+    name: check-provision-k8s-1.22-ipv6
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.22-ipv6 && ../provision.sh
+        image: quay.io/kubevirtci/golang:v20210316-d295087
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 1
     name: check-provision-k8s-1.23
     optional: true
     spec:


### PR DESCRIPTION
In order to be able to develop, provision and test the new k8s-1.22-ipv6 provider,
add this job.

For now it isn't `always run`, once it is ready we will make it mandatory.

Would need this lane for developing https://github.com/kubevirt/kubevirtci/pull/721
which creates the new provider `k8s-1.22-ipv6` in a dedicated folder.

Signed-off-by: Or Shoval <oshoval@redhat.com>