### PR TITLE
periodic, sriov: Add missing pc

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -641,6 +641,7 @@ periodics:
         path: /dev/vfio/
         type: Directory
       name: vfio
+    priorityClassName: sriov
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -83,7 +83,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-      priorityClassName: sriov  
+      priorityClassName: sriov
   - always_run: true
     cluster: prow-workloads
     decorate: true


### PR DESCRIPTION
Since we have now sriov place holder,
the jobs of sriov should have
pc of sriov, so they can preempt the place holder,
and run instead.

Remove trailing spaces.