### PR TITLE
Skip reporting on pull-project-infra-check-testgrid-config due to failures

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -643,7 +643,9 @@ presubmits:
     - org: kubernetes
       repo: test-infra
       base_ref: master
+    # TODO: make it required again after https://github.com/kubernetes/test-infra/issues/25938 is fixed
     optional: true
+    skip_report: true
     spec:
       containers:
       - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414


### PR DESCRIPTION
The pull-project-infra-check-testgrid-config has been failing constantly
due to an issue in the test-infra repo. An issue has been raised in the
kubernetes/test-infra repo.

The job was already marked as optional. This change stops reporting the
failures.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>