### PR TITLE
Shard the job configs into configmaps per org

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -10,6 +10,26 @@ config_updater:
       clusters:
         default:
           - kubevirt-prow
+    github/ci/prow-deploy/files/jobs/kubevirt/**/*.yaml:
+      name: job-config-kubevirt
+      clusters:
+        default:
+          - kubevirt-prow
+    github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/**/*.yaml:
+      name: job-config-k8snetworkplumbingwg
+      clusters:
+        default:
+          - kubevirt-prow
+    github/ci/prow-deploy/files/jobs/kubernetes-sigs/**/*.yaml:
+      name: job-config-kubernetes-sigs
+      clusters:
+        default:
+          - kubevirt-prow
+    github/ci/prow-deploy/files/jobs/nmstate/**/*.yaml:
+      name: job-config-nmstate
+      clusters:
+        default:
+          - kubevirt-prow
     github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml:
       name: plugins
       clusters:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -11,21 +11,25 @@ config_updater:
         default:
           - kubevirt-prow
     github/ci/prow-deploy/files/jobs/kubevirt/**/*.yaml:
+      gzip: true
       name: job-config-kubevirt
       clusters:
         default:
           - kubevirt-prow
     github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/**/*.yaml:
+      gzip: true
       name: job-config-k8snetworkplumbingwg
       clusters:
         default:
           - kubevirt-prow
     github/ci/prow-deploy/files/jobs/kubernetes-sigs/**/*.yaml:
+      gzip: true
       name: job-config-kubernetes-sigs
       clusters:
         default:
           - kubevirt-prow
     github/ci/prow-deploy/files/jobs/nmstate/**/*.yaml:
+      gzip: true
       name: job-config-nmstate
       clusters:
         default:

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -41,5 +41,13 @@ spec:
               configMap:
                 name: config
             - name: job-config
-              configMap:
-                name: job-config
+              projected:
+                sources:
+                  - configMap:
+                      name: job-config-kubevirt
+                  - configMap:
+                      name: job-config-k8snetworkplumbingwg
+                  - configMap:
+                      name: job-config-kubernetes-sigs
+                  - configMap:
+                      name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -76,8 +76,16 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+            - configMap:
+                name: job-config-kubevirt
+            - configMap:
+                name: job-config-k8snetworkplumbingwg
+            - configMap:
+                name: job-config-kubernetes-sigs
+            - configMap:
+                name: job-config-nmstate
       - name: oauth
         secret:
           secretName: oauth-token

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -124,8 +124,16 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate
       - name: plugins
         configMap:
           name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -114,8 +114,16 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate
       - name: plugins
         configMap:
           name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -55,5 +55,13 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -90,5 +90,13 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -56,5 +56,13 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -66,8 +66,16 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate
       - name: plugins
         configMap:
           name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -67,5 +67,13 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
@@ -61,5 +61,13 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -74,5 +74,13 @@ spec:
         configMap:
           name: config
       - name: job-config
-        configMap:
-          name: job-config
+        projected:
+          sources:
+          - configMap:
+              name: job-config-kubevirt
+          - configMap:
+              name: job-config-k8snetworkplumbingwg
+          - configMap:
+              name: job-config-kubernetes-sigs
+          - configMap:
+              name: job-config-nmstate

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/bootstrap.yaml
@@ -36,3 +36,87 @@ data:
             containers:
               - image: quay.io/kubevirtci/hello-world
                 command: ["/bin/true"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-config-kubevirt
+  namespace: kubevirt-prow
+data:
+  kubevirt_test_job_config.yaml: |
+    presubmits:
+      kubevirt/testrepo:
+        - name: test-job
+          decorate: true
+          always_run: true
+          skip_report: false
+          spec:
+            nodeSelector:
+              type: vm
+              zone: ci
+            containers:
+              - image: quay.io/kubevirtci/hello-world
+                command: ["/bin/true"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-config-k8snetworkplumbingwg
+  namespace: kubevirt-prow
+data:
+  k8snetworkplumbingwg_test_job_config.yaml: |
+    presubmits:
+      k8snetworkplumbingwg/testrepo:
+        - name: test-job
+          decorate: true
+          always_run: true
+          skip_report: false
+          spec:
+            nodeSelector:
+              type: vm
+              zone: ci
+            containers:
+              - image: quay.io/kubevirtci/hello-world
+                command: ["/bin/true"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-config-kubernetes-sigs
+  namespace: kubevirt-prow
+data:
+  kubernetes-sigs_test_job_config.yaml: |
+    presubmits:
+      kubernetes-sigs/testrepo:
+        - name: test-job
+          decorate: true
+          always_run: true
+          skip_report: false
+          spec:
+            nodeSelector:
+              type: vm
+              zone: ci
+            containers:
+              - image: quay.io/kubevirtci/hello-world
+                command: ["/bin/true"]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-config-nmstate
+  namespace: kubevirt-prow
+data:
+  nmstate_test_job_config.yaml: |
+    presubmits:
+      nmstate/testrepo:
+        - name: test-job
+          decorate: true
+          always_run: true
+          skip_report: false
+          spec:
+            nodeSelector:
+              type: vm
+              zone: ci
+            containers:
+              - image: quay.io/kubevirtci/hello-world
+                command: ["/bin/true"]


### PR DESCRIPTION
This is a quick interim solution to fix the 0.52 jobconfig, we still
need to provide a proper generation of configmaps per repo later on.

See here for motivation of the change: https://github.com/kubevirt/kubevirt/pull/7609

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @brianmcarey 