### PR TITLE
manual bump job: Fix Running job from within kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -65,6 +65,8 @@ presubmits:
         command: ["/bin/sh", "-ce"]
         args:
         - |
+          HEAD=$(git ls-remote --heads https://github.com/kubevirt/kubevirt.git | grep refs/heads/main | cut -f1)
+          git reset --hard $HEAD
           export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
           git-pr.sh -c "make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -T main
         securityContext:


### PR DESCRIPTION
In case we run the manual job `pull-kubevirtci-bump-kubevirt` from the bump PR itself
it will update the description with just the new differences
since the previous bump if exists.
Because the changes are already there and it calculate the difference.

In case we run it from a PR of kubevirt that is not related,
It will include in the bump those commits which are not related,
since it checkouts the code of that PR.

Adding reset --hard to kubevirt main in order to avoid those.

Signed-off-by: Or Shoval <oshoval@redhat.com>