### PR TITLE
prow-deploy: fix missing ansbile variable for deployment

### DIFF
--- a/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
+++ b/github/ci/prow-deploy/vars/ibmcloud-production/main.yml
@@ -14,3 +14,4 @@ shell_environment:
 SRIOVNodes: []
 remote_cluster_prow_jobs_context: ibm-prow-jobs
 ansible_python_interpreter: /usr/bin/python3
+delete_priority_classes: false


### PR DESCRIPTION
As was seen in the [error](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-prow-control-plane-deployment/1524310295969796096#1:build-log.txt%3A188) log from postsubmit, the priority class deletion variable should be defined in all the ansible roles.
 
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>