### PR TITLE
Reduce memory requirements for prow-deploy test 

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -329,9 +329,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "6Gi"
             limits:
-              memory: "29Gi"
+              memory: "6Gi"
           volumeMounts:
           - name: molecule-docker
             mountPath: /tmp/prow-deploy-molecule


### PR DESCRIPTION
Reducing the memory requirements could improve the likelihood of this
prow job getting scheduled to run. According to metrics collected from
successful runs of this job - the maximum memory used is 5.19Gi.

Signed-off-by: Brian Carey <bcarey@redhat.com>