### PR TITLE
Set mem limits and golang version for capk presubmit 

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -27,6 +27,8 @@ presubmits:
         resources:
           requests:
             memory: 16Gi
+          limits:
+            memory: 16Gi
         securityContext:
           privileged: true
         env:

--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -33,6 +33,6 @@ presubmits:
           privileged: true
         env:
           - name: GIMME_GO_VERSION
-            value: "1.17"
+            value: "1.18"
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
We are seeing some flakiness in our capk CI job that could be attributed to shared resources. I've also updated the golang version to 1.18 which matches what we are using in our containerized builds and published artifacts of capk.