### PR TITLE
prow-deploy: add the place-holder daemonset to kustomize list

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - resources/multus-cni.yaml
   - resources/metrics-server.yaml
   - resources/priority-classes.yaml
+  - resources/place-holder.yaml
   - ../../components/docker-mirror-proxy/base
   - ../../components/greenhouse/base
 


### PR DESCRIPTION
This PR should add the missing part for #2068, that the new place-holder DS wasn't treated by Kustomize.

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>