### PR TITLE
[release 0.50]Remove ipv6 lane as required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -1304,7 +1304,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.50
     cluster: prow-workloads


### PR DESCRIPTION
Release 0.50 does not contain single stack IPv6 support that was added to kubevirt here https://github.com/kubevirt/kubevirt/pull/7158

Signed-off-by: fossedihelm <ffossemo@redhat.com>

/cc @dhiller 