### PR TITLE
k8s-1.24-ipv6: Add provision lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -380,3 +380,30 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 1
+    name: check-provision-k8s-1.24-ipv6
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.24-ipv6 && ../provision.sh
+        image: quay.io/kubevirtci/golang:v20220512-78048f1
+        name: ""
+        resources:
+          requests:
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external


### PR DESCRIPTION
Add k8s-1.24-ipv6 lane

Depends on https://github.com/kubevirt/kubevirtci/pull/808