### PR TITLE
Remove unsupported deck url for hmac

### DIFF
--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -52,7 +52,6 @@
       --hmac-token-secret-name=hmac-token \
       --hmac-token-key=hmac \
       --hook-url https://prow.ci.kubevirt.io/hook \
-      --deck-url https://prow.ci.kubevirt.io/ \
       --dry-run=false
   environment:
     PROW_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/config/config.yaml"


### PR DESCRIPTION
See deployment failure here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1481897605402202112#1:build-log.txt%3A148

/cc @fgimenez @brianmcarey 