### PR TITLE
Add the github credentials preset for a selection of prowjobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -3,6 +3,8 @@ periodics:
   cron: "55 0 * * *"
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
@@ -21,15 +23,10 @@ periodics:
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -37,6 +34,8 @@ periodics:
   cron: "15 1 * * *"
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
@@ -55,15 +54,10 @@ periodics:
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -71,6 +65,8 @@ periodics:
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
@@ -89,15 +85,10 @@ periodics:
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
+        preset-github-credentials: "true"
       cluster: ibm-prow-jobs
       spec:
         containers:
@@ -22,10 +23,3 @@ postsubmits:
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
-            volumeMounts:
-              - name: github-token
-                mountPath: /etc/github
-        volumes:
-          - name: github-token
-            secret:
-              secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -15,13 +15,12 @@ postsubmits:
           base_ref: master
       annotations:
         testgrid-create-test-group: "false"
+      labels:
+        preset-github-credentials: "true"
       decorate: true
       spec:
         containers:
           - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
-            env:
-              - name: GIT_ASKPASS
-                value: /go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
             command: [ "/bin/sh" , "-c" ]
             args:
               - |
@@ -31,15 +30,9 @@ postsubmits:
                 mkdir -p $TARGET_DIR
                 pip3 install ruamel.yaml
                 ../project-infra/hack/git-pr.sh -c "python3 $(pwd)/hack/generate-devstats-repo-sql.py --repo-groups-sql $TARGET_DIR/repo_groups.sql" -p $REPO_DIR -o cncf -r devstats -b update-kubevirt-devstats-repo-sql
-            volumeMounts:
-              - name: token
-                mountPath: /etc/github
             resources:
               requests:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
-        volumes:
-          - name: token
-            secret:
-              secretName: oauth-token
+

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -3,6 +3,8 @@ periodics:
   cron: "0 1 * * *"
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
@@ -22,15 +24,10 @@ periodics:
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -38,6 +35,8 @@ periodics:
   cron: "35 0 * * *"
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
@@ -57,15 +56,10 @@ periodics:
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -73,6 +67,8 @@ periodics:
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
@@ -92,15 +88,10 @@ periodics:
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -91,6 +91,7 @@ postsubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "false"
+      preset-github-credentials: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
@@ -114,13 +115,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token
   - name: push-containerized-data-importer-main
     branches:
     - main
@@ -138,6 +132,7 @@ postsubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "false"
+      preset-github-credentials: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
@@ -161,13 +156,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token
   - name: push-containerized-data-importer-builder
     branches:
     - main
@@ -185,6 +173,7 @@ postsubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
+      preset-github-credentials: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
@@ -207,15 +196,10 @@ postsubmits:
           requests:
             memory: "8Gi"
         volumeMounts:
-        - name: token
-          mountPath: /etc/github
         - name: gcs
           mountPath: /etc/gcs
           readOnly: true
       volumes:
-      - name: token
-        secret:
-          secretName: oauth-token
       - name: gcs
         secret:
           secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -13,6 +13,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-kubevirtci-quay-credential: "true"
+        preset-github-credentials: "true"
       annotations:
         testgrid-create-test-group: "false"
         rehearsal.allowed: "true"
@@ -21,17 +22,12 @@ postsubmits:
         nodeSelector:
           type: bare-metal-external
         volumes:
-          - name: token
-            secret:
-              secretName: oauth-token
           - name: gcs
             secret:
               secretName: gcs
         containers:
           - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
             env:
-              - name: GIT_ASKPASS
-                value: "../project-infra/hack/git-askpass.sh"
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /etc/gcs/service-account.json
             command:
@@ -42,8 +38,6 @@ postsubmits:
                 cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin &&
                 make push REPO=quay.io/kubevirt IMAGE=csi-driver TAG=latest
             volumeMounts:
-              - name: token
-                mountPath: /etc/github
               # docker-in-docker needs privileged mode
               - name: gcs
                 mountPath: /etc/gcs

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -542,7 +542,7 @@ presets:
     preset-github-credentials: "true"
   env:
   - name: GIT_ASKPASS
-    value: ../project-infra/hack/git-askpass.sh
+    value: /go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
   - name: GITHUB_TOKEN
     value: "/etc/github/oauth"
   volumes:


### PR DESCRIPTION
Adding the github credential preset for prowjobs in:
- cluster-network-addons-operator
- community
- containerized-data-importer
- csi-driver

This also includes an update to the GIT_ASKPASS environment variable to use the absolute path.

Issue #1730

Signed-off-by: Brian Carey <bcarey@redhat.com>