### PR TITLE
sriov: Introduce place holder DaemonSet

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/place-holder.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/place-holder.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sriov-place-holder
+  labels:
+    name: sriov-place-holder
+spec:
+  selector:
+    matchLabels:
+      name: sriov-place-holder
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: sriov-place-holder
+        sriov-pod: "true"
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      terminationGracePeriodSeconds: 1
+      priorityClassName: sriov-place-holder
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: sriov-place-holder
+        image: k8s.gcr.io/busybox
+        command: [ "/bin/sh", "-c", "while true; do sleep 86400; done" ]
+        resources:
+          requests:
+            memory: 29Gi

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/priority-classes.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/priority-classes.yaml
@@ -3,8 +3,8 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: sriov
-value: 1000000
-preemptionPolicy: Never
+value: 1000001
+preemptionPolicy: PreemptLowerPriority
 globalDefault: false
 description: "Allows sriov jobs to be scheduled with higher priority."
 ---
@@ -16,3 +16,12 @@ value: 1000000
 preemptionPolicy: Never
 globalDefault: false
 description: "Allows gpu jobs to be scheduled with higher priority."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: sriov-place-holder
+value: 1000000
+preemptionPolicy: Never
+globalDefault: false
+description: "Allows to have sriov place holder jobs"


### PR DESCRIPTION
CI SR-IOV nodes are running both SR-IOV job and regular jobs.
SR-IOV jobs have a higher priority class, which isn't preemptive.
Therefore a new SR-IOV might need to wait until a regular job finishes.

This PR introduces a DaemonSet that will spin a pod, 
that reserves the resources needed for SR-IOV job.

Once a SR-IOV job is scheduled it will preempt the place holder, and run until completed.
Once it is done, the place holder will be rescheduled, saving again the resources.
This way SR-IOV jobs won't need to wait and a dedicate place holder pod will wait for them.

Since the place holder requests the same resources that the real SR-IOV job needs and has
a higher priority than regular jobs, it will not let other pods replace it, nor take those resources.

The place holder pods have anti affinity of `sriov-pod` label, so it won't run when a real SR-IOV jobs runs.
On the other hand, it has the `sriov-pod` label as well, so it will be the one that is preempted by
the SR-IOV pod, because otherwise the SR-IOV pod can't run.
The scheduler preempts only pods that if preempted the designated pod can run instead.
