### PR TITLE
Make check-provision required for 1.23

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -348,7 +348,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -358,7 +358,6 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.23
-    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
Now that 1.23 provider has gotten merged we need to make the check-provision for it mandatory, otherwise we'll miss when it breaks. This would then impact the 1.23 kubevirt lanes.