### PR TITLE
sync crio repos with 1.22,1.23 versions

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.20,1.21"
+            value: "1.20,1.21,1.22,1.23"
         command: ["/bin/sh", "-c"]
         args:
           - ./hack/mirror-crio.sh


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

add versions 1.22 and 1.23 to GCP cri-o mirror