### PR TITLE
Bump containerdisks repo to golang 1.17

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
         ./build.sh
       env:
       - name: GIMME_GO_VERSION
-        value: "1.16"
+        value: "1.17"
       image: quay.io/kubevirtci/golang:v20220211-d7d6c59
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
         - ./build.sh -b
         env:
         - name: GIMME_GO_VERSION
-          value: "1.16"
+          value: "1.17"
         image: quay.io/kubevirtci/golang:v20220211-d7d6c59
         name: ""
         resources:


### PR DESCRIPTION
Needed for https://github.com/kubevirt/containerdisks/pull/18