### PR TITLE
Fix gcloud rsync by adding explicit sa activation

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -32,9 +32,11 @@ periodics:
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
             value: "1.20,1.21,1.22,1.23"
-        command: ["/bin/sh", "-c"]
+        command: ["/bin/sh", "-ce"]
         args:
-          - ./hack/mirror-crio.sh
+          - |
+            gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
+            ./hack/mirror-crio.sh
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
According to [this article](https://stackoverflow.com/questions/49302859/gsutil-serviceexception-401-anonymous-caller-does-not-have-storage-objects-list#comment105668942_56952730) for certain operations you need to explicitly activate the service account.

Successful job run here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-mirror-crio-repository-weekly/1488099413959118848

Please note that you could further improve the gsutil operation by using the `-m` flag: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-mirror-crio-repository-weekly/1488099413959118848#1:build-log.txt%3A516

/cc @rhrazdil @brianmcarey 