### PR TITLE
Add GCS credentials preset to project-infra prowjobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -200,26 +200,17 @@ periodics:
   interval: 24h
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-gcs-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
       - image: quay.io/kubevirtci/indexpagecreator:v20210428-c869d6302-dirty
-        env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
         command:
           - "/app/robots/cmd/indexpagecreator/app.binary"
         args:
           - --dry-run=false
-        volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
-    volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
 
 - name: periodic-kubevirt-mirror-uploader
   cron: "05 7 * * *"
@@ -227,6 +218,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   decoration_config:
@@ -249,9 +241,6 @@ periodics:
       runAsUser: 0
     containers:
       - image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs/service-account.json
         command: ["/bin/sh"]
         args:
           - "-c"
@@ -262,17 +251,9 @@ periodics:
             hack/git-pr.sh -c "bazelisk run //robots/cmd/uploader:uploader -- -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt -L lgtm,approved,release-note-none -T main &&
             hack/git-pr.sh -c "bazelisk run //robots/cmd/uploader:uploader -- -workspace ${PWD}/../containerized-data-importer/WORKSPACE -dry-run=false" -p ../containerized-data-importer -r containerized-data-importer -T main -L lgtm,approved,release-note-none
             hack/git-pr.sh -c "bazelisk run //robots/cmd/uploader:uploader -- -workspace ${PWD}/WORKSPACE -dry-run=false" -p ${PWD} -r project-infra -T main -L lgtm,approved,release-note-none
-        volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: true
         resources:
           requests:
             memory: "200Mi"
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-kubevirtci-cluster-patchversion-updater
   interval: 24h
   max_concurrency: 1
@@ -665,14 +646,13 @@ periodics:
       base_ref: main
       workdir: true
   labels:
+    preset-gcs-credentials: "true"
     preset-shared-images: "true"
   cluster: prow-workloads
   spec:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
         env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           - name: BUCKET_DIR
             value: kubevirtci-istioctl-mirror
           - name: ISTIO_VERSIONS
@@ -683,14 +663,6 @@ periodics:
         resources:
           requests:
             memory: "2Gi"
-        volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: false
-    volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
 
 - name: periodic-project-infra-prow-job-image-bump
   cron: "30 0 * * *"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -338,6 +338,7 @@ postsubmits:
       - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -347,8 +348,6 @@ postsubmits:
         containers:
         - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           - name: DEPLOY_ENVIRONMENT
             value: ibmcloud-production
           command:
@@ -362,9 +361,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -372,9 +368,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-workloads-cluster-deployment
       always_run: false
       run_if_changed: "github/ci/prow-deploy/kustom/overlays/workloads-production/.*|github/ci/prow-deploy/kustom/componenets/.*"
@@ -385,6 +378,7 @@ postsubmits:
       - ^main$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -394,8 +388,6 @@ postsubmits:
         containers:
         - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           - name: DEPLOY_ENVIRONMENT
             value: workloads-production
           command:
@@ -409,9 +401,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -419,9 +408,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-workloads-bootstrap-nodes
       always_run: false
       annotations:
@@ -432,6 +418,7 @@ postsubmits:
       - ^prow-workloads-bootstrap-nodes-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -441,8 +428,6 @@ postsubmits:
         containers:
         - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           - name: DEPLOY_ENVIRONMENT
             value: workloads-production
           command:
@@ -456,9 +441,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -466,9 +448,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-workloads-services-deployment
       always_run: false
       annotations:
@@ -479,6 +458,7 @@ postsubmits:
       - ^prow-workloads-services-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -487,9 +467,6 @@ postsubmits:
           runAsUser: 0
         containers:
         - image: quay.io/kubespray/kubespray:v2.15.0
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
             - "/bin/bash"
             - "-c"
@@ -500,9 +477,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -510,9 +484,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-performance-workloads-bootstrap-nodes
       always_run: false
       annotations:
@@ -523,6 +494,7 @@ postsubmits:
       - ^prow-performance-workloads-bootstrap-nodes-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -531,9 +503,6 @@ postsubmits:
           runAsUser: 0
         containers:
         - image: quay.io/kubespray/kubespray:v2.17.1
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
             - "/bin/bash"
             - "-c"
