### PR TITLE
Bump node-exporter to image version v1.3.1

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/common/node-exporter.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/common/node-exporter.yaml
@@ -167,7 +167,7 @@ spec:
         runAsUser: 65534
       containers:
         - name: node-exporter
-          image: "quay.io/prometheus/node-exporter:v1.0.1"
+          image: "quay.io/prometheus/node-exporter:v1.3.1"
           imagePullPolicy: IfNotPresent
           args:
             - --path.procfs=/host/proc


### PR DESCRIPTION
Upgrading node-exporter to image version v.1.3.1 due to issue seen with high context switching alert.

/cc @fgimenez @dhiller  

Signed-off-by: Brian Carey <bcarey@redhat.com>