### PR TITLE
Fix prow job image bump for branch configs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
+      - image: quay.io/kubevirtci/bootstrap:v20220110-4643253
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -53,7 +53,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
+      - image: quay.io/kubevirtci/bootstrap:v20220110-4643253
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - image: quay.io/kubevirtci/bootstrap:v20220110-4643253
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -50,7 +50,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20210311-09ebaa2
+        - image: quay.io/kubevirtci/bootstrap:v20220110-4643253
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -7,6 +7,16 @@ if ! command -V skopeo; then
     exit 1
 fi
 
+if [ $# -gt 1 ]; then
+    if [ ! -d "$2" ]; then
+        echo "$2 is not a directory!"
+        exit 1
+    fi
+    job_dir="$2"
+else
+    job_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname "$0")" && pwd)"'/../github/ci/prow-deploy/files/jobs' && pwd)")"
+fi
+
 IMAGE_NAME="$1"
 latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( contains("latest") | not )' | tail -1)
 if [ -z "$latest_image_tag" ]; then
@@ -16,7 +26,5 @@ fi
 IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$latest_image_tag"
 
 replace_regex='s#'"$IMAGE_NAME"'(@sha256\:|:v[a-z0-9]+-).*$#'"$IMAGE_NAME_WITH_TAG"'#g'
-
-job_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname "$0")" && pwd)"'/../github/ci/prow-deploy/files/jobs' && pwd)")"
 
 find "$job_dir" -regextype egrep -regex '.*-(periodics|presubmits|postsubmits)\.yaml' -exec sed -i -E "$replace_regex" {} +

--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -27,4 +27,4 @@ IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$latest_image_tag"
 
 replace_regex='s#'"$IMAGE_NAME"'(@sha256\:|:v[a-z0-9]+-).*$#'"$IMAGE_NAME_WITH_TAG"'#g'
 
-find "$job_dir" -regextype egrep -regex '.*-(periodics|presubmits|postsubmits)\.yaml' -exec sed -i -E "$replace_regex" {} +
+find "$job_dir" -regextype egrep -regex '.*-(periodics|presubmits|postsubmits)(-master|-main)?\.yaml' -exec sed -i -E "$replace_regex" {} +


### PR DESCRIPTION
Fixes a bug that does not take job config files with default branch name into account.

Adds a parameter to the script `hack/update-jobs-with-latest-image.sh` to select the directory for which the job configs should get bumped.

Finally bumps the node-maintenance-operator job configs.

Job instances with new image:
* [pull-node-maintenance-operator-build](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_node-maintenance-operator/172/pull-node-maintenance-operator-build/1483124046433357824)
* [pull-node-maintenance-operator-check](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_node-maintenance-operator/172/pull-node-maintenance-operator-check/1483124656822030336)

/cc @machadovilaca @slintes 