### PR TITLE
Set user-guide default branch to main

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -463,6 +463,7 @@ orgs:
         has_projects: false
         has_wiki: false
         homepage: https://kubevirt.io/user-guide
+        default_branch: main
       v2v-job:
         allow_rebase_merge: false
         allow_squash_merge: false


### PR DESCRIPTION
Tell peribolos to rename default branch of user-guide from master to main per compassionate language project
https://github.com/kubevirt/user-guide/issues/430

Signed-off-by: cwilkers <cwilkers@redhat.com>