### PR TITLE
Fix: override GIT_ASKPASS to make the job work again

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -29,6 +29,7 @@ postsubmits:
                 TARGET_DIR=$REPO_DIR/scripts/kubevirt/
                 mkdir -p $TARGET_DIR
                 pip3 install ruamel.yaml
+                export GIT_ASKPASS=$PWD/../project-infra/hack/git-askpass.sh
                 ../project-infra/hack/git-pr.sh -c "python3 $(pwd)/hack/generate-devstats-repo-sql.py --repo-groups-sql $TARGET_DIR/repo_groups.sql" -p $REPO_DIR -o cncf -r devstats -b update-kubevirt-devstats-repo-sql
             resources:
               requests:


### PR DESCRIPTION
Failing job: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/postsubmit-community-update-kubevirt-devstats-repo-sql/1531670941363343360

Successful run using fix: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/postsubmit-community-update-kubevirt-devstats-repo-sql/1532320183941599232

/cc @brianmcarey @xpivarc 