### PR TITLE
Create bootstrap-legacy image for existing docker bootstrap prow jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -117,6 +117,37 @@ postsubmits:
                 memory: "8Gi"
               limits:
                 memory: "8Gi"
+    - name: publish-bootstrap-legacy-images
+      always_run: false
+      run_if_changed: "images/golang-legacy/.*|images/bootstrap-legacy/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: ibm-prow-jobs
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cd images
+                ./publish_image.sh bootstrap-legacy quay.io kubevirtci
+                ./publish_image.sh golang-legacy quay.io kubevirtci
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "1Gi"
+              limits:
+                memory: "1Gi"
     - name: publish-kubekins-e2e-image
       always_run: false
       run_if_changed: "images/kubekins-e2e/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -116,6 +116,33 @@ presubmits:
               memory: "8Gi"
             limits:
               memory: "8Gi"
+  - name: build-bootstrap-legacy-images
+    always_run: false
+    run_if_changed: "images/bootstrap-legacy/.*|images/golang-legacy/.*"
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    cluster: ibm-prow-jobs
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-ce"
+            - |
+              cd images
+              ./publish_image.sh -b bootstrap-legacy quay.io kubevirtci
+              ./publish_image.sh -b golang-legacy quay.io kubevirtci
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
   - name: build-kubekins-e2e-image
     always_run: false
     run_if_changed: "images/kubekins-e2e/.*"

--- a/images/bootstrap-legacy/Dockerfile
+++ b/images/bootstrap-legacy/Dockerfile
@@ -1,0 +1,118 @@
+# Copyright 2017 The Kubernetes Authors.
+# Copyright 2021 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes basic workspace setup, with gcloud and a bootstrap runner
+FROM fedora:36
+
+WORKDIR /workspace
+RUN mkdir -p /workspace
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+# Install packages
+RUN dnf install -y \
+    cpio \
+    dnf-plugins-core \
+    findutils \
+    gcc \
+    gcc-c++ \
+    gettext \
+    git \
+    glibc-devel \
+    glibc-static \
+    iproute \
+    java-11-openjdk-devel \
+    jq \
+    libstdc++-static \
+    libvirt-devel \
+    make \
+    mercurial \
+    patch \
+    protobuf-compiler \
+    python3-devel \
+    python-unversioned-command \
+    redhat-rpm-config \
+    rsync \
+    rsync-daemon \
+    skopeo \
+    sudo \
+    buildah \
+    qemu-user-static \
+    wget &&\
+  dnf -y clean all
+
+# Install gcloud
+ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+    tar xzf google-cloud-sdk.tar.gz -C / && \
+    rm google-cloud-sdk.tar.gz && \
+    /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false && \
+    gcloud components install alpha beta kubectl && \
+    gcloud info | tee /workspace/gcloud-info.txt
+
+#
+# BEGIN: DOCKER IN DOCKER SETUP
+#
+# Install packages
+
+RUN dnf install -y \
+        kmod \
+        procps-ng \
+        moby-engine && \
+    dnf -y clean all
+
+# Create directory for docker storage location
+# NOTE this should be mounted and persisted as a volume ideally (!)
+# We will make a fallback one now just in case
+RUN mkdir /docker-graph
+
+#
+# END: DOCKER IN DOCKER SETUP
+#
+
+# Cache the most commonly used bazel versions in the container
+RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && \
+     chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
+     cd /usr/local/bin && ln -s bazelisk bazel
+
+# Cache the most commonly used bazel versions inside the image
+# and remove resulting cache directories to save a few hundred MB
+RUN USE_BAZEL_VERSION=4.1.0 bazel version && \
+    USE_BAZEL_VERSION=4.2.1 bazel version && \
+    rm -rf /root/.cache/bazel
+
+# create mixin directories
+RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
+
+# Trust git repositories used for e2e jobs
+RUN git config --global --add safe.directory '*'
+
+# note the runner is also responsible for making docker in docker function if
+# env DOCKER_IN_DOCKER_ENABLED is set and similarly responsible for generating
+# .bazelrc files if bazel remote caching is enabled
+COPY ["entrypoint.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
+        "/usr/local/bin/"]
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/bootstrap-legacy/README.md
+++ b/images/bootstrap-legacy/README.md
@@ -1,0 +1,18 @@
+Bootstrap image
+===============
+
+KubeVirt CI general purpose image for prow jobs.
+
+**Note: this image doesn't have `golang` builtin, use the golang image in this case.**
+
+Docker debug logs
+-----------------
+
+To enable docker debug logs, add this to the prowjob container configuration
+
+```yaml
+env:
+...
+- name: DOCKER_DEBUG
+  value: "true"
+```

