### PR TITLE
kubevirci-bump lane: Fix GIT_ASKPASS

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -257,6 +257,7 @@ presubmits:
         command: ["/bin/sh", "-ce"]
         args:
         - |
+          export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
           git-pr.sh -c "make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -T main
         securityContext:
           privileged: true


### PR DESCRIPTION
Since we run it from kubevirt and not from project-infra
we need a valid path.
Use the script from the image.

Signed-off-by: Or Shoval <oshoval@redhat.com>