### PR TITLE
Add preset for GCS credentials to remaining prowjobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
@@ -18,10 +18,6 @@ postsubmits:
       spec:
         nodeSelector:
           type: bare-metal-external
-        volumes:
-        - name: gcs
-          secret:
-            secretName: gcs
         containers:
         - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
           command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -76,10 +76,6 @@ presubmits:
     spec:
       nodeSelector:
         type: bare-metal-external
-      volumes:
-        - name: gcs
-          secret:
-            secretName: gcs
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
           command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -5,6 +5,7 @@ periodics:
   cron: 5 * * * *
   decorate: true
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
@@ -19,26 +20,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       name: ""
       resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
   cron: 45 0 * * *
   decorate: true
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
@@ -53,26 +44,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       name: ""
       resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
   cron: 25 0 * * *
   decorate: true
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
@@ -87,20 +68,9 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       name: ""
       resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
@@ -110,6 +80,7 @@ periodics:
     timeout: 4h0m0s
   interval: 168h
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
@@ -124,20 +95,9 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       name: ""
       resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-alert-email: bodnopoz@redhat.com, kubevirtci-sysprep-test@googlegroups.com
     testgrid-alert-stale-results-hours: "1"
@@ -392,6 +352,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
@@ -442,8 +403,6 @@ periodics:
         export GIT_ASKPASS=$PWD/../project-infra/hack/git-askpass.sh
         hack/publish-staging.sh
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       image: quay.io/kubevirtci/golang:v20220110-c066ff5
@@ -453,15 +412,8 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
@@ -477,6 +429,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
   max_concurrency: 1
@@ -522,8 +475,6 @@ periodics:
         gsutil cp ./_out/commit gs://$bucket_dir/commit-arm64
         gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       - name: BUILD_ARCH
@@ -535,15 +486,8 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
@@ -554,6 +498,7 @@ periodics:
     timeout: 1h0m0s
   labels:
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-shared-images: "true"
   max_concurrency: 1
   name: periodic-kubevirt-clean-nightly-build
@@ -572,21 +517,11 @@ periodics:
             gsutil -m rm -r ${nightly_build_dir};
           fi;
         done
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
       name: ""
       resources:
         requests:
           memory: 200Mi
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
@@ -725,6 +660,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   max_concurrency: 1
   name: bump-kubevirt-rpms-weekly
@@ -735,9 +671,6 @@ periodics:
       - -c
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main -R
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
       name: ""
       resources:
@@ -745,13 +678,6 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -17,6 +17,7 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
@@ -27,8 +28,6 @@ postsubmits:
           value: quay.io/kubevirt
         - name: GH_CLI_VERSION
           value: "1.5.0"
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs/service-account.json
         - name: GITHUB_TOKEN_PATH
           value: /etc/github/oauth
         - name: GITHUB_REPOSITORY
@@ -50,14 +49,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: true
-      volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
   - name: push-update-testing-manifests-on-kubevirt-tag
     branches:
     - ^v0\.3[46]\.[0-9]+$
@@ -72,12 +63,10 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
-        env:
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs/service-account.json
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
         - |
@@ -96,14 +85,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: true
-      volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
   - name: push-kubevirt-main
     branches:
     - main
@@ -120,6 +101,7 @@ postsubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
@@ -128,8 +110,6 @@ postsubmits:
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /etc/gcs/service-account.json
         - name: GIT_USER_NAME
           value: kubevirt-bot
         - name: GITHUB_TOKEN_PATH
@@ -143,14 +123,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-        volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: true
-      volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
   - name: push-kubevirt-goveralls
     cluster: ibm-prow-jobs
     branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -14,14 +14,13 @@ periodics:
       base_ref: main
       workdir: true
   labels:
+    preset-gcs-credentials: "true"
     preset-shared-images: "true"
   cluster: prow-workloads
   spec:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
         env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           - name: OS
             value: CentOS_8_Stream
           - name: BUCKET_DIR
@@ -40,14 +39,6 @@ periodics:
         resources:
           requests:
             memory: "2Gi"
-        volumeMounts:
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: false
-    volumes:
-      - name: gcs
-        secret:
-          secretName: gcs
 - name: periodic-kubevirtci-bump-kubevirt
   cron: "0 */12 * * *"
   annotations:
@@ -66,18 +57,12 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   cluster: prow-workloads
   spec:
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
     containers:
     - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command: ["/bin/sh", "-c"]
       args:
       - |
@@ -85,11 +70,6 @@ periodics:
         if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
           git-pr.sh -c "cd ../kubevirt && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../kubevirt -T main
         fi
-      volumeMounts:
-      # docker-in-docker needs privileged mode
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: false
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -17,21 +17,15 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
-        preset-kubevirtci-quay-credential: "true"
+        preset-gcs-credentials: "true"
         preset-github-credentials: "true"
+        preset-kubevirtci-quay-credential: "true"
       cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
-        volumes:
-        - name: gcs
-          secret:
-            secretName: gcs
         containers:
         - image: quay.io/kubevirtci/golang:v20220110-c066ff5
-          env:
-          - name: GOOGLE_APPLICATION_CREDENTIALS
-            value: /etc/gcs/service-account.json
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"
@@ -41,11 +35,7 @@ postsubmits:
             ./publish.sh &&
             echo "$(git tag --points-at HEAD | head -1)" > latest &&
             gsutil cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest
-          volumeMounts:
           # docker-in-docker needs privileged mode
-          - name: gcs
-            mountPath: /etc/gcs
-            readOnly: false
           securityContext:
             privileged: true
           resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -16,6 +16,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-gcs-credentials: "true"
   extra_refs:
    - org: kubevirt
      repo: libguestfs-appliance
@@ -25,9 +26,6 @@ periodics:
   spec:
     containers:
     - image: quay.io/kubevirtci/bootstrap:v20220110-c066ff5
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -45,11 +43,3 @@ periodics:
       resources:
         requests:
           memory: "2Gi"
-      volumeMounts:
-        - name: gcs
-          mountPath: /etc/gcs
-          readOnly: false
-    volumes:
-      - name: gcs
-        secret:
-          secretName: gcs


### PR DESCRIPTION
The preset is added to the prowjobs under:
- kubevirt
- kubevirtci
- libguestfs-appliance

This preset allows for a reduction in duplication in the prowjob
definitions

Unused gcs volumes are also removed from the prowjobs in
kubectl-virt-plugin

Fixes https://github.com/kubevirt/project-infra/issues/1899

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>