### PR TITLE
Update bootstrap image to Fedora 36

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:34
+FROM fedora:36
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -106,9 +106,8 @@ RUN USE_BAZEL_VERSION=4.1.0 bazel version && \
 # create mixin directories
 RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
 
-# Workaround error when running buildah
-# 'overlay' is not supported over overlayfs, a mount_program is required: backing file system is unsupported for this graph driver
-RUN sed -i -e 's,#mount_program,mount_program,' /etc/containers/storage.conf
+# Trust git repositories used for e2e jobs
+RUN git config --global --add safe.directory '*'
 
 # note the runner is also responsible for making docker in docker function if
 # env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating


### PR DESCRIPTION
Fedora 36 has been released so the bootstrap image should be updated.

As F36 comes with git version 2.36.1 which has strict rules around
directory ownership of git repos[1], an update to the git config to trust
repos was required. This was an issue when testing e2e jobs with phaino.

[1] https://git-scm.com/docs/git-config/2.35.2#Documentation/git-config.txt-safedirectory

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>