### PR TITLE
Add kubevirt lane for k8s with swap enabled

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2055,6 +2055,50 @@ presubmits:
   - always_run: false
     annotations:
       fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.23-swap-enabled
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.23
+        - name: KUBEVIRT_E2E_FOCUS
+          value: "SwapTest"
+        - name: KUBEVIRT_SWAP_ON
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20220211-d7d6c59
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
     cluster: prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
We add a lane for running KubeVirt tests in a k8s cluster with swap enabled. This lane is currently not reporting and can only be run manually.

See kubevirt/kubevirt#7171

/cc @Barakmor1 @brianmcarey @jean-edouard 