### PR TITLE
Add packages to bootstrap (to build multi-arch containers)

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -52,6 +52,8 @@ RUN dnf install -y \
     rsync-daemon \
     skopeo \
     sudo \
+    buildah \
+    qemu-user-static \
     wget &&\
   dnf -y clean all
 
@@ -103,6 +105,10 @@ RUN USE_BAZEL_VERSION=4.1.0 bazel version && \
 
 # create mixin directories
 RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
+
+# Workaround error when running buildah
+# 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver
+RUN sed -i -e 's,#mount_program,mount_program,' /etc/containers/storage.conf
 
 # note the runner is also responsible for making docker in docker function if
 # env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating


### PR DESCRIPTION
CDI uses `docker build` to build a builder, and it uses this builder
to do other builds.

Having an aarch64 builder will allow us to do native aarch64 builds,
and for that we need a fancier `docker build` like buildah (or buildx).

qemu-user-static allows us to execute non-native (e.g. aarch64)
binaries.

Part of tackling https://github.com/kubevirt/containerized-data-importer/issues/2211