### PR TITLE
prow-deploy: delete priority classes before re-deployment

### DIFF
--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -28,6 +28,13 @@
     KUBECONFIG: "{{ kubeconfig_path }}"
   when: bootstrap_full_config
 
+- name: Delete priority classes on prow-workloads BM cluster
+  when: delete_priority_classes
+  shell: |
+    kubectl delete pc sriov vgpu
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+
 - name: Launch deployment
   shell: |
     # for now cant execute "kubectl apply --server-side" reliably on

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -30,6 +30,7 @@ coverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
 bootstrap_full_config: true
 reconcile_github_webhooks: false
 rescale_pushgateway_deployment: true
+delete_priority_classes: false
 
 kubeconfig_path: /root/.kube/config
 

--- a/github/ci/prow-deploy/vars/workloads-production/main.yml
+++ b/github/ci/prow-deploy/vars/workloads-production/main.yml
@@ -19,3 +19,4 @@ SRIOVNodes:
 
 remote_cluster_prow_jobs_context: prow-workloads
 ansible_python_interpreter: /usr/bin/python3
+delete_priority_classes: true


### PR DESCRIPTION
Ansible role was updated to delete the prirority classes prior
to the launch of the deployment itself. This is because updating
the priority class that is in use will fail, thus its requried
to re-create it.

**Discalimer**
* Trivial approach (no usage of `yq`)
* Currently w/o testing via Molecule. 

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>