### PR TITLE
Update k8s-testimages/bootstrap image in CNAO jobs to latest version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: gcr.io/k8s-testimages/bootstrap:v20210913-fc7c4e8
             securityContext:
               privileged: true
             resources:
@@ -86,7 +86,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: gcr.io/k8s-testimages/bootstrap:v20210913-fc7c4e8
             securityContext:
               privileged: true
             resources:
@@ -118,7 +118,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
+          - image: gcr.io/k8s-testimages/bootstrap:v20210913-fc7c4e8
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Update k8s-testimages/bootstrap image in cluster-network-addons-operator-presubmits to latest version

Jobs in kubevirt/cluster-network-addons-operator/pull/1142 are failing when building a `Dockefile` with a `centos:stream9` because of the use of an older `k8s-testimages/bootstrap` 

/cc @dhiller @RamLavi @phoracek @qinqon

Signed-off-by: João Vilaça <jvilaca@redhat.com>