### PR TITLE
Use golang image for postsubmit job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -53,7 +53,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220110-4643253
+      - image: quay.io/kubevirtci/golang:v20220110-4643253
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
A [nmo postsubmit failed due to missing go](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/push-tagged-node-maintenance-operator). This PR changes the job definition to use the golang image (which is based on our bootstrap image)

/cc @slintes