### PR TITLE
Remove 'latest' tag from list of image tags

### DIFF
--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -8,7 +8,7 @@ if ! command -V skopeo; then
 fi
 
 IMAGE_NAME="$1"
-latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[]' | tail -1)
+latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( contains("latest") | not )' | tail -1)
 if [ -z "$latest_image_tag" ]; then
     echo "Couldn't find latest_image_tag"
     exit 1
@@ -17,6 +17,6 @@ IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$latest_image_tag"
 
 replace_regex='s#'"$IMAGE_NAME"'(@sha256\:|:v[a-z0-9]+-).*$#'"$IMAGE_NAME_WITH_TAG"'#g'
 
-job_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname $0)" && pwd)"'/../github/ci/prow-deploy/files/jobs' && pwd)")"
+job_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname "$0")" && pwd)"'/../github/ci/prow-deploy/files/jobs' && pwd)")"
 
-find "$job_dir" -regextype egrep -regex '.*-(periodics|presubmits|postsubmits)\.yaml' -exec sed -i -E $replace_regex {} +
+find "$job_dir" -regextype egrep -regex '.*-(periodics|presubmits|postsubmits)\.yaml' -exec sed -i -E "$replace_regex" {} +


### PR DESCRIPTION
The script doesn't filter out `latest` image tags. See https://github.com/kubevirt/project-infra/pull/1850/files#diff-642559bcaf57a97a9c127a55ec4d5f37d3c366d158c23a72c19d28056592208cR10

/cc @brianmcarey 

