### PR TITLE
Add istio version 1.14.0 to the kubevirtci mirror

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -656,7 +656,7 @@ periodics:
           - name: BUCKET_DIR
             value: kubevirtci-istioctl-mirror
           - name: ISTIO_VERSIONS
-            value: "1.10.0,1.13.0"
+            value: "1.10.0,1.13.0,1.14.0"
         command: ["/bin/sh", "-c"]
         args:
           - ./hack/mirror-istioctl.sh


### PR DESCRIPTION
Istio version 1.14.0 adds support for Kubernetes version 1.24 [1]

KubeVirt CI is currently using 1.10.0 [2] - this should be updated to 1.14.0

[1] https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
[2] https://github.com/kubevirt/kubevirtci/blob/da6af0433636565a75bbcdc39e82c8c38e5d7cab/cluster-provision/k8s/1.23/provision.sh#L21

/cc @dhiller @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>