### PR TITLE
Revert "Add podman to bootstrap images (#2196)"

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -53,7 +53,6 @@ RUN dnf install -y \
     skopeo \
     sudo \
     buildah \
-    podman \
     qemu-user-static \
     wget &&\
   dnf -y clean all


### PR DESCRIPTION
This reverts commit 139f21be7fc69ee931b2c8e159158215eb528022.

The PRs needing podman specifically were re-written so docker
is supported as well, to aid the proposed plan of gradually
transitioning CI lanes to podman by having a separate
podman-only image.