--- a/images/bootstrap-legacy/create_bazel_cache_rcs.sh
+++ b/images/bootstrap-legacy/create_bazel_cache_rcs.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2021 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CACHE_HOST="${CACHE_HOST:-bazel-cache.kubevirt-prow.svc.cluster.local}"
+CACHE_PORT="${CACHE_PORT:-8080}"
+
+# get the installed version of a rpm package
+package_to_version () {
+    rpm -q --qf "%{VERSION}" "$1"
+}
+
+# look up a binary with `command -v $1` and return the rpm package it belongs to
+command_to_package () {
+    # NOTE: First resolve symlinks so that we are sure that we really get the package
+    # which provides the binary.
+    local binary_path
+    binary_path=$(readlink -f "$(command -v "$1")")
+    # Get the name of the package from where the binary comes from
+    rpm -q --queryformat "%{NAME}" --whatprovides "${binary_path}"
+}
+
+# get the installed package version relating to a binary
+command_to_version () {
+    local package
+    package=$(command_to_package "$1")
+    package_to_version "${package}"
+}
+
+hash_toolchains () {
+    # if $CC is set bazel will use this to detect c/c++ toolchains, otherwise gcc
+    # https://blog.bazel.build/2016/03/31/autoconfiguration.html
+    local cc="${CC:-gcc}"
+    local cc_version
+    cc_version=$(command_to_version "$cc")
+    # NOTE: IIRC some rules call python internally, this can't hurt
+    local python_version
+    python_version=$(command_to_version python)
+    # the rpm packaging rules use rpmbuild
+    local rpmbuild_version
+    rpmbuild_version=$(command_to_version rpm)
+    # combine all tool versions into a hash
+    # NOTE: if we change the set of tools considered we should
+    # consider prepending the hash with a """schema version""" for completeness
+    local tool_versions
+    tool_versions="CC:${cc_version},PY:${python_version},RPM:${rpmbuild_version}"
+    echo "${tool_versions}" 1>&2;
+    echo "${tool_versions}" | md5sum | cut -d" " -f1
+}
+
+get_workspace () {
+    # get org/repo from prow, otherwise use $PWD
+    if [[ -n "${REPO_NAME}" ]] && [[ -n "${REPO_OWNER}" ]]; then
+        echo "${REPO_OWNER}/${REPO_NAME}"
+    else
+        echo "$(basename "$(dirname "$PWD")")/$(basename "$PWD")"
+    fi
+}
+
+make_bazel_rc () {
+    # this is the default for recent releases but we set it explicitly
+    # since this is the only hash our cache supports
+    echo "startup --host_jvm_args=-Dbazel.DigestFunction=sha256"
+    # don't fail if the cache is unavailable
+    echo "build --remote_local_fallback"
+    # point bazel at our http cache ...
+    # NOTE our caches are versioned by all path segments up until the last two
+    # IE PUT /foo/bar/baz/cas/asdf -> is in cache "/foo/bar/baz"
+    local cache_id
+    cache_id="$(get_workspace),$(hash_toolchains)"
+    local cache_url
+    cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
+    echo "build --remote_http_cache=${cache_url}"
+}
+
+# https://docs.bazel.build/versions/master/user-manual.html#bazelrc
+# bazel will look for two RC files, taking the first option in each set of paths
+# firstly:
+# - The path specified by the --bazelrc=file startup option. If specified, this option must appear before the command name (e.g. build)
+# - A file named .bazelrc in your base workspace directory
+# - A file named .bazelrc in your home directory
+bazel_rc_contents=$(make_bazel_rc)
+echo "create_bazel_cache_rcs.sh: Configuring '${HOME}/.bazelrc' and '/etc/bazel.bazelrc' with"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}" >> "${HOME}/.bazelrc"
+# Aside from the optional configuration file described above, Bazel also looks for a master rc file next to the binary, in the workspace at tools/bazel.rc or system-wide at /etc/bazel.bazelrc.
+# These files are here to support installation-wide options or options shared between users. Reading of this file can be disabled using the --nomaster_bazelrc option.
+echo "${bazel_rc_contents}" >> "/etc/bazel.bazelrc"
+# hopefully no repos create *both* of these ...

