### PR TITLE
Remove GITHUB_TOKEN from github preset due to issues in some jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -340,6 +340,8 @@ presubmits:
           env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /etc/gcs/service-account.json
+          - name: GITHUB_TOKEN
+            value: "/etc/github/oauth"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -543,8 +543,6 @@ presets:
   env:
   - name: GIT_ASKPASS
     value: ../project-infra/hack/git-askpass.sh
-  - name: GITHUB_TOKEN
-    value: "/etc/github/oauth"
   volumes:
   - name: github-token
     secret:


### PR DESCRIPTION
Setting the GITHUB_TOKEN env variable as part of the github credentials preset caused issues in some jobs.

Removing GITHUB_TOKEN from the preset and adding it back to the pull-project-infra-prow-deploy-test job definition.

Signed-off-by: Brian Carey <bcarey@redhat.com>