### PR TITLE
Fix path to bootstrap script for prow-workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -434,7 +434,7 @@ postsubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-c"
-            - "github/ci/prow-deploy/hack/bootstrap.sh"
+            - "github/ci/prow-workloads/hack/bootstrap.sh"
           resources:
             requests:
               memory: "8Gi"


### PR DESCRIPTION
/cc @brianmcarey 

I think this is the missing part. We already have the inventory inside the secrets (look for `.prowWorkloads.hostsYml`). Also the key is extracted in the shellscript that this job points to.

Note: the inventory may be outdated, we should discuss next week on how to proceed. 