### PR TITLE
Add new secret to allow prow pods to start

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20211118-4107081ce0"
-        initupload: "gcr.io/k8s-prow/initupload:v20211118-4107081ce0"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20211118-4107081ce0"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20211118-4107081ce0"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220303-21d4df3f17"
+        initupload: "gcr.io/k8s-prow/initupload:v20220303-21d4df3f17"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220303-21d4df3f17"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220303-21d4df3f17"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20211118-4107081ce0
+              image: gcr.io/k8s-prow/branchprotector:v20220303-21d4df3f17
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/cherrypicker:v20220303-21d4df3f17
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20211118-4107081ce0
+              image: gcr.io/k8s-prow/label_sync:v20220303-21d4df3f17
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20211118-4107081ce0
+              image: gcr.io/k8s-prow/label_sync:v20220303-21d4df3f17
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/crier:v20220303-21d4df3f17
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
@@ -48,13 +48,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-test-infra-trusted
+          name: kubeconfig-build-test-infra-trusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -85,3 +88,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: kubeconfig-build-test-infra-trusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-test-infra-trusted

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/deck:v20220303-21d4df3f17
         imagePullPolicy: Always
         ports:
         - name: http
@@ -63,7 +63,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/githuboauth
@@ -73,6 +73,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-test-infra-trusted
+          name: kubeconfig-build-test-infra-trusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -113,6 +116,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: kubeconfig-build-test-infra-trusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-test-infra-trusted
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/ghproxy:v20220303-21d4df3f17
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/hook:v20220303-21d4df3f17
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -51,7 +51,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
         ports:
         - name: http
           containerPort: 8888
@@ -83,6 +83,9 @@ spec:
           readOnly: true
         - name: kubeconfig
           mountPath: /etc/kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-test-infra-trusted
+          name: kubeconfig-build-test-infra-trusted
           readOnly: true
         livenessProbe:
           httpGet:
@@ -126,3 +129,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: kubeconfig-build-test-infra-trusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-test-infra-trusted

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/horologium:v20220303-21d4df3f17
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/needs-rebase:v20220303-21d4df3f17
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220303-21d4df3f17
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -48,13 +48,16 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-test-infra-trusted
+          name: kubeconfig-build-test-infra-trusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -79,6 +82,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: kubeconfig-build-test-infra-trusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-test-infra-trusted
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -8,6 +8,7 @@ metadata:
   creationTimestamp: null
   name: prowjobs.prow.k8s.io
 spec:
+  preserveUnknownFields: false
   group: prow.k8s.io
   names:
     kind: ProwJob
@@ -1297,12 +1298,14 @@ spec:
                                           is not provided. Variable references $(VAR_NAME)
                                           are expanded using the container''s environment.
                                           If a variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -1313,12 +1316,14 @@ spec:
                                           references $(VAR_NAME) are expanded using
                                           the container''s environment. If a variable
                                           cannot be resolved, the reference in the
-                                          input string will be unchanged. The $(VAR_NAME)
-                                          syntax can be escaped with a double $$,
-                                          ie: $$(VAR_NAME). Escaped references will
-                                          never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          input string will be unchanged. Double $$
+                                          are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -1335,17 +1340,19 @@ spec:
                                               type: string
                                             value:
                                               description: 'Variable references $(VAR_NAME)
-                                                are expanded using the previous defined
-                                                environment variables in the container
-                                                and any service environment variables.
-                                                If a variable cannot be resolved,
-                                                the reference in the input string
-                                                will be unchanged. The $(VAR_NAME)
-                                                syntax can be escaped with a double
-                                                $$, ie: $$(VAR_NAME). Escaped references
-                                                will never be expanded, regardless
-                                                of whether the variable exists or
-                                                not. Defaults to "".'
+                                                are expanded using the previously
+                                                defined environment variables in the
+                                                container and any service environment
+                                                variables. If a variable cannot be
+                                                resolved, the reference in the input
+                                                string will be unchanged. Double $$
+                                                are reduced to a single $, which allows
+                                                for escaping the $(VAR_NAME) syntax:
+                                                i.e. "$$(VAR_NAME)" will produce the
+                                                string literal "$(VAR_NAME)". Escaped
+                                                references will never be expanded,
+                                                regardless of whether the variable
+                                                exists or not. Defaults to "".'
                                               type: string
                                             valueFrom:
                                               description: Source for the environment
@@ -1904,9 +1911,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -2125,9 +2133,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -2176,8 +2185,10 @@ spec:
                                           or Args."
                                         type: string
                                       securityContext:
-                                        description: 'Security options the pod should
-                                          run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        description: 'SecurityContext defines the
+                                          security options the container should be
+                                          run with. If set, the fields of SecurityContext
+                                          override the equivalent fields of PodSecurityContext.
                                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                         properties:
                                           allowPrivilegeEscalation:
@@ -2342,6 +2353,24 @@ spec:
                                                   is the name of the GMSA credential
                                                   spec to use.
                                                 type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
                                               runAsUserName:
                                                 description: The UserName in Windows
                                                   to run the entrypoint of the container
