### PR TITLE
Add mirror for previous minor release of cri-o

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.20,1.21,1.22,1.23"
+            value: "1.20:1.20.6,1.20,1.21:1.21.5,1.21,1.22:1.22.2,1.22,1.23:1.23.1,1.23"
         command: ["/bin/sh", "-ce"]
         args:
           - |

--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -13,6 +13,11 @@ mirror_crio_repo_for_version () {
     then
         CRIO_SUBDIR=""
         REPOID=$BASE_REPOID
+    elif [[ $1 = *":"* ]]
+    then    
+	CRIO_SUBDIR=":cri-o:$1"
+	REPOID_VER=$(echo $1 | sed 's/:/_/g')
+	REPOID="${BASE_REPOID}_cri-o_$REPOID_VER"
     else
         CRIO_SUBDIR=":cri-o:$1"
         REPOID="${BASE_REPOID}_cri-o_$1"


### PR DESCRIPTION
An issue with the latest release of cri-o caused failures in kubevirtci
presubmits. Using the previous minor releases avoided these failures.
This change adds the previous cri-o minor releases to the kubevirtci
mirror

See https://github.com/kubevirt/kubevirtci/pull/796 for more details

/cc @xpivarc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>