### PR TITLE
Add ssh secret to access private repos with prow

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-presubmits.yaml
@@ -4,6 +4,10 @@ presubmits:
     skip_if_only_changed: .*\.md
     cluster: ibm-prow-jobs
     decorate: true
+    decoration_config:
+      ssh_key_secrets:
+      - prow-kubevirtbot-github-ssh-secret
+    clone_uri: "git@github.com:kubevirt/secrets.git"
     extra_refs:
     - base_ref: main
       org: kubevirt

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -356,3 +356,9 @@ secretGenerator:
       # fossaToken
       - token=secrets/kubevirtci-fossa-token
     type: Opaque
+  - name: prow-kubevirtbot-github-ssh-secret
+    namespace: kubevirt-prow-jobs
+    files:
+      # prowKubevirtbotSSHPrivateKey
+      - token=secrets/prow-kubevirtbot-github-ssh-secret
+    type: Opaque

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -80,3 +80,9 @@ secretGenerator:
       # fossaToken
       - token=secrets/kubevirtci-fossa-token
     type: Opaque
+  - name: prow-kubevirtbot-github-ssh-secret
+    namespace: kubevirt-prow-jobs
+    files:
+    # prowKubevirtbotSSHPrivateKey
+    - token=secrets/prow-kubevirtbot-github-ssh-secret
+    type: Opaque

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -109,3 +109,8 @@
   copy:
     content: '{{ fossaToken }}'
     dest: '{{ secrets_dir }}/kubevirtci-fossa-token'
+
+- name: Create Prow GitHub Kubevirtbot SSH private key secret
+  copy:
+    content: '{{ prowKubevirtbotSSHPrivateKey }}'
+    dest: '{{ secrets_dir }}/prow-kubevirtbot-github-ssh-secret'

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -38,3 +38,5 @@ windowsProductKeys:
   sysprep-001: "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE"
 
 fossaToken: d3c481176ace1b6c5eb417b0d3dd01497
+
+prowKubevirtbotSSHPrivateKey: "fakie fake"


### PR DESCRIPTION
In order to access private repositories with prow we need to use an SSH
key as described here:

https://github.com/kubernetes/test-infra/blob/cab76bdbd3760143a7b45dc35cf0b4d8d43b6c77/prow/pod-utilities.md#how-to-configure

/cc @brianmcarey @xpivarc @enp0s3 