@@ -2508,9 +2537,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -2666,12 +2696,14 @@ spec:
                                         provided. Variable references $(VAR_NAME)
                                         are expanded using the container''s environment.
                                         If a variable cannot be resolved, the reference
-                                        in the input string will be unchanged. The
-                                        $(VAR_NAME) syntax can be escaped with a double
-                                        $$, ie: $$(VAR_NAME). Escaped references will
-                                        never be expanded, regardless of whether the
-                                        variable exists or not. Cannot be updated.
-                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        in the input string will be unchanged. Double
+                                        $$ are reduced to a single $, which allows
+                                        for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal
+                                        "$(VAR_NAME)". Escaped references will never
+                                        be expanded, regardless of whether the variable
+                                        exists or not. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                       items:
                                         type: string
                                       type: array
@@ -2682,12 +2714,13 @@ spec:
                                         references $(VAR_NAME) are expanded using
                                         the container''s environment. If a variable
                                         cannot be resolved, the reference in the input
-                                        string will be unchanged. The $(VAR_NAME)
-                                        syntax can be escaped with a double $$, ie:
-                                        $$(VAR_NAME). Escaped references will never
-                                        be expanded, regardless of whether the variable
-                                        exists or not. Cannot be updated. More info:
-                                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                        string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the
+                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded,
+                                        regardless of whether the variable exists
+                                        or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                       items:
                                         type: string
                                       type: array
@@ -2704,13 +2737,15 @@ spec:
                                             type: string
                                           value:
                                             description: 'Variable references $(VAR_NAME)
-                                              are expanded using the previous defined
+                                              are expanded using the previously defined
                                               environment variables in the container
                                               and any service environment variables.
                                               If a variable cannot be resolved, the
                                               reference in the input string will be
-                                              unchanged. The $(VAR_NAME) syntax can
-                                              be escaped with a double $$, ie: $$(VAR_NAME).
+                                              unchanged. Double $$ are reduced to
+                                              a single $, which allows for escaping
+                                              the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                              will produce the string literal "$(VAR_NAME)".
                                               Escaped references will never be expanded,
                                               regardless of whether the variable exists
                                               or not. Defaults to "".'
@@ -3252,8 +3287,10 @@ spec:
                                             must be non-negative integer. The value
                                             zero indicates stop immediately via the
                                             kill signal (no opportunity to shut down).
-                                            This is an alpha field and requires enabling
+                                            This is a beta field and requires enabling
                                             ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
@@ -3467,8 +3504,10 @@ spec:
                                             must be non-negative integer. The value
                                             zero indicates stop immediately via the
                                             kill signal (no opportunity to shut down).
-                                            This is an alpha field and requires enabling
+                                            This is a beta field and requires enabling
                                             ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
@@ -3510,8 +3549,10 @@ spec:
                                           type: object
                                       type: object
                                     securityContext:
-                                      description: 'Security options the pod should
-                                        run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                      description: 'SecurityContext defines the security
+                                        options the container should be run with.
+                                        If set, the fields of SecurityContext override
+                                        the equivalent fields of PodSecurityContext.
                                         More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                       properties:
                                         allowPrivilegeEscalation:
@@ -3673,6 +3714,22 @@ spec:
                                                 is the name of the GMSA credential
                                                 spec to use.
                                               type: string
+                                            hostProcess:
+                                              description: HostProcess determines
+                                                if a container should be run as a
+                                                'Host Process' container. This field
+                                                is alpha-level and will only be honored
+                                                by components that enable the WindowsHostProcessContainers
+                                                feature flag. Setting this field without
+                                                the feature flag will result in errors
+                                                when validating the Pod. All of a
+                                                Pod's containers must have the same
+                                                effective HostProcess value (it is
+                                                not allowed to have a mix of HostProcess
+                                                containers and non-HostProcess containers).  In
+                                                addition, if HostProcess is true then
+                                                HostNetwork must also be set to true.
+                                              type: boolean
                                             runAsUserName:
                                               description: The UserName in Windows
                                                 to run the entrypoint of the container
@@ -3836,8 +3893,10 @@ spec:
                                             must be non-negative integer. The value
                                             zero indicates stop immediately via the
                                             kill signal (no opportunity to shut down).
-                                            This is an alpha field and requires enabling
+                                            This is a beta field and requires enabling
                                             ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds
+                                            is used if unset.
                                           format: int64
                                           type: integer
                                         timeoutSeconds:
@@ -3992,12 +4051,14 @@ spec:
                                           is not provided. Variable references $(VAR_NAME)
                                           are expanded using the container''s environment.
                                           If a variable cannot be resolved, the reference
-                                          in the input string will be unchanged. The
-                                          $(VAR_NAME) syntax can be escaped with a
-                                          double $$, ie: $$(VAR_NAME). Escaped references
-                                          will never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          in the input string will be unchanged. Double
+                                          $$ are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -4008,12 +4069,14 @@ spec:
                                           references $(VAR_NAME) are expanded using
                                           the container''s environment. If a variable
                                           cannot be resolved, the reference in the
