### PR TITLE
Enable two week retention period for loki table manager

### DIFF
--- a/github/ci/services/loki/secrets/production-control-plane/loki-config/loki.yaml
+++ b/github/ci/services/loki/secrets/production-control-plane/loki-config/loki.yaml
@@ -42,5 +42,5 @@ storage_config:
   gcs:
     bucket_name: kubevirt-loki
 table_manager:
-  retention_deletes_enabled: false
-  retention_period: 0s
+  retention_deletes_enabled: true
+  retention_period: 336h


### PR DESCRIPTION
Enabling a two week [retention period](https://grafana.com/docs/loki/latest/operations/storage/table-manager/#retention) on the Loki Table Manager will help control the amount of storage used.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>