### PR TITLE
Add jberkus to our org

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -88,6 +88,7 @@ orgs:
       - itamarh
       - j-griffith
       - jakub-dzon
+      - jberkus
       - jean-edouard
       - jelkosz
       - jhernand


### PR DESCRIPTION
Adding @jberkus to  the kubevirt org. He does incredibly valuable community work for us.

Sponsors according to https://github.com/kubevirt/community/blob/main/membership_policy.md:

Sponsor 1: @rmohr 
Sponsor 2: @fabiand 