### PR TITLE
Update flake-report-creator to show failuresForJobs in report and json

### DIFF
--- a/hack/flake-report-creator.sh
+++ b/hack/flake-report-creator.sh
@@ -6,7 +6,7 @@ docker run -v /etc/pki:/etc/pki -v /etc/ssl:/etc/ssl \
         -e GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
         -v "${tmp_dir}:/tmp:Z" \
         --network host \
-        quay.io/kubevirtci/flake-report-creator:v20220630-5050e576 \
+        quay.io/kubevirtci/flake-report-creator:v20220706-f742d17f \
         --overwrite --outputFile=/tmp/report.html \
         "$@"
 

--- a/robots/cmd/flake-report-creator/cmd/jenkins.go
+++ b/robots/cmd/flake-report-creator/cmd/jenkins.go
@@ -87,6 +87,10 @@ const (
 			.center {
 				text-align:center
 			}
+			.right {
+				text-align: right;
+				width: 100%;
+			}
 
 			.popup {
 				position: relative;
@@ -110,7 +114,26 @@ const (
 				margin-left: -110px;
 			}
 
+            .popup .popuptextjoblist {
+                display: none;
+                width: 350px;
+                background-color: #FFFFFF;
+                text-align: center;
+                border-radius: 6px;
+                padding: 8px 8px;
+                position: absolute;
+                z-index: 1;
+                left: 100%;
+                margin-left: -350px;
+            }
+
 			.popup:hover .popuptext {
+				display: block;
+				-webkit-animation: fadeIn 1s;
+				animation: fadeIn 1s;
+			}
+
+			.popup:hover .popuptextjoblist {
 				display: block;
 				-webkit-animation: fadeIn 1s;
 				animation: fadeIn 1s;
@@ -142,6 +165,26 @@ const (
 {{ if not .Headers }}
 	<div>No failing tests! 🙂</div>
 {{ else }}
+<div id="failuresForJobs" class="popup right" >
+	<u>list of job runs</u>
+	<div class="popuptextjoblist right" id="targetfailuresForJobs">
+		<table width="100%">
+			{{ range $key, $jobFailures := $.FailuresForJobs }}<tr class="unimportant">
+				<td>
+					<a href="{{ $.JenkinsBaseURL }}/job/{{.Job}}"><span title="job">{{.Job}}</span></a>
+				</td>
+				<td>
+					<a href="{{ $.JenkinsBaseURL }}/job/{{.Job}}/{{.BuildNumber}}"><span title="job build number">{{.BuildNumber}}</span></a>
+				</td>
+				<td>
+					<div class="tests_failed"><span title="test failures">{{ .Failures }}</span></div>
+				</td>
+			</tr>{{ end }}
+		</table>
+	</div>
+</div>
+
+
 <table>
     <tr>
         <td></td>
@@ -165,7 +208,7 @@ const (
                 <span class="tests_failed" title="failed tests">{{ (index $.Data $test $header).Failed }}</span>/<span class="tests_passed" title="passed tests">{{ (index $.Data $test $header).Succeeded }}</span>/<span class="tests_skipped" title="skipped tests">{{ (index $.Data $test $header).Skipped }}</span>{{ if (index $.Data $test $header).Jobs }}
                 <div class="popuptext" id="targetr{{$row}}c{{$col}}">
                     {{ range $Job := (index $.Data $test $header).Jobs }}
-                    <div class="{{.Severity}} nowrap">{{ if ne .PR 0 }}<a href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/{{.BuildNumber}}">{{.BuildNumber}}</a>{{ else }}<a href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/{{.BuildNumber}}">{{.BuildNumber}}</a>{{ end }}</div>
+                    <div class="{{.Severity}} nowrap"><a href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/{{.BuildNumber}}">{{.BuildNumber}}</a> (<span class="tests_failed" title="failed tests in job run">{{ (index $.FailuresForJobs (printf "%s-%d" $header .BuildNumber)).Failures }}</span>)</div>
                     {{ end }}
                 </div>{{ end }}
             </div>

--- a/robots/cmd/flake-report-creator/cmd/jenkins.go
+++ b/robots/cmd/flake-report-creator/cmd/jenkins.go
@@ -554,7 +554,12 @@ func writeJSONToOutputFile(jsonOutputFile string, parameters flakefinder.Params)
 	defer reportOutputWriter.Close()
 
 	encoder := json.NewEncoder(reportOutputWriter)
-	err := encoder.Encode(parameters.Data)
+	err := encoder.Encode(
+		map[string]interface{}{
+			"data":            parameters.Data,
+			"failuresForJobs": parameters.FailuresForJobs,
+		},
+	)
 	if err != nil {
 		jLog.Fatalf("failed to write report: %v", err)
 	}

--- a/robots/cmd/flakefinder/report_test.go
+++ b/robots/cmd/flakefinder/report_test.go
@@ -174,14 +174,14 @@ var _ = Describe("report.go", func() {
 					{BuildNumber: 1742, Severity: "red", PR: 1427, Job: "testblah"},
 				}}},
 			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: "kubevirt", Repo: "kubevirt",
-				FailuresForJobs: map[int]*flakefinder.JobFailures{
-					1742: {
+				FailuresForJobs: map[string]*flakefinder.JobFailures{
+					"1742": {
 						BuildNumber: 1742,
 						PR:          17,
 						Job:         "k8s-1.18-whatever",
 						Failures:    66,
 					},
-					4217: {
+					"4217": {
 						BuildNumber: 4217,
 						PR:          42,
 						Job:         "k8s-1.19-whocares",

--- a/robots/pkg/flakefinder/report_data.go
+++ b/robots/pkg/flakefinder/report_data.go
@@ -36,10 +36,10 @@ type Job struct {
 }
 
 type JobFailures struct {
-	BuildNumber int
-	PR          int
-	Job         string
-	Failures    int
+	BuildNumber int    `json:"buildNumber"`
+	PR          int    `json:"pr"`
+	Job         string `json:"job"`
+	Failures    int    `json:"failures"`
 }
 
 type Jobs []*Job

--- a/robots/pkg/flakefinder/report_data.go
+++ b/robots/pkg/flakefinder/report_data.go
@@ -1,6 +1,7 @@
 package flakefinder
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -16,7 +17,7 @@ type Params struct {
 	PrNumbers       []int
 	Org             string
 	Repo            string
-	FailuresForJobs map[int]*JobFailures
+	FailuresForJobs map[string]*JobFailures
 }
 
 type Details struct {
@@ -54,8 +55,12 @@ func CreateFlakeReportData(results []*JobResult, prNumbers []int, endOfReport ti
 	data := map[string]map[string]*Details{}
 	headers := []string{}
 	tests := []string{}
-	failuresForJobs := map[int]*JobFailures{}
+	failuresForJobs := map[string]*JobFailures{}
 	headerMap := map[string]struct{}{}
+
+	createFailuresForJobsKey := func(result *JobResult) string {
+		return fmt.Sprintf("%s-%d", result.Job, result.BuildNumber)
+	}
 
 	for _, result := range results {
 
@@ -64,16 +69,17 @@ func CreateFlakeReportData(results []*JobResult, prNumbers []int, endOfReport ti
 			for _, test := range suite.Tests {
 				if test.Status == junit.StatusFailed || test.Status == junit.StatusError {
 
-					_, exists := failuresForJobs[result.BuildNumber]
+					failuresForJobsKey := createFailuresForJobsKey(result)
+					_, exists := failuresForJobs[failuresForJobsKey]
 					if !exists {
-						failuresForJobs[result.BuildNumber] = &JobFailures{
+						failuresForJobs[failuresForJobsKey] = &JobFailures{
 							BuildNumber: result.BuildNumber,
 							PR:          result.PR,
 							Job:         result.Job,
 							Failures:    0,
 						}
 					}
-					failuresForJobs[result.BuildNumber].Failures = failuresForJobs[result.BuildNumber].Failures + 1
+					failuresForJobs[failuresForJobsKey].Failures = failuresForJobs[failuresForJobsKey].Failures + 1
 
 					testEntry := data[test.Name]
 					if testEntry == nil {
@@ -98,7 +104,7 @@ func CreateFlakeReportData(results []*JobResult, prNumbers []int, endOfReport ti
 
 	// second enrich failed tests with additional information
 	for _, result := range results {
-		if _, exists := failuresForJobs[result.BuildNumber]; !exists {
+		if _, exists := failuresForJobs[createFailuresForJobsKey(result)]; !exists {
 			// if not in the map now, then skip it
 			continue
 		}
@@ -125,7 +131,7 @@ func CreateFlakeReportData(results []*JobResult, prNumbers []int, endOfReport ti
 	// third, calculate the severity
 	// second enrich failed tests with additional information
 	for _, result := range results {
-		if _, exists := failuresForJobs[result.BuildNumber]; !exists {
+		if _, exists := failuresForJobs[createFailuresForJobsKey(result)]; !exists {
 			// if not in the map now, then skip it
 			continue
 		}


### PR DESCRIPTION
Updates the flake-report-creator to have a new popup showing the failures per build in the upper right corner of the report. Additionally each test popup now has the number of total failures shown in braces for easier orientation.

JSON is also extended to include the failuresForJobs base data, such that it is now a map that has two keys `data` and `failuresForJobs`, where each of the values has the corresponding data. `failuresForJobs` is a map where the key is created as `{job}-{buildNumber}`.

![Screenshot from 2022-08-16 12-16-29](https://user-images.githubusercontent.com/809335/184856724-d6edb2fa-130a-4f7a-bb38-c18beac7ca3c.png)

![image](https://user-images.githubusercontent.com/809335/184871413-07d55105-bcae-4614-9139-236d572b789e.png)
