### PR TITLE
Update bootstrap image for bootstrap and golang image build

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -96,7 +96,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20210906-994b913
+          - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"


### PR DESCRIPTION
As [moving it to the workloads cluster didn't fix it](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-bootstrap-image/1480471070967336960), I updated the bootstrap image, worked locally.

Successful cluster run for new job config here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-bootstrap-image/1480491623212126208