### PR TITLE
Revert "kubevirtci kubevirt bump: Increase periodic rate"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -40,7 +40,7 @@ periodics:
           requests:
             memory: "2Gi"
 - name: periodic-kubevirtci-bump-kubevirt
-  cron: "0 */3 * * *"
+  cron: "0 */12 * * *"
   annotations:
     testgrid-create-test-group: "false"
   decorate: true


### PR DESCRIPTION
Reverts kubevirt/project-infra#2175

Since the job will rebase the bump PR again and again,
it waste CI resources, and even might interrupt jobs that didn't finish yet on the bump PR.
Of course unless there are labesl, and then it doesn't rebase, but sometimes it take time until
we review, or we first want to see the jobs status.

If we had logic that in case of rebase only without actual kubevirtci change, doesn't rebase
it would be safer.
