### PR TITLE
Add preset for GCS credentials to subset of prowjobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -4,15 +4,13 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -22,28 +20,18 @@ periodics:
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-publish-cnao-flakefinder-daily-report
   cron: "15 1 * * *"
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -53,28 +41,18 @@ periodics:
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-publish-cnao-flakefinder-four-weekly-report
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -84,11 +62,3 @@ periodics:
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -4,15 +4,13 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -23,28 +21,18 @@ periodics:
       - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-publish-cdi-flakefinder-daily-report
   cron: "35 0 * * *"
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -55,28 +43,18 @@ periodics:
       - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-publish-cdi-flakefinder-four-weekly-report
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
   cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -87,14 +65,6 @@ periodics:
       - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-containerized-data-importer-push-nightly-ARM64
   cron: "2 3 * * *"
   decorate: true
@@ -107,6 +77,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
   extra_refs:
     - org: kubevirt
@@ -120,8 +91,6 @@ periodics:
     containers:
     - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       - name: BUILD_ARCH
@@ -138,11 +107,3 @@ periodics:
       resources:
         requests:
           memory: "8Gi"
-      volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: false
-    volumes:
-      - name: gcs
-        secret:
-          secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -172,14 +172,13 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-quay-credential: "true"
+      preset-gcs-credentials: "true"
       preset-github-credentials: "true"
+      preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
         env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs/service-account.json
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
         command:
@@ -195,11 +194,3 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: true
-      volumes:
-      - name: gcs
-        secret:
-          secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -12,8 +12,9 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
-        preset-kubevirtci-quay-credential: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
+        preset-kubevirtci-quay-credential: "true"
       annotations:
         testgrid-create-test-group: "false"
         rehearsal.allowed: "true"
@@ -21,15 +22,8 @@ postsubmits:
       spec:
         nodeSelector:
           type: bare-metal-external
-        volumes:
-          - name: gcs
-            secret:
-              secretName: gcs
         containers:
           - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /etc/gcs/service-account.json
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -37,11 +31,6 @@ postsubmits:
               - >
                 cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin &&
                 make push REPO=quay.io/kubevirt IMAGE=csi-driver TAG=latest
-            volumeMounts:
-              # docker-in-docker needs privileged mode
-              - name: gcs
-                mountPath: /etc/gcs
-                readOnly: false
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -11,6 +11,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-shared-images: "true"
     preset-kubevirtci-quay-credential: "true"
     rehearsal.allowed: "true"
@@ -25,9 +26,6 @@ periodics:
       type: bare-metal-external
     containers:
     - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"
@@ -39,11 +37,3 @@ periodics:
       resources:
         requests:
           memory: "8Gi"
-      volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: false
-    volumes:
-      - name: gcs
-        secret:
-          secretName: gcs


### PR DESCRIPTION
The preset was added to all relevant prowjobs in the following
components:
- cluster-network-addons-operator
- containerized-data-importer
- csi-driver
- hyperconverged-cluster-operator

The preset helps to reduce some duplication in prowjob definitions

Issue: #1899

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>