### PR TITLE
Enable loki alerting rules and push them to alertmanager

### DIFF
--- a/github/ci/services/loki/manifests/common/loki.yaml
+++ b/github/ci/services/loki/manifests/common/loki.yaml
@@ -194,6 +194,10 @@ spec:
             - name: gcs
               mountPath: /etc/gcs
               readOnly: true
+            - name: temp
+              mountPath: /tmp
+            - name: rules
+              mountPath: /tmp/loki/rules/fake
           ports:
             - name: http-metrics
               containerPort: 3100
@@ -233,6 +237,11 @@ spec:
             secretName: loki-config
         - name: storage
           emptyDir: {}
+        - name: temp
+          emptyDir: {}
         - name: gcs
           secret:
             secretName: gcs
+        - name: rules
+          configMap:
+            name: loki-alerting-rules

--- a/github/ci/services/loki/manifests/common/rules.yaml
+++ b/github/ci/services/loki/manifests/common/rules.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-alerting-rules
+  labels:
+    app: loki
+    chart: loki-2.1.1
+    release: loki
+    heritage: Helm
+data:
+  loki-alerting-rules.yaml: |-
+    groups:
+      - name: GrafanaLogAlerts
+        rules:
+        - alert: HighPercentageError
+          expr: |
+            sum(rate({app="grafana", namespace="monitoring"} |= "error" [5m])) by (job)
+              /
+            sum(rate({app="grafana", namespace="monitoring"}[5m])) by (job)
+              > 0.1
+          for: 10m
+          labels:
+              severity: "warning"
+          annotations:
+              summary: "High percentage of errors in the logs"
+        - alert: HighFailedLoginsGrafana
+          expr: | 
+            rate({app="grafana"} |= "Invalid username or password" [5m]) 
+            > 0.2
+          for: 10m
+          labels:
+            severity: "warning"
+          annotations:
+            summary: "High number of failed logins to Grafana"
+      - name: CiSearchLogAlerts
+        rules:
+        - alert: CiSearchFullPersistentVolume
+          expr: |
+            rate({app="search"} |= "failed to write job" [5m])
+            > 0.1
+          for: 10m
+          labels:
+            severity: "critical"
+          annotations:
+            summary: "CI Search persistent volume is full"

--- a/github/ci/services/loki/secrets/production-control-plane/loki-config/loki.yaml
+++ b/github/ci/services/loki/secrets/production-control-plane/loki-config/loki.yaml
@@ -44,3 +44,14 @@ storage_config:
 table_manager:
   retention_deletes_enabled: true
   retention_period: 336h
+ruler:
+  alertmanager_url: http://prometheus-stack-kube-prom-alertmanager:9093
+  enable_api: true
+  ring:
+    kvstore:
+      store: inmemory
+  rule_path: /tmp/scratch
+  storage:
+    local:
+      directory: /tmp/loki/rules
+    type: local

--- a/github/ci/services/loki/secrets/testing/loki-config/loki.yaml
+++ b/github/ci/services/loki/secrets/testing/loki-config/loki.yaml
@@ -42,3 +42,14 @@ storage_config:
 table_manager:
   retention_deletes_enabled: false
   retention_period: 0s
+ruler:
+  alertmanager_url: http://prometheus-stack-kube-prom-alertmanager:9093
+  enable_api: true
+  ring:
+    kvstore:
+      store: inmemory
+  rule_path: /tmp/scratch
+  storage:
+    local:
+      directory: /tmp/loki/rules
+    type: local


### PR DESCRIPTION
The loki alerting rules are provided as a configmap which is included in
the loki deployment and mounted under the ruler storage.

The loki configuration is updated to include ruler storage and the
alertmanager_url

See the [loki docs](https://grafana.com/docs/loki/latest/rules/) for more information on ruler configuration

This change also includes a couple of simple alert rules for grafana and ci-search

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>