### PR TITLE
Create kubeconfig-build-test-infra-trusted for higher environments

### DIFF
--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -62,6 +62,14 @@
         content: '{{ kubeconfig }}'
         dest: '{{ kubeconfig_path }}'
 
+- name: Create kubeconfig-build-test-infra-trusted secret
+  when: kubeconfig is defined
+  block:
+    - name: Create kubeconfig-build-test-infra-trusted file
+      copy:
+        content: '{{ kubeconfig }}'
+        dest: '{{ secrets_dir }}/kubeconfig-build-test-infra-trusted'
+
 - name: Create docker proxy CA key
   copy:
     content: '{{ dockerMirrorProxyCA.key }}'


### PR DESCRIPTION
The kubeconfig-build-test-infra-trusted secret was introduced in #1944 but was not included for higher environments which caused post-deploy tasks to fail. 

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1505851124660310016#1:build-log.txt%3A177

/cc @dhiller 



Signed-off-by: Brian Carey <bcarey@redhat.com>