### PR TITLE
k8s-1.22-ipv6: Make the lane mandatory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -322,7 +322,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
Since the lane is already passing with it's current configuration,
and it is part of the kubevirtci package,
it should be marked as mandatory.

Signed-off-by: Or Shoval <oshoval@redhat.com>