### PR TITLE
Update bump prow images job to request review from taskforce

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -693,7 +693,7 @@ periodics:
       args:
       - |
         if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
-          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main
+          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B "Bump Prow Job images /cc @kubevirt/prow-job-taskforce"
         fi
       resources:
         requests:


### PR DESCRIPTION
Currently kubevirt-bot requests review from around 15 contributors on the
automated bump prow images PR [1]. It should be enough to request review
from the prow-job-taskforce for this PR and good to reduce noise for other
contributors.

[1] https://github.com/kubevirt/project-infra/pull/2213

/cc @kubevirt/prow-job-taskforce

Signed-off-by: Brian Carey <bcarey@redhat.com>