### PR TITLE
Mirror multiarch images to quay.io

### DIFF
--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -22,7 +22,7 @@ do
   image_in_target="${image_in_source//\//-}" # replace / with -
 
   echo "Mirroring from $source_registry/$image_in_source to $target_registry/$image_in_target"
-  skopeo copy "docker://$source_registry/$image_in_source" "docker://$target_registry/$image_in_target" 
+  skopeo copy --multi-arch all "docker://$source_registry/$image_in_source" "docker://$target_registry/$image_in_target"
 done
 
 echo "DONE!"


### PR DESCRIPTION
According to docs here

https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md

skopeo has a --multiarch option of which the default is `system`, so we
need to set it to `all` to mirror all images

/cc @oshoval 

TODO
- [ ] check whether skopeo version in bootstrap image supports that parameter