### PR TITLE
Update to stop reporting on fossa jobs due to CDI issue

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -172,7 +172,8 @@ postsubmits:
     annotations:
       testgrid-create-test-group: "false"
     always_run: true
-    optional: false
+    optional: true
+    skip_report: true
     decorate: true
     decoration_config:
       timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1011,6 +1011,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-fossa
     optional: true
+    skip_report: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Both the presubmit and postsubmit fossa prowjobs have been failing for
the past few weeks due to an open issue in the CDI project[1]. This
change will stop reporting on these failures until this issue has been
resolved.

[1] https://github.com/kubevirt/containerized-data-importer/issues/2320

/cc @enp0s3 @xpivarc @awels 

Signed-off-by: Brian Carey <bcarey@redhat.com>