### PR TITLE
Update golang image to use go 1.17.8

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -87,7 +87,7 @@ presubmits:
               memory: "1Gi"
   - name: build-bootstrap-image
     always_run: false
-    run_if_changed: "images/bootstrap/.*"
+    run_if_changed: "images/bootstrap/.*|images/golang/.*"
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -101,32 +101,10 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-ce"
-            - "cd images && ./publish_image.sh -b bootstrap quay.io kubevirtci"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "1Gi"
-            limits:
-              memory: "1Gi"
-  - name: build-golang-image
-    always_run: false
-    run_if_changed: "images/golang/.*"
-    decorate: true
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
-    spec:
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220602-ac34bf7
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-ce"
-            - "cd images && ./publish_image.sh -b golang quay.io kubevirtci"
+            - |
+              cd images
+              ./publish_image.sh -b bootstrap quay.io kubevirtci
+              ./publish_image.sh -b golang quay.io kubevirtci
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/images/golang/Dockerfile
+++ b/images/golang/Dockerfile
@@ -1,10 +1,10 @@
 FROM bootstrap
 
-ENV GIMME_GO_VERSION=1.15.8
+ENV GIMME_GO_VERSION=1.17.8
 
 # Cache latest stable golang version
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
-RUN gimme 1.15.8
+RUN gimme $GIMME_GO_VERSION
 
 # GIMME_GO_VERSION is not expanded, so that it can be overwritten on container start
 RUN echo 'eval $(gimme ${GIMME_GO_VERSION})' > /etc/setup.mixin.d/golang.sh


### PR DESCRIPTION
The kubevirt builder image uses go version 1.17.8[1] - the golang image
used for testing should default to the same.

This change also includes the build of the golang image in the build-bootstrap-image presubmit as it requires a locally built bootstrap image. 

/cc @dhiller @xpivarc 

[1] https://github.com/kubevirt/kubevirt/blob/fadd752f0392a320483524aae753fe53930a6ba6/hack/builder/Dockerfile#L7