### PR TITLE
knmstate: Call publish only on main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -3,6 +3,7 @@ postsubmits:
     - name: publish-kubernetes-nmstate
       skip_branches:
         - gh-pages
+        - release*
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
@@ -18,7 +19,6 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - main
-        - release*
       cluster: ibm-prow-jobs
       spec:
         containers:


### PR DESCRIPTION
The publish job push to quay.io latest but latest has to point only to code at
main branch. This change disable publish at release branches.

Signed-off-by: Quique Llorente <ellorent@redhat.com>