### PR TITLE
Increase KubePodNotReady alert timeout to 3 hours to reduce noise

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/production-e2e-workloads/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/production-e2e-workloads/kubernetes-apps.yaml
@@ -12,11 +12,11 @@ spec:
     - alert: KubePodNotReady
       annotations:
         message: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
-          state for longer than 1h30m.'
+          state for longer than 3 hours.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready
       expr: |
         sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
-      for: 90m
+      for: 180m
       labels:
         severity: critical
         namespace: monitoring


### PR DESCRIPTION
Large number of critical alerts were raised due to high load on clusters and pods not being ready within 1h30m.

These critical alerts resolved themselves over time as load reduced.

Increasing the time to trigger this alert to 3 hours to reduce noise. 

/cc @fgimenez @dhiller

Signed-off-by: Brian Carey <bcarey@redhat.com>