### PR TITLE
Add cri-o version 1.24 to periodic mirror job for 1.24 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.20,1.21,1.22,1.23"
+            value: "1.21,1.22,1.23,1.24"
         command: ["/bin/sh", "-ce"]
         args:
           - |


### PR DESCRIPTION
The 1.24 version of cri-o will be required to be present in the
kubevirtci mirror to allow for testing with the 1.24 kubernetes cluster
provider.

Signed-off-by: Brian Carey <bcarey@redhat.com>