### PR TITLE
cloud-provider-kubevirt: Change Presubmit Golang version to 1.17

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
@@ -29,6 +29,9 @@ presubmits:
             - "/bin/sh"
             - "-c"
             - "make test"
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.17"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Change Golang version to 1.17 in "pull-cloud-provider-kubevirt-unit-tests" container