### PR TITLE
Increase nodes memory to support Windows 11

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -533,11 +533,13 @@ presubmits:
         env:
         - name: TARGET
           value: windows2016
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 8G
         image: quay.io/kubevirtci/bootstrap:v20220512-78048f1
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 32Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
Increase memory for nodes running as part of the
windows2016 lane to support testing Windows 11.

Signed-off-by: Antonio Cardace <acardace@redhat.com>