### PR TITLE
Always run cgroups v2 presubmit job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1345,50 +1345,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 9,17,0 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 7h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.20-cgroupsv2
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: TARGET
-        value: k8s-1.20-sig-compute
-      - name: KUBEVIRT_CGROUPV2
-        value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20210906-994b913
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
   cron: 0 6 * * *
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -345,7 +345,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -362,7 +362,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.20-cgroupsv2
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -374,11 +373,9 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20
+          value: k8s-1.20-sig-compute
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        - name: KUBEVIRT_E2E_SKIP
-          value: Multus|SRIOV|GPU|Macvtap|MediatedDevices
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         name: ""
         resources:


### PR DESCRIPTION
The PR makes cgroups v2 presubmit job mandatory instead of runnig the periodic job.

With the test scope reduced to sig-compute only the results look more stable now: https://prow.ci.kubevirt.io/?job=periodic-kubevirt-e2e-k8s-1.20-cgroupsv2

@rmohr , @fgimenez FYI. We can monitor the periodic a bit more if there are doubts about it. But I think it should be fine to have  a mandatory presubmit.