### PR TITLE
Remove previous minor release of cri-o from mirror job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.20:1.20.6,1.20,1.21:1.21.5,1.21,1.22:1.22.2,1.22,1.23:1.23.1,1.23"
+            value: "1.20,1.21,1.22,1.23"
         command: ["/bin/sh", "-ce"]
         args:
           - |


### PR DESCRIPTION
The previous minor releases were added to the mirror due to an issue
with the latest cri-o release. The previous minor releases have been rebuilt
and now has the same issue.

The previous minor releases were introduced here https://github.com/kubevirt/project-infra/pull/2086 but are no longer needed.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>