### PR TITLE
Update CNAO release 0.65 presumbmit based on main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
@@ -9,9 +9,9 @@ presubmits:
       decorate: true
       decoration_config:
         timeout: 4h
-        grace_period: 10m
+        grace_period: 5m
+      max_concurrency: 6
       cluster: prow-workloads
-      max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -20,7 +20,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -40,17 +40,17 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      max_concurrency: 6
       cluster: prow-workloads
-      max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror-proxy: "true"
+        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
             securityContext:
               privileged: true
             resources:
@@ -70,21 +70,22 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
+      max_concurrency: 6
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror-proxy: "true"
+        preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20211122-ca88fb4
+          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
             securityContext:
               privileged: true
             resources:
               requests:
-                memory: "4Gi"
+                memory: "29Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -100,8 +101,8 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
+      max_concurrency: 6
       cluster: prow-workloads
-      max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -110,7 +111,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -131,17 +132,17 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      max_concurrency: 4
+      max_concurrency: 6
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -162,17 +163,17 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      max_concurrency: 4
+      max_concurrency: 6
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -193,7 +194,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      max_concurrency: 4
+      max_concurrency: 6
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
@@ -203,12 +204,15 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6
             securityContext:
               privileged: true
             resources:
               requests:
                 memory: "29Gi"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -224,7 +228,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      max_concurrency: 4
+      max_concurrency: 6
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
@@ -234,7 +238,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:
@@ -255,7 +259,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      max_concurrency: 4
+      max_concurrency: 6
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
@@ -265,7 +269,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20201119-a5880e0
+          - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
The configuration for 0.65 was copied from the previous stable branch
instead of the current main. Due to that, some of the recent changes
were not taken. Due to a missing Go dependency, this caused a failing CI
lane.

With this patch, release 0.65 is synced with the main config.

Signed-off-by: Petr Horáček <phoracek@redhat.com>