### PR TITLE
Disable goproxy.io due to network failures

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -589,7 +589,7 @@ presets:
 # default preset with no labels, settings common to all jobs
 - env:
   - name: GOPROXY
-    value: "https://proxy.golang.org|https://goproxy.io|direct"
+    value: "https://proxy.golang.org|direct"
 
 managed_webhooks:
   # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.


### PR DESCRIPTION
We recently are experiencing failures on goproxy.io, so we disable it
for now.

https://search.ci.kubevirt.io/?search=https%3A%2F%2Fgoproxy.io%2F&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Signed-off-by: Daniel Hiller <dhiller@redhat.com>

/cc @qinqon @enp0s3 