### PR TITLE
Use description instead of summary annotation for loki alerts

### DIFF
--- a/github/ci/services/loki/manifests/common/rules.yaml
+++ b/github/ci/services/loki/manifests/common/rules.yaml
@@ -22,7 +22,7 @@ data:
           labels:
               severity: "warning"
           annotations:
-              summary: "High percentage of errors in the logs"
+              description: "High percentage of errors in the logs"
         - alert: HighFailedLoginsGrafana
           expr: | 
             rate({app="grafana"} |= "Invalid username or password" [5m]) 
@@ -31,7 +31,7 @@ data:
           labels:
             severity: "warning"
           annotations:
-            summary: "High number of failed logins to Grafana"
+            description: "High number of failed logins to Grafana"
       - name: CiSearchLogAlerts
         rules:
         - alert: CiSearchFullPersistentVolume
@@ -42,4 +42,4 @@ data:
           labels:
             severity: "critical"
           annotations:
-            summary: "CI Search persistent volume is full"
+            description: "CI Search persistent volume is full"


### PR DESCRIPTION
The [alertmanager configuration](https://github.com/kubevirt/project-infra/blob/main/github/ci/services/prometheus-stack/manifests/stack/common/alertmanager-config.yaml#L58) expects a description field to pass
alerts to slack. Updating the loki alerts to have a description annotation.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>