### PR TITLE
kind-1.19-sriov: Disable job autorun

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubevirt/kubevirtci:
-  - always_run: true
+  - always_run: false
+    optional: true
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     cluster: prow-workloads


### PR DESCRIPTION
We now have kind-1.22-sriov which is the operational one.

Signed-off-by: Or Shoval <oshoval@redhat.com>