### PR TITLE
Disable the release-blocker plugin until it is fixed

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -427,13 +427,11 @@ external_plugins:
     events:
       - pull_request
   - name: cherrypicker
-  - name: release-blocker
   kubevirt:
   - name: needs-rebase
     events:
       - pull_request
   - name: cherrypicker
-  - name: release-blocker
   k8snetworkplumbingwg/ovs-cni:
   - name: needs-rebase
     events:


### PR DESCRIPTION
The release-blocker plugin is currently in a loop where it endlessly
removes and adds the release-plocker label.

The outcome can be observed at https://github.com/kubevirt/kubevirt/pull/8246.