### PR TITLE
Make check-testgrid-config non required until spelling got fixed

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -611,6 +611,8 @@ presubmits:
     - org: kubernetes
       repo: test-infra
       base_ref: master
+    # TODO: make it required again after https://github.com/kubernetes/test-infra/pull/25175 is fixed
+    optional: true
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
@@ -702,4 +704,4 @@ presubmits:
         - --only=nmstate/kubernetes-nmstate
         - --token=/etc/github/oauth
       restartPolicy: Never
-     
+


### PR DESCRIPTION
According to https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-project-infra-check-testgrid-config
we had every presubmit fail for a spelling error totally unrelated to
our site: https://github.com/kubernetes/test-infra/pull/25175

Switching this presubmit to optional for the time being.

/cc @brianmcarey 

Signed-off-by: Daniel Hiller <dhiller@redhat.com>