### PR TITLE
Enable reporting for sig-monitoring

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2100,7 +2100,6 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     optional: true
-    skip_report: true
     run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
After observing the lane for a while and ensuring it works, we can enable reporting now.
It will be still optional but developers will be warned about the issues. After a while, it can
be mandatory as well.

https://prow.ci.kubevirt.io/?job=pull-kubevirt-e2e-k8s-1.22-sig-monitoring

Signed-off-by: Erkan Erol <eerol@redhat.com>