### PR TITLE
Narrow down image bump to only use images with valid tag

### DIFF
--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -18,7 +18,7 @@ else
 fi
 
 IMAGE_NAME="$1"
-latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( contains("latest") | not )' | tail -1)
+latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("v[0-9]+-[a-z0-9]+") )' | tail -1)
 if [ -z "$latest_image_tag" ]; then
     echo "Couldn't find latest_image_tag"
     exit 1


### PR DESCRIPTION
A valid tag is a tag that is matching our schema of
`v<reverse-date>-<short-git-sha>`.

/cc @brianmcarey 