### PR TITLE
Add area/instancetype label

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -325,6 +325,9 @@ repos:
       - name: area/monitoring
         color: bfd4f2
         target: both
+      - name: area/instancetype
+        color: bfd4f2
+        target: both
       - name: topic/api
         color: c5def5
         target: both


### PR DESCRIPTION
It would be nice to start tagging and tracking specific instancetype API
bugs under a single label, this change introduces the label.