-                                          input string will be unchanged. The $(VAR_NAME)
-                                          syntax can be escaped with a double $$,
-                                          ie: $$(VAR_NAME). Escaped references will
-                                          never be expanded, regardless of whether
-                                          the variable exists or not. Cannot be updated.
-                                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                          input string will be unchanged. Double $$
+                                          are reduced to a single $, which allows
+                                          for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal
+                                          "$(VAR_NAME)". Escaped references will never
+                                          be expanded, regardless of whether the variable
+                                          exists or not. Cannot be updated. More info:
+                                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                         items:
                                           type: string
                                         type: array
@@ -4030,17 +4093,19 @@ spec:
                                               type: string
                                             value:
                                               description: 'Variable references $(VAR_NAME)
-                                                are expanded using the previous defined
-                                                environment variables in the container
-                                                and any service environment variables.
-                                                If a variable cannot be resolved,
-                                                the reference in the input string
-                                                will be unchanged. The $(VAR_NAME)
-                                                syntax can be escaped with a double
-                                                $$, ie: $$(VAR_NAME). Escaped references
-                                                will never be expanded, regardless
-                                                of whether the variable exists or
-                                                not. Defaults to "".'
+                                                are expanded using the previously
+                                                defined environment variables in the
+                                                container and any service environment
+                                                variables. If a variable cannot be
+                                                resolved, the reference in the input
+                                                string will be unchanged. Double $$
+                                                are reduced to a single $, which allows
+                                                for escaping the $(VAR_NAME) syntax:
+                                                i.e. "$$(VAR_NAME)" will produce the
+                                                string literal "$(VAR_NAME)". Escaped
+                                                references will never be expanded,
+                                                regardless of whether the variable
+                                                exists or not. Defaults to "".'
                                               type: string
                                             valueFrom:
                                               description: Source for the environment
@@ -4599,9 +4664,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -4820,9 +4886,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -4871,8 +4938,10 @@ spec:
                                           or Args."
                                         type: string
                                       securityContext:
-                                        description: 'Security options the pod should
-                                          run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                                        description: 'SecurityContext defines the
+                                          security options the container should be
+                                          run with. If set, the fields of SecurityContext
+                                          override the equivalent fields of PodSecurityContext.
                                           More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                         properties:
                                           allowPrivilegeEscalation:
@@ -5037,6 +5106,24 @@ spec:
                                                   is the name of the GMSA credential
                                                   spec to use.
                                                 type: string
+                                              hostProcess:
+                                                description: HostProcess determines
+                                                  if a container should be run as
+                                                  a 'Host Process' container. This
+                                                  field is alpha-level and will only
+                                                  be honored by components that enable
+                                                  the WindowsHostProcessContainers
+                                                  feature flag. Setting this field
+                                                  without the feature flag will result
+                                                  in errors when validating the Pod.
+                                                  All of a Pod's containers must have
+                                                  the same effective HostProcess value
+                                                  (it is not allowed to have a mix
+                                                  of HostProcess containers and non-HostProcess
+                                                  containers).  In addition, if HostProcess
+                                                  is true then HostNetwork must also
+                                                  be set to true.
+                                                type: boolean
                                               runAsUserName:
                                                 description: The UserName in Windows
                                                   to run the entrypoint of the container
@@ -5203,9 +5290,10 @@ spec:
                                               Value must be non-negative integer.
                                               The value zero indicates stop immediately
                                               via the kill signal (no opportunity
-                                              to shut down). This is an alpha field
+                                              to shut down). This is a beta field
                                               and requires enabling ProbeTerminationGracePeriod
-                                              feature gate.
+                                              feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                              is used if unset.
                                             format: int64
                                             type: integer
                                           timeoutSeconds:
@@ -5905,17 +5993,76 @@ spec:
                                                       existing VolumeSnapshot object
                                                       (snapshot.storage.k8s.io/VolumeSnapshot)
                                                       * An existing PVC (PersistentVolumeClaim)
-                                                      * An existing custom resource
-                                                      that implements data population
-                                                      (Alpha) In order to use custom
-                                                      resource types that implement
-                                                      data population, the AnyVolumeDataSource
-                                                      feature gate must be enabled.
                                                       If the provisioner or an external
                                                       controller can support the specified
                                                       data source, it will create
                                                       a new volume based on the contents
