### PR TITLE
Make check-testgrid-config job required again

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -613,8 +613,6 @@ presubmits:
     - org: kubernetes
       repo: test-infra
       base_ref: master
-    # TODO: make it required again after https://github.com/kubernetes/test-infra/pull/25175 is fixed
-    optional: true
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414


### PR DESCRIPTION
Fix for the spelling error was merged so moving the check-testgrid-config job back to being required.

Signed-off-by: Brian Carey <bcarey@redhat.com>