### PR TITLE
Increase alert time for high context switching to reduce noise from short spikes

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/node-exporter-alerting.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/node-exporter-alerting.yaml
@@ -194,7 +194,7 @@ spec:
         summary: Host context switching (instance {{ $labels.instance }})
         description: "Context switching is growing on node (> 8000 / s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
       expr: (rate(node_context_switches_total[5m])) / (count without(cpu, mode) (node_cpu_seconds_total{mode="idle"})) > 8000
-      for: 3m
+      for: 6m
       labels:
         severity: warning
         namespace: monitoring


### PR DESCRIPTION
Short spikes are causing lots of alerts to fire for high context switching. 

These alerts are not causing any issues for the e2e jobs so increasing the time to reduce noise. 

/cc @dhiller @fgimenez 

Signed-off-by: Brian Carey <bcarey@redhat.com>