--- a/images/bootstrap-legacy/entrypoint.sh
+++ b/images/bootstrap-legacy/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2021 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# actually start bootstrap and the job, under the runner (which handles dind etc.)
+/usr/local/bin/runner.sh "$@"

--- a/images/bootstrap-legacy/runner.sh
+++ b/images/bootstrap-legacy/runner.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2021 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generic runner script, handles DIND, bazelrc for caching, etc.
+
+# Give bazel a well defined output_user_root directory independent of the user
+# used in the image. This allows mounting an emptyDir at this location, instead
+# of writing into the container overlay.
+mkdir -p /tmp/cache/bazel
+echo "startup --output_user_root=/tmp/cache/bazel" >> "${HOME}/.bazelrc"
+echo "startup --output_user_root=/tmp/cache/bazel" >> "/etc/bazel.bazelrc"
+
+# Check if the job has opted-in to bazel remote caching and if so generate
+# .bazelrc entries pointing to the remote cache
+export BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
+if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
+    echo "Bazel remote cache is enabled, generating .bazelrcs ..."
+    /usr/local/bin/create_bazel_cache_rcs.sh
+fi
+
+# setup custom certificates for the container registry mirror
+setup_ca(){
+    if [ -f "${CA_CERT_FILE}" ]; then
+        echo "Adding ${CA_CERT_FILE} as a trusted root CA"
+        cp "${CA_CERT_FILE}" /etc/pki/ca-trust/source/anchors/
+
+        update-ca-trust
+    fi
+}
+
+# runs custom docker data root cleanup binary and debugs remaining resources
+cleanup_dind() {
+    if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+        if [[ "${DOCKER_DEBUG:-false}" == "true" ]]; then
+            echo "Copying docker log to ARTIFACTS"
+            cp /var/log/dockerd.log $ARTIFACTS
+        fi
+        echo "Cleaning up after docker"
+        docker ps -aq | xargs -r docker rm -f || true
+        kill "$(</var/run/docker.pid)" || true
+        wait "$(</var/run/docker.pid)" || true
+    fi
+}
+
+early_exit_handler() {
+    cleanup_dind
+}
+
+# setup certificates before anything gets started
+setup_ca
+
+# optionally enable ipv6 docker
+export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
+    echo "Enabling IPV6 for Docker."
+    # configure the daemon with ipv6
+    mkdir -p /etc/docker/
+    cat <<EOF >/etc/docker/daemon.json
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "fc00:db8:1::/64"
+}
+EOF
+    # enable ipv6
+    sysctl net.ipv6.conf.all.disable_ipv6=0
+    sysctl net.ipv6.conf.all.forwarding=1
+    # enable ipv6 iptables
+    modprobe -v ip6table_nat
+fi
+
+# Check if the job has opted-in to docker-in-docker availability.
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Docker in Docker enabled, initializing..."
+
+    export DOCKER_DEBUG=${DOCKER_DEBUG:-false}
+    if [[ "${DOCKER_DEBUG}" == "true" ]]; then
+        mkdir -p /etc/docker/
+        # TODO: do not rely on this file not existing!
+        cat <<EOF >/etc/docker/daemon.json
+{
+  "debug": true,
+  "log-level": "debug"
+}
+EOF
+    fi
+
+    printf '=%.0s' {1..80}; echo
+    # If we have opted in to docker in docker, start the docker daemon,
+    (
+        if [ -f "/etc/default/docker" ]; then
+            source /etc/default/docker
+        fi
+        /usr/bin/dockerd \
+            -p /var/run/docker.pid \
+            --data-root=/docker-graph \
+            --init-path /usr/libexec/docker/docker-init \
+            --userland-proxy-path /usr/libexec/docker/docker-proxy \
+            ${DOCKER_OPTS} \
+                >/var/log/dockerd.log 2>&1 &
+    )
+    # the service can be started but the docker socket not ready, wait for ready
+    WAIT_N=0
+    MAX_WAIT=5
+    while true; do
+        # docker ps -q should only work if the daemon is ready
+        docker ps -q > /dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N+1))
+            echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo "Reached maximum attempts, not waiting any longer..."
+	    echo "Docker daemon failed to start successfully"
+            exit 1
+        fi
+    done
+    printf '=%.0s' {1..80}; echo
+    echo "Done setting up docker in docker."
+fi
+
+trap early_exit_handler INT TERM
+
+# disable error exit so we can run post-command cleanup
+set +o errexit
+
+# add $GOPATH/bin to $PATH
+export PATH="${GOPATH}/bin:${PATH}"
+mkdir -p "${GOPATH}/bin"
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+# Use a reproducible build date based on the most recent git commit timestamp.
+SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+export SOURCE_DATE_EPOCH
+
+# run setup mixins
+for file in $(find /etc/setup.mixin.d/ -maxdepth 1 -name '*.sh' -print -quit); do source $file; done
+
+# actually start bootstrap and the job
+set -o xtrace
+"$@"
+EXIT_VALUE=$?
+set +o xtrace
+
+# run teardown mixins
+for file in $(find /etc/teardown.mixin.d/ -maxdepth 1 -name '*.sh' -print -quit); do source $file; done
+
+# cleanup after job
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Cleaning up after docker in docker."
+    printf '=%.0s' {1..80}; echo
+    cleanup_dind
+    printf '=%.0s' {1..80}; echo
+    echo "Done cleaning up after docker in docker."
+fi
+
+# preserve exit value from job / bootstrap
+exit ${EXIT_VALUE}

--- a/images/golang-legacy/Dockerfile
+++ b/images/golang-legacy/Dockerfile
@@ -1,0 +1,10 @@
+FROM bootstrap-legacy
+
+ENV GIMME_GO_VERSION=1.17.8
+
+# Cache latest stable golang version
+RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
+RUN gimme $GIMME_GO_VERSION
+
+# GIMME_GO_VERSION is not expanded, so that it can be overwritten on container start
+RUN echo 'eval $(gimme ${GIMME_GO_VERSION})' > /etc/setup.mixin.d/golang.sh


### PR DESCRIPTION
This change creates two new images called bootstrap-legacy and
golang-legacy which are based off of the current bootstrap and golang
images. These images wiil provide projects a fallback option in the case
that the new proposed podman changes[1] cause issues in their CI lanes.

- Copy bootstrap directory to bootstrap-legacy
- Copy golang directory to golang-legacy
- Update golang-legacy Dockerfile to use bootstrap-legacy image as base
- Add presubmit job to test build of legacy images
- Add postsubmit job to publish legacy images to quay

[1] https://github.com/kubevirt/project-infra/pull/2055

/cc @xpivarc @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>