### PR TITLE
knmstate: add e2e upgrade lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -168,3 +168,38 @@ presubmits:
               - "/bin/sh"
               - "-c"
               - "automation/check-patch.e2e-operator-k8s.sh"
+    - name: pull-kubernetes-nmstate-e2e-upgrade-k8s
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+      always_run: true
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/golang:v20220211-d7d6c59
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "29Gi"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.16"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-upgrade-k8s.sh"


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

Add job for kubernetes-nmstate upgrade lane.
It's not required at the beginning, we can make it required later when we see it's stable.