### PR TITLE
Use go version 1.18 for check testgrid config

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -657,7 +657,7 @@ presubmits:
             memory: "8Gi"
         env:
         - name: GIMME_GO_VERSION
-          value: "1.16"
+          value: "1.18"
   - name: pull-kubevirt-org-github-config-updater
     run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
     annotations:


### PR DESCRIPTION
The build for configurator fails with go version 1.16
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2049/pull-project-infra-check-testgrid-config/1518868129835388928

test-infra was updated to use go version 1.18
https://github.com/kubernetes/test-infra/commit/52e11cab1ea80f71e7af5f69573ffbb17b234cca

/cc @dhiller @rmohr 

Signed-off-by: Brian Carey <bcarey@redhat.com>