### PR TITLE
Update configs to switch to default branch main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -2,7 +2,7 @@ postsubmits:
   kubevirt/csi-driver:
     - name: publish-csi-driver
       branches:
-        - master
+        - main
       decorate: true
       max_concurrency: 1
       extra_refs:

--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -292,6 +292,7 @@ orgs:
       csi-driver:
         description: KubeVirt CSI driver
         has_projects: true
+        default_branch: main
       demo:
         allow_rebase_merge: false
         description: Easy to use KubeVirt demo based on minikube.

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -365,7 +365,7 @@ branch-protection:
               protect: true
         csi-driver:
           branches:
-            master:
+            main:
               protect: true
         kubectl-virt-plugin:
           protect: true


### PR DESCRIPTION
Changes the configurations to prepare to switch default branch for kubevirt/csi-driver to main.

/hold to synchronize the change in all places