### PR TITLE
Upgrade presubmits Kubevirt SR-IOV lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -784,7 +784,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 40 22,10 * * *
+  cron: 0 22, 10 * * *
   decorate: true
   decoration_config:
     grace_period: 30m0s
@@ -796,6 +796,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.22-sriov
   reporter_config:
     slack:
@@ -829,90 +830,6 @@ periodics:
         value: "true"
       - name: TARGET
         value: kind-1.22-sriov
-      - name: GIMME_GO_VERSION
-        value: 1.13.8
-      image: quay.io/kubevirtci/golang:v20210316-d295087
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-      volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
-      - mountPath: /sys/fs/cgroup
-        name: cgroup
-      - mountPath: /dev/vfio/
-        name: vfio
-    nodeSelector:
-      hardwareSupport: sriov-nic
-    volumes:
-    - hostPath:
-        path: /lib/modules
-        type: Directory
-      name: modules
-    - hostPath:
-        path: /sys/fs/cgroup
-        type: Directory
-      name: cgroup
-    - hostPath:
-        path: /dev/vfio/
-        type: Directory
-      name: vfio
-- annotations:
-    k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 0 22,10 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 30m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.19-sriov
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    affinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-            - key: sriov-pod
-              operator: In
-              values:
-              - "true"
-          topologyKey: kubernetes.io/hostname
-        - labelSelector:
-            matchExpressions:
-            - key: sriov-pod-multi
-              operator: In
-              values:
-              - "true"
-          topologyKey: kubernetes.io/hostname
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/bash
-      - -ce
-      - |
-        automation/test.sh
-      env:
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: kind-1.19-sriov
       - name: GIMME_GO_VERSION
         value: 1.13.8
       image: quay.io/kubevirtci/golang:v20210316-d295087

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -806,7 +806,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -820,10 +820,11 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      rehearsal.allowed: "true"
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.22-sriov
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -853,87 +854,6 @@ presubmits:
         env:
         - name: TARGET
           value: kind-1.22-sriov
-        - name: GIMME_GO_VERSION
-          value: 1.13.8
-        image: quay.io/kubevirtci/bootstrap:v20210906-994b913
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /dev/vfio/
-          name: vfio
-      nodeSelector:
-        hardwareSupport: sriov-nic
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - hostPath:
-          path: /dev/vfio/
-          type: Directory
-        name: vfio
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 30m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-      rehearsal.allowed: "true"
-      sriov-pod: "true"
-    max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.19-sriov
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod-multi
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - |
-          automation/test.sh
-        env:
-        - name: TARGET
-          value: kind-1.19-sriov
         - name: GIMME_GO_VERSION
           value: 1.13.8
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913


### PR DESCRIPTION
This PR sets the new Kubevirt SR-IOV lane, `kubevirt-pull-e2e-kind-1.22-sriov`, 
as voting lane instead of ` kubevirt-pull-e2e-kind-1.19-sriov`.

The new lane periodic job results show that its stable for more then two weeks:
https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.22-sriov

Signed-off-by: Or Mergi <ormergi@redhat.com>