### PR TITLE
Increase periodic performance jobs mem

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -998,7 +998,7 @@ periodics:
       - name: KUBEVIRT_STORAGE
         value: hpp
       - name: KUBEVIRT_MEMORY_SIZE
-        value: 9G
+        value: 10G
       - name: KUBEVIRT_NUM_NODES
         value: "4"
       - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -1010,7 +1010,7 @@ periodics:
       resources:
         requests:
           cpu: "12"
-          memory: 44Gi
+          memory: 48Gi
       securityContext:
         privileged: true
     nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -445,7 +445,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 12G
+          value: 10G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -457,7 +457,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 52Gi
+            memory: 48Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
The perf periodic job needs more memory.  Also, make the presubmit job the same memory.

fixes: https://github.com/kubevirt/kubevirt/issues/7658