### PR TITLE
Update ci search alert description to better reflect error

### DIFF
--- a/github/ci/services/loki/manifests/common/rules.yaml
+++ b/github/ci/services/loki/manifests/common/rules.yaml
@@ -45,4 +45,4 @@ data:
             severity: "critical"
             namespace: "monitoring"
           annotations:
-            description: "CI Search persistent volume is full"
+            description: "High rate of failed writes to CI Search persistent volumes"


### PR DESCRIPTION
The alert triggers when there is a high rate of failed writes occurring
in the logs of the ci-search pods. This can occur when the persistent
volume is full but it can also occur in other scenarios.

This updates the description to better reflect the error that is occurring.

/cc @dhiller @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>