### PR TITLE
Add a GOPROXY fallback if the main proxy rejects us

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -556,7 +556,7 @@ presets:
 # default preset with no labels, settings common to all jobs
 - env:
   - name: GOPROXY
-    value: "https://goproxy.io,direct"
+    value: "https://proxy.golang.org|https://goproxy.io|direct"
 
 managed_webhooks:
   # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.


### PR DESCRIPTION
Add a second proxy and ensure that go will download from the next
specified source in case of any failure.

The old value was `https://proxy.golang.org,direct`, the new value is `https://proxy.golang.org|https://goproxy.io|direct`.

This fixes an issue where the jobs sometimes gets a GOAWAY which leads
to an immediate error, since direct download is only considered if a 404
or a 410 error code is returned.

Note that there is a difference between `,` and `|` separators. If `,` is used, only in the mentioned cases above retries are happening. Details are here: https://go.dev/doc/go1.15#go-command

Signed-off-by: Roman Mohr <rmohr@redhat.com>