### PR TITLE
cgroups: Make lanes non optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -193,6 +193,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_if_changed: pkg/virt-handler/cgroup/.*
+    optional: false
+    skip_report: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -209,7 +212,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
-    run_if_changed: pkg/virt-handler/cgroup/.*
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -234,6 +236,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
+    optional: false
+    skip_report: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -250,8 +255,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
-    optional: true
-    run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Since cgroups jobs are conditional,
they have implicit `optional: true` added.
Once they run they run as non required.
Make them required by setting `optional: false`.

One of the jobs had even an explicit optional field that was updated.

Add also skip_report: false, to be explicit.

Signed-off-by: Or Shoval <oshoval@redhat.com>