### PR TITLE
kubevirt/presubmits/lint: Add privileged security context

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1908,6 +1908,8 @@ presubmits:
         resources:
           requests:
             memory: 4Gi
+        securityContext:
+          privileged: true
   - always_run: true
     annotations:
       fork-per-release: "true"


### PR DESCRIPTION
The lint job runs kubevirt `lint` target (`make lint`) which uses the
dockerized wrapper.

In order to run the docker service, there is a need for privileged
access.