### PR TITLE
Change GIT_ASKPASS env variable back to using the relative path

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -542,7 +542,7 @@ presets:
     preset-github-credentials: "true"
   env:
   - name: GIT_ASKPASS
-    value: /go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
+    value: ../project-infra/hack/git-askpass.sh
   - name: GITHUB_TOKEN
     value: "/etc/github/oauth"
   volumes:


### PR DESCRIPTION
Job failing with file not found error when using /go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh

eg. https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-cluster-patchversion-updater/1489279885993054208

Signed-off-by: Brian Carey <bcarey@redhat.com>