### PR TITLE
qe-tools: Update to go 1.16

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
@@ -16,3 +16,6 @@ presubmits:
         resources:
           requests:
             memory: "500Mi"
+        env:
+          - name: GIMME_GO_VERSION
+            value: "1.16"


### PR DESCRIPTION
In order to use gingko 2.0 on qe-tools
we need go 1.16
