### PR TITLE
sig-performance: Increase timeout to 1h30m0s

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -409,7 +409,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 1h0m0s
+      timeout: 1h30m0s
     labels:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"


### PR DESCRIPTION
The job has been failing for a few days now [1], timing out and then
failing to dump logs. The latter is being looked into by issue #7170,
this change simply increases the timeout to hopefully allow the job to
complete before ever running this logic.

[1] https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.21-sig-performance

Signed-off-by: Lee Yarwood <lyarwood@redhat.com>