### PR TITLE
Move multiarch bootstrap jobs to prow-workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -96,7 +96,7 @@ postsubmits:
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -96,7 +96,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220630-ded5dcd


### PR DESCRIPTION
The arm64 build of the bootstrap image fails[1] on the ibm-prow-jobs
cluster as it requires more resources. The job completes successfully
when it is run on the prow-workloads cluster.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-multiarch-bootstrap-image/1552545593149100032

/cc @zhlhahaha @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>