### PR TITLE
Reinstate goproxy.io

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -574,7 +574,7 @@ presets:
 # default preset with no labels, settings common to all jobs
 - env:
   - name: GOPROXY
-    value: "https://proxy.golang.org|direct"
+    value: "https://proxy.golang.org|https://goproxy.io|direct"
 
 managed_webhooks:
   # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.


### PR DESCRIPTION
We previously removed goproxy.io due to 500 errors IIRC, here we reinstate it again.