### PR TITLE
Move prometheus stack service monitors from kubevirt-prow to monitoring namespace

### DIFF
--- a/github/ci/services/prometheus-stack/BUILD.bazel
+++ b/github/ci/services/prometheus-stack/BUILD.bazel
@@ -90,14 +90,14 @@ PRODUCTION_USER_PERFORMANCE_WORKLOADS = "kubernetes-admin"
         patches = glob([
             "patches/service-monitors/%s/*.yaml" % NAME,
         ]),
-        namespace = NAMESPACE,
+        namespace = "monitoring",
         user = USER,
     )
-    for NAME, CLUSTER, USER, NAMESPACE in [
-        ("testing", TEST_CLUSTER, TEST_USER, "kubevirt-prow"),
-        ("production-control-plane", PRODUCTION_CLUSTER_CONTROL_PLANE, PRODUCTION_USER_CONTROL_PLANE, "kubevirt-prow"),
-        ("production-e2e-workloads", PRODUCTION_CLUSTER_E2E_WORKLOADS, PRODUCTION_USER_E2E_WORKLOADS, "kubevirt-prow"),
-        ("production-performance-workloads", PRODUCTION_CLUSTER_PERFORMANCE_WORKLOADS, PRODUCTION_USER_PERFORMANCE_WORKLOADS, "monitoring"),
+    for NAME, CLUSTER, USER in [
+        ("testing", TEST_CLUSTER, TEST_USER),
+        ("production-control-plane", PRODUCTION_CLUSTER_CONTROL_PLANE, PRODUCTION_USER_CONTROL_PLANE),
+        ("production-e2e-workloads", PRODUCTION_CLUSTER_E2E_WORKLOADS, PRODUCTION_USER_E2E_WORKLOADS),
+        ("production-performance-workloads", PRODUCTION_CLUSTER_PERFORMANCE_WORKLOADS, PRODUCTION_USER_PERFORMANCE_WORKLOADS),
     ]
 ]
 

--- a/github/ci/services/prometheus-stack/manifests/service-monitors/common/servicemonitors.yaml
+++ b/github/ci/services/prometheus-stack/manifests/service-monitors/common/servicemonitors.yaml
@@ -49,31 +49,6 @@ spec:
   - port: http-metrics
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
 ---
-# Source: kube-prometheus-stack/templates/exporters/kube-controller-manager/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-stack-kube-prom-kube-controller-manager
-  namespace: default
-  labels:
-    app: kube-prometheus-stack-kube-controller-manager
-    chart: kube-prometheus-stack-13.6.0
-    release: "prometheus-stack"
-    heritage: "Helm"
-    group: kubevirtci
-spec:
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: kube-prometheus-stack-kube-controller-manager
-      release: "prometheus-stack"
-  namespaceSelector:
-    matchNames:
-      - kube-system
-  endpoints:
-  - port: http-metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
----
 # Source: kube-prometheus-stack/templates/exporters/kube-etcd/servicemonitor.yaml
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -91,56 +66,6 @@ spec:
   selector:
     matchLabels:
       app: kube-prometheus-stack-kube-etcd
-      release: "prometheus-stack"
-  namespaceSelector:
-    matchNames:
-      - kube-system
-  endpoints:
-  - port: http-metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
----
-# Source: kube-prometheus-stack/templates/exporters/kube-proxy/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-stack-kube-prom-kube-proxy
-  namespace: default
-  labels:
-    app: kube-prometheus-stack-kube-proxy
-    chart: kube-prometheus-stack-13.6.0
-    release: "prometheus-stack"
-    heritage: "Helm"
-    group: kubevirtci
-spec:
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: kube-prometheus-stack-kube-proxy
-      release: "prometheus-stack"
-  namespaceSelector:
-    matchNames:
-      - kube-system
-  endpoints:
-  - port: http-metrics
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
----
-# Source: kube-prometheus-stack/templates/exporters/kube-scheduler/servicemonitor.yaml
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: prometheus-stack-kube-prom-kube-scheduler
-  namespace: default
-  labels:
-    app: kube-prometheus-stack-kube-scheduler
-    chart: kube-prometheus-stack-13.6.0
-    release: "prometheus-stack"
-    heritage: "Helm"
-    group: kubevirtci
-spec:
-  jobLabel: jobLabel
-  selector:
-    matchLabels:
-      app: kube-prometheus-stack-kube-scheduler
       release: "prometheus-stack"
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
After updating the prometheus stack to be deployed to the performance cluster, the prow-workloads cluster started getting alerts about some service monitors.

Although the [original code](https://github.com/kubevirt/project-infra/pull/1778/files#diff-8ac0dadb1c90800200076b5a36d0b123da3490b0ec96c52574119230d91e0f40L63) has been configured to deploy the service monitors in the `kubevirt-prow` namespace. `kubevirt-prow` prow cluster actually has the service monitors deployed in the `monitoring` namespace.
![image](https://user-images.githubusercontent.com/5133121/148634096-f15e85af-70e0-486b-952d-f51c714f8ae1.png)
So this PR is changing all service monitor deployments to be in the `monitoring` namespace.

Also, the service monitors to extract metrics from `controller-manager`, kube-proxy` and `kube-scheduler` are not healthy. Even the old ones in the `monitoring` namespace and the new ones deployed in the `kubevirt-prow` namespace.
![image](https://user-images.githubusercontent.com/5133121/148633865-1732b5c2-3660-4237-8d46-e2b193a7bb33.png)
As far as I know, no one is looking at these metrics, so I've commented out these service monitors.
In fact, the kube proxy is not being deployed to expose metrics on the clusters, except on the performance cluster.

/cc @fgimenez @dhiller 

Signed-off-by: Marcelo Amaral <marcelo.amaral1@ibm.com>