### PR TITLE
Revert "Make nonroot network lane required (#1900)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -315,7 +315,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -332,7 +332,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
-    optional: false
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
There are only 2 nodes that can run SR-IOV jobs, each at the moment
can only run a single job at a time.

Running the nonroot jobs for pre-submit is overloading what seems to be
a not yet stable CI workload.

This reverts commit eb4115da872dcdff53ad5d87bbb322990164e84f.