### PR TITLE
Register bridge-marker 0.9.1 to CI

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "14Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
@@ -1,0 +1,33 @@
+---
+presubmits:
+  kubevirt/bridge-marker:
+    - name: pull-bridge-marker-test-0.9.1
+      branches:
+        - release-0.9.1
+      always_run: true
+      optional: false
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      cluster: prow-workloads
+      max_concurrency: 6
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20220512-78048f1
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "29Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "14Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"


### PR DESCRIPTION
New stable branch was created. This time it is awkwardly on a patch release due to breakage in Go version dependency introduced in 0.9.2.

Signed-off-by: Petr Horáček <phoracek@redhat.com>