### PR TITLE
Update hco presubmit to use regular bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20220425-b167bb8
+      - image: quay.io/kubevirtci/golang:v20220630-ded5dcd
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"


### PR DESCRIPTION
The main bootstrap image sees more regular updates and is more widely
used than the kubevirt-infra-bootstrap. Jobs should use the main
bootstrap image where possible.

Signed-off-by: Brian Carey <bcarey@redhat.com>