### PR TITLE
Add priority class for windows e2e jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -449,6 +449,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.50
+    priorityClassName: windows
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -449,6 +449,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.51
+    priorityClassName: windows
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -448,6 +448,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.52
+    priorityClassName: windows
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
@@ -447,6 +447,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016-0.53
+    priorityClassName: windows
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -521,6 +521,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016
+    priorityClassName: windows
     skip_branches:
     - release-\d+\.\d+
     spec:

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/priority-classes.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/priority-classes.yaml
@@ -20,6 +20,15 @@ description: "Allows gpu jobs to be scheduled with higher priority."
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
+  name: windows
+value: 900000
+preemptionPolicy: Never
+globalDefault: false
+description: "Allows windows jobs to be scheduled with higher priority."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
   name: sriov-place-holder
 value: 1000000
 preemptionPolicy: Never

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -31,7 +31,7 @@
 - name: Delete priority classes on prow-workloads BM cluster
   when: delete_priority_classes
   shell: |
-    kubectl delete pc sriov sriov-place-holder vgpu
+    kubectl delete pc --ignore-not-found=true sriov sriov-place-holder vgpu windows
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
 


### PR DESCRIPTION
Currently there is only a maximum of 1 windows e2e job allowed run at a
time.

This can lead to build up of windows job queues.

Due the restriction of the 1 job at a time - there should always be one
job running if there is a queue. This is not the case at the moment as
other regualar e2e jobs can get scheduled ahead of them.

Adding a priority class for the windows jobs should ensure that there is
always one job running when there is a queue

/cc @dhiller @enp0s3 @EdDev 

Signed-off-by: Brian Carey <bcarey@redhat.com>