-                                                      of the specified data source.'
+                                                      of the specified data source.
+                                                      If the AnyVolumeDataSource feature
+                                                      gate is enabled, this field
+                                                      will always have the same contents
+                                                      as the DataSourceRef field.'
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the
+                                                          group for the resource being
+                                                          referenced. If APIGroup
+                                                          is not specified, the specified
+                                                          Kind must be in the core
+                                                          API group. For any other
+                                                          third-party types, APIGroup
+                                                          is required.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type
+                                                          of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name
+                                                          of resource being referenced
+                                                        type: string
+                                                    required:
+                                                    - kind
+                                                    - name
+                                                    type: object
+                                                  dataSourceRef:
+                                                    description: 'Specifies the object
+                                                      from which to populate the volume
+                                                      with data, if a non-empty volume
+                                                      is desired. This may be any
+                                                      local object from a non-empty
+                                                      API group (non core object)
+                                                      or a PersistentVolumeClaim object.
+                                                      When this field is specified,
+                                                      volume binding will only succeed
+                                                      if the type of the specified
+                                                      object matches some installed
+                                                      volume populator or dynamic
+                                                      provisioner. This field will
+                                                      replace the functionality of
+                                                      the DataSource field and as
+                                                      such if both fields are non-empty,
+                                                      they must have the same value.
+                                                      For backwards compatibility,
+                                                      both fields (DataSource and
+                                                      DataSourceRef) will be set to
+                                                      the same value automatically
+                                                      if one of them is empty and
+                                                      the other is non-empty. There
+                                                      are two important differences
+                                                      between DataSource and DataSourceRef:
+                                                      * While DataSource only allows
+                                                      two specific types of objects,
+                                                      DataSourceRef   allows any non-core
+                                                      object, as well as PersistentVolumeClaim
+                                                      objects. * While DataSource
+                                                      ignores disallowed values (dropping
+                                                      them), DataSourceRef   preserves
+                                                      all values, and generates an
+                                                      error if a disallowed value
+                                                      is   specified. (Alpha) Using
+                                                      this field requires the AnyVolumeDataSource
+                                                      feature gate to be enabled.'
                                                     properties:
                                                       apiGroup:
                                                         description: APIGroup is the
@@ -7520,9 +7667,9 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is alpha-level and is only
-                                            honored when PodAffinityNamespaceSelector
-                                            feature is enabled.
+                                            This field is beta-level and is only honored
+                                            when PodAffinityNamespaceSelector feature
+                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -7692,7 +7839,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -7861,9 +8008,9 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is alpha-level and is only
-                                            honored when PodAffinityNamespaceSelector
-                                            feature is enabled.
+                                            This field is beta-level and is only honored
+                                            when PodAffinityNamespaceSelector feature
+                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -8033,7 +8180,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -8362,6 +8509,19 @@ spec:
                                 description: GMSACredentialSpecName is the name of
                                   the GMSA credential spec to use.
                                 type: string
+                              hostProcess:
+                                description: HostProcess determines if a container
+                                  should be run as a 'Host Process' container. This
+                                  field is alpha-level and will only be honored by
+                                  components that enable the WindowsHostProcessContainers
+                                  feature flag. Setting this field without the feature
+                                  flag will result in errors when validating the Pod.
+                                  All of a Pod's containers must have the same effective
+                                  HostProcess value (it is not allowed to have a mix
+                                  of HostProcess containers and non-HostProcess containers).  In
+                                  addition, if HostProcess is true then HostNetwork
+                                  must also be set to true.
+                                type: boolean
                               runAsUserName:
                                 description: The UserName in Windows to run the entrypoint
                                   of the container process. Defaults to the user specified
@@ -8898,15 +9058,64 @@ spec:
                                             specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
-                                            * An existing custom resource that implements
-                                            data population (Alpha) In order to use
-                                            custom resource types that implement data
-                                            population, the AnyVolumeDataSource feature
-                                            gate must be enabled. If the provisioner
-                                            or an external controller can support
-                                            the specified data source, it will create
-                                            a new volume based on the contents of
-                                            the specified data source.'
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        dataSourceRef:
+                                          description: 'Specifies the object from
+                                            which to populate the volume with data,
+                                            if a non-empty volume is desired. This
+                                            may be any local object from a non-empty
+                                            API group (non core object) or a PersistentVolumeClaim
+                                            object. When this field is specified,
+                                            volume binding will only succeed if the
+                                            type of the specified object matches some
+                                            installed volume populator or dynamic
+                                            provisioner. This field will replace the
+                                            functionality of the DataSource field
+                                            and as such if both fields are non-empty,
+                                            they must have the same value. For backwards
+                                            compatibility, both fields (DataSource
+                                            and DataSourceRef) will be set to the
+                                            same value automatically if one of them
+                                            is empty and the other is non-empty. There
+                                            are two important differences between
+                                            DataSource and DataSourceRef: * While
+                                            DataSource only allows two specific types
+                                            of objects, DataSourceRef   allows any
+                                            non-core object, as well as PersistentVolumeClaim
+                                            objects. * While DataSource ignores disallowed
+                                            values (dropping them), DataSourceRef   preserves
+                                            all values, and generates an error if
+                                            a disallowed value is   specified. (Alpha)
+                                            Using this field requires the AnyVolumeDataSource
+                                            feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for
@@ -10408,7 +10617,7 @@ spec:
                                                   and null or empty namespaces list
                                                   means "this pod's namespace". An
                                                   empty selector ({}) matches all
