### PR TITLE
kubevirt: Add manual lane to bump kubevirtci at kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -241,6 +241,38 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 5m0s
+      timeout: 1h
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-gcs-credentials: "true"
+      preset-github-credentials: "true"
+    max_concurrency: 1
+    name: pull-kubevirtci-bump-kubevirt
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+        command: ["/bin/sh", "-ce"]
+        args:
+        - |
+          git-pr.sh -c "make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -T main
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"


### PR DESCRIPTION
Sometimes we want to refresh kubevirtci bumps at kubevirt manually.
This lane can be used for it.
The lane doesn't check labels of the bump PR if exists, as the periodic
does.

Signed-off-by: Or Shoval <oshoval@redhat.com>