### PR TITLE
sriov, release-0.42: Use prow-workloads for running jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
@@ -764,7 +764,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.17-sriov
     decorate: true
     decoration_config:


### PR DESCRIPTION
Align it to the cluster which runs sriov jobs for
other releases (i.e 0.41) and main branch.

We can see it hangs on the previous cluster
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/6209/pull-kubevirt-e2e-kind-1.17-sriov-0.42/1468605263404601344