-                                                  namespaces. This field is alpha-level
+                                                  namespaces. This field is beta-level
                                                   and is only honored when PodAffinityNamespaceSelector
                                                   feature is enabled.
                                                 properties:
@@ -10597,7 +10806,7 @@ spec:
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
+                                              This field is beta-level and is only
                                               honored when PodAffinityNamespaceSelector
                                               feature is enabled.
                                             properties:
@@ -10784,7 +10993,7 @@ spec:
                                                   and null or empty namespaces list
                                                   means "this pod's namespace". An
                                                   empty selector ({}) matches all
-                                                  namespaces. This field is alpha-level
+                                                  namespaces. This field is beta-level
                                                   and is only honored when PodAffinityNamespaceSelector
                                                   feature is enabled.
                                                 properties:
@@ -10973,7 +11182,7 @@ spec:
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
-                                              This field is alpha-level and is only
+                                              This field is beta-level and is only
                                               honored when PodAffinityNamespaceSelector
                                               feature is enabled.
                                             properties:
@@ -11319,6 +11528,20 @@ spec:
                                       description: GMSACredentialSpecName is the name
                                         of the GMSA credential spec to use.
                                       type: string
+                                    hostProcess:
+                                      description: HostProcess determines if a container
+                                        should be run as a 'Host Process' container.
+                                        This field is alpha-level and will only be
+                                        honored by components that enable the WindowsHostProcessContainers
+                                        feature flag. Setting this field without the
+                                        feature flag will result in errors when validating
+                                        the Pod. All of a Pod's containers must have
+                                        the same effective HostProcess value (it is
+                                        not allowed to have a mix of HostProcess containers
+                                        and non-HostProcess containers).  In addition,
+                                        if HostProcess is true then HostNetwork must
+                                        also be set to true.
+                                      type: boolean
                                     runAsUserName:
                                       description: The UserName in Windows to run
                                         the entrypoint of the container process. Defaults
@@ -11899,16 +12122,71 @@ spec:
                                                   to specify either: * An existing
                                                   VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
-                                                  * An existing custom resource that
-                                                  implements data population (Alpha)
-                                                  In order to use custom resource
-                                                  types that implement data population,
+                                                  If the provisioner or an external
+                                                  controller can support the specified
+                                                  data source, it will create a new
+                                                  volume based on the contents of
+                                                  the specified data source. If the
+                                                  AnyVolumeDataSource feature gate
+                                                  is enabled, this field will always
+                                                  have the same contents as the DataSourceRef
+                                                  field.'
+                                                properties:
+                                                  apiGroup:
+                                                    description: APIGroup is the group
+                                                      for the resource being referenced.
+                                                      If APIGroup is not specified,
+                                                      the specified Kind must be in
+                                                      the core API group. For any
+                                                      other third-party types, APIGroup
+                                                      is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              dataSourceRef:
+                                                description: 'Specifies the object
+                                                  from which to populate the volume
+                                                  with data, if a non-empty volume
+                                                  is desired. This may be any local
+                                                  object from a non-empty API group
+                                                  (non core object) or a PersistentVolumeClaim
+                                                  object. When this field is specified,
+                                                  volume binding will only succeed
+                                                  if the type of the specified object
+                                                  matches some installed volume populator
+                                                  or dynamic provisioner. This field
+                                                  will replace the functionality of
+                                                  the DataSource field and as such
+                                                  if both fields are non-empty, they
+                                                  must have the same value. For backwards
+                                                  compatibility, both fields (DataSource
+                                                  and DataSourceRef) will be set to
+                                                  the same value automatically if
+                                                  one of them is empty and the other
+                                                  is non-empty. There are two important
+                                                  differences between DataSource and
+                                                  DataSourceRef: * While DataSource
+                                                  only allows two specific types of
+                                                  objects, DataSourceRef   allows
+                                                  any non-core object, as well as
+                                                  PersistentVolumeClaim objects. *
+                                                  While DataSource ignores disallowed
+                                                  values (dropping them), DataSourceRef   preserves
+                                                  all values, and generates an error
+                                                  if a disallowed value is   specified.
+                                                  (Alpha) Using this field requires
                                                   the AnyVolumeDataSource feature
-                                                  gate must be enabled. If the provisioner
-                                                  or an external controller can support
-                                                  the specified data source, it will
-                                                  create a new volume based on the
-                                                  contents of the specified data source.'
+                                                  gate to be enabled.'
                                                 properties:
                                                   apiGroup:
                                                     description: APIGroup is the group
@@ -13277,14 +13555,58 @@ spec:
                                 dataSource:
                                   description: 'This field can be used to specify
                                     either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) * An
