### PR TITLE
sriov: Add namespace to the place holder ds

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/place-holder.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/place-holder.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: sriov-place-holder
+  namespace: kubevirt-prow-jobs
   labels:
     name: sriov-place-holder
 spec:

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -31,7 +31,7 @@
 - name: Delete priority classes on prow-workloads BM cluster
   when: delete_priority_classes
   shell: |
-    kubectl delete pc sriov vgpu
+    kubectl delete pc sriov sriov-place-holder vgpu
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 


### PR DESCRIPTION
Without the namespace, the anti affinity
doesn't make sure that only either
sriov or place-holder are running.

Add sriov-place-holder PC to the delete command
so when we are redeploying it will clean the previous PCs as needed.
