### PR TITLE
single-node lane: add a "focus all" option to avoid storage-req auto-focus

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2109,7 +2109,9 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23
+          value: "k8s-1.23"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: ".*"
         - name: KUBEVIRT_NUM_NODES
           value: "1"
         - name: KUBEVIRT_INFRA_REPLICAS


### PR DESCRIPTION
Adding `KUBEVIRT_STORAGE="rook-ceph-default"` actually focuses the whole lane on `storage-req` tests...
Specifying a focus of "all tests" works around that.