### PR TITLE
Update runner.sh to exit when docker daemon fails to start

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -124,7 +124,8 @@ EOF
             sleep ${WAIT_N}
         else
             echo "Reached maximum attempts, not waiting any longer..."
-            break
+	    echo "Docker daemon failed to start successfully"
+            exit 1
         fi
     done
     printf '=%.0s' {1..80}; echo


### PR DESCRIPTION
If the bootstrap container fails to start the docker daemon,
currently prow jobs that require the docker daemon will continue. This
makes it difficult to identify the cause of the failure in the job. The
script should exit if it fails to start the docker daemon.

/cc @xpivarc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>