### PR TITLE
emphasize tests with higher number of failures over those with higher ratio

### DIFF
--- a/robots/pkg/flakefinder/report_data_test.go
+++ b/robots/pkg/flakefinder/report_data_test.go
@@ -78,43 +78,80 @@ var _ = Describe("report.go", func() {
 			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
 		})
 
-		DescribeTable("returns tests of same severity weighted by total number of tests", func(t1Failed, t2Failed, t3Failed, t1Succeeded, t2Succeeded, t3Succeeded []int, expected []string) {
-			data := map[string]map[string]*Details{}
-			data["t1"] = map[string]*Details{}
-			for index, failed := range t1Failed {
-				data["t1"][fmt.Sprint(index)] = &Details{Failed: failed, Succeeded: t1Succeeded[index], Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}
-			}
-			data["t2"] = map[string]*Details{}
-			for index, failed := range t2Failed {
-				data["t2"][fmt.Sprint(index)] = &Details{Failed: failed, Succeeded: t2Succeeded[index], Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}
-			}
-			data["t3"] = map[string]*Details{}
-			for index, failed := range t3Failed {
-				data["t3"][fmt.Sprint(index)] = &Details{Failed: failed, Succeeded: t3Succeeded[index], Skipped: 2, Severity: HeavilyFlaky, Jobs: []*Job{}}
+		type testExpectations struct {
+			testName string
+			failed []int
+			succeeded []int
+			skipped []int
+			severity string
+		}
+
+		DescribeTable("returns tests of same severity weighted by total number of tests", func(expectations []testExpectations, expectedTestNameOrder []string) {
+			testData := map[string]map[string]*Details{}
+			for _, expectation := range expectations {
+				testData[expectation.testName] = map[string]*Details{}
+				for index, failed := range expectation.failed {
+					testData[expectation.testName][fmt.Sprint(index)] = &Details{Failed: failed, Succeeded: expectation.succeeded[index], Skipped: expectation.skipped[index], Severity: expectation.severity, Jobs: []*Job{}}
+				}
 			}
 
-			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo(expected))
+			Expect(SortTestsByRelevance(testData, tests)).To(BeEquivalentTo(expectedTestNameOrder))
 		},
 			Entry("zeros shouldn't be a problem",
-				[]int{2}, []int{1}, []int{3}, []int{0}, []int{0}, []int{0}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{2}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{1}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{3}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 			Entry("the more failures the higher",
-				[]int{2}, []int{1}, []int{3}, []int{1}, []int{1}, []int{1}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{2}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{1}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{3}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 			Entry("multiple values with zeros",
-				[]int{2, 0}, []int{1, 0}, []int{3, 0}, []int{1, 0}, []int{1, 0}, []int{1, 0}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{2, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{1, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{3, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 			Entry("multiple values",
-				[]int{4, 5}, []int{3, 4}, []int{6, 7}, []int{1, 1}, []int{1, 1}, []int{1, 1}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{4, 5}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{3, 4}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{6, 7}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 			Entry("errors high, ratios small",
-				[]int{6, 7}, []int{4, 5}, []int{11, 12}, []int{5, 6}, []int{3, 4}, []int{10, 11}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{6, 7}, succeeded: []int{5, 6}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{4, 5}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{11, 12}, succeeded: []int{10, 11}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 			Entry("higher ratio, the higher",
-				[]int{6, 7}, []int{4, 5}, []int{11, 12}, []int{3, 4}, []int{2, 3}, []int{2, 1}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{6, 7}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{4, 5}, succeeded: []int{2, 3}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{11, 12}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 			Entry("mixed lengths",
-				[]int{8, 10}, []int{3, 4, 5}, []int{22}, []int{2, 1}, []int{1, 2, 3}, []int{2}, []string{"t3", "t1", "t2"},
+				[]testExpectations{
+					{ testName: "t1", failed: []int{8, 10}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{ testName: "t2", failed: []int{3, 4, 5}, succeeded: []int{1, 2, 3}, skipped: []int{2, 2, 2}, severity: HeavilyFlaky },
+					{ testName: "t3", failed: []int{22}, succeeded: []int{2}, skipped: []int{2}, severity: HeavilyFlaky },
+				},
+				[]string{"t3", "t1", "t2"},
 			),
 		)
 

--- a/robots/pkg/flakefinder/report_data_test.go
+++ b/robots/pkg/flakefinder/report_data_test.go
@@ -78,7 +78,7 @@ var _ = Describe("report.go", func() {
 			Expect(SortTestsByRelevance(data, tests)).To(BeEquivalentTo([]string{"t3", "t1", "t2"}))
 		})
 
-		type testExpectations struct {
+		type testData struct {
 			testName  string
 			failed    []int
 			succeeded []int
@@ -86,7 +86,7 @@ var _ = Describe("report.go", func() {
 			severity  string
 		}
 
-		DescribeTable("returns tests of same severity weighted by total number of tests", func(expectations []testExpectations, expectedTestNameOrder []string) {
+		DescribeTable("returns tests of same severity weighted by total number of tests", func(expectations []testData, expectedTestNameOrder []string) {
 			testData := map[string]map[string]*Details{}
 			for _, expectation := range expectations {
 				testData[expectation.testName] = map[string]*Details{}
@@ -98,7 +98,7 @@ var _ = Describe("report.go", func() {
 			Expect(SortTestsByRelevance(testData, tests)).To(BeEquivalentTo(expectedTestNameOrder))
 		},
 			Entry("zeros shouldn't be a problem",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{2}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{1}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{3}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
@@ -106,7 +106,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("the more failures the higher",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{2}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{1}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{3}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
@@ -114,7 +114,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("multiple values with zeros",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{2, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{1, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{3, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky},
@@ -122,7 +122,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("multiple values",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{4, 5}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{3, 4}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{6, 7}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
@@ -130,7 +130,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("errors high, ratios small",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{6, 7}, succeeded: []int{5, 6}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{4, 5}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{11, 12}, succeeded: []int{10, 11}, skipped: []int{2, 2}, severity: HeavilyFlaky},
@@ -138,7 +138,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("higher ratio, the higher",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{6, 7}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{4, 5}, succeeded: []int{2, 3}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{11, 12}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
@@ -146,7 +146,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("mixed lengths",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{8, 10}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{3, 4, 5}, succeeded: []int{1, 2, 3}, skipped: []int{2, 2, 2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{22}, succeeded: []int{2}, skipped: []int{2}, severity: HeavilyFlaky},
@@ -156,7 +156,7 @@ var _ = Describe("report.go", func() {
 
 			// while the ratio here is higher for t2, we still want to emphazise the cases with higher failures more
 			Entry("real life case 1: 10/9/2 > 9/9/3 > 6/3/12",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{9}, succeeded: []int{9}, skipped: []int{3}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{6}, succeeded: []int{3}, skipped: []int{12}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{10}, succeeded: []int{9}, skipped: []int{2}, severity: HeavilyFlaky},
@@ -164,7 +164,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("real life case 2: 6/3/12 > 5/0/2 > 4/1/2",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{5}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{4}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{6}, succeeded: []int{3}, skipped: []int{12}, severity: HeavilyFlaky},
@@ -172,7 +172,7 @@ var _ = Describe("report.go", func() {
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("real life case 1: 15/1/0 > 13/0/3 > 3/0/13 > ",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{13}, succeeded: []int{0}, skipped: []int{3}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{3}, succeeded: []int{0}, skipped: []int{13}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{15}, succeeded: []int{1}, skipped: []int{0}, severity: HeavilyFlaky},
@@ -181,7 +181,7 @@ var _ = Describe("report.go", func() {
 			),
 
 			Entry("less number of succeeded, more severe: 5/1/13 > 5/3/3 > 5/5/0",
-				[]testExpectations{
+				[]testData{
 					{testName: "t1", failed: []int{5}, succeeded: []int{3}, skipped: []int{3}, severity: HeavilyFlaky},
 					{testName: "t2", failed: []int{5}, succeeded: []int{5}, skipped: []int{13}, severity: HeavilyFlaky},
 					{testName: "t3", failed: []int{5}, succeeded: []int{1}, skipped: []int{0}, severity: HeavilyFlaky},

--- a/robots/pkg/flakefinder/report_data_test.go
+++ b/robots/pkg/flakefinder/report_data_test.go
@@ -79,11 +79,11 @@ var _ = Describe("report.go", func() {
 		})
 
 		type testExpectations struct {
-			testName string
-			failed []int
+			testName  string
+			failed    []int
 			succeeded []int
-			skipped []int
-			severity string
+			skipped   []int
+			severity  string
 		}
 
 		DescribeTable("returns tests of same severity weighted by total number of tests", func(expectations []testExpectations, expectedTestNameOrder []string) {
@@ -99,57 +99,92 @@ var _ = Describe("report.go", func() {
 		},
 			Entry("zeros shouldn't be a problem",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{2}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{1}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{3}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{2}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{1}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{3}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("the more failures the higher",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{2}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{1}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{3}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{2}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{1}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{3}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("multiple values with zeros",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{2, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{1, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{3, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{2, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{1, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{3, 0}, succeeded: []int{1, 0}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("multiple values",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{4, 5}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{3, 4}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{6, 7}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{4, 5}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{3, 4}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{6, 7}, succeeded: []int{1, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("errors high, ratios small",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{6, 7}, succeeded: []int{5, 6}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{4, 5}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{11, 12}, succeeded: []int{10, 11}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{6, 7}, succeeded: []int{5, 6}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{4, 5}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{11, 12}, succeeded: []int{10, 11}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("higher ratio, the higher",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{6, 7}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{4, 5}, succeeded: []int{2, 3}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{11, 12}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{6, 7}, succeeded: []int{3, 4}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{4, 5}, succeeded: []int{2, 3}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{11, 12}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),
 			Entry("mixed lengths",
 				[]testExpectations{
-					{ testName: "t1", failed: []int{8, 10}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky },
-					{ testName: "t2", failed: []int{3, 4, 5}, succeeded: []int{1, 2, 3}, skipped: []int{2, 2, 2}, severity: HeavilyFlaky },
-					{ testName: "t3", failed: []int{22}, succeeded: []int{2}, skipped: []int{2}, severity: HeavilyFlaky },
+					{testName: "t1", failed: []int{8, 10}, succeeded: []int{2, 1}, skipped: []int{2, 2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{3, 4, 5}, succeeded: []int{1, 2, 3}, skipped: []int{2, 2, 2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{22}, succeeded: []int{2}, skipped: []int{2}, severity: HeavilyFlaky},
+				},
+				[]string{"t3", "t1", "t2"},
+			),
+
+			// while the ratio here is higher for t2, we still want to emphazise the cases with higher failures more
+			Entry("real life case 1: 10/9/2 > 9/9/3 > 6/3/12",
+				[]testExpectations{
+					{testName: "t1", failed: []int{9}, succeeded: []int{9}, skipped: []int{3}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{6}, succeeded: []int{3}, skipped: []int{12}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{10}, succeeded: []int{9}, skipped: []int{2}, severity: HeavilyFlaky},
+				},
+				[]string{"t3", "t1", "t2"},
+			),
+			Entry("real life case 2: 6/3/12 > 5/0/2 > 4/1/2",
+				[]testExpectations{
+					{testName: "t1", failed: []int{5}, succeeded: []int{0}, skipped: []int{2}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{4}, succeeded: []int{1}, skipped: []int{2}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{6}, succeeded: []int{3}, skipped: []int{12}, severity: HeavilyFlaky},
+				},
+				[]string{"t3", "t1", "t2"},
+			),
+			Entry("real life case 1: 15/1/0 > 13/0/3 > 3/0/13 > ",
+				[]testExpectations{
+					{testName: "t1", failed: []int{13}, succeeded: []int{0}, skipped: []int{3}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{3}, succeeded: []int{0}, skipped: []int{13}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{15}, succeeded: []int{1}, skipped: []int{0}, severity: HeavilyFlaky},
+				},
+				[]string{"t3", "t1", "t2"},
+			),
+
+			Entry("less number of succeeded, more severe: 5/1/13 > 5/3/3 > 5/5/0",
+				[]testExpectations{
+					{testName: "t1", failed: []int{5}, succeeded: []int{3}, skipped: []int{3}, severity: HeavilyFlaky},
+					{testName: "t2", failed: []int{5}, succeeded: []int{5}, skipped: []int{13}, severity: HeavilyFlaky},
+					{testName: "t3", failed: []int{5}, succeeded: []int{1}, skipped: []int{0}, severity: HeavilyFlaky},
 				},
 				[]string{"t3", "t1", "t2"},
 			),


### PR DESCRIPTION
Counting the occurrences a test failed will cause tests with lower number of failures but same number of appearances to appear before tests that have higher number of failures.

Also using the ratio of #tests_failed / #tests_succeeded as a factor emphasizes tests with less failures but a high ratio far more than tests with higher number of tests.

As we want to emphasize tests that have higher failure numbers over those that have less failures, we tabularize the severity as a factor according to the relation of `#tests_failed / #tests_succeeded` .
We then multiply that value by the number of failures.

Besides that we refactor the tests using a struct to increase readability.

/cc @enp0s3 @xpivarc 