### PR TITLE
images mirror: Add library/registry:2

### DIFF
--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -1,2 +1,3 @@
+docker.io,library/registry:2,quay.io/kubevirtci
 docker.io,library/registry:2.7.1,quay.io/kubevirtci
 docker.io,rook/ceph:v1.5.8,quay.io/kubevirtci


### PR DESCRIPTION
library/registry:2.7.1 doesn't support arm64
where library/registry:2 does.

Signed-off-by: Or Shoval <oshoval@redhat.com>