### PR TITLE
Force change for job definitions on release-0.52

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -2021,3 +2021,4 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+


### PR DESCRIPTION
using config-updater manually doesn't seem to work, so we try to
re-update it by adding a commit.

This is while investigating https://github.com/kubevirt/kubevirt/pull/7609

/cc @brianmcarey 