### PR TITLE
Reduce the scope of cgroups v2 periodic job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1373,11 +1373,9 @@ periodics:
       - automation/test.sh
       env:
       - name: TARGET
-        value: k8s-1.20
+        value: k8s-1.20-sig-compute
       - name: KUBEVIRT_CGROUPV2
         value: "true"
-      - name: KUBEVIRT_E2E_SKIP
-        value: Multus|SRIOV|GPU|Macvtap|MediatedDevices
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
       name: ""
       resources:


### PR DESCRIPTION
The job is very unstable when all possible tests are executed. Focus only on sig-compute to make it less flaky.

https://prow.ci.kubevirt.io/?job=periodic-kubevirt-e2e-k8s-1.20-cgroupsv2