### PR TITLE
Disable coveralls reporting due to service outage

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -131,6 +131,7 @@ postsubmits:
       testgrid-create-test-group: "false"
     always_run: true
     optional: false
+    skip_reporting: true
     decorate: true
     decoration_config:
       timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1094,6 +1094,7 @@ presubmits:
     optional: true
     skip_branches:
     - release-\d+\.\d+
+    skip_reporting: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
We need to check [the status page](https://status.coveralls.io/) before we take this back in.

/cc @brianmcarey @xpivarc @enp0s3 
