### PR TITLE
Sync version Istioctl version 1.13

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -676,7 +676,7 @@ periodics:
           - name: BUCKET_DIR
             value: kubevirtci-istioctl-mirror
           - name: ISTIO_VERSIONS
-            value: "1.10.0,1.10.1"
+            value: "1.10.0,1.13.0"
         command: ["/bin/sh", "-c"]
         args:
           - ./hack/mirror-istioctl.sh


### PR DESCRIPTION
Substitute 1.10.1 with 1.13, as we're not using 1.10.1 anywhere anyway.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>