### PR TITLE
jobs: add missing preset labels to the kubevirt code-linter presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1882,6 +1882,10 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
+    labels:
+      preset-bazel-cache: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs


### PR DESCRIPTION
The job calls a Makefile target that is using `hack/dockerized` so DinD support is needed
otherwise the job will fail. 

Signed-off-by: Igor Bezukh <ibezukh@redhat.com>