### PR TITLE
Reset custom GIT_ASKPASS path in bump-cdi job after overwrite from preset

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -117,7 +117,7 @@ periodics:
     - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
       command: ["/bin/sh", "-c"]
       args:
-      - git-pr.sh -c "./hack/bump-cdi.sh" -r kubevirtci -b bump-cdi -T main -p $(pwd)
+      - GIT_ASKPASS=/usr/local/bin/git-askpass.sh git-pr.sh -c "./hack/bump-cdi.sh" -r kubevirtci -b bump-cdi -T main -p $(pwd)
       resources:
         requests:
           memory: "200Mi"


### PR DESCRIPTION
The [periodic-kubevirtci-bump-cdi job](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-cdi/1491222982280876032) fails as the GIT_ASKPASS set in preset-github-credentials is not present.



The pr-creator container image is built with the GIT_ASKPASS environment variable set to /usr/local/bin/git-askpass.sh and the preset overwrites this.
https://github.com/kubevirt/project-infra/blob/b412c95c1dc971a4c1882f3eac4fa610ac3a1a8e/images/pr-creator/Dockerfile#L27

/cc @dhiller 


Signed-off-by: Brian Carey <bcarey@redhat.com>