### PR TITLE
flakefinder: fix timeouts for jenkins build retrieval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ querier := robots/cmd/release-querier
 kubevirtci := robots/cmd/kubevirtci-bumper
 bazelbin := bazelisk
 
-.PHONY: all clean deps-update $(limiter) $(flake-report-writer) $(querier) $(kubevirtci) $(flake-issue-creator)
+.PHONY: all clean deps-update gazelle-update-repos $(limiter) $(flake-report-writer) $(querier) $(kubevirtci) $(flake-issue-creator)
 all: deps-update $(limiter) $(flake-report-writer) $(querier) $(kubevirtci) $(flake-issue-creator)
 
 clean:
@@ -24,6 +24,9 @@ deps-update:
 
 gazelle:
 	bazel run //:gazelle -- robots/
+
+gazelle-update-repos:
+	bazel run //:gazelle -- update-repos -from_file=go.mod
 
 install-bazelisk:
 	go get -u github.com/bazelbuild/bazelisk

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,6 +127,13 @@ go_repository(
     version = "v1.1.0",
 )
 
+go_repository(
+    name = "com_github_avast_retry_go",
+    importpath = "github.com/avast/retry-go",
+    sum = "h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=",
+    version = "v3.0.0+incompatible",
+)
+
 gazelle_dependencies()
 
 register_toolchains("//:py_toolchain")

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ require (
 	cloud.google.com/go v0.66.0
 	cloud.google.com/go/storage v1.12.0
 	github.com/Masterminds/semver v1.5.0
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bazelbuild/buildtools v0.0.0-20200922170545-10384511ce98
-	github.com/bndr/gojenkins v1.1.0 // indirect
+	github.com/bndr/gojenkins v1.1.0
 	github.com/go-git/go-git/v5 v5.3.0
 	github.com/go-test/deep v1.0.7
-	github.com/golang/mock v1.5.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v28 v28.1.1
 	github.com/google/go-github/v32 v32.0.0
@@ -17,9 +17,8 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/prometheus/client_golang v1.11.0
-	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 // indirect
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/cobra v1.1.3 // indirect
+	github.com/spf13/cobra v1.1.3
 	golang.org/x/mod v0.4.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	google.golang.org/api v0.32.0

--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-k8s-tester v0.0.0-20190114231546-b411acf57dfe/go.mod h1:1ADF5tAtU1/mVtfMcHAYSm2fPw71DA7fFk0yed64/0I=
 github.com/aws/aws-k8s-tester v0.9.3/go.mod h1:nsh1f7joi8ZI1lvR+Ron6kJM2QdCYPU/vFePghSSuTc=
 github.com/aws/aws-k8s-tester v1.0.0 h1:Zr5NWiRK5fhmRIlhrsTwrY8yB488FyN6iulci2D7VaI=
@@ -776,9 +778,8 @@ github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFU
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
-github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
-github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/go_third_party.bzl
+++ b/go_third_party.bzl
@@ -1483,8 +1483,8 @@ def go_deps():
         name = "com_github_golang_mock",
         build_file_proto_mode = "disable",
         importpath = "github.com/golang/mock",
-        sum = "h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=",
-        version = "v1.5.0",
+        sum = "h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=",
+        version = "v1.4.4",
     )
     go_repository(
         name = "com_github_golang_protobuf",

--- a/robots/cmd/flake-report-creator/cmd/BUILD.bazel
+++ b/robots/cmd/flake-report-creator/cmd/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//robots/pkg/flakefinder:go_default_library",
         "//robots/pkg/flakefinder/junit-merge:go_default_library",
+        "@com_github_avast_retry_go//:go_default_library",
         "@com_github_bndr_gojenkins//:go_default_library",
         "@com_github_joshdk_go_junit//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/robots/cmd/flake-report-creator/cmd/jenkins.go
+++ b/robots/cmd/flake-report-creator/cmd/jenkins.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	retry "github.com/avast/retry-go"
 	"github.com/bndr/gojenkins"
 	"github.com/joshdk/go-junit"
 	log "github.com/sirupsen/logrus"
@@ -381,15 +382,15 @@ func fetchReportDataForJob(filteredJob gojenkins.InnerJob, jenkins *gojenkins.Je
 func fetchCompletedBuildsForJob(startOfReport time.Time, lastBuildNumber int64, job *gojenkins.Job, ctx context.Context, fLog *log.Entry) []*gojenkins.Build {
 	fLog.Printf("Fetching completed builds, starting at %d", lastBuildNumber)
 	var completedBuilds []*gojenkins.Build
-	for i := lastBuildNumber; i > 0; i-- {
-		fLog.Printf("Fetching build no %d", i)
-		build, err := job.GetBuild(ctx, i)
-		if err != nil {
-			fLog.Warnf("failed to fetch build data for build no %d: %v", i, err)
-			if statusCode := httpStatusOrDie(err, fLog); statusCode == http.StatusNotFound {
-				continue
+	for buildNumber := lastBuildNumber; buildNumber > 0; buildNumber-- {
+		fLog.Printf("Fetching build no %d", buildNumber)
+		build, statusCode, err := getBuildWithRetry(job, ctx, buildNumber, fLog)
+
+		if build == nil {
+			if statusCode != http.StatusNotFound {
+				fLog.Fatalf("failed to fetch build data for build no %d: %v", buildNumber, err)
 			}
-			fLog.Fatalf("failed to fetch build data for build no %d: %v", i, err)
+			continue
 		}
 
 		if build.GetResult() != "SUCCESS" &&
@@ -411,8 +412,32 @@ func fetchCompletedBuildsForJob(startOfReport time.Time, lastBuildNumber int64, 
 	return completedBuilds
 }
 
-// httpStatusOrDie fetches stringly typed error code produced by jenkins client or logs a fatal error if conversion to
-// int is not possible
+func getBuildWithRetry(job *gojenkins.Job, ctx context.Context, buildNumber int64, fLog *log.Entry) (build *gojenkins.Build, statusCode int, err error) {
+	retry.Do(
+		func() error {
+			build, err = job.GetBuild(ctx, buildNumber)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+		retry.RetryIf(func(err error) bool {
+			fLog.Warningf("failed to fetch build data for build no %d: %v", buildNumber, err)
+			statusCode = httpStatusOrDie(err, fLog)
+			if statusCode == http.StatusNotFound {
+				return false
+			}
+			if statusCode == http.StatusGatewayTimeout {
+				return true
+			}
+			return false
+		}),
+	)
+	return build, statusCode, err
+}
+
+// httpStatusOrDie fetches [stringly typed](https://wiki.c2.com/?StringlyTyped) error code produced by jenkins client
+// or logs a fatal error if conversion to int is not possible
 func httpStatusOrDie(err error, fLog *log.Entry) int {
 	statusCode, err2 := strconv.Atoi(err.Error())
 	if err2 != nil {


### PR DESCRIPTION
We were seeing two things:

1. get latest build returned a build struct with `0` as number for latest build
2. get build failed with 504, which failed the whole process

Issue 1 was fixed by removing the call to GetLatestBuild, and using the build number that was already present in the `job.Raw.LastBuild.Number`.
Issue 2 was fixed by using a retry for the GetBuild step in case a 504 was issued.

/cc @lukas-bednar