### PR TITLE
Fix wrong lane disabled in release 0.49

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -146,7 +146,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     branches:
     - release-0.49
     cluster: prow-workloads
@@ -184,7 +184,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.49
     cluster: prow-workloads


### PR DESCRIPTION
In https://github.com/kubevirt/project-infra/pull/1970 has been disabled the wrong lane. Re-enable pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2-0.49 and disable pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2-0.49

Signed-off-by: fossedihelm <ffossemo@redhat.com>

/cc @dhiller 