### PR TITLE
Make pull-kubevirt-e2e-kind-1.22-sriov job optional due to constant failures

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -729,6 +729,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.22-sriov
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Investigations are ongoing to the cause of the failures but this is
blocking the merge queue and causing a build up of PRs.

https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-kind-1.22-sriov

It is suggested to make the lane optional while the investigation is
ongoing to unblock the queue.


/cc @dhiller @EdDev @ormergi 

Signed-off-by: Brian Carey <bcarey@redhat.com>