### PR TITLE
container images: Mirror needed images to quay

### DIFF
--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -1,3 +1,10 @@
 docker.io,library/registry:2.7.1,quay.io/kubevirtci
 docker.io,rook/ceph:v1.5.8,quay.io/kubevirtci
+docker.io,rook/ceph:v1.8.9,quay.io/kubevirtci
 docker.io,kindest/node:v1.23.4,quay.io/kubevirtci
+docker.io,grafana/grafana:7.5.4,quay.io/kubevirtci
+docker.io,istio/install-cni:1.10.0,quay.io/kubevirtci
+docker.io,istio/operator:1.10.0,quay.io/kubevirtci
+docker.io,istio/pilot:1.10.0,quay.io/kubevirtci
+docker.io,istio/proxyv2:1.10.0,quay.io/kubevirtci
+docker.io,rpardini/docker-registry-proxy:0.6.2,quay.io/kubevirtci


### PR DESCRIPTION
Those images are used by kubevirtci and are still on `docker.io`.
Mirror them to quay, so we can use them without rate limits.

Once they are mirrored, we need one time to make the new repos public.
