### PR TITLE
Use 2 nodes in pull-kubevirt-e2e-k8s-1.22-sig-monitoring

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1916,6 +1916,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.22-sig-monitoring
+        - name: KUBEVIRT_NUM_NODES
+          value: "2"
         image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd
         name: ""
         resources:


### PR DESCRIPTION
Signed-off-by: João Vilaça <jvilaca@redhat.com>

Some new monitoring tests in https://github.com/kubevirt/kubevirt/pull/8199 require migrations to be performed. This can only be achieved if the cluster has at least 2 nodes 