### PR TITLE
[Release 0.51] IPv6 lane shouldn't be required and should be optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -1304,7 +1304,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.51
     cluster: prow-workloads
@@ -1321,6 +1321,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network-0.51
+    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
Release 0.51 does not contain single stack IPv6 support that was added to
kubevirt here kubevirt/kubevirt#7158