### PR TITLE
Improve alert message for high percentage of errors in Grafana

### DIFF
--- a/github/ci/services/loki/manifests/common/rules.yaml
+++ b/github/ci/services/loki/manifests/common/rules.yaml
@@ -12,7 +12,7 @@ data:
     groups:
       - name: GrafanaLogAlerts
         rules:
-        - alert: HighPercentageError
+        - alert: HighPercentageErrorGrafana
           expr: |
             sum(rate({app="grafana", namespace="monitoring"} |= "error" [5m])) by (job)
               /
@@ -23,7 +23,7 @@ data:
               severity: "warning"
               namespace: "monitoring"
           annotations:
-              description: "High percentage of errors in the logs"
+              description: "High percentage of errors in Grafana logs"
         - alert: HighFailedLoginsGrafana
           expr: | 
             rate({app="grafana"} |= "Invalid username or password" [5m]) 


### PR DESCRIPTION
The previous message was not clear on which application was experiencing
high levels of errors in the logs.

/cc @dhiller @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>