### PR TITLE
Add ceph to single replica lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2116,6 +2116,8 @@ presubmits:
           value: "1"
         - name: KUBEVIRT_WITH_CNAO
           value: "true"
+        - name: KUBEVIRT_STORAGE
+          value: "rook-ceph-default"
         image: quay.io/kubevirtci/bootstrap:v20220211-d7d6c59
         name: ""
         resources:


### PR DESCRIPTION
The single-replica lane is not bound to a sig, so it needs a storage backend to run sig-storage tests.