### PR TITLE
cnao: Run release only on main and "release-"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -2,6 +2,9 @@ postsubmits:
   kubevirt/cluster-network-addons-operator:
     - name: release-cluster-network-addons-operator
       run_if_changed: "^version/version.go"
+      branches:
+      - ^main$
+      - ^release-.*$
       annotations:
         testgrid-create-test-group: "false"
       decorate: true


### PR DESCRIPTION
The CNAO repo has now a workflow_distpatch to create release PR
manually, those releases PR are branchs at origin and they don't have to
run the release job, the release job is for when those PRs get merged to
"main" or "release-x.y" branches.

Signed-off-by: Quique Llorente <ellorent@redhat.com>