### PR TITLE
Make kind-1.23-vgpu lane run always

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -849,7 +849,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -864,6 +864,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-kind-1.23-vgpu
+    optional: true
     skip_branches:
       - release-\d+\.\d+
     skip_report: true


### PR DESCRIPTION
In order to collect stability data of the lane, make it always run and optional

1.23 lane jobs can be viewed here:
[https://prow.ci.kubevirt.io/?repo=kubevirt%2Fkubevirt&job=*-kind-1.23-vgpu](https://prow.ci.kubevirt.io/?repo=kubevirt%2Fkubevirt&job=*-kind-1.23-vgpu)

/cc @dhiller 