### PR TITLE
Deploy rook on the migration test job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1668,6 +1668,8 @@ presubmits:
           value: Migration
         - name: KUBEVIRT_NUM_NODES
           value: "3"
+        - name: KUBEVIRT_STORAGE
+          value: "rook-ceph-default"
         image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
         name: ""
         resources:


### PR DESCRIPTION
To be able to run all of our migration tests, rook needs to be deployed.