### PR TITLE
sig-performance: Increase KUBEVIRT_MEMORY_SIZE to 10G

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -445,7 +445,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 9G
+          value: 10G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -457,7 +457,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 44Gi
+            memory: 48Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -409,7 +409,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 1h30m0s
+      timeout: 1h0m0s
     labels:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"


### PR DESCRIPTION
https://github.com/kubevirt/kubevirt/issues/7658 identified that the sig-performance job was timing out due to ~12 VMIs becoming unschedulable due to memory pressure in the test environment. 

This PR simply increases the available k8s/KubeVirt memory in the env by ~4G to allow these final 12 VMIs to launch. A previous increase to the overall job timeout is also removed as this shouldn't be required anymore with the job typically completing in around ~30 mins prior to this issue.