### PR TITLE
Remove branch protection for secrets

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -389,10 +389,6 @@ branch-protection:
           branches:
             main:
               protect: true
-        secrets:
-          branches:
-            master:
-              protect: true
     k8snetworkplumbingwg:
       repos:
         kubemacpool:


### PR DESCRIPTION
Using branch protection for private repos is a pro feature,
thus we can not use it.

/cc @brianmcarey @enp0s3 