### PR TITLE
Make 1.20 check-provision jobs optional for kubevirtci

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -177,6 +177,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.20
+    optional: true
     spec:
       containers:
       - command:
@@ -229,6 +230,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.20-cgroupsv2
+    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
In order to prepare for removing the providers with https://github.com/kubevirt/kubevirtci/pull/747
we make those jobs optional.

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @brianmcarey 