### PR TITLE
Set prow-deploy image back to the tag of working version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -344,7 +344,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210924-5271db4
+        - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -397,7 +397,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210924-5271db4
+        - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
@@ -450,7 +450,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210924-5271db4
+        - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -336,7 +336,7 @@ presubmits:
       securityContext:
         runAsUser: 0
       containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20210924-5271db4
+        - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json


### PR DESCRIPTION
kubevirt/project-infra#1616 set a new version for the prow-deploy image on the jobs, which gave the following error: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1846/pull-project-infra-prow-deploy-test/1481666249732657152#1:build-log.txt%3A22

We reset back to the previous working version.
