### PR TITLE
Move migration tests to a separate lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1650,7 +1650,93 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
+    optional: true
+    skip_branches:
+      - release-\d+\.\d+
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -c
+            - automation/test.sh
+          env:
+            - name: TARGET
+              value: k8s-1.21-sig-compute
+            - name: KUBEVIRT_NUM_NODES
+              value: "3"
+            - name: KUBEVIRT_STORAGE
+              value: "rook-ceph-default"
+          image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
+          name: ""
+          resources:
+            requests:
+              memory: 29Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
+    optional: true
+    skip_branches:
+      - release-\d+\.\d+
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -c
+            - automation/test.sh
+          env:
+            - name: TARGET
+              value: k8s-1.22-sig-compute
+            - name: KUBEVIRT_NUM_NODES
+              value: "3"
+            - name: KUBEVIRT_STORAGE
+              value: "rook-ceph-default"
+          image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
+          name: ""
+          resources:
+            requests:
+              memory: 29Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1663,9 +1749,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-compute
-        - name: KUBEVIRT_E2E_FOCUS
-          value: Migration
+          value: k8s-1.23-sig-compute
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: KUBEVIRT_STORAGE


### PR DESCRIPTION
Ensure that we have optional 1.21, 1.22 and 1.23 lanes for migrations. Still optional. The KUBEVIRT_E2E_FOCUS is removed. The filtering will be done in https://github.com/kubevirt/kubevirt/pull/7165.

Needed as preparation for: https://github.com/kubevirt/kubevirt/pull/7165.