### PR TITLE
Fix highlight expression

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -43,7 +43,7 @@ deck:
           - panic\b
           # own patterns
           - \[FAILED\]
-          - "^(fatal|failed):"
+          - "fatal: "
       required_files:
         - build-log.txt
     - lens:


### PR DESCRIPTION
The [previous one](https://github.com/kubevirt/project-infra/pull/2154) was causing deck to not load. This could be reproduced
by removing the entry from the `highlight_regexes:` part of the
kubevirt-prow config configmap and rescaling the deck deployment.

/cc @brianmcarey 