### PR TITLE
Make Brian an owner of the kubevirt org

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -1,12 +1,12 @@
 orgs:
   kubevirt:
     admins:
+      - brianmcarey
       - caniszczyk
       - codificat
       - davidvossel
       - dhiller
       - fabiand
-      - fgimenez
       - kubevirt-bot
       - rmohr
       - stoniko
@@ -41,7 +41,6 @@ orgs:
       - beekhof
       - booxter
       - borod108
-      - brianmcarey
       - brybacki
       - crobinso
       - cwilkers
@@ -64,6 +63,7 @@ orgs:
       - ezrasilvera
       - fabiendupont
       - fedepaol
+      - fgimenez
       - fossedihelm
       - fromanirh
       - gabrielecerami


### PR DESCRIPTION
Since Brian is part of the CI team, he needs access to things like
webhook configurations.

Furter make Federico a normal member since he left the CI team.