### PR TITLE
Set check-provision-k8s-1.24 to required to test new provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -155,7 +155,7 @@ presubmits:
           type: Directory
         name: vfio
       priorityClassName: vgpu
-  - always_run: true
+  - always_run: false
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -165,6 +165,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.21
+    optional: true
     spec:
       containers:
       - command:
@@ -353,7 +354,7 @@ presubmits:
           path: /dev
           type: Directory
         name: devices
-  - always_run: false
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -363,7 +364,6 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.24
-    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
The `check-provision-k8s-1.24` should be required and should always run
when the kubernetes 1.24 provider becomes available in kubevirtci.

This change also moves the `check-provision-k8s-1.21 prow` job to optional in
preparation for phasing out the 1.21 provider.

/hold 

Hold can be removed once https://github.com/kubevirt/kubevirtci/pull/800 is merged.

/cc @dhiller @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>