### PR TITLE
Add new kubeconfig secret required to deploy prow services 

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220512-991c32830b"
-        initupload: "gcr.io/k8s-prow/initupload:v20220512-991c32830b"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220512-991c32830b"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220512-991c32830b"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220526-c15dd4997d"
+        initupload: "gcr.io/k8s-prow/initupload:v20220526-c15dd4997d"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220526-c15dd4997d"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220526-c15dd4997d"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20220512-991c32830b
+              image: gcr.io/k8s-prow/branchprotector:v20220526-c15dd4997d
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220512-991c32830b
+        image: gcr.io/k8s-prow/cherrypicker:v20220526-c15dd4997d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220512-991c32830b
+              image: gcr.io/k8s-prow/label_sync:v20220526-c15dd4997d
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220512-991c32830b
+              image: gcr.io/k8s-prow/label_sync:v20220526-c15dd4997d
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220512-991c32830b
+        image: gcr.io/k8s-prow/crier:v20220526-c15dd4997d
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
@@ -58,6 +58,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-build-test-infra-trusted
           name: kubeconfig-build-test-infra-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-k8s-prow-builds
+          name: kubeconfig-build-k8s-prow-builds
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -92,3 +95,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-test-infra-trusted
+      - name: kubeconfig-build-k8s-prow-builds
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-k8s-prow-builds

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220512-991c32830b
+        image: gcr.io/k8s-prow/deck:v20220526-c15dd4997d
         imagePullPolicy: Always
         ports:
         - name: http
@@ -63,7 +63,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig"
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/githuboauth
@@ -76,6 +76,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-build-test-infra-trusted
           name: kubeconfig-build-test-infra-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-k8s-prow-builds
+          name: kubeconfig-build-k8s-prow-builds
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -120,6 +123,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-test-infra-trusted
+      - name: kubeconfig-build-k8s-prow-builds
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-k8s-prow-builds
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220512-991c32830b
+        image: gcr.io/k8s-prow/ghproxy:v20220526-c15dd4997d
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220512-991c32830b
+        image: gcr.io/k8s-prow/hook:v20220526-c15dd4997d
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -51,7 +51,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig"
         ports:
         - name: http
           containerPort: 8888
@@ -86,6 +86,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-build-test-infra-trusted
           name: kubeconfig-build-test-infra-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-k8s-prow-builds
+          name: kubeconfig-build-k8s-prow-builds
           readOnly: true
         livenessProbe:
           httpGet:
@@ -133,3 +136,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-test-infra-trusted
+      - name: kubeconfig-build-k8s-prow-builds
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-k8s-prow-builds

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220512-991c32830b
+        image: gcr.io/k8s-prow/horologium:v20220526-c15dd4997d
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20220512-991c32830b
+        image: gcr.io/k8s-prow/needs-rebase:v20220526-c15dd4997d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220512-991c32830b
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220526-c15dd4997d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
@@ -58,6 +58,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-build-test-infra-trusted
           name: kubeconfig-build-test-infra-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-k8s-prow-builds
+          name: kubeconfig-build-k8s-prow-builds
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -86,6 +89,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-test-infra-trusted
+      - name: kubeconfig-build-k8s-prow-builds
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-k8s-prow-builds
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,11 +22,11 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20220512-991c32830b
+        image: gcr.io/k8s-prow/sinker:v20220526-c15dd4997d
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090
@@ -36,6 +36,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-build-test-infra-trusted
           name: kubeconfig-build-test-infra-trusted
+          readOnly: true
+        - mountPath: /etc/kubeconfig-build-k8s-prow-builds
+          name: kubeconfig-build-k8s-prow-builds
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -52,6 +55,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-build-test-infra-trusted
+      - name: kubeconfig-build-k8s-prow-builds
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-build-k8s-prow-builds
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220512-991c32830b
+        image: gcr.io/k8s-prow/status-reconciler:v20220526-c15dd4997d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220512-991c32830b
+        image: gcr.io/k8s-prow/tide:v20220526-c15dd4997d
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/kustomization.yaml
@@ -314,6 +314,9 @@ secretGenerator:
   - name: kubeconfig-build-test-infra-trusted
     files:
       - kubeconfig=secrets/kubeconfig-build-test-infra-trusted
+  - name: kubeconfig-build-k8s-prow-builds
+    files:
+      - kubeconfig=secrets/kubeconfig-build-k8s-prow-builds
   - name: unsplash-api-key
     literals:
       - honk.txt=

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20220512-991c32830b
+        image: gcr.io/k8s-prow/exporter:v20220526-c15dd4997d
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -91,6 +91,12 @@
         dest: '{{ secrets_dir }}/kubeconfig-build-test-infra-trusted'
         remote_src: true
 
+    - name: Create kubeconfig-build-k8s-prow-builds
+      copy:
+        src: '{{ kubeconfig_path }}'
+        dest: '{{ secrets_dir }}/kubeconfig-build-k8s-prow-builds'
+        remote_src: true
+
     - name: copy production kustomize files
       synchronize:
         src: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/{{ item }}'

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -70,6 +70,14 @@
         content: '{{ kubeconfig }}'
         dest: '{{ secrets_dir }}/kubeconfig-build-test-infra-trusted'
 
+- name: Create kubeconfig-build-k8s-prow-builds secret
+  when: kubeconfig is defined
+  block:
+    - name: Create kubeconfig-build-k8s-prow-builds file
+      copy:
+        content: '{{ kubeconfig }}'
+        dest: '{{ secrets_dir }}/kubeconfig-build-k8s-prow-builds'
+
 - name: Create docker proxy CA key
   copy:
     content: '{{ dockerMirrorProxyCA.key }}'


### PR DESCRIPTION
A new kubeconfig secret was added to the upstream test-infra prow
deployment definitions. The kubevirt prow services will fail to deploy
without this secret.

These changes are applied on top of the changes from - https://github.com/kubevirt/project-infra/pull/2119/

Fixes #2120 

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>