-                                    existing custom resource that implements data
-                                    population (Alpha) In order to use custom resource
-                                    types that implement data population, the AnyVolumeDataSource
-                                    feature gate must be enabled. If the provisioner
-                                    or an external controller can support the specified
-                                    data source, it will create a new volume based
-                                    on the contents of the specified data source.'
+                                    * An existing PVC (PersistentVolumeClaim) If the
+                                    provisioner or an external controller can support
+                                    the specified data source, it will create a new
+                                    volume based on the contents of the specified
+                                    data source. If the AnyVolumeDataSource feature
+                                    gate is enabled, this field will always have the
+                                    same contents as the DataSourceRef field.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                dataSourceRef:
+                                  description: 'Specifies the object from which to
+                                    populate the volume with data, if a non-empty
+                                    volume is desired. This may be any local object
+                                    from a non-empty API group (non core object) or
+                                    a PersistentVolumeClaim object. When this field
+                                    is specified, volume binding will only succeed
+                                    if the type of the specified object matches some
+                                    installed volume populator or dynamic provisioner.
+                                    This field will replace the functionality of the
+                                    DataSource field and as such if both fields are
+                                    non-empty, they must have the same value. For
+                                    backwards compatibility, both fields (DataSource
+                                    and DataSourceRef) will be set to the same value
+                                    automatically if one of them is empty and the
+                                    other is non-empty. There are two important differences
+                                    between DataSource and DataSourceRef: * While
+                                    DataSource only allows two specific types of objects,
+                                    DataSourceRef   allows any non-core object, as
+                                    well as PersistentVolumeClaim objects. * While
+                                    DataSource ignores disallowed values (dropping
+                                    them), DataSourceRef   preserves all values, and
+                                    generates an error if a disallowed value is   specified.
+                                    (Alpha) Using this field requires the AnyVolumeDataSource
+                                    feature gate to be enabled.'
                                   properties:
                                     apiGroup:
                                       description: APIGroup is the group for the resource
@@ -13786,7 +14108,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -13948,7 +14270,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is alpha-level
+                                    ({}) matches all namespaces. This field is beta-level
                                     and is only honored when PodAffinityNamespaceSelector
                                     feature is enabled.
                                   properties:
@@ -14110,7 +14432,7 @@ spec:
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
                                         selector ({}) matches all namespaces. This
-                                        field is alpha-level and is only honored when
+                                        field is beta-level and is only honored when
                                         PodAffinityNamespaceSelector feature is enabled.
                                       properties:
                                         matchExpressions:
@@ -14272,7 +14594,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is alpha-level
+                                    ({}) matches all namespaces. This field is beta-level
                                     and is only honored when PodAffinityNamespaceSelector
                                     feature is enabled.
                                   properties:
@@ -14365,11 +14687,12 @@ spec:
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. The $(VAR_NAME) syntax
-                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -14379,10 +14702,12 @@ spec:
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
-                            unchanged. The $(VAR_NAME) syntax can be escaped with
-                            a double $$, ie: $$(VAR_NAME). Escaped references will
-                            never be expanded, regardless of whether the variable
-                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -14399,14 +14724,16 @@ spec:
                                 type: string
                               value:
                                 description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
+                                  expanded using the previously defined environment
                                   variables in the container and any service environment
                                   variables. If a variable cannot be resolved, the
                                   reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -14876,8 +15203,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -15066,8 +15394,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -15106,8 +15435,9 @@ spec:
                               type: object
                           type: object
                         securityContext:
-                          description: 'Security options the pod should run with.
-                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
@@ -15247,6 +15577,19 @@ spec:
                                   description: GMSACredentialSpecName is the name
                                     of the GMSA credential spec to use.
                                   type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
                                 runAsUserName:
                                   description: The UserName in Windows to run the
                                     entrypoint of the container process. Defaults
@@ -15387,8 +15730,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -15589,11 +15933,12 @@ spec:
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. The $(VAR_NAME) syntax
-                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -15603,10 +15948,12 @@ spec:
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
-                            unchanged. The $(VAR_NAME) syntax can be escaped with
-                            a double $$, ie: $$(VAR_NAME). Escaped references will
-                            never be expanded, regardless of whether the variable
-                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -15623,14 +15970,16 @@ spec:
                                 type: string
                               value:
                                 description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
+                                  expanded using the previously defined environment
                                   variables in the container and any service environment
                                   variables. If a variable cannot be resolved, the
                                   reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -16094,8 +16443,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -16271,8 +16621,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -16312,8 +16663,10 @@ spec:
                               type: object
                           type: object
                         securityContext:
-                          description: SecurityContext is not allowed for ephemeral
-                            containers.
+                          description: 'Optional: SecurityContext defines the security
+                            options the ephemeral container should be run with. If
+                            set, the fields of SecurityContext override the equivalent
+                            fields of PodSecurityContext.'
                           properties:
                             allowPrivilegeEscalation:
                               description: 'AllowPrivilegeEscalation controls whether
@@ -16452,6 +16805,19 @@ spec:
                                   description: GMSACredentialSpecName is the name
                                     of the GMSA credential spec to use.
                                   type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
                                 runAsUserName:
                                   description: The UserName in Windows to run the
                                     entrypoint of the container process. Defaults
