### PR TITLE
Bump capik job to golang 1.17

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -29,5 +29,8 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
+        env:
+          - name: GIMME_GO_VERSION
+            value: "1.17"
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
capik goes to golang 1.17 and will not compile with 1.16 anymore which is our current default.