### PR TITLE
Upgrade Grafana to version 8.4

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/grafana.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/grafana.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
@@ -64,7 +64,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   allowPrivilegeEscalation: true
@@ -96,7 +96,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
   name: grafana
   namespace: default
@@ -109,7 +109,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
   name: grafana-test
   namespace: default
@@ -124,7 +124,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |
@@ -187,7 +187,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
     dashboard-provider: default
 data:
@@ -5647,7 +5647,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-
@@ -5668,7 +5668,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
   finalizers:
     - kubernetes.io/pvc-protection
@@ -5687,7 +5687,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
   name: grafana-clusterrole
 rules: []
@@ -5701,7 +5701,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount
@@ -5722,7 +5722,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:      ['extensions']
@@ -5740,7 +5740,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:      ['policy']
@@ -5758,7 +5758,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5779,7 +5779,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -5800,7 +5800,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -5824,7 +5824,7 @@ metadata:
     helm.sh/chart: grafana-6.3.0
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: grafana
-    app.kubernetes.io/version: "7.4.0"
+    app.kubernetes.io/version: "8.4.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -5881,7 +5881,7 @@ spec:
               mountPath: "/var/lib/grafana"
       containers:
         - name: grafana
-          image: "grafana/grafana:7.4.0"
+          image: "grafana/grafana:8.4.0"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config


### PR DESCRIPTION
Grafana version 8.4 provides an improved view of alerts from both
prometheus and loki

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>