### PR TITLE
Add ansible output highlighting

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -43,6 +43,7 @@ deck:
           - panic\b
           # own patterns
           - \[FAILED\]
+          - "^(fatal|failed):"
       required_files:
         - build-log.txt
     - lens:


### PR DESCRIPTION
[This](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2119/pull-project-infra-prow-deploy-test/1535142515663966208#1:build-log.txt%3A1580) should be expanded, so we add an expression for it.