### PR TITLE
Add document about CNCF tools

### DIFF
--- a/docs/cncf-tools.md
+++ b/docs/cncf-tools.md
@@ -1,0 +1,27 @@
+# CNCF tools
+
+We use several tools provided by CNCF, mainly netlify to manage the kubevirt.io
+domain and several rooms in CNCF's slack, including [kubevirt-ci-monitoring].
+
+In order to get access and configure these services you need to create tickets in
+[CNCF's service desk]. These are the required steps to get access to this service
+desk:
+
+* Become a kubevirt maintainer:
+  * Be included in the [list of maintainers in the community repo], see the
+  [requirements to become a maintainer]
+  * Be included in the [list of maintainers in the CNCF project maintainers list],
+  basically propose a PR with the changes once the user is added to KubeVirt's
+  community repo.
+* Send an email to amye@linuxfoundation.org requesting access to [CNCF's service desk],
+mentioning that the user is already listed in CNCF's maintainer list.
+
+Once the access to the service desk is granted then the user can create tickets to
+request access to the DNS tools for the KubeVirt domain, request changes in KubeVirt's
+slack rooms or any other technical issue related to the services provided by CNCF.
+
+[kubevirt-ci-monitoring]: https://cloud-native.slack.com/archives/C02GACK29RV
+[CNCF's service desk]: https://cncfservicedesk.atlassian.net/
+[list of maintainers in the community repo]: https://github.com/kubevirt/community/blob/main/MAINTAINERS.md
+[requirements to become a maintainer]: https://github.com/kubevirt/community/blob/main/GOVERNANCE.md#selecting-maintainers
+[list of maintainers in the CNCF project maintainers list]: https://github.com/cncf/foundation/blob/master/project-maintainers.csv


### PR DESCRIPTION
Describes how to get access to https://servicedesk.cncf.io/ and the tools provided from there.

/cc @dhiller @rmohr 

Signed-off-by: Federico Gimenez <fgimenez@redhat.com>