### PR TITLE
Fix config-bootstrapper call

### DIFF
--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -20,7 +20,8 @@
       --plugin-config=$PLUGIN_CONFIG_PATH \
       --job-config-path=$JOB_CONFIG_PATH
   environment:
-    CONFIG_ROOT: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs"
+    # NOTE: the `--source-path`/`CONFIG_ROOT` MUST NOT contain parts of the relative path that we are using in the plugins config!
+    CONFIG_ROOT: "{{ project_infra_root }}/"
     JOB_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/files/jobs/"
     PROW_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/config/config.yaml"
     PLUGIN_CONFIG_PATH: "{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/configs/plugins/plugins.yaml"


### PR DESCRIPTION
The [config-bootstrapper](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/config-bootstrapper) requires that relative pathes used in the
configs (i.e. plugins.yaml) MUST NOT be part of the --source-path
attribute. The [filter logic](https://github.com/kubernetes/test-infra/blob/64ee58efac4ff2dbbefefc1f9cb668748101836f/prow/plugins/updateconfig/updateconfig.go#L217-L234) otherwise throws the changes away as it
can't match them.

/cc @brianmcarey @xpivarc 