### PR TITLE
kubevirtci, sriov: Add missing pc

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -83,6 +83,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+      priorityClassName: sriov  
   - always_run: true
     cluster: prow-workloads
     decorate: true


### PR DESCRIPTION
Since we have now sriov place holder,
the jobs of kubevirtci sriov should have
pc of sriov, so they can preempt the place holder,
and run instead.

Related to https://github.com/kubevirt/project-infra/pull/2068