### PR TITLE
mirror: Update istio images naming so we can use them with istio operator

### DIFF
--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -1,6 +1,4 @@
 docker.io,library/registry:2.7.1,quay.io/kubevirtci
-docker.io,rook/ceph:v1.5.8,quay.io/kubevirtci
-docker.io,rook/ceph:v1.8.9,quay.io/kubevirtci
 docker.io,kindest/node:v1.23.4,quay.io/kubevirtci
 docker.io,grafana/grafana:7.5.4,quay.io/kubevirtci
 docker.io,istio/install-cni:1.10.0,quay.io/kubevirtci

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -20,7 +20,14 @@ do
   # we cannot use full path of original image which contain user+image name.
   # example: docker.io/user/image:v1 -> quay.io/kubevirtci/user-image:v1
   image_in_target="${image_in_source//\//-}" # replace / with -
-
+  if [[ $image_in_target =~ istio- ]]; then
+    # Istio is deployed with Istio operator, which can only be configured to use different registry repository
+    # but will always use container image names: pilot, proxyv2, etc.
+    # Therefore the images should not have the "istio-" prefix
+    # example: istio-pilot:v1 -> pilot:v1
+    # this way the istio operator will use quay.io/kubevirtci/pilot:v1 instead of docker.io/istio/pilot:v1
+    image_in_target="${image_in_target//istio-/}"
+  fi
   echo "Mirroring from $source_registry/$image_in_source to $target_registry/$image_in_target"
   skopeo copy --multi-arch all "docker://$source_registry/$image_in_source" "docker://$target_registry/$image_in_target"
 done


### PR DESCRIPTION
Istio is deployed with Istio operator, which can only be configured to use different registry repository
but will always use container image names: pilot, proxyv2, etc.
Therefore the images should not have the "istio-" prefix
this way the istio operator will use `quay.io/kubevirtci/pilot:v1` instead of `docker.io/istio/pilot:v1`
see https://github.com/kubevirt/kubevirtci/pull/851

Additional changes:
According https://github.com/rook/rook/issues/7213
docker.io/rook/ceph doesn't have rate limits.
We are also using its docker.io version, not the quay one.
Removing it from the mirroring list.
    

