### PR TITLE
Add preset for github credentials to the remaining prowjobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -90,6 +90,7 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
+      preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
@@ -114,10 +115,3 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -90,6 +90,7 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
+      preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
@@ -114,10 +115,3 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -9,6 +9,7 @@ postsubmits:
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
+        preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
       cluster: ibm-prow-jobs
       spec:
@@ -24,15 +25,8 @@ postsubmits:
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
-            volumeMounts:
-              - name: github-token
-                mountPath: /etc/github
             resources:
               requests:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
-        volumes:
-          - name: github-token
-            secret:
-              secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -43,6 +43,7 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"
+      preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     cluster: ibm-prow-jobs
     spec:
@@ -58,15 +59,8 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: github-token
-          mountPath: /etc/github
         resources:
           requests:
             memory: "1Gi"
           limits:
             memory: "1Gi"
-      volumes:
-      - name: github-token
-        secret:
-          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
@@ -19,14 +19,13 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-github-credentials: "true"
     preset-shared-images: "true"
   cluster: ibm-prow-jobs
   spec:
     containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1
         env:
-          - name: GIT_ASKPASS
-            value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
           - name: GITHUB_USER
             value: kubevirt-bot
           - name: GITHUB_EMAIL
@@ -43,10 +42,3 @@ periodics:
         resources:
           requests:
             memory: "1Gi"
-        volumeMounts:
-          - name: token
-            mountPath: /etc/github
-    volumes:
-      - name: token
-        secret:
-          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
@@ -12,15 +12,13 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
+        preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
       cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
         volumes:
-        - name: token
-          secret:
-            secretName: oauth-token
         - name: gcs
           secret:
             secretName: gcs
@@ -38,9 +36,6 @@ postsubmits:
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
-          volumeMounts:
-          - name: token
-            mountPath: /etc/github
           resources:
             requests:
               memory: "1Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -71,14 +71,12 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-github-credentials: "true"
     cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
       volumes:
-        - name: token
-          secret:
-            secretName: oauth-token
         - name: gcs
           secret:
             secretName: gcs
@@ -92,9 +90,6 @@ presubmits:
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
-          volumeMounts:
-            - name: token
-              mountPath: /etc/github
           resources:
             requests:
               memory: "1Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
@@ -90,6 +90,7 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
+      preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
@@ -114,10 +115,3 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
@@ -7,6 +7,8 @@ postsubmits:
       testgrid-create-test-group: "false"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+    labels:
+      preset-github-credentials: "true"
     decorate: true
     extra_refs:
     - org: kubevirt
@@ -19,8 +21,6 @@ postsubmits:
       containers:
       - image: quay.io/kubevirtci/ruby:v20210628-647402e
         env:
-        - name: GIT_ASKPASS
-          value: ../project-infra/hack/git-askpass.sh
         - name: GIT_AUTHOR_NAME
           value: kubevirt-bot
         - name: GIT_AUTHOR_EMAIL
@@ -46,10 +46,3 @@ postsubmits:
           git add -A
           git commit --signoff -m "Postsubmit site update from $commit"
           git push "https://kubevirt-bot@github.com/kubevirt/kubevirt.github.io.git" HEAD:gh-pages
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -33,6 +33,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
+        preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
       cluster: ibm-prow-jobs
       spec:
@@ -46,10 +47,3 @@ postsubmits:
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
-            volumeMounts:
-              - name: github-token
-                mountPath: /etc/github
-        volumes:
-          - name: github-token
-            secret:
-              secretName: oauth-token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
@@ -5,6 +5,8 @@ postsubmits:
     - ^main$
     annotations:
       testgrid-create-test-group: "false"
+    labels:
+      preset-github-credentials: "true"
     decorate: true
     extra_refs:
     - org: kubevirt
@@ -17,8 +19,6 @@ postsubmits:
       containers:
       - image: docker.io/library/python:3.7
         env:
-        - name: GIT_ASKPASS
-          value: ../project-infra/hack/git-askpass.sh
         - name: GIT_AUTHOR_NAME
           value: kubevirt-bot
         - name: GIT_AUTHOR_EMAIL
@@ -44,10 +44,3 @@ postsubmits:
           git add -A
           git commit --signoff -m "Postsubmit site update from $commit"
           git push "https://kubevirt-bot@github.com/kubevirt/user-guide.git" HEAD:gh-pages
-        volumeMounts:
-        - name: token
-          mountPath: /etc/github
-      volumes:
-      - name: token
-        secret:
-          secretName: oauth-token


### PR DESCRIPTION
Adding the github credentials preset to the prowjobs under:
- hostpath-provisioner-operator
- hostpath-provisioner
- hyperconverged-cluster-operator
- kubectl-virt-plugin
- kubevirt-velero-plugin
- kubevirt.github.io
- macvtap-cni
- user-guide

Issue #1730

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>