### PR TITLE
Update kubemacpool presubmits to use regular bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20220425-b167bb8
+          - image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd
             securityContext:
               privileged: true
             command:
@@ -50,7 +50,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20220425-b167bb8
+          - image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
The main bootstrap image sees more regular updates and is more widely
used than the kubevirt-infra-bootstrap. Jobs should use the main
bootstrap image where possible.

Signed-off-by: Brian Carey <bcarey@redhat.com>