### PR TITLE
Use go to run check-testgrid-config tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -643,12 +643,9 @@ presubmits:
     - org: kubernetes
       repo: test-infra
       base_ref: master
-    # TODO: make it required again after https://github.com/kubernetes/test-infra/issues/25938 is fixed
-    optional: true
-    skip_report: true
     spec:
       containers:
-      - image: gcr.io/k8s-prow/transfigure:v20210224-afd05eb414
+      - image: quay.io/projectquay/golang:1.17
         command:
         - github/ci/testgrid/hack/check.sh
         securityContext:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -645,7 +645,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-      - image: quay.io/projectquay/golang:1.17
+      - image: quay.io/kubevirtci/golang:v20220405-a56be88
         command:
         - github/ci/testgrid/hack/check.sh
         securityContext:
@@ -655,6 +655,9 @@ presubmits:
             memory: "8Gi"
           limits:
             memory: "8Gi"
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.16"
   - name: pull-kubevirt-org-github-config-updater
     run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
     annotations:

--- a/github/ci/testgrid/hack/check.sh
+++ b/github/ci/testgrid/hack/check.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink -f --canonicalize ${BASEDIR}/../../../..)
+eval $(gimme ${GIMME_GO_VERSION})
+
 if [ -d ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra ]; then
     TEST_INFRA_ROOT=$(readlink -f --canonicalize ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra)
 fi


### PR DESCRIPTION
Bazel rules are no longer relevant in kubernetes/test-infra. This causes
failures in the check-testgrid-config tests due to bazel builds failing. eg. https://github.com/kubernetes/test-infra/issues/25938

This change is to run the check-testgrid-config tests using go instead of bazel.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>