### PR TITLE
Remove GIMME_GO_VERSION from kind prow jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -609,8 +609,6 @@ periodics:
         value: "true"
       - name: TARGET
         value: kind-1.22-sriov
-      - name: GIMME_GO_VERSION
-        value: 1.13.8
       image: quay.io/kubevirtci/golang:v20220512-78048f1
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -589,8 +589,6 @@ presubmits:
         env:
         - name: TARGET
           value: kind-1.22-sriov
-        - name: GIMME_GO_VERSION
-          value: 1.13.8
         - name: FEATURE_GATES
           value: NonRoot
         - name: KUBEVIRT_NONROOT
@@ -674,8 +672,6 @@ presubmits:
         env:
         - name: TARGET
           value: kind-1.22-sriov
-        - name: GIMME_GO_VERSION
-          value: 1.13.8
         image: quay.io/kubevirtci/bootstrap:v20220512-78048f1
         name: ""
         resources:
@@ -736,8 +732,6 @@ presubmits:
           env:
             - name: TARGET
               value: kind-1.23-vgpu
-            - name: GIMME_GO_VERSION
-              value: 1.13.8
           image: quay.io/kubevirtci/bootstrap:v20220512-78048f1
           name: ""
           resources:
@@ -812,8 +806,6 @@ presubmits:
           value: "true"
         - name: TARGET
           value: kind-1.23-vgpu
-        - name: GIMME_GO_VERSION
-          value: 1.13.8
         image: quay.io/kubevirtci/golang:v20220512-78048f1
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -43,8 +43,6 @@ presubmits:
           make cluster-up
           ./cluster-up/cluster/kind/check-cluster-up.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.13.8
         - name: KUBEVIRT_PROVIDER
           value: kind-1.22-sriov
         - name: KUBEVIRT_NUM_NODES
@@ -108,8 +106,6 @@ presubmits:
           make cluster-up
           ./cluster-up/cluster/kind/check-cluster-up.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.13.8
         - name: KUBEVIRT_PROVIDER
           value: kind-1.23-vgpu
         - name: KUBEVIRT_NUM_NODES


### PR DESCRIPTION
Prow jobs should use the default Go version from the kubevirtci golang
image where possible.
https://github.com/kubevirt/project-infra/blob/26ca49f8e110861cdd4aacb501e51e0e9f7ff869/images/golang/Dockerfile#L3

A successful test run of [periodic-kubevirt-e2e-k8s-1.22-sriov](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sriov/1527234012848852992) was carried out using `GIMME_GO_VERSION=1.15.8`

/cc @dhiller @EdDev @oshoval 

Signed-off-by: Brian Carey <bcarey@redhat.com>