### PR TITLE
overwrite GIT_ASKPASS declaration in script

### DIFF
--- a/github/ci/prow-deploy/hack/deploy.sh
+++ b/github/ci/prow-deploy/hack/deploy.sh
@@ -16,6 +16,7 @@ main(){
 
     # run playbook
     cd ${base_dir}
+    export GIT_ASKPASS=${project_infra_root}/hack/git-askpass.sh
     cat << EOF > inventory
 [local]
 localhost ansible_connection=local


### PR DESCRIPTION
For the post deploy job the general env var declaration for `GIT_ASKPASS` does not work. Overwriting it in the script into an absolute path, so that it still works.