@@ -16584,8 +16950,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -16793,11 +17160,12 @@ spec:
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. The $(VAR_NAME) syntax
-                            can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME)
+                            syntax: i.e. "$$(VAR_NAME)" will produce the string literal
+                            "$(VAR_NAME)". Escaped references will never be expanded,
+                            regardless of whether the variable exists or not. Cannot
+                            be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -16807,10 +17175,12 @@ spec:
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
-                            unchanged. The $(VAR_NAME) syntax can be escaped with
-                            a double $$, ie: $$(VAR_NAME). Escaped references will
-                            never be expanded, regardless of whether the variable
-                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            unchanged. Double $$ are reduced to a single $, which
+                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                            will produce the string literal "$(VAR_NAME)". Escaped
+                            references will never be expanded, regardless of whether
+                            the variable exists or not. Cannot be updated. More info:
+                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -16827,14 +17197,16 @@ spec:
                                 type: string
                               value:
                                 description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
+                                  expanded using the previously defined environment
                                   variables in the container and any service environment
                                   variables. If a variable cannot be resolved, the
                                   reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
+                                  Double $$ are reduced to a single $, which allows
+                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                  will produce the string literal "$(VAR_NAME)". Escaped
+                                  references will never be expanded, regardless of
+                                  whether the variable exists or not. Defaults to
+                                  "".'
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -17304,8 +17676,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -17494,8 +17867,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -17534,8 +17908,9 @@ spec:
                               type: object
                           type: object
                         securityContext:
-                          description: 'Security options the pod should run with.
-                            More info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          description: 'SecurityContext defines the security options
+                            the container should be run with. If set, the fields of
+                            SecurityContext override the equivalent fields of PodSecurityContext.
                             More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                           properties:
                             allowPrivilegeEscalation:
@@ -17675,6 +18050,19 @@ spec:
                                   description: GMSACredentialSpecName is the name
                                     of the GMSA credential spec to use.
                                   type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container
+                                    should be run as a 'Host Process' container. This
+                                    field is alpha-level and will only be honored
+                                    by components that enable the WindowsHostProcessContainers
+                                    feature flag. Setting this field without the feature
+                                    flag will result in errors when validating the
+                                    Pod. All of a Pod's containers must have the same
+                                    effective HostProcess value (it is not allowed
+                                    to have a mix of HostProcess containers and non-HostProcess
+                                    containers).  In addition, if HostProcess is true
+                                    then HostNetwork must also be set to true.
+                                  type: boolean
                                 runAsUserName:
                                   description: The UserName in Windows to run the
                                     entrypoint of the container process. Defaults
@@ -17815,8 +18203,9 @@ spec:
                                 by the pod spec. Value must be non-negative integer.
                                 The value zero indicates stop immediately via the
                                 kill signal (no opportunity to shut down). This is
-                                an alpha field and requires enabling ProbeTerminationGracePeriod
-                                feature gate.
+                                a beta field and requires enabling ProbeTerminationGracePeriod
+                                feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                                is used if unset.
                               format: int64
                               type: integer
                             timeoutSeconds:
@@ -17954,6 +18343,7 @@ spec:
                       labels for the pod to be scheduled on that node. More info:
                       https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                     type: object
+                    x-kubernetes-map-type: atomic
                   overhead:
                     additionalProperties:
                       anyOf:
@@ -17970,8 +18360,8 @@ spec:
                       the overhead already set. If RuntimeClass is configured and
                       selected in the PodSpec, Overhead will be set to the value defined
                       in the corresponding RuntimeClass, otherwise it will remain
-                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
-                      This field is alpha-level as of Kubernetes v1.16, and is only
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                      This field is beta-level as of Kubernetes v1.18, and is only
                       honored by servers that enable the PodOverhead feature.'
                     type: object
                   preemptionPolicy:
@@ -18000,7 +18390,7 @@ spec:
                     description: 'If specified, all readiness gates will be evaluated
                       for pod readiness. A pod is ready when all its containers are
                       ready AND all conditions specified in the readiness gates have
-                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
+                      status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates'
                     items:
                       description: PodReadinessGate contains the reference to a pod
                         condition
@@ -18024,7 +18414,7 @@ spec:
                       no RuntimeClass resource matches the named class, the pod will
                       not be run. If unset or empty, the "legacy" RuntimeClass will
                       be used, which is an implicit class with an empty definition
-                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
                       This is a beta feature as of Kubernetes v1.14.'
                     type: string
                   schedulerName:
@@ -18171,6 +18561,18 @@ spec:
                             description: GMSACredentialSpecName is the name of the
                               GMSA credential spec to use.
                             type: string
+                          hostProcess:
+                            description: HostProcess determines if a container should
+                              be run as a 'Host Process' container. This field is
+                              alpha-level and will only be honored by components that
+                              enable the WindowsHostProcessContainers feature flag.
+                              Setting this field without the feature flag will result
+                              in errors when validating the Pod. All of a Pod's containers
+                              must have the same effective HostProcess value (it is
+                              not allowed to have a mix of HostProcess containers
+                              and non-HostProcess containers).  In addition, if HostProcess
+                              is true then HostNetwork must also be set to true.
+                            type: boolean
                           runAsUserName:
                             description: The UserName in Windows to run the entrypoint
                               of the container process. Defaults to the user specified
