### PR TITLE
Add priority classes for the sriov and vgpu jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -625,6 +625,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+      priorityClassName: sriov
   - always_run: true
     annotations:
       fork-per-release: "true"
@@ -705,6 +706,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+      priorityClassName: sriov
   - always_run: true
     annotations:
       fork-per-release: "true"
@@ -776,6 +778,7 @@ presubmits:
             path: /dev/vfio/
             type: Directory
           name: vfio
+      priorityClassName: vgpu
   - always_run: true
     annotations:
       fork-per-release: "true"
@@ -851,6 +854,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+      priorityClassName: vgpu
   - always_run: true
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - resources/ingress-controller.yaml
   - resources/multus-cni.yaml
   - resources/metrics-server.yaml
+  - resources/priority-classes.yaml
   - ../../components/docker-mirror-proxy/base
   - ../../components/greenhouse/base
 

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/priority-classes.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/priority-classes.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: sriov
+value: 1000000
+preemptionPolicy: Never
+globalDefault: false
+description: "Allows sriov jobs to be scheduled with higher priority."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: vgpu
+value: 1000000
+preemptionPolicy: Never
+globalDefault: false
+description: "Allows gpu jobs to be scheduled with higher priority."


### PR DESCRIPTION
This will make the scheduler prefer sriov and vgpu jobs. But it will not
preempt them above others.

/cc @brianmcarey 