### PR TITLE
Use golang image for job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1104,7 +1104,7 @@ periodics:
         value: Always
       - name: GIT_ASKPASS
         value: ../project-infra/hack/git-askpass.sh
-      image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
+      image: quay.io/kubevirtci/golang:v20220110-c066ff5
       resources:
         requests:
           memory: 4Gi


### PR DESCRIPTION
Job is failing due to missing go:
* job instance: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-performance-cluster-density-test/1484385458820485120#1:build-log.txt%3A89
* testgrid: https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-performance-cluster-density-test

Job run with new config: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-performance-cluster-density-test/1484454515934498816