### PR TITLE
release-0.52, sriov: Add missing pc (#2096)

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -548,6 +548,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+      priorityClassName: sriov  
   - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -711,6 +712,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+      priorityClassName: sriov  
   - always_run: true
     branches:
     - release-0.52


### PR DESCRIPTION
Since we have now sriov place holder,
the jobs of sriov should have
pc of sriov, so they can preempt the place holder,
and run instead.

Out of the releases, only 0.52 missed it,
so this PR add it manually.

Signed-off-by: Or Shoval <oshoval@redhat.com>