@@ -18840,15 +19242,61 @@ spec:
                                       description: 'This field can be used to specify
                                         either: * An existing VolumeSnapshot object
                                         (snapshot.storage.k8s.io/VolumeSnapshot) *
-                                        An existing PVC (PersistentVolumeClaim) *
-                                        An existing custom resource that implements
-                                        data population (Alpha) In order to use custom
-                                        resource types that implement data population,
-                                        the AnyVolumeDataSource feature gate must
-                                        be enabled. If the provisioner or an external
-                                        controller can support the specified data
-                                        source, it will create a new volume based
-                                        on the contents of the specified data source.'
+                                        An existing PVC (PersistentVolumeClaim) If
+                                        the provisioner or an external controller
+                                        can support the specified data source, it
+                                        will create a new volume based on the contents
+                                        of the specified data source. If the AnyVolumeDataSource
+                                        feature gate is enabled, this field will always
+                                        have the same contents as the DataSourceRef
+                                        field.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the
+                                            resource being referenced. If APIGroup
+                                            is not specified, the specified Kind must
+                                            be in the core API group. For any other
+                                            third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: 'Specifies the object from which
+                                        to populate the volume with data, if a non-empty
+                                        volume is desired. This may be any local object
+                                        from a non-empty API group (non core object)
+                                        or a PersistentVolumeClaim object. When this
+                                        field is specified, volume binding will only
+                                        succeed if the type of the specified object
+                                        matches some installed volume populator or
+                                        dynamic provisioner. This field will replace
+                                        the functionality of the DataSource field
+                                        and as such if both fields are non-empty,
+                                        they must have the same value. For backwards
+                                        compatibility, both fields (DataSource and
+                                        DataSourceRef) will be set to the same value
+                                        automatically if one of them is empty and
+                                        the other is non-empty. There are two important
+                                        differences between DataSource and DataSourceRef:
+                                        * While DataSource only allows two specific
+                                        types of objects, DataSourceRef   allows any
+                                        non-core object, as well as PersistentVolumeClaim
+                                        objects. * While DataSource ignores disallowed
+                                        values (dropping them), DataSourceRef   preserves
+                                        all values, and generates an error if a disallowed
+                                        value is   specified. (Alpha) Using this field
+                                        requires the AnyVolumeDataSource feature gate
+                                        to be enabled.'
                                       properties:
                                         apiGroup:
                                           description: APIGroup is the group for the
@@ -19975,10 +20423,19 @@ spec:
                           description: ProwJobState specifies whether the job is running
                           type: string
                         type: array
+                      report:
+                        description: 'Report is derived from JobStatesToReport, it''s
+                          used for differentiating nil from empty slice, as yaml roundtrip
+                          by design can''t tell the difference when omitempty is supplied.
+                          See https://github.com/kubernetes/test-infra/pull/24168
+                          for details Priority-wise, it goes by following order: -
+                          `report: true/false`` in job config - `JobStatesToReport:
+                          <anything including empty slice>` in job config - `report:
+                          true/false`` in global config - `JobStatesToReport:` in
+                          global config'
+                        type: boolean
                       report_template:
                         type: string
-                    required:
-                    - job_states_to_report
                     type: object
                 type: object
               rerun_auth_config:

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,17 +22,20 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/sinker:v20220303-21d4df3f17
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-test-infra-trusted
+          name: kubeconfig-build-test-infra-trusted
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -45,6 +48,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
+      - name: kubeconfig-build-test-infra-trusted
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-test-infra-trusted
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/status-reconciler:v20220303-21d4df3f17
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/tide:v20220303-21d4df3f17
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -311,6 +311,9 @@ secretGenerator:
     files:
       - config=secrets/kubeconfig
     type: Opaque
+  - name: kubeconfig-build-test-infra-trusted
+    files:
+      - kubeconfig=secrets/kubeconfig-build-test-infra-trusted
   - name: unsplash-api-key
     literals:
       - honk.txt=

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20211118-4107081ce0
+        image: gcr.io/k8s-prow/exporter:v20220303-21d4df3f17
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -85,6 +85,12 @@
         dest: '{{ secrets_dir }}/kubeconfig'
         remote_src: true
 
+    - name: Create kubeconfig-build-test-infra-trusted secret
+      copy:
+        src: '{{ kubeconfig_path }}'
+        dest: '{{ secrets_dir }}/kubeconfig-build-test-infra-trusted'
+        remote_src: true
+
     - name: copy production kustomize files
       synchronize:
         src: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/{{ item }}'


### PR DESCRIPTION
This secret has been added to the deployment specs for prow services
such as sinker as part of the prow bump. The pods remain in pending state when this secret is not
in place.

See #1768

/cc @dhiller 