### PR TITLE
Increase resource requests and limits for the Loki service

### DIFF
--- a/github/ci/services/loki/manifests/common/loki.yaml
+++ b/github/ci/services/loki/manifests/common/loki.yaml
@@ -210,11 +210,11 @@ spec:
             initialDelaySeconds: 45
           resources:
             limits:
-              cpu: 200m
-              memory: 256Mi
+              cpu: 700m
+              memory: 3Gi
             requests:
-              cpu: 100m
-              memory: 128Mi
+              cpu: 500m
+              memory: 2Gi
           securityContext:
             readOnlyRootFilesystem: true
           env:


### PR DESCRIPTION
The default resource limits were too small for a large cluster which
causes the loki pod to restart

Increasing the resource limits to match what is used for prometheus

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>