### PR TITLE
Kubevirt prow namespace to monitoring

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1012,6 +1012,120 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+  cluster: ibm-prow-jobs
+  cron: 40 4 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  - base_ref: main
+    org: kubevirt
+    repo: project-infra
+  labels:
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-kubevirtci-quay-credential: "true"
+    preset-shared-images: "true"
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  name: periodic-kubevirt-performance-cluster-density-test
+  max_concurrency: 1
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - |
+        # install yq
+        curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+        chmod +x ./yq && mv ./yq /usr/local/bin/yq
+
+        # get kubectl
+        curl -L "https://dl.k8s.io/release/v1.19.7/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+        chmod +x /usr/local/bin/kubectl
+
+        # get kubeconfig
+        source ../project-infra/hack/manage-secrets.sh
+        decrypt_secrets
+        extract_secret 'kubeconfigPerf' /kubeconfig
+
+        # login quay.io
+        cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+
+        # run the test
+        make clean
+        make bazel-build
+        make cluster-sync
+        make cluster-deploy
+        start_timestamp=$(date -u +%Y-%m-%dT%TZ
+        sleep 30
+        _out/cmd/perfscale-load-generator/perfscale-load-generator \
+          -container-prefix $DOCKER_PREFIX \
+          -container-tag $DOCKER_TAG \
+          -v 6 \
+          -workload tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-density.yaml
+
+        # collect metrics      
+        kubectl -n monitoring port-forward service/prometheus-stack-kube-prom-prometheus ${PROMETHEUS_PORT} &> /dev/null &
+        sleep 30
+        stop_timestamp=$(date -u +%Y-%m-%dT%TZ)
+        cat <<EOF >perfscale-audit-cfg.json
+        {
+          "prometheusURL": "http://127.0.0.1:${PROMETHEUS_PORT}",
+          "startTime": "$start_timestamp",
+          "endTime": "$stop_timestamp"
+        }
+        EOF
+        _out/cmd/perfscale-audit/perfscale-audit -config-file perfscale-audit-cfg.json
+      env:
+      - name: TARGET
+        value: external
+      - name: KUBEVIRT_PROVIDER
+        value: external
+      - name: KUBEVIRT_STORAGE
+        value: hpp
+      - name: DOCKER_PREFIX
+        value: quay.io/kubevirtci
+      - name: KUBECONFIG
+        value: /kubeconfig
+      - name: PROMETHEUS_PORT
+        value: "9090"
+      - name: kubectl
+        value: /usr/local/bin/kubectl
+      - name: IMAGE_PULL_POLICY
+        value: Always
+      - name: GIT_ASKPASS
+        value: ../project-infra/hack/git-askpass.sh
+      image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+      resources:
+        requests:
+          memory: 4Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /etc/github
+        name: token
+      - mountPath: /etc/pgp
+        name: pgp-bot-key
+        readOnly: true
+    volumes:
+    - name: token
+      secret:
+        secretName: oauth-token
+    - name: pgp-bot-key
+      secret:
+        secretName: pgp-bot-key
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 7,15,23 * * *
   decorate: true

--- a/github/ci/services/prometheus-stack/BUILD.bazel
+++ b/github/ci/services/prometheus-stack/BUILD.bazel
@@ -90,14 +90,14 @@ PRODUCTION_USER_PERFORMANCE_WORKLOADS = "kubernetes-admin"
         patches = glob([
             "patches/service-monitors/%s/*.yaml" % NAME,
         ]),
-        namespace = NAMESPACE,
+        namespace = "monitoring",
         user = USER,
     )
-    for NAME, CLUSTER, USER, NAMESPACE in [
-        ("testing", TEST_CLUSTER, TEST_USER, "kubevirt-prow"),
-        ("production-control-plane", PRODUCTION_CLUSTER_CONTROL_PLANE, PRODUCTION_USER_CONTROL_PLANE, "kubevirt-prow"),
-        ("production-e2e-workloads", PRODUCTION_CLUSTER_E2E_WORKLOADS, PRODUCTION_USER_E2E_WORKLOADS, "kubevirt-prow"),
-        ("production-performance-workloads", PRODUCTION_CLUSTER_PERFORMANCE_WORKLOADS, PRODUCTION_USER_PERFORMANCE_WORKLOADS, "monitoring"),
+    for NAME, CLUSTER, USER in [
+        ("testing", TEST_CLUSTER, TEST_USER),
+        ("production-control-plane", PRODUCTION_CLUSTER_CONTROL_PLANE, PRODUCTION_USER_CONTROL_PLANE),
+        ("production-e2e-workloads", PRODUCTION_CLUSTER_E2E_WORKLOADS, PRODUCTION_USER_E2E_WORKLOADS),
+        ("production-performance-workloads", PRODUCTION_CLUSTER_PERFORMANCE_WORKLOADS, PRODUCTION_USER_PERFORMANCE_WORKLOADS),
     ]
 ]
 

--- a/github/ci/services/prometheus-stack/manifests/service-monitors/common/servicemonitors.yaml
+++ b/github/ci/services/prometheus-stack/manifests/service-monitors/common/servicemonitors.yaml
@@ -48,31 +48,31 @@ spec:
   endpoints:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
----
-# Source: kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-stack-kube-prom-kube-controller-manager
-  namespace: default
-  labels:
-    app: kube-prometheus-stack-kube-controller-manager
-    chart: kube-prometheus-stack-13.6.0
-    release: "prometheus-stack"
-    heritage: "Helm"
-    group: kubevirtci
-spec:
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: kube-prometheus-stack-kube-controller-manager
-      release: "prometheus-stack"
-  namespaceSelector:
-    matchNames:
-      - kube-system
-  endpoints:
-  - port: http-metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+# ---
+# # Source: kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: prometheus-stack-kube-prom-kube-controller-manager
+#   namespace: default
+#   labels:
+#     app: kube-prometheus-stack-kube-controller-manager
+#     chart: kube-prometheus-stack-13.6.0
+#     release: "prometheus-stack"
+#     heritage: "Helm"
+#     group: kubevirtci
+# spec:
+#   jobLabel: jobLabel
+#   selector:
+#     matchLabels:
+#       app: kube-prometheus-stack-kube-controller-manager
+#       release: "prometheus-stack"
+#   namespaceSelector:
+#     matchNames:
+#       - kube-system
+#   endpoints:
+#   - port: http-metrics
+#     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 ---
 # Source: kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
@@ -98,56 +98,56 @@ spec:
   endpoints:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
----
-# Source: kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-stack-kube-prom-kube-proxy
-  namespace: default
-  labels:
-    app: kube-prometheus-stack-kube-proxy
-    chart: kube-prometheus-stack-13.6.0
-    release: "prometheus-stack"
-    heritage: "Helm"
-    group: kubevirtci
-spec:
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: kube-prometheus-stack-kube-proxy
-      release: "prometheus-stack"
-  namespaceSelector:
-    matchNames:
-      - kube-system
-  endpoints:
-  - port: http-metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
----
-# Source: kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-stack-kube-prom-kube-scheduler
-  namespace: default
-  labels:
-    app: kube-prometheus-stack-kube-scheduler
-    chart: kube-prometheus-stack-13.6.0
-    release: "prometheus-stack"
-    heritage: "Helm"
-    group: kubevirtci
-spec:
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: kube-prometheus-stack-kube-scheduler
-      release: "prometheus-stack"
-  namespaceSelector:
-    matchNames:
-      - kube-system
-  endpoints:
-  - port: http-metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+# ---
+# # Source: kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: prometheus-stack-kube-prom-kube-proxy
+#   namespace: default
+#   labels:
+#     app: kube-prometheus-stack-kube-proxy
+#     chart: kube-prometheus-stack-13.6.0
+#     release: "prometheus-stack"
+#     heritage: "Helm"
+#     group: kubevirtci
+# spec:
+#   jobLabel: jobLabel
+#   selector:
+#     matchLabels:
+#       app: kube-prometheus-stack-kube-proxy
+#       release: "prometheus-stack"
+#   namespaceSelector:
+#     matchNames:
+#       - kube-system
+#   endpoints:
+#   - port: http-metrics
+#     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+# ---
+# # Source: kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: prometheus-stack-kube-prom-kube-scheduler
+#   namespace: default
+#   labels:
+#     app: kube-prometheus-stack-kube-scheduler
+#     chart: kube-prometheus-stack-13.6.0
+#     release: "prometheus-stack"
+#     heritage: "Helm"
+#     group: kubevirtci
+# spec:
+#   jobLabel: jobLabel
+#   selector:
+#     matchLabels:
+#       app: kube-prometheus-stack-kube-scheduler
+#       release: "prometheus-stack"
+#   namespaceSelector:
+#     matchNames:
+#       - kube-system
+#   endpoints:
+#   - port: http-metrics
+#     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 ---
 # Source: kube-prometheus-stack/templates/exporters/kube-state-metrics/serviceMonitor.yaml
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
After updating the prometheus stack to be deployed to the performance cluster, the prow-workloads cluster started getting alerts about some service monitors.

Although the [original code](https://github.com/kubevirt/project-infra/pull/1778/files#diff-8ac0dadb1c90800200076b5a36d0b123da3490b0ec96c52574119230d91e0f40L63) has been configured to deploy the service monitors in the `kubevirt-prow` namespace. `kubevirt-prow` prow cluster actually has the service monitors deployed in the `monitoring` namespace.
![image](https://user-images.githubusercontent.com/5133121/148634096-f15e85af-70e0-486b-952d-f51c714f8ae1.png)
So this PR is changing all service monitor deployments to be in the `monitoring` namespace.

Also, the service monitors to extract metrics from `controller-manager`, kube-proxy` and `kube-scheduler` are not healthy. Even the old ones in the `monitoring` namespace and the new ones deployed in the `kubevirt-prow` namespace.
![image](https://user-images.githubusercontent.com/5133121/148633865-1732b5c2-3660-4237-8d46-e2b193a7bb33.png)
As far as I know, no one is looking at these metrics, so I've commented out these service monitors.
In fact, the kube proxy is not being deployed to expose metrics on the clusters, except on the performance cluster.