@@ -544,9 +513,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -554,9 +520,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-performance-workload-cluster-deployment
       always_run: false
       annotations:
@@ -567,6 +530,7 @@ postsubmits:
       - ^prow-performance-workload-cluster-deployment-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -575,9 +539,6 @@ postsubmits:
           runAsUser: 0
         containers:
         - image: quay.io/kubespray/kubespray:v2.17.1
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
             - "/bin/bash"
             - "-c"
@@ -588,9 +549,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -598,9 +556,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-arm-workloads-bootstrap-nodes
       always_run: false
       annotations:
@@ -611,6 +566,7 @@ postsubmits:
       - ^prow-arm-workloads-bootstrap-nodes-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -619,9 +575,6 @@ postsubmits:
           runAsUser: 0
         containers:
         - image: quay.io/kubespray/kubespray:v2.15.0
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
             - "/bin/bash"
             - "-c"
@@ -632,9 +585,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -642,9 +592,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-prow-arm-workloads-cluster-deployment
       always_run: false
       annotations:
@@ -655,6 +602,7 @@ postsubmits:
       - ^prow-arm-workloads-cluster-deployment-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       labels:
         preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
       skip_report: false
       cluster: ibm-prow-jobs
@@ -663,9 +611,6 @@ postsubmits:
           runAsUser: 0
         containers:
         - image: quay.io/kubespray/kubespray:v2.15.0
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
             - "/bin/bash"
             - "-c"
@@ -676,9 +621,6 @@ postsubmits:
             limits:
               memory: "8Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: pgp-bot-key
             mountPath: /etc/pgp
             readOnly: true
@@ -686,9 +628,6 @@ postsubmits:
         - name: pgp-bot-key
           secret:
             secretName: pgp-bot-key
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: post-project-infra-cert-manager-deployment
       always_run: false
       annotations:
@@ -980,14 +919,13 @@ postsubmits:
       - main
       annotations:
         testgrid-create-test-group: "false"
+      labels:
+        preset-gcs-credentials: "true"
       decorate: true
       cluster: ibm-prow-jobs
       spec:
         containers:
         - image: gcr.io/k8s-prow/configurator:v20210526-1d9416cb76
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
           - /app/testgrid/cmd/configurator/app.binary
           args:
@@ -1001,13 +939,6 @@ postsubmits:
           resources:
             requests:
               memory: "1Gi"
-          volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-        volumes:
-        - name: gcs
-          secret:
-            secretName: gcs
     - name: publish-ci-usage-exporter-image
       always_run: false
       run_if_changed: "robots/.*/ci-usage-exporter/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -329,6 +329,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
     cluster: prow-workloads
     spec:
       nodeSelector:
@@ -338,8 +339,6 @@ presubmits:
       containers:
         - image: quay.io/kubevirtci/prow-deploy:v20210924-4c47964
           env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           - name: GITHUB_TOKEN
             value: "/etc/github/oauth"
           command:
@@ -356,9 +355,6 @@ presubmits:
             limits:
               memory: "29Gi"
           volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: true
           - name: molecule-docker
             mountPath: /tmp/prow-deploy-molecule
           - name: pgp-bot-key
@@ -367,9 +363,6 @@ presubmits:
           - name: unprivileged-token
             mountPath: /etc/github
       volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
       - name: molecule-docker
         emptyDir: {}
       - name: pgp-bot-key

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -551,6 +551,20 @@ presets:
   volumeMounts:
     - name: github-token
       mountPath: /etc/github
+- labels:
+    preset-gcs-credentials: "true"
+  env:
+  - name: GOOGLE_APPLICATION_CREDENTIALS
+    value: /etc/gcs/service-account.json
+  volumes:
+  - name: gcs
+    secret:
+      secretName: gcs
+      defaultMode: 0400
+  volumeMounts:
+  - name: gcs
+    mountPath: /etc/gcs
+    readOnly: true
 # default preset with no labels, settings common to all jobs
 - env:
   - name: GOPROXY


### PR DESCRIPTION
Reduce some duplication by adding a preset for the GCS credentials used by the prowjobs.

Issue: #1899

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>