### PR TITLE
Make check-testgrid-config not required due to spell check failure

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -643,6 +643,7 @@ presubmits:
     - org: kubernetes
       repo: test-infra
       base_ref: master
+    optional: true
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414


### PR DESCRIPTION
A spell check error in the kubernetes/test-infra repo is causing the check-testgrid-config job to fail constantly leading to blocked pull requests. Moving the check-testgrid-config job to optional until this spell check error is fixed.

An example of the failure:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/1948/pull-project-infra-check-testgrid-config/1500931020109647872

/cc @dhiller 