### PR TITLE
Use recreate strategy for Grafana deployment update

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/grafana.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/grafana.yaml
@@ -5834,7 +5834,7 @@ spec:
       app.kubernetes.io/name: grafana
       app.kubernetes.io/instance: grafana
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Updating the grafana deployment using the RollingUpdate strategy fails due to being unable to claim a mount from existing pod

The [Recreate strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) will remove the old pod before creating the updated pod.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>