### PR TITLE
Make pull-kubevirt-verify-go-mod lane required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -933,7 +933,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-verify-go-mod
-    optional: true
     run_if_changed: ^vendor/.*|^staging/.*|go\.mod$|go\.sum$
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
Since people sometime forget to `make deps-sync`, this lane sometimes fails constantly just because of human-error. Instead, this lane should be required to ensure our dependencies are always synced.

As in [this comment](https://github.com/kubevirt/kubevirt/pull/8062#issuecomment-1176180982), the reason this lane was optional is because of a worry that this lane may be unstable since it requires access to quite some external resources. But since the lane proved itself being stable, it can be required now.