### PR TITLE
Migrate plugin config to new format

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -22,343 +22,397 @@ config_updater:
           - kubevirt-prow
 
 plugins:
+
+  k8snetworkplumbingwg/kubemacpool:
+    plugins:
+    - approve
+    - assign
+    - blunderbuss
+    - cat
+    - dco
+    - dog
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - pony
+    - release-note
+    - size
+    - skip
+    - trigger
+    - verify-owners
+    - wip
+
+  k8snetworkplumbingwg/ovs-cni:
+    plugins:
+    - approve
+    - dco
+    - hold
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+    - verify-owners
+    - wip
+
+
   # we don't get events from there, it has no effect
   # but it is needed to host jobs on our prow and still
   # have a consistent valid config.
   kubernetes-sigs/cluster-api-provider-kubevirt:
-  - trigger
-  kubevirt/must-gather:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
+    plugins:
+    - trigger
 
-  kubevirt/ssp-operator:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/kubevirt-ssp-operator:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/libguestfs-appliance:
-  - trigger
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/common-templates:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/kubevirt-template-validator:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/node-labeller:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/cpu-nfd-plugin:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/kvm-info-nfd-plugin:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  virtblocks:
-  - trigger
-  - dco
 
   kubevirt:
-  - size
-  - label
-  - hold
-  - assign
-  - blunderbuss
-  - lifecycle
-  - verify-owners
-  - skip
-  - override
-  - wip
-  - pony
-  - dog
-  - cat
-  - dco
-  - invalidcommitmsg
-
-  kubevirt/kubevirt:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/containerdisks:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/bridge-marker:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  k8snetworkplumbingwg/ovs-cni:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-  - hold
-  - wip
-  - verify-owners
-  - dco
-
-  kubevirt/macvtap-cni:
-  - trigger
-  - owners-label
-  - lgtm
-  - approve
-  - release-note
-
-  kubevirt/machine-remediation-operator:
-  - trigger
-  - lgtm
-  - approve
-
-  kubevirt/containerized-data-importer:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/cluster-api-provider-kubevirt:
-  - trigger
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/kubevirt-ansible:
-  - release-note
-
-  kubevirt/project-infra:
-  - trigger
-  - lgtm
-  - approve
-  - config-updater
-
-  kubevirt/kubevirtci:
-  - trigger
-  - lgtm
-  - approve
-
-  kubevirt/kubevirt.github.io:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/katacoda-scenarios:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/demo:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/kubevirt-tutorial:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/cloud-image-builder:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/community:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/hostpath-provisioner:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/hostpath-provisioner-operator:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/cluster-network-addons-operator:
-  - trigger
-  - owners-label
-  - release-note
-  - lgtm
-  - approve
-
-  nmstate/kubernetes-nmstate:
-  - size
-  - label
-  - hold
-  - lgtm
-  - approve
-  - release-note
-  - owners-label
-  - assign
-  - blunderbuss
-  - lifecycle
-  - verify-owners
-  - skip
-  - override
-  - wip
-  - pony
-  - dog
-  - cat
-  - dco
-  - trigger
-
-  nmstate/nmstate:
-  - trigger
-  - override
-
-  k8snetworkplumbingwg/kubemacpool:
-  - size
-  - label
-  - hold
-  - lgtm
-  - approve
-  - release-note
-  - assign
-  - blunderbuss
-  - lifecycle
-  - verify-owners
-  - skip
-  - override
-  - wip
-  - pony
-  - dog
-  - cat
-  - dco
-  - trigger
-
-  kubevirt/kubectl-virt-plugin:
-  - trigger
-  - lgtm
-  - approve
-
-  kubevirt/kubevirt-velero-plugin:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/node-maintenance-operator:
-  - trigger
-  - owners-label
-  - release-note
-  - lgtm
-  - approve
+    plugins:
+    - assign
+    - blunderbuss
+    - cat
+    - dco
+    - dog
+    - hold
+    - invalidcommitmsg
+    - label
+    - lifecycle
+    - override
+    - pony
+    - size
+    - skip
+    - verify-owners
+    - wip
 
   kubevirt/ansible-kubevirt-modules:
-  - trigger
-  - owners-label
-  - release-note
-  - lgtm
-  - approve
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
 
-  kubevirt/hyperconverged-cluster-operator:
-  - trigger
-  - owners-label
-  - release-note
-  - lgtm
-  - approve
+  kubevirt/bridge-marker:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
 
-  kubevirt/vm-import-operator:
-  - trigger
-  - owners-label
-  - release-note
-  - lgtm
-  - approve
-
-  kubevirt/csi-driver:
-  - trigger
-  - release-note
-  - owners-label
-  - lgtm
-  - approve
-
-  kubevirt/controller-lifecycle-operator-sdk:
-  - trigger
-  - owners-label
-  - release-note
-  - lgtm
-  - approve
-
-  kubevirt/user-guide:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
-
-  kubevirt/terraform-provider-kubevirt:
-  - trigger
-  - approve
-  - lgtm
-  - owners-label
-
-  kubevirt/qe-tools:
-  - approve
-  - lgtm
-  - owners-label
-  - trigger
+  kubevirt/cloud-image-builder:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
 
   kubevirt/cloud-provider-kubevirt:
-  - trigger
-  - approve
-  - lgtm
-  - owners-label
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/cluster-api-provider-kubevirt:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/cluster-network-addons-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/common-templates:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/community:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/containerdisks:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/containerized-data-importer:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/controller-lifecycle-operator-sdk:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/csi-driver:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/cpu-nfd-plugin:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/demo:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/hostpath-provisioner:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/hostpath-provisioner-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/hyperconverged-cluster-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/katacoda-scenarios:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/kubectl-virt-plugin:
+    plugins:
+    - approve
+    - lgtm
+    - trigger
+
+  kubevirt/kubevirt:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/kubevirt-ansible:
+    plugins:
+    - release-note
+
+  kubevirt/kubevirt-ssp-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/kubevirt-template-validator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/kubevirt-tutorial:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/kubevirt-velero-plugin:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/kubevirt.github.io:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/kubevirtci:
+    plugins:
+    - approve
+    - lgtm
+    - trigger
+
+  kubevirt/kvm-info-nfd-plugin:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/libguestfs-appliance:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/must-gather:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/macvtap-cni:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/machine-remediation-operator:
+    plugins:
+    - approve
+    - lgtm
+    - trigger
+
+  kubevirt/node-labeller:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/node-maintenance-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/project-infra:
+    plugins:
+    - approve
+    - config-updater
+    - lgtm
+    - trigger
+
+  kubevirt/qe-tools:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/ssp-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+  kubevirt/terraform-provider-kubevirt:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/user-guide:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
+  kubevirt/vm-import-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
+
+  nmstate/kubernetes-nmstate:
+    plugins:
+    - approve
+    - assign
+    - blunderbuss
+    - cat
+    - dco
+    - dog
+    - hold
+    - label
+    - lgtm
+    - lifecycle
+    - override
+    - owners-label
+    - pony
+    - release-note
+    - size
+    - skip
+    - trigger
+    - verify-owners
+    - wip
+
+  nmstate/nmstate:
+    plugins:
+    - override
+    - trigger
+
+
+  virtblocks:
+    plugins:
+    - dco
+    - trigger
+
 
 external_plugins:
   libguestfs-appliance:


### PR DESCRIPTION
Old format is deprecated and produces warnings.

See https://github.com/kubernetes/test-infra/issues/20631#issuecomment-787693609

Requires update of configcheck image: #1991