### PR TITLE
Add quay oauth token to the quay credentials secret

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -505,6 +505,8 @@ presets:
     value: /etc/kubevirtci-cred/username
   - name: QUAY_PASSWORD
     value: /etc/kubevirtci-cred/password
+  - name: QUAY_OAUTH_TOKEN
+    value: /etc/kubevirtci-cred/token
   volumes:
   - name: kubevirtci-cred
     secret:
@@ -571,6 +573,7 @@ presets:
   - name: gcs
     mountPath: /etc/gcs
     readOnly: true
+
 # default preset with no labels, settings common to all jobs
 - env:
   - name: GOPROXY

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -46,6 +46,7 @@ secretGenerator:
     namespace: kubevirt-prow-jobs
     # username=quayUser
     # password=quayPass
+    # token=quayOAuthToken
     envs:
     - secrets/kubevirtci-quay-credential
     type: Opaque

--- a/github/ci/prow-deploy/templates/quay_credentials.j2
+++ b/github/ci/prow-deploy/templates/quay_credentials.j2
@@ -1,2 +1,3 @@
 username={{ quayUser | default("user") }}
 password={{ quayPass | default("pass") }}
+token={{ quayOAuthToken | default("pass") }}


### PR DESCRIPTION
To directly talk to the quay api an oauth token needs to be used. This token can be used for interacting with the containerdisks repo to push docs there.