### PR TITLE
periodics: Move all non sriov jobs to non sriov nodes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -142,7 +142,7 @@ periodics:
       - mountPath: /etc/win-sysprep
         name: win-sysprep
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
     volumes:
     - name: win-sysprep
       secret:
@@ -192,7 +192,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -238,7 +238,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -284,7 +284,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -332,7 +332,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
@@ -413,7 +413,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
@@ -487,7 +487,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
@@ -557,7 +557,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     testgrid-dashboards: kubevirt-periodics
@@ -762,7 +762,7 @@ periodics:
         name: pgp-bot-key
         readOnly: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
     volumes:
     - name: pgp-bot-key
       secret:
@@ -1014,7 +1014,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1060,7 +1060,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1106,7 +1106,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1152,7 +1152,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1200,7 +1200,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1266,7 +1266,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1312,7 +1312,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1358,7 +1358,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1404,7 +1404,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1452,7 +1452,7 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload
 
 - annotations:
     testgrid-dashboards: kubevirt-periodics
@@ -1503,4 +1503,4 @@ periodics:
       securityContext:
         privileged: true
     nodeSelector:
-      type: bare-metal-external
+      variant: workload


### PR DESCRIPTION
Although the presubmit jobs have been updated to not run on SR-IOV
nodes, the periodic ones have not.
Include them as well to reduce load on the SR-IOV nodes to attempt and
recover them from the latest CI outage.