### PR TITLE
Use podman for mkpj.sh script if installed

### DIFF
--- a/hack/mkpj.sh
+++ b/hack/mkpj.sh
@@ -10,5 +10,11 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 config="${root}/github/ci/prow-deploy/files/config.yaml"
 job_config_path="${root}/github/ci/prow-deploy/files/jobs"
 
-docker pull gcr.io/k8s-prow/mkpj 1>&2 || true
-docker run -i --rm -v "${root}:${root}:z" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"
+if podman ps >/dev/null 2>&1; then
+    _cri_bin=podman
+else
+    _cri_bin=docker
+fi
+
+${_cri_bin} pull gcr.io/k8s-prow/mkpj 1>&2 || true
+${_cri_bin} run -i --rm -v "${root}:${root}:z" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"


### PR DESCRIPTION
When the mkpj.sh script is run and the docker daemon is not running it fails. If podman is installed, I would prefer it to use podman as it doesn't require a running daemon.

```
./hack/mkpj.sh
Using default tag: latest 
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running? 
```

/cc @dhiller 
Signed-off-by: Brian Carey <bcarey@redhat.com>