### PR TITLE
[kubevirt-presubmits]: update the sig-monitoring job configuration

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2042,11 +2042,9 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
-    optional: true
     run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
remove the optional flag so the lane will always run upon
monitoring code change. Also make the report visible since
not all the contributors are familiar with the Prow dashboard.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>