### PR TITLE
Remove -gcs-workers flag from crier deployment

### DIFF
--- a/github/ci/prow-deploy/README.md
+++ b/github/ci/prow-deploy/README.md
@@ -183,7 +183,7 @@ works correctly. At the moment only smoke tests are available.
 You can enter the test instance and access the deployed cluster with:
 
     $ molecule login
-    # export KUBECONFIG=/workspace/repos/project-infra-master/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/kubeconfig
+    # export KUBECONFIG=/workspace/repos/project-infra-main/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/kubeconfig
 
 then you can execute kubectl commands as usual:
 

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220526-c15dd4997d"
-        initupload: "gcr.io/k8s-prow/initupload:v20220526-c15dd4997d"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220526-c15dd4997d"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220526-c15dd4997d"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220803-65793402b8"
+        initupload: "gcr.io/k8s-prow/initupload:v20220803-65793402b8"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220803-65793402b8"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220803-65793402b8"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20220526-c15dd4997d
+              image: gcr.io/k8s-prow/branchprotector:v20220803-65793402b8
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/cherrypicker:v20220803-65793402b8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220526-c15dd4997d
+              image: gcr.io/k8s-prow/label_sync:v20220803-65793402b8
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220526-c15dd4997d
+              image: gcr.io/k8s-prow/label_sync:v20220803-65793402b8
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/crier:v20220803-65793402b8
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/deck:v20220803-65793402b8
         imagePullPolicy: Always
         ports:
         - name: http

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/ghproxy:v20220803-65793402b8
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/hook:v20220803-65793402b8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/horologium:v20220803-65793402b8
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/needs-rebase:v20220803-65793402b8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220803-65793402b8
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -551,15 +551,23 @@ spec:
                         name:
                           type: string
                         value:
-                          description: ArrayOrString is a type that can hold a single
+                          description: 'ArrayOrString is a type that can hold a single
                             string or string array. Used in JSON unmarshalling so
                             that a single JSON field can accept either an individual
-                            string or an array of strings.
+                            string or an array of strings. TODO (@chuangw6): This
+                            struct will be renamed or be embedded in a new struct
+                            to take into consideration the object case after the community
+                            reaches an agreement on it.'
                           properties:
                             arrayVal:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
+                            objectVal:
+                              additionalProperties:
+                                type: string
+                              type: object
                             stringVal:
                               type: string
                             type:
@@ -569,6 +577,7 @@ spec:
                               type: string
                           required:
                           - arrayVal
+                          - objectVal
                           - stringVal
                           - type
                           type: object
@@ -584,9 +593,40 @@ spec:
                       apiVersion:
                         description: API version of the referent
                         type: string
+                      bundle:
+                        description: Bundle url reference to a Tekton Bundle.
+                        type: string
                       name:
                         description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                         type: string
+                      resolver:
+                        description: Resolver is the name of the resolver that should
+                          perform resolution of the referenced Tekton resource, such
+                          as "git".
+                        type: string
+                      resource:
+                        description: Resource contains the parameters used to identify
+                          the referenced Tekton resource. Example entries might include
+                          "repo" or "path" but the set of params ultimately depends
+                          on the chosen resolver.
+                        items:
+                          description: ResolverParam is a single parameter passed
+                            to a resolver.
+                          properties:
+                            name:
+                              description: Name is the name of the parameter that
+                                will be passed to the resolver.
+                              type: string
+                            value:
+                              description: Value is the string value of the parameter
+                                that will be passed to the resolver.
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                     type: object
                   pipelineSpec:
                     description: PipelineSpec defines the desired state of Pipeline.
@@ -613,6 +653,11 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
+                                objectVal:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
                                 stringVal:
                                   type: string
                                 type:
@@ -622,6 +667,7 @@ spec:
                                   type: string
                               required:
                               - arrayVal
+                              - objectVal
                               - stringVal
                               - type
                               type: object
@@ -633,10 +679,24 @@ spec:
                               description: Name declares the name by which a parameter
                                 is referenced.
                               type: string
+                            properties:
+                              additionalProperties:
+                                description: PropertySpec defines the struct for object
+                                  keys
+                                properties:
+                                  type:
+                                    description: ParamType indicates the type of an
+                                      input parameter; Used to distinguish between
+                                      a single string and an array of strings.
+                                    type: string
+                                type: object
+                              description: Properties is the JSON Schema properties
+                                to support key-value pairs parameter.
+                              type: object
                             type:
                               description: Type is the user-specified type of the
-                                parameter. The possible types are currently "string"
-                                and "array", and "string" is the default.
+                                parameter. The possible types are currently "string",
+                                "array" and "object", and "string" is the default.
                               type: string
                           required:
                           - name
@@ -726,16 +786,25 @@ spec:
                                         name:
                                           type: string
                                         value:
-                                          description: ArrayOrString is a type that
+                                          description: 'ArrayOrString is a type that
                                             can hold a single string or string array.
                                             Used in JSON unmarshalling so that a single
                                             JSON field can accept either an individual
-                                            string or an array of strings.
+                                            string or an array of strings. TODO (@chuangw6):
+                                            This struct will be renamed or be embedded
+                                            in a new struct to take into consideration
+                                            the object case after the community reaches
+                                            an agreement on it.'
                                           properties:
                                             arrayVal:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
+                                            objectVal:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
                                             stringVal:
                                               type: string
                                             type:
@@ -746,6 +815,7 @@ spec:
                                               type: string
                                           required:
                                           - arrayVal
+                                          - objectVal
                                           - stringVal
                                           - type
                                           type: object
@@ -754,6 +824,7 @@ spec:
                                       - value
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   resources:
                                     description: Resources declare the resources provided
                                       to this Condition as input
@@ -773,6 +844,7 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                         name:
                                           description: Name is the name of the PipelineResource
                                             as declared by the Task.
@@ -786,6 +858,7 @@ spec:
                                       - resource
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                 - conditionRef
                                 type: object
@@ -806,16 +879,24 @@ spec:
                                   name:
                                     type: string
                                   value:
-                                    description: ArrayOrString is a type that can
+                                    description: 'ArrayOrString is a type that can
                                       hold a single string or string array. Used in
                                       JSON unmarshalling so that a single JSON field
                                       can accept either an individual string or an
-                                      array of strings.
+                                      array of strings. TODO (@chuangw6): This struct
+                                      will be renamed or be embedded in a new struct
+                                      to take into consideration the object case after
+                                      the community reaches an agreement on it.'
                                     properties:
                                       arrayVal:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
+                                      objectVal:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
                                       stringVal:
                                         type: string
                                       type:
@@ -826,6 +907,7 @@ spec:
                                         type: string
                                     required:
                                     - arrayVal
+                                    - objectVal
                                     - stringVal
                                     - type
                                     type: object
@@ -856,6 +938,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       name:
                                         description: Name is the name of the PipelineResource
                                           as declared by the Task.
@@ -869,6 +952,7 @@ spec:
                                     - resource
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 outputs:
                                   description: Outputs holds the mapping from the
                                     PipelineResources declared in DeclaredPipelineResources
@@ -893,6 +977,7 @@ spec:
                                     - resource
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             retries:
                               description: 'Retries represents how many times this
@@ -912,6 +997,9 @@ spec:
                                 apiVersion:
                                   description: API version of the referent
                                   type: string
+                                bundle:
+                                  description: Bundle url reference to a Tekton Bundle.
+                                  type: string
                                 kind:
                                   description: TaskKind indicates the kind of the
                                     task, namespaced or cluster scoped.
@@ -919,6 +1007,36 @@ spec:
                                 name:
                                   description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                   type: string
+                                resolver:
+                                  description: Resolver is the name of the resolver
+                                    that should perform resolution of the referenced
+                                    Tekton resource, such as "git".
+                                  type: string
+                                resource:
+                                  description: Resource contains the parameters used
+                                    to identify the referenced Tekton resource. Example
+                                    entries might include "repo" or "path" but the
+                                    set of params ultimately depends on the chosen
+                                    resolver.
+                                  items:
+                                    description: ResolverParam is a single parameter
+                                      passed to a resolver.
+                                    properties:
+                                      name:
+                                        description: Name is the name of the parameter
+                                          that will be passed to the resolver.
+                                        type: string
+                                      value:
+                                        description: Value is the string value of
+                                          the parameter that will be passed to the
+                                          resolver.
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             taskSpec:
                               description: TaskSpec is specification of a task
@@ -953,6 +1071,11 @@ spec:
                                                 items:
                                                   type: string
                                                 type: array
+                                                x-kubernetes-list-type: atomic
+                                              objectVal:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
                                               stringVal:
                                                 type: string
                                               type:
@@ -963,6 +1086,7 @@ spec:
                                                 type: string
                                             required:
                                             - arrayVal
+                                            - objectVal
                                             - stringVal
                                             - type
                                             type: object
@@ -975,11 +1099,28 @@ spec:
                                             description: Name declares the name by
                                               which a parameter is referenced.
                                             type: string
+                                          properties:
+                                            additionalProperties:
+                                              description: PropertySpec defines the
+                                                struct for object keys
+                                              properties:
+                                                type:
+                                                  description: ParamType indicates
+                                                    the type of an input parameter;
+                                                    Used to distinguish between a
+                                                    single string and an array of
+                                                    strings.
+                                                  type: string
+                                              type: object
+                                            description: Properties is the JSON Schema
+                                              properties to support key-value pairs
+                                              parameter.
+                                            type: object
                                           type:
                                             description: Type is the user-specified
                                               type of the parameter. The possible
-                                              types are currently "string" and "array",
-                                              and "string" is the default.
+                                              types are currently "string", "array"
+                                              and "object", and "string" is the default.
                                             type: string
                                         required:
                                         - name
@@ -1136,6 +1277,11 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
+                                          objectVal:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
                                           stringVal:
                                             type: string
                                           type:
@@ -1146,6 +1292,7 @@ spec:
                                             type: string
                                         required:
                                         - arrayVal
+                                        - objectVal
                                         - stringVal
                                         - type
                                         type: object
@@ -1158,16 +1305,32 @@ spec:
                                         description: Name declares the name by which
                                           a parameter is referenced.
                                         type: string
+                                      properties:
+                                        additionalProperties:
+                                          description: PropertySpec defines the struct
+                                            for object keys
+                                          properties:
+                                            type:
+                                              description: ParamType indicates the
+                                                type of an input parameter; Used to
+                                                distinguish between a single string
+                                                and an array of strings.
+                                              type: string
+                                          type: object
+                                        description: Properties is the JSON Schema
+                                          properties to support key-value pairs parameter.
+                                        type: object
                                       type:
                                         description: Type is the user-specified type
                                           of the parameter. The possible types are
-                                          currently "string" and "array", and "string"
-                                          is the default.
+                                          currently "string", "array" and "object",
+                                          and "string" is the default.
                                         type: string
                                     required:
                                     - name
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 resources:
                                   description: Resources is a list input and output
                                     resource to run the task Resources are represented
@@ -1224,6 +1387,7 @@ spec:
                                         - type
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     outputs:
                                       description: Outputs holds the mapping from
                                         the PipelineResources declared in DeclaredPipelineResources
@@ -1275,6 +1439,7 @@ spec:
                                         - type
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   type: object
                                 results:
                                   description: Results are values that this Task can
@@ -1290,18 +1455,25 @@ spec:
                                       name:
                                         description: Name the given name
                                         type: string
+                                      type:
+                                        description: Type is the user-specified type
+                                          of the result. The possible type is currently
+                                          "string" and will support "array" in following
+                                          work.
+                                        type: string
                                     required:
                                     - name
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 sidecars:
                                   description: Sidecars are run alongside the Task's
                                     step containers. They begin before the steps start
                                     and end after the steps complete.
                                   items:
-                                    description: Step embeds the Container type, which
-                                      allows it to include fields not provided by
-                                      Container.
+                                    description: Sidecar has nearly the same data
+                                      structure as Step but does not have the ability
+                                      to timeout.
                                     properties:
                                       args:
                                         description: 'Arguments to the entrypoint.
@@ -1320,6 +1492,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       command:
                                         description: 'Entrypoint array. Not executed
                                           within a shell. The docker image''s ENTRYPOINT
@@ -1338,6 +1511,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       env:
                                         description: List of environment variables
                                           to set in the container. Cannot be updated.
@@ -1470,6 +1644,7 @@ spec:
                                           - name
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       envFrom:
                                         description: List of sources to populate environment
                                           variables in the container. The keys defined
@@ -1521,6 +1696,7 @@ spec:
                                               type: object
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       image:
                                         description: 'Docker image name. More info:
                                           https://kubernetes.io/docs/concepts/containers/images
@@ -1551,9 +1727,8 @@ spec:
                                               info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                             properties:
                                               exec:
-                                                description: One and only one of the
-                                                  following should be specified. Exec
-                                                  specifies the action to take.
+                                                description: Exec specifies the action
+                                                  to take.
                                                 properties:
                                                   command:
                                                     description: Command is the command
@@ -1628,11 +1803,12 @@ spec:
                                                 - port
                                                 type: object
                                               tcpSocket:
-                                                description: 'TCPSocket specifies
-                                                  an action involving a TCP port.
-                                                  TCP hooks not yet supported TODO:
-                                                  implement a realistic TCP lifecycle
-                                                  hook'
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
                                                 properties:
                                                   host:
                                                     description: 'Optional: Host name
@@ -1660,22 +1836,20 @@ spec:
                                               such as liveness/startup probe failure,
                                               preemption, resource contention, etc.
                                               The handler is not called if the container
-                                              crashes or exits. The reason for termination
-                                              is passed to the handler. The Pod''s
-                                              termination grace period countdown begins
-                                              before the PreStop hooked is executed.
-                                              Regardless of the outcome of the handler,
-                                              the container will eventually terminate
-                                              within the Pod''s termination grace
-                                              period. Other management of the container
-                                              blocks until the hook completes or until
-                                              the termination grace period is reached.
-                                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                              crashes or exits. The Pod''s termination
+                                              grace period countdown begins before
+                                              the PreStop hook is executed. Regardless
+                                              of the outcome of the handler, the container
+                                              will eventually terminate within the
+                                              Pod''s termination grace period (unless
+                                              delayed by finalizers). Other management
+                                              of the container blocks until the hook
+                                              completes or until the termination grace
+                                              period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                             properties:
                                               exec:
-                                                description: One and only one of the
-                                                  following should be specified. Exec
-                                                  specifies the action to take.
+                                                description: Exec specifies the action
+                                                  to take.
                                                 properties:
                                                   command:
                                                     description: Command is the command
@@ -1750,11 +1924,12 @@ spec:
                                                 - port
                                                 type: object
                                               tcpSocket:
-                                                description: 'TCPSocket specifies
-                                                  an action involving a TCP port.
-                                                  TCP hooks not yet supported TODO:
-                                                  implement a realistic TCP lifecycle
-                                                  hook'
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
                                                 properties:
                                                   host:
                                                     description: 'Optional: Host name
@@ -1783,9 +1958,8 @@ spec:
                                           info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -1810,6 +1984,28 @@ spec:
                                               3. Minimum value is 1.
                                             format: int32
                                             type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
                                           httpGet:
                                             description: HTTPGet specifies the http
                                               request to perform.
@@ -1883,10 +2079,8 @@ spec:
                                             format: int32
                                             type: integer
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2005,9 +2199,8 @@ spec:
                                           Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2032,6 +2225,28 @@ spec:
                                               3. Minimum value is 1.
                                             format: int32
                                             type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
                                           httpGet:
                                             description: HTTPGet specifies the http
                                               request to perform.
@@ -2105,10 +2320,8 @@ spec:
                                             format: int32
                                             type: integer
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2210,13 +2423,17 @@ spec:
                                               flag will be set on the container process.
                                               AllowPrivilegeEscalation is true always
                                               when the container is: 1) run as Privileged
-                                              2) has CAP_SYS_ADMIN'
+                                              2) has CAP_SYS_ADMIN Note that this
+                                              field cannot be set when spec.os.name
+                                              is windows.'
                                             type: boolean
                                           capabilities:
                                             description: The capabilities to add/drop
                                               when running containers. Defaults to
                                               the default set of capabilities granted
-                                              by the container runtime.
+                                              by the container runtime. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
                                             properties:
                                               add:
                                                 description: Added capabilities
@@ -2237,7 +2454,9 @@ spec:
                                             description: Run container in privileged
                                               mode. Processes in privileged containers
                                               are essentially equivalent to root on
-                                              the host. Defaults to false.
+                                              the host. Defaults to false. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
                                             type: boolean
                                           procMount:
                                             description: procMount denotes the type
@@ -2246,12 +2465,14 @@ spec:
                                               uses the container runtime defaults
                                               for readonly paths and masked paths.
                                               This requires the ProcMountType feature
-                                              flag to be enabled.
+                                              flag to be enabled. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             type: string
                                           readOnlyRootFilesystem:
                                             description: Whether this container has
                                               a read-only root filesystem. Default
-                                              is false.
+                                              is false. Note that this field cannot
+                                              be set when spec.os.name is windows.
                                             type: boolean
                                           runAsGroup:
                                             description: The GID to run the entrypoint
@@ -2260,7 +2481,8 @@ spec:
                                               PodSecurityContext.  If set in both
                                               SecurityContext and PodSecurityContext,
                                               the value specified in SecurityContext
-                                              takes precedence.
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             format: int64
                                             type: integer
                                           runAsNonRoot:
@@ -2283,7 +2505,8 @@ spec:
                                               unspecified. May also be set in PodSecurityContext.  If
                                               set in both SecurityContext and PodSecurityContext,
                                               the value specified in SecurityContext
-                                              takes precedence.
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             format: int64
                                             type: integer
                                           seLinuxOptions:
@@ -2294,7 +2517,8 @@ spec:
                                               also be set in PodSecurityContext.  If
                                               set in both SecurityContext and PodSecurityContext,
                                               the value specified in SecurityContext
-                                              takes precedence.
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             properties:
                                               level:
                                                 description: Level is SELinux level
@@ -2318,7 +2542,8 @@ spec:
                                               by this container. If seccomp options
                                               are provided at both the pod & container
                                               level, the container options override
-                                              the pod options.
+                                              the pod options. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             properties:
                                               localhostProfile:
                                                 description: localhostProfile indicates
@@ -2350,6 +2575,8 @@ spec:
                                               will be used. If set in both SecurityContext
                                               and PodSecurityContext, the value specified
                                               in SecurityContext takes precedence.
+                                              Note that this field cannot be set when
+                                              spec.os.name is linux.
                                             properties:
                                               gmsaCredentialSpec:
                                                 description: GMSACredentialSpec is
@@ -2409,9 +2636,8 @@ spec:
                                           info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -2436,6 +2662,28 @@ spec:
                                               3. Minimum value is 1.
                                             format: int32
                                             type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
                                           httpGet:
                                             description: HTTPGet specifies the http
                                               request to perform.
@@ -2509,10 +2757,8 @@ spec:
                                             format: int32
                                             type: integer
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -2637,6 +2883,7 @@ spec:
                                           - name
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       volumeMounts:
                                         description: Pod volumes to mount into the
                                           container's filesystem. Cannot be updated.
@@ -2686,16 +2933,52 @@ spec:
                                           - name
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       workingDir:
                                         description: Container's working directory.
                                           If not specified, the container runtime's
                                           default will be used, which might be configured
                                           in the container image. Cannot be updated.
                                         type: string
+                                      workspaces:
+                                        description: "This is an alpha field. You
+                                          must set the \"enable-api-fields\" feature
+                                          flag to \"alpha\" for this field to be supported.
+                                          \n Workspaces is a list of workspaces from
+                                          the Task that this Sidecar wants exclusive
+                                          access to. Adding a workspace to this list
+                                          means that any other Step or Sidecar that
+                                          does not also request this Workspace will
+                                          not have access to it."
+                                        items:
+                                          description: WorkspaceUsage is used by a
+                                            Step or Sidecar to declare that it wants
+                                            isolated access to a Workspace defined
+                                            in a Task.
+                                          properties:
+                                            mountPath:
+                                              description: MountPath is the path that
+                                                the workspace should be mounted to
+                                                inside the Step or Sidecar, overriding
+                                                any MountPath specified in the Task's
+                                                WorkspaceDeclaration.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                workspace this Step or Sidecar wants
+                                                access to.
+                                              type: string
+                                          required:
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - name
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 stepTemplate:
                                   description: StepTemplate can be used as the basis
                                     for all step containers within the Task, so that
@@ -2718,6 +3001,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     command:
                                       description: 'Entrypoint array. Not executed
                                         within a shell. The docker image''s ENTRYPOINT
@@ -2735,6 +3019,7 @@ spec:
                                       items:
                                         type: string
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     env:
                                       description: List of environment variables to
                                         set in the container. Cannot be updated.
@@ -2862,6 +3147,7 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     envFrom:
                                       description: List of sources to populate environment
                                         variables in the container. The keys defined
@@ -2911,6 +3197,7 @@ spec:
                                             type: object
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     image:
                                       description: 'Docker image name. More info:
                                         https://kubernetes.io/docs/concepts/containers/images
@@ -2926,9 +3213,10 @@ spec:
                                         otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                       type: string
                                     lifecycle:
-                                      description: Actions that the management system
-                                        should take in response to container lifecycle
-                                        events. Cannot be updated.
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Actions that
+                                        the management system should take in response
+                                        to container lifecycle events. Cannot be updated.
                                       properties:
                                         postStart:
                                           description: 'PostStart is called immediately
@@ -2939,9 +3227,8 @@ spec:
                                             until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: Exec specifies the action
+                                                to take.
                                               properties:
                                                 command:
                                                   description: Command is the command
@@ -3014,10 +3301,12 @@ spec:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3044,21 +3333,20 @@ spec:
                                             as liveness/startup probe failure, preemption,
                                             resource contention, etc. The handler
                                             is not called if the container crashes
-                                            or exits. The reason for termination is
-                                            passed to the handler. The Pod''s termination
-                                            grace period countdown begins before the
-                                            PreStop hooked is executed. Regardless
-                                            of the outcome of the handler, the container
-                                            will eventually terminate within the Pod''s
-                                            termination grace period. Other management
-                                            of the container blocks until the hook
-                                            completes or until the termination grace
-                                            period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                            or exits. The Pod''s termination grace
+                                            period countdown begins before the PreStop
+                                            hook is executed. Regardless of the outcome
+                                            of the handler, the container will eventually
+                                            terminate within the Pod''s termination
+                                            grace period (unless delayed by finalizers).
+                                            Other management of the container blocks
+                                            until the hook completes or until the
+                                            termination grace period is reached. More
+                                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: Exec specifies the action
+                                                to take.
                                               properties:
                                                 command:
                                                   description: Command is the command
@@ -3131,10 +3419,12 @@ spec:
                                               - port
                                               type: object
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: Deprecated. TCPSocket is
+                                                NOT supported as a LifecycleHandler
+                                                and kept for the backward compatibility.
+                                                There are no validation of this field
+                                                and lifecycle hooks will fail in runtime
+                                                when tcp handler is specified.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -3156,14 +3446,15 @@ spec:
                                           type: object
                                       type: object
                                     livenessProbe:
-                                      description: 'Periodic probe of container liveness.
-                                        Container will be restarted if the probe fails.
-                                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. Periodic probe
+                                        of container liveness. Container will be restarted
+                                        if the probe fails. Cannot be updated. More
+                                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: Exec specifies the action to
+                                            take.
                                           properties:
                                             command:
                                               description: Command is the command
@@ -3188,6 +3479,28 @@ spec:
                                             Minimum value is 1.
                                           format: int32
                                           type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
                                         httpGet:
                                           description: HTTPGet specifies the http
                                             request to perform.
@@ -3261,10 +3574,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3312,22 +3623,24 @@ spec:
                                           type: integer
                                       type: object
                                     name:
-                                      description: Name of the container specified
-                                        as a DNS_LABEL. Each container in a pod must
-                                        have a unique name (DNS_LABEL). Cannot be
-                                        updated.
+                                      description: Deprecated. This field will be
+                                        removed in a future release. DeprecatedName
+                                        of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique
+                                        name (DNS_LABEL). Cannot be updated.
                                       type: string
                                     ports:
-                                      description: List of ports to expose from the
-                                        container. Exposing a port here gives the
-                                        system additional information about the network
-                                        connections a container uses, but is primarily
-                                        informational. Not specifying a port here
-                                        DOES NOT prevent that port from being exposed.
-                                        Any port which is listening on the default
-                                        "0.0.0.0" address inside a container will
-                                        be accessible from the network. Cannot be
-                                        updated.
+                                      description: Deprecated. This field will be
+                                        removed in a future release. List of ports
+                                        to expose from the container. Exposing a port
+                                        here gives the system additional information
+                                        about the network connections a container
+                                        uses, but is primarily informational. Not
+                                        specifying a port here DOES NOT prevent that
+                                        port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address
+                                        inside a container will be accessible from
+                                        the network. Cannot be updated.
                                       items:
                                         description: ContainerPort represents a network
                                           port in a single container.
@@ -3372,15 +3685,16 @@ spec:
                                       - protocol
                                       x-kubernetes-list-type: map
                                     readinessProbe:
-                                      description: 'Periodic probe of container service
-                                        readiness. Container will be removed from
-                                        service endpoints if the probe fails. Cannot
-                                        be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. Periodic probe
+                                        of container service readiness. Container
+                                        will be removed from service endpoints if
+                                        the probe fails. Cannot be updated. More info:
+                                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: Exec specifies the action to
+                                            take.
                                           properties:
                                             command:
                                               description: Command is the command
@@ -3405,6 +3719,28 @@ spec:
                                             Minimum value is 1.
                                           format: int32
                                           type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
                                         httpGet:
                                           description: HTTPGet specifies the http
                                             request to perform.
@@ -3478,10 +3814,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3573,13 +3907,17 @@ spec:
                                             controls if the no_new_privs flag will
                                             be set on the container process. AllowPrivilegeEscalation
                                             is true always when the container is:
-                                            1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                            1) run as Privileged 2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when
+                                            spec.os.name is windows.'
                                           type: boolean
                                         capabilities:
                                           description: The capabilities to add/drop
                                             when running containers. Defaults to the
                                             default set of capabilities granted by
-                                            the container runtime.
+                                            the container runtime. Note that this
+                                            field cannot be set when spec.os.name
+                                            is windows.
                                           properties:
                                             add:
                                               description: Added capabilities
@@ -3600,7 +3938,9 @@ spec:
                                           description: Run container in privileged
                                             mode. Processes in privileged containers
                                             are essentially equivalent to root on
-                                            the host. Defaults to false.
+                                            the host. Defaults to false. Note that
+                                            this field cannot be set when spec.os.name
+                                            is windows.
                                           type: boolean
                                         procMount:
                                           description: procMount denotes the type
@@ -3609,12 +3949,14 @@ spec:
                                             uses the container runtime defaults for
                                             readonly paths and masked paths. This
                                             requires the ProcMountType feature flag
-                                            to be enabled.
+                                            to be enabled. Note that this field cannot
+                                            be set when spec.os.name is windows.
                                           type: string
                                         readOnlyRootFilesystem:
                                           description: Whether this container has
                                             a read-only root filesystem. Default is
-                                            false.
+                                            false. Note that this field cannot be
+                                            set when spec.os.name is windows.
                                           type: boolean
                                         runAsGroup:
                                           description: The GID to run the entrypoint
@@ -3622,7 +3964,8 @@ spec:
                                             default if unset. May also be set in PodSecurityContext.  If
                                             set in both SecurityContext and PodSecurityContext,
                                             the value specified in SecurityContext
-                                            takes precedence.
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         runAsNonRoot:
@@ -3645,7 +3988,8 @@ spec:
                                             May also be set in PodSecurityContext.  If
                                             set in both SecurityContext and PodSecurityContext,
                                             the value specified in SecurityContext
-                                            takes precedence.
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
                                           format: int64
                                           type: integer
                                         seLinuxOptions:
@@ -3656,7 +4000,8 @@ spec:
                                             also be set in PodSecurityContext.  If
                                             set in both SecurityContext and PodSecurityContext,
                                             the value specified in SecurityContext
-                                            takes precedence.
+                                            takes precedence. Note that this field
+                                            cannot be set when spec.os.name is windows.
                                           properties:
                                             level:
                                               description: Level is SELinux level
@@ -3680,7 +4025,8 @@ spec:
                                             by this container. If seccomp options
                                             are provided at both the pod & container
                                             level, the container options override
-                                            the pod options.
+                                            the pod options. Note that this field
+                                            cannot be set when spec.os.name is windows.
                                           properties:
                                             localhostProfile:
                                               description: localhostProfile indicates
@@ -3711,7 +4057,9 @@ spec:
                                             the options from the PodSecurityContext
                                             will be used. If set in both SecurityContext
                                             and PodSecurityContext, the value specified
-                                            in SecurityContext takes precedence.
+                                            in SecurityContext takes precedence. Note
+                                            that this field cannot be set when spec.os.name
+                                            is linux.
                                           properties:
                                             gmsaCredentialSpec:
                                               description: GMSACredentialSpec is where
@@ -3754,22 +4102,22 @@ spec:
                                           type: object
                                       type: object
                                     startupProbe:
-                                      description: 'StartupProbe indicates that the
-                                        Pod has successfully initialized. If specified,
-                                        no other probes are executed until this completes
-                                        successfully. If this probe fails, the Pod
-                                        will be restarted, just as if the livenessProbe
-                                        failed. This can be used to provide different
-                                        probe parameters at the beginning of a Pod''s
-                                        lifecycle, when it might take a long time
-                                        to load data or warm a cache, than during
-                                        steady-state operation. This cannot be updated.
-                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. DeprecatedStartupProbe
+                                        indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed
+                                        until this completes successfully. If this
+                                        probe fails, the Pod will be restarted, just
+                                        as if the livenessProbe failed. This can be
+                                        used to provide different probe parameters
+                                        at the beginning of a Pod''s lifecycle, when
+                                        it might take a long time to load data or
+                                        warm a cache, than during steady-state operation.
+                                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                       properties:
                                         exec:
-                                          description: One and only one of the following
-                                            should be specified. Exec specifies the
-                                            action to take.
+                                          description: Exec specifies the action to
+                                            take.
                                           properties:
                                             command:
                                               description: Command is the command
@@ -3794,6 +4142,28 @@ spec:
                                             Minimum value is 1.
                                           format: int32
                                           type: integer
+                                        grpc:
+                                          description: GRPC specifies an action involving
+                                            a GRPC port. This is a beta field and
+                                            requires enabling GRPCContainerProbe feature
+                                            gate.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              description: "Service is the name of
+                                                the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                \n If this is not specified, the default
+                                                behavior is defined by gRPC."
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
                                         httpGet:
                                           description: HTTPGet specifies the http
                                             request to perform.
@@ -3867,10 +4237,8 @@ spec:
                                           format: int32
                                           type: integer
                                         tcpSocket:
-                                          description: 'TCPSocket specifies an action
-                                            involving a TCP port. TCP hooks not yet
-                                            supported TODO: implement a realistic
-                                            TCP lifecycle hook'
+                                          description: TCPSocket specifies an action
+                                            involving a TCP port.
                                           properties:
                                             host:
                                               description: 'Optional: Host name to
@@ -3918,55 +4286,63 @@ spec:
                                           type: integer
                                       type: object
                                     stdin:
-                                      description: Whether this container should allocate
-                                        a buffer for stdin in the container runtime.
-                                        If this is not set, reads from stdin in the
-                                        container will always result in EOF. Default
-                                        is false.
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Whether this
+                                        container should allocate a buffer for stdin
+                                        in the container runtime. If this is not set,
+                                        reads from stdin in the container will always
+                                        result in EOF. Default is false.
                                       type: boolean
                                     stdinOnce:
-                                      description: Whether the container runtime should
-                                        close the stdin channel after it has been
-                                        opened by a single attach. When stdin is true
-                                        the stdin stream will remain open across multiple
-                                        attach sessions. If stdinOnce is set to true,
-                                        stdin is opened on container start, is empty
-                                        until the first client attaches to stdin,
-                                        and then remains open and accepts data until
-                                        the client disconnects, at which time stdin
-                                        is closed and remains closed until the container
-                                        is restarted. If this flag is false, a container
-                                        processes that reads from stdin will never
-                                        receive an EOF. Default is false
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Whether the container
+                                        runtime should close the stdin channel after
+                                        it has been opened by a single attach. When
+                                        stdin is true the stdin stream will remain
+                                        open across multiple attach sessions. If stdinOnce
+                                        is set to true, stdin is opened on container
+                                        start, is empty until the first client attaches
+                                        to stdin, and then remains open and accepts
+                                        data until the client disconnects, at which
+                                        time stdin is closed and remains closed until
+                                        the container is restarted. If this flag is
+                                        false, a container processes that reads from
+                                        stdin will never receive an EOF. Default is
+                                        false
                                       type: boolean
                                     terminationMessagePath:
-                                      description: 'Optional: Path at which the file
-                                        to which the container''s termination message
-                                        will be written is mounted into the container''s
-                                        filesystem. Message written is intended to
-                                        be brief final status, such as an assertion
-                                        failure message. Will be truncated by the
-                                        node if greater than 4096 bytes. The total
-                                        message length across all containers will
-                                        be limited to 12kb. Defaults to /dev/termination-log.
-                                        Cannot be updated.'
+                                      description: 'Deprecated. This field will be
+                                        removed in a future release. Optional: Path
+                                        at which the file to which the container''s
+                                        termination message will be written is mounted
+                                        into the container''s filesystem. Message
+                                        written is intended to be brief final status,
+                                        such as an assertion failure message. Will
+                                        be truncated by the node if greater than 4096
+                                        bytes. The total message length across all
+                                        containers will be limited to 12kb. Defaults
+                                        to /dev/termination-log. Cannot be updated.'
                                       type: string
                                     terminationMessagePolicy:
-                                      description: Indicate how the termination message
-                                        should be populated. File will use the contents
-                                        of terminationMessagePath to populate the
-                                        container status message on both success and
-                                        failure. FallbackToLogsOnError will use the
-                                        last chunk of container log output if the
-                                        termination message file is empty and the
-                                        container exited with an error. The log output
-                                        is limited to 2048 bytes or 80 lines, whichever
-                                        is smaller. Defaults to File. Cannot be updated.
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Indicate how
+                                        the termination message should be populated.
+                                        File will use the contents of terminationMessagePath
+                                        to populate the container status message on
+                                        both success and failure. FallbackToLogsOnError
+                                        will use the last chunk of container log output
+                                        if the termination message file is empty and
+                                        the container exited with an error. The log
+                                        output is limited to 2048 bytes or 80 lines,
+                                        whichever is smaller. Defaults to File. Cannot
+                                        be updated.
                                       type: string
                                     tty:
-                                      description: Whether this container should allocate
-                                        a TTY for itself, also requires 'stdin' to
-                                        be true. Default is false.
+                                      description: Deprecated. This field will be
+                                        removed in a future release. Whether this
+                                        container should allocate a DeprecatedTTY
+                                        for itself, also requires 'stdin' to be true.
+                                        Default is false.
                                       type: boolean
                                     volumeDevices:
                                       description: volumeDevices is the list of block
@@ -3989,6 +4365,7 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     volumeMounts:
                                       description: Pod volumes to mount into the container's
                                         filesystem. Cannot be updated.
@@ -4038,6 +4415,7 @@ spec:
                                         - name
                                         type: object
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                     workingDir:
                                       description: Container's working directory.
                                         If not specified, the container runtime's
@@ -4052,9 +4430,7 @@ spec:
                                     step is run sequentially with the source mounted
                                     into /workspace.
                                   items:
-                                    description: Step embeds the Container type, which
-                                      allows it to include fields not provided by
-                                      Container.
+                                    description: Step runs a subcomponent of a Task
                                     properties:
                                       args:
                                         description: 'Arguments to the entrypoint.
@@ -4073,6 +4449,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       command:
                                         description: 'Entrypoint array. Not executed
                                           within a shell. The docker image''s ENTRYPOINT
@@ -4091,6 +4468,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       env:
                                         description: List of environment variables
                                           to set in the container. Cannot be updated.
@@ -4223,6 +4601,7 @@ spec:
                                           - name
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       envFrom:
                                         description: List of sources to populate environment
                                           variables in the container. The keys defined
@@ -4274,6 +4653,7 @@ spec:
                                               type: object
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       image:
                                         description: 'Docker image name. More info:
                                           https://kubernetes.io/docs/concepts/containers/images
@@ -4290,9 +4670,11 @@ spec:
                                           https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                         type: string
                                       lifecycle:
-                                        description: Actions that the management system
-                                          should take in response to container lifecycle
-                                          events. Cannot be updated.
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Actions that
+                                          the management system should take in response
+                                          to container lifecycle events. Cannot be
+                                          updated.
                                         properties:
                                           postStart:
                                             description: 'PostStart is called immediately
@@ -4304,9 +4686,8 @@ spec:
                                               info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                             properties:
                                               exec:
-                                                description: One and only one of the
-                                                  following should be specified. Exec
-                                                  specifies the action to take.
+                                                description: Exec specifies the action
+                                                  to take.
                                                 properties:
                                                   command:
                                                     description: Command is the command
@@ -4381,11 +4762,12 @@ spec:
                                                 - port
                                                 type: object
                                               tcpSocket:
-                                                description: 'TCPSocket specifies
-                                                  an action involving a TCP port.
-                                                  TCP hooks not yet supported TODO:
-                                                  implement a realistic TCP lifecycle
-                                                  hook'
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
                                                 properties:
                                                   host:
                                                     description: 'Optional: Host name
@@ -4413,22 +4795,20 @@ spec:
                                               such as liveness/startup probe failure,
                                               preemption, resource contention, etc.
                                               The handler is not called if the container
-                                              crashes or exits. The reason for termination
-                                              is passed to the handler. The Pod''s
-                                              termination grace period countdown begins
-                                              before the PreStop hooked is executed.
-                                              Regardless of the outcome of the handler,
-                                              the container will eventually terminate
-                                              within the Pod''s termination grace
-                                              period. Other management of the container
-                                              blocks until the hook completes or until
-                                              the termination grace period is reached.
-                                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                              crashes or exits. The Pod''s termination
+                                              grace period countdown begins before
+                                              the PreStop hook is executed. Regardless
+                                              of the outcome of the handler, the container
+                                              will eventually terminate within the
+                                              Pod''s termination grace period (unless
+                                              delayed by finalizers). Other management
+                                              of the container blocks until the hook
+                                              completes or until the termination grace
+                                              period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                             properties:
                                               exec:
-                                                description: One and only one of the
-                                                  following should be specified. Exec
-                                                  specifies the action to take.
+                                                description: Exec specifies the action
+                                                  to take.
                                                 properties:
                                                   command:
                                                     description: Command is the command
@@ -4503,11 +4883,12 @@ spec:
                                                 - port
                                                 type: object
                                               tcpSocket:
-                                                description: 'TCPSocket specifies
-                                                  an action involving a TCP port.
-                                                  TCP hooks not yet supported TODO:
-                                                  implement a realistic TCP lifecycle
-                                                  hook'
+                                                description: Deprecated. TCPSocket
+                                                  is NOT supported as a LifecycleHandler
+                                                  and kept for the backward compatibility.
+                                                  There are no validation of this
+                                                  field and lifecycle hooks will fail
+                                                  in runtime when tcp handler is specified.
                                                 properties:
                                                   host:
                                                     description: 'Optional: Host name
@@ -4530,15 +4911,15 @@ spec:
                                             type: object
                                         type: object
                                       livenessProbe:
-                                        description: 'Periodic probe of container
-                                          liveness. Container will be restarted if
-                                          the probe fails. Cannot be updated. More
-                                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. Periodic
+                                          probe of container liveness. Container will
+                                          be restarted if the probe fails. Cannot
+                                          be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -4563,6 +4944,28 @@ spec:
                                               3. Minimum value is 1.
                                             format: int32
                                             type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
                                           httpGet:
                                             description: HTTPGet specifies the http
                                               request to perform.
@@ -4636,10 +5039,8 @@ spec:
                                             format: int32
                                             type: integer
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4695,17 +5096,27 @@ spec:
                                           must have a unique name (DNS_LABEL). Cannot
                                           be updated.
                                         type: string
+                                      onError:
+                                        description: OnError defines the exiting behavior
+                                          of a container on error can be set to [
+                                          continue | stopAndFail ] stopAndFail indicates
+                                          exit the taskRun if the container exits
+                                          with non-zero exit code continue indicates
+                                          continue executing the rest of the steps
+                                          irrespective of the container exit code
+                                        type: string
                                       ports:
-                                        description: List of ports to expose from
-                                          the container. Exposing a port here gives
-                                          the system additional information about
-                                          the network connections a container uses,
-                                          but is primarily informational. Not specifying
-                                          a port here DOES NOT prevent that port from
-                                          being exposed. Any port which is listening
-                                          on the default "0.0.0.0" address inside
-                                          a container will be accessible from the
-                                          network. Cannot be updated.
+                                        description: Deprecated. This field will be
+                                          removed in a future release. List of ports
+                                          to expose from the container. Exposing a
+                                          port here gives the system additional information
+                                          about the network connections a container
+                                          uses, but is primarily informational. Not
+                                          specifying a port here DOES NOT prevent
+                                          that port from being exposed. Any port which
+                                          is listening on the default "0.0.0.0" address
+                                          inside a container will be accessible from
+                                          the network. Cannot be updated.
                                         items:
                                           description: ContainerPort represents a
                                             network port in a single container.
@@ -4752,15 +5163,16 @@ spec:
                                         - protocol
                                         x-kubernetes-list-type: map
                                       readinessProbe:
-                                        description: 'Periodic probe of container
-                                          service readiness. Container will be removed
-                                          from service endpoints if the probe fails.
-                                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. Periodic
+                                          probe of container service readiness. Container
+                                          will be removed from service endpoints if
+                                          the probe fails. Cannot be updated. More
+                                          info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -4785,6 +5197,28 @@ spec:
                                               3. Minimum value is 1.
                                             format: int32
                                             type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
                                           httpGet:
                                             description: HTTPGet specifies the http
                                               request to perform.
@@ -4858,10 +5292,8 @@ spec:
                                             format: int32
                                             type: integer
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -4946,7 +5378,7 @@ spec:
                                         description: "Script is the contents of an
                                           executable file to execute. \n If Script
                                           is not empty, the Step cannot have an Command
-                                          or Args."
+                                          and the Args will be passed to the Script."
                                         type: string
                                       securityContext:
                                         description: 'SecurityContext defines the
@@ -4963,13 +5395,17 @@ spec:
                                               flag will be set on the container process.
                                               AllowPrivilegeEscalation is true always
                                               when the container is: 1) run as Privileged
-                                              2) has CAP_SYS_ADMIN'
+                                              2) has CAP_SYS_ADMIN Note that this
+                                              field cannot be set when spec.os.name
+                                              is windows.'
                                             type: boolean
                                           capabilities:
                                             description: The capabilities to add/drop
                                               when running containers. Defaults to
                                               the default set of capabilities granted
-                                              by the container runtime.
+                                              by the container runtime. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
                                             properties:
                                               add:
                                                 description: Added capabilities
@@ -4990,7 +5426,9 @@ spec:
                                             description: Run container in privileged
                                               mode. Processes in privileged containers
                                               are essentially equivalent to root on
-                                              the host. Defaults to false.
+                                              the host. Defaults to false. Note that
+                                              this field cannot be set when spec.os.name
+                                              is windows.
                                             type: boolean
                                           procMount:
                                             description: procMount denotes the type
@@ -4999,12 +5437,14 @@ spec:
                                               uses the container runtime defaults
                                               for readonly paths and masked paths.
                                               This requires the ProcMountType feature
-                                              flag to be enabled.
+                                              flag to be enabled. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             type: string
                                           readOnlyRootFilesystem:
                                             description: Whether this container has
                                               a read-only root filesystem. Default
-                                              is false.
+                                              is false. Note that this field cannot
+                                              be set when spec.os.name is windows.
                                             type: boolean
                                           runAsGroup:
                                             description: The GID to run the entrypoint
@@ -5013,7 +5453,8 @@ spec:
                                               PodSecurityContext.  If set in both
                                               SecurityContext and PodSecurityContext,
                                               the value specified in SecurityContext
-                                              takes precedence.
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             format: int64
                                             type: integer
                                           runAsNonRoot:
@@ -5036,7 +5477,8 @@ spec:
                                               unspecified. May also be set in PodSecurityContext.  If
                                               set in both SecurityContext and PodSecurityContext,
                                               the value specified in SecurityContext
-                                              takes precedence.
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             format: int64
                                             type: integer
                                           seLinuxOptions:
@@ -5047,7 +5489,8 @@ spec:
                                               also be set in PodSecurityContext.  If
                                               set in both SecurityContext and PodSecurityContext,
                                               the value specified in SecurityContext
-                                              takes precedence.
+                                              takes precedence. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             properties:
                                               level:
                                                 description: Level is SELinux level
@@ -5071,7 +5514,8 @@ spec:
                                               by this container. If seccomp options
                                               are provided at both the pod & container
                                               level, the container options override
-                                              the pod options.
+                                              the pod options. Note that this field
+                                              cannot be set when spec.os.name is windows.
                                             properties:
                                               localhostProfile:
                                                 description: localhostProfile indicates
@@ -5103,6 +5547,8 @@ spec:
                                               will be used. If set in both SecurityContext
                                               and PodSecurityContext, the value specified
                                               in SecurityContext takes precedence.
+                                              Note that this field cannot be set when
+                                              spec.os.name is linux.
                                             properties:
                                               gmsaCredentialSpec:
                                                 description: GMSACredentialSpec is
@@ -5148,11 +5594,12 @@ spec:
                                             type: object
                                         type: object
                                       startupProbe:
-                                        description: 'StartupProbe indicates that
-                                          the Pod has successfully initialized. If
-                                          specified, no other probes are executed
-                                          until this completes successfully. If this
-                                          probe fails, the Pod will be restarted,
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. DeprecatedStartupProbe
+                                          indicates that the Pod has successfully
+                                          initialized. If specified, no other probes
+                                          are executed until this completes successfully.
+                                          If this probe fails, the Pod will be restarted,
                                           just as if the livenessProbe failed. This
                                           can be used to provide different probe parameters
                                           at the beginning of a Pod''s lifecycle,
@@ -5162,9 +5609,8 @@ spec:
                                           info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         properties:
                                           exec:
-                                            description: One and only one of the following
-                                              should be specified. Exec specifies
-                                              the action to take.
+                                            description: Exec specifies the action
+                                              to take.
                                             properties:
                                               command:
                                                 description: Command is the command
@@ -5189,6 +5635,28 @@ spec:
                                               3. Minimum value is 1.
                                             format: int32
                                             type: integer
+                                          grpc:
+                                            description: GRPC specifies an action
+                                              involving a GRPC port. This is a beta
+                                              field and requires enabling GRPCContainerProbe
+                                              feature gate.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC
+                                                  service. Number must be in the range
+                                                  1 to 65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                description: "Service is the name
+                                                  of the service to place in the gRPC
+                                                  HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                  \n If this is not specified, the
+                                                  default behavior is defined by gRPC."
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
                                           httpGet:
                                             description: HTTPGet specifies the http
                                               request to perform.
@@ -5262,10 +5730,8 @@ spec:
                                             format: int32
                                             type: integer
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action
-                                              involving a TCP port. TCP hooks not
-                                              yet supported TODO: implement a realistic
-                                              TCP lifecycle hook'
+                                            description: TCPSocket specifies an action
+                                              involving a TCP port.
                                             properties:
                                               host:
                                                 description: 'Optional: Host name
@@ -5316,46 +5782,51 @@ spec:
                                             type: integer
                                         type: object
                                       stdin:
-                                        description: Whether this container should
-                                          allocate a buffer for stdin in the container
-                                          runtime. If this is not set, reads from
-                                          stdin in the container will always result
-                                          in EOF. Default is false.
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Whether this
+                                          container should allocate a buffer for stdin
+                                          in the container runtime. If this is not
+                                          set, reads from stdin in the container will
+                                          always result in EOF. Default is false.
                                         type: boolean
                                       stdinOnce:
-                                        description: Whether the container runtime
-                                          should close the stdin channel after it
-                                          has been opened by a single attach. When
-                                          stdin is true the stdin stream will remain
-                                          open across multiple attach sessions. If
-                                          stdinOnce is set to true, stdin is opened
-                                          on container start, is empty until the first
-                                          client attaches to stdin, and then remains
-                                          open and accepts data until the client disconnects,
-                                          at which time stdin is closed and remains
-                                          closed until the container is restarted.
-                                          If this flag is false, a container processes
-                                          that reads from stdin will never receive
-                                          an EOF. Default is false
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Whether the
+                                          container runtime should close the stdin
+                                          channel after it has been opened by a single
+                                          attach. When stdin is true the stdin stream
+                                          will remain open across multiple attach
+                                          sessions. If stdinOnce is set to true, stdin
+                                          is opened on container start, is empty until
+                                          the first client attaches to stdin, and
+                                          then remains open and accepts data until
+                                          the client disconnects, at which time stdin
+                                          is closed and remains closed until the container
+                                          is restarted. If this flag is false, a container
+                                          processes that reads from stdin will never
+                                          receive an EOF. Default is false
                                         type: boolean
                                       terminationMessagePath:
-                                        description: 'Optional: Path at which the
-                                          file to which the container''s termination
-                                          message will be written is mounted into
-                                          the container''s filesystem. Message written
-                                          is intended to be brief final status, such
-                                          as an assertion failure message. Will be
-                                          truncated by the node if greater than 4096
-                                          bytes. The total message length across all
-                                          containers will be limited to 12kb. Defaults
-                                          to /dev/termination-log. Cannot be updated.'
+                                        description: 'Deprecated. This field will
+                                          be removed in a future release. Optional:
+                                          Path at which the file to which the container''s
+                                          termination message will be written is mounted
+                                          into the container''s filesystem. Message
+                                          written is intended to be brief final status,
+                                          such as an assertion failure message. Will
+                                          be truncated by the node if greater than
+                                          4096 bytes. The total message length across
+                                          all containers will be limited to 12kb.
+                                          Defaults to /dev/termination-log. Cannot
+                                          be updated.'
                                         type: string
                                       terminationMessagePolicy:
-                                        description: Indicate how the termination
-                                          message should be populated. File will use
-                                          the contents of terminationMessagePath to
-                                          populate the container status message on
-                                          both success and failure. FallbackToLogsOnError
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Indicate how
+                                          the termination message should be populated.
+                                          File will use the contents of terminationMessagePath
+                                          to populate the container status message
+                                          on both success and failure. FallbackToLogsOnError
                                           will use the last chunk of container log
                                           output if the termination message file is
                                           empty and the container exited with an error.
@@ -5363,10 +5834,18 @@ spec:
                                           or 80 lines, whichever is smaller. Defaults
                                           to File. Cannot be updated.
                                         type: string
+                                      timeout:
+                                        description: 'Timeout is the time after which
+                                          the step times out. Defaults to never. Refer
+                                          to Go''s ParseDuration documentation for
+                                          expected format: https://golang.org/pkg/time/#ParseDuration'
+                                        type: string
                                       tty:
-                                        description: Whether this container should
-                                          allocate a TTY for itself, also requires
-                                          'stdin' to be true. Default is false.
+                                        description: Deprecated. This field will be
+                                          removed in a future release. Whether this
+                                          container should allocate a DeprecatedTTY
+                                          for itself, also requires 'stdin' to be
+                                          true. Default is false.
                                         type: boolean
                                       volumeDevices:
                                         description: volumeDevices is the list of
@@ -5390,6 +5869,7 @@ spec:
                                           - name
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       volumeMounts:
                                         description: Pod volumes to mount into the
                                           container's filesystem. Cannot be updated.
@@ -5439,16 +5919,52 @@ spec:
                                           - name
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       workingDir:
                                         description: Container's working directory.
                                           If not specified, the container runtime's
                                           default will be used, which might be configured
                                           in the container image. Cannot be updated.
                                         type: string
+                                      workspaces:
+                                        description: "This is an alpha field. You
+                                          must set the \"enable-api-fields\" feature
+                                          flag to \"alpha\" for this field to be supported.
+                                          \n Workspaces is a list of workspaces from
+                                          the Task that this Step wants exclusive
+                                          access to. Adding a workspace to this list
+                                          means that any other Step or Sidecar that
+                                          does not also request this Workspace will
+                                          not have access to it."
+                                        items:
+                                          description: WorkspaceUsage is used by a
+                                            Step or Sidecar to declare that it wants
+                                            isolated access to a Workspace defined
+                                            in a Task.
+                                          properties:
+                                            mountPath:
+                                              description: MountPath is the path that
+                                                the workspace should be mounted to
+                                                inside the Step or Sidecar, overriding
+                                                any MountPath specified in the Task's
+                                                WorkspaceDeclaration.
+                                              type: string
+                                            name:
+                                              description: Name is the name of the
+                                                workspace this Step or Sidecar wants
+                                                access to.
+                                              type: string
+                                          required:
+                                          - mountPath
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                     - name
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 volumes:
                                   description: Volumes is a collection of volumes
                                     that are available to mount into the steps of
@@ -5459,139 +5975,144 @@ spec:
                                       in the pod.
                                     properties:
                                       awsElasticBlockStore:
-                                        description: 'AWSElasticBlockStore represents
+                                        description: 'awsElasticBlockStore represents
                                           an AWS Disk resource that is attached to
                                           a kubelet''s host machine and then exposed
                                           to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         properties:
                                           fsType:
-                                            description: 'Filesystem type of the volume
-                                              that you want to mount. Tip: Ensure
-                                              that the filesystem type is supported
-                                              by the host operating system. Examples:
-                                              "ext4", "xfs", "ntfs". Implicitly inferred
-                                              to be "ext4" if unspecified. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                            description: 'fsType is the filesystem
+                                              type of the volume that you want to
+                                              mount. Tip: Ensure that the filesystem
+                                              type is supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                               TODO: how do we prevent errors in the
                                               filesystem from compromising the machine'
                                             type: string
                                           partition:
-                                            description: 'The partition in the volume
-                                              that you want to mount. If omitted,
-                                              the default is to mount by volume name.
-                                              Examples: For volume /dev/sda1, you
-                                              specify the partition as "1". Similarly,
-                                              the volume partition for /dev/sda is
-                                              "0" (or you can leave the property empty).'
+                                            description: 'partition is the partition
+                                              in the volume that you want to mount.
+                                              If omitted, the default is to mount
+                                              by volume name. Examples: For volume
+                                              /dev/sda1, you specify the partition
+                                              as "1". Similarly, the volume partition
+                                              for /dev/sda is "0" (or you can leave
+                                              the property empty).'
                                             format: int32
                                             type: integer
                                           readOnly:
-                                            description: 'Specify "true" to force
-                                              and set the ReadOnly property in VolumeMounts
-                                              to "true". If omitted, the default is
-                                              "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                            description: 'readOnly value true will
+                                              force the readOnly setting in VolumeMounts.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                             type: boolean
                                           volumeID:
-                                            description: 'Unique ID of the persistent
-                                              disk resource in AWS (Amazon EBS volume).
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                            description: 'volumeID is unique ID of
+                                              the persistent disk resource in AWS
+                                              (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       azureDisk:
-                                        description: AzureDisk represents an Azure
+                                        description: azureDisk represents an Azure
                                           Data Disk mount on the host and bind mount
                                           to the pod.
                                         properties:
                                           cachingMode:
-                                            description: 'Host Caching mode: None,
-                                              Read Only, Read Write.'
+                                            description: 'cachingMode is the Host
+                                              Caching mode: None, Read Only, Read
+                                              Write.'
                                             type: string
                                           diskName:
-                                            description: The Name of the data disk
-                                              in the blob storage
+                                            description: diskName is the Name of the
+                                              data disk in the blob storage
                                             type: string
                                           diskURI:
-                                            description: The URI the data disk in
-                                              the blob storage
+                                            description: diskURI is the URI of data
+                                              disk in the blob storage
                                             type: string
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". Implicitly inferred to
-                                              be "ext4" if unspecified.
+                                            description: fsType is Filesystem type
+                                              to mount. Must be a filesystem type
+                                              supported by the host operating system.
+                                              Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           kind:
-                                            description: 'Expected values Shared:
-                                              multiple blob disks per storage account  Dedicated:
-                                              single blob disk per storage account  Managed:
-                                              azure managed data disk (only in managed
-                                              availability set). defaults to shared'
+                                            description: 'kind expected values are
+                                              Shared: multiple blob disks per storage
+                                              account  Dedicated: single blob disk
+                                              per storage account  Managed: azure
+                                              managed data disk (only in managed availability
+                                              set). defaults to shared'
                                             type: string
                                           readOnly:
-                                            description: Defaults to false (read/write).
-                                              ReadOnly here will force the ReadOnly
-                                              setting in VolumeMounts.
+                                            description: readOnly Defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                         required:
                                         - diskName
                                         - diskURI
                                         type: object
                                       azureFile:
-                                        description: AzureFile represents an Azure
+                                        description: azureFile represents an Azure
                                           File Service mount on the host and bind
                                           mount to the pod.
                                         properties:
                                           readOnly:
-                                            description: Defaults to false (read/write).
-                                              ReadOnly here will force the ReadOnly
-                                              setting in VolumeMounts.
+                                            description: readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretName:
-                                            description: the name of secret that contains
-                                              Azure Storage Account Name and Key
+                                            description: secretName is the  name of
+                                              secret that contains Azure Storage Account
+                                              Name and Key
                                             type: string
                                           shareName:
-                                            description: Share Name
+                                            description: shareName is the azure share
+                                              Name
                                             type: string
                                         required:
                                         - secretName
                                         - shareName
                                         type: object
                                       cephfs:
-                                        description: CephFS represents a Ceph FS mount
+                                        description: cephFS represents a Ceph FS mount
                                           on the host that shares a pod's lifetime
                                         properties:
                                           monitors:
-                                            description: 'Required: Monitors is a
-                                              collection of Ceph monitors More info:
-                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            description: 'monitors is Required: Monitors
+                                              is a collection of Ceph monitors More
+                                              info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             items:
                                               type: string
                                             type: array
                                           path:
-                                            description: 'Optional: Used as the mounted
-                                              root, rather than the full Ceph tree,
-                                              default is /'
+                                            description: 'path is Optional: Used as
+                                              the mounted root, rather than the full
+                                              Ceph tree, default is /'
                                             type: string
                                           readOnly:
-                                            description: 'Optional: Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.
+                                            description: 'readOnly is Optional: Defaults
+                                              to false (read/write). ReadOnly here
+                                              will force the ReadOnly setting in VolumeMounts.
                                               More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: boolean
                                           secretFile:
-                                            description: 'Optional: SecretFile is
-                                              the path to key ring for User, default
-                                              is /etc/ceph/user.secret More info:
-                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            description: 'secretFile is Optional:
+                                              SecretFile is the path to key ring for
+                                              User, default is /etc/ceph/user.secret
+                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: string
                                           secretRef:
-                                            description: 'Optional: SecretRef is reference
-                                              to the authentication secret for User,
-                                              default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            description: 'secretRef is Optional: SecretRef
+                                              is reference to the authentication secret
+                                              for User, default is empty. More info:
+                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             properties:
                                               name:
                                                 description: 'Name of the referent.
@@ -5601,36 +6122,36 @@ spec:
                                                 type: string
                                             type: object
                                           user:
-                                            description: 'Optional: User is the rados
-                                              user name, default is admin More info:
-                                              https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                            description: 'user is optional: User is
+                                              the rados user name, default is admin
+                                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                             type: string
                                         required:
                                         - monitors
                                         type: object
                                       cinder:
-                                        description: 'Cinder represents a cinder volume
+                                        description: 'cinder represents a cinder volume
                                           attached and mounted on kubelets host machine.
                                           More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         properties:
                                           fsType:
-                                            description: 'Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Examples:
-                                              "ext4", "xfs", "ntfs". Implicitly inferred
-                                              to be "ext4" if unspecified. More info:
-                                              https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                            description: 'fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: string
                                           readOnly:
-                                            description: 'Optional: Defaults to false
+                                            description: 'readOnly defaults to false
                                               (read/write). ReadOnly here will force
                                               the ReadOnly setting in VolumeMounts.
                                               More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: boolean
                                           secretRef:
-                                            description: 'Optional: points to a secret
-                                              object containing parameters used to
-                                              connect to OpenStack.'
+                                            description: 'secretRef is optional: points
+                                              to a secret object containing parameters
+                                              used to connect to OpenStack.'
                                             properties:
                                               name:
                                                 description: 'Name of the referent.
@@ -5640,76 +6161,76 @@ spec:
                                                 type: string
                                             type: object
                                           volumeID:
-                                            description: 'volume id used to identify
+                                            description: 'volumeID used to identify
                                               the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       configMap:
-                                        description: ConfigMap represents a configMap
+                                        description: configMap represents a configMap
                                           that should populate this volume
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on created files
-                                              by default. Must be an octal value between
-                                              0000 and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. Defaults to 0644.
-                                              Directories within the path are not
-                                              affected by this setting. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
+                                            description: 'defaultMode is optional:
+                                              mode bits used to set permissions on
+                                              created files by default. Must be an
+                                              octal value between 0000 and 0777 or
+                                              a decimal value between 0 and 511. YAML
+                                              accepts both octal and decimal values,
+                                              JSON requires decimal values for mode
+                                              bits. Defaults to 0644. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              ConfigMap will be projected into the
-                                              volume as a file whose name is the key
-                                              and content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the ConfigMap,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -5724,30 +6245,30 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       csi:
-                                        description: CSI (Container Storage Interface)
+                                        description: csi (Container Storage Interface)
                                           represents ephemeral storage that is handled
                                           by certain external CSI drivers (Beta feature).
                                         properties:
                                           driver:
-                                            description: Driver is the name of the
+                                            description: driver is the name of the
                                               CSI driver that handles this volume.
                                               Consult with your admin for the correct
                                               name as registered in the cluster.
                                             type: string
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Ex. "ext4", "xfs", "ntfs". If not provided,
-                                              the empty value is passed to the associated
+                                            description: fsType to mount. Ex. "ext4",
+                                              "xfs", "ntfs". If not provided, the
+                                              empty value is passed to the associated
                                               CSI driver which will determine the
                                               default filesystem to apply.
                                             type: string
                                           nodePublishSecretRef:
-                                            description: NodePublishSecretRef is a
+                                            description: nodePublishSecretRef is a
                                               reference to the secret object containing
                                               sensitive information to pass to the
                                               CSI driver to complete the CSI NodePublishVolume
@@ -5765,13 +6286,14 @@ spec:
                                                 type: string
                                             type: object
                                           readOnly:
-                                            description: Specifies a read-only configuration
-                                              for the volume. Defaults to false (read/write).
+                                            description: readOnly specifies a read-only
+                                              configuration for the volume. Defaults
+                                              to false (read/write).
                                             type: boolean
                                           volumeAttributes:
                                             additionalProperties:
                                               type: string
-                                            description: VolumeAttributes stores driver-specific
+                                            description: volumeAttributes stores driver-specific
                                               properties that are passed to the CSI
                                               driver. Consult your driver's documentation
                                               for supported values.
@@ -5780,7 +6302,7 @@ spec:
                                         - driver
                                         type: object
                                       downwardAPI:
-                                        description: DownwardAPI represents downward
+                                        description: downwardAPI represents downward
                                           API about the pod that should populate this
                                           volume
                                         properties:
@@ -5889,36 +6411,37 @@ spec:
                                             type: array
                                         type: object
                                       emptyDir:
-                                        description: 'EmptyDir represents a temporary
+                                        description: 'emptyDir represents a temporary
                                           directory that shares a pod''s lifetime.
                                           More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         properties:
                                           medium:
-                                            description: 'What type of storage medium
-                                              should back this directory. The default
-                                              is "" which means to use the node''s
-                                              default medium. Must be an empty string
-                                              (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                            description: 'medium represents what type
+                                              of storage medium should back this directory.
+                                              The default is "" which means to use
+                                              the node''s default medium. Must be
+                                              an empty string (default) or Memory.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                             type: string
                                           sizeLimit:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: 'Total amount of local storage
-                                              required for this EmptyDir volume. The
-                                              size limit is also applicable for memory
-                                              medium. The maximum usage on memory
-                                              medium EmptyDir would be the minimum
-                                              value between the SizeLimit specified
-                                              here and the sum of memory limits of
-                                              all containers in a pod. The default
-                                              is nil which means that the limit is
-                                              undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                            description: 'sizeLimit is the total amount
+                                              of local storage required for this EmptyDir
+                                              volume. The size limit is also applicable
+                                              for memory medium. The maximum usage
+                                              on memory medium EmptyDir would be the
+                                              minimum value between the SizeLimit
+                                              specified here and the sum of memory
+                                              limits of all containers in a pod. The
+                                              default is nil which means that the
+                                              limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                         type: object
                                       ephemeral:
-                                        description: "Ephemeral represents a volume
+                                        description: "ephemeral represents a volume
                                           that is handled by a cluster storage driver.
                                           The volume's lifecycle is tied to the pod
                                           that defines it - it will be created before
@@ -5941,10 +6464,7 @@ spec:
                                           used that way - see the documentation of
                                           the driver for more information. \n A pod
                                           can use both types of ephemeral volumes
-                                          and persistent volumes at the same time.
-                                          \n This is a beta feature and only available
-                                          when the GenericEphemeralVolume feature
-                                          gate is enabled."
+                                          and persistent volumes at the same time."
                                         properties:
                                           volumeClaimTemplate:
                                             description: "Will be used to create a
@@ -5991,7 +6511,7 @@ spec:
                                                   valid here.
                                                 properties:
                                                   accessModes:
-                                                    description: 'AccessModes contains
+                                                    description: 'accessModes contains
                                                       the desired access modes the
                                                       volume should have. More info:
                                                       https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
@@ -5999,10 +6519,10 @@ spec:
                                                       type: string
                                                     type: array
                                                   dataSource:
-                                                    description: 'This field can be
-                                                      used to specify either: * An
-                                                      existing VolumeSnapshot object
-                                                      (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    description: 'dataSource field
+                                                      can be used to specify either:
+                                                      * An existing VolumeSnapshot
+                                                      object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                       * An existing PVC (PersistentVolumeClaim)
                                                       If the provisioner or an external
                                                       controller can support the specified
@@ -6037,11 +6557,11 @@ spec:
                                                     - name
                                                     type: object
                                                   dataSourceRef:
-                                                    description: 'Specifies the object
-                                                      from which to populate the volume
-                                                      with data, if a non-empty volume
-                                                      is desired. This may be any
-                                                      local object from a non-empty
+                                                    description: 'dataSourceRef specifies
+                                                      the object from which to populate
+                                                      the volume with data, if a non-empty
+                                                      volume is desired. This may
+                                                      be any local object from a non-empty
                                                       API group (non core object)
                                                       or a PersistentVolumeClaim object.
                                                       When this field is specified,
@@ -6071,7 +6591,7 @@ spec:
                                                       them), DataSourceRef   preserves
                                                       all values, and generates an
                                                       error if a disallowed value
-                                                      is   specified. (Alpha) Using
+                                                      is   specified. (Beta) Using
                                                       this field requires the AnyVolumeDataSource
                                                       feature gate to be enabled.'
                                                     properties:
@@ -6098,9 +6618,16 @@ spec:
                                                     - name
                                                     type: object
                                                   resources:
-                                                    description: 'Resources represents
+                                                    description: 'resources represents
                                                       the minimum resources the volume
-                                                      should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                      should have. If RecoverVolumeExpansionFailure
+                                                      feature is enabled users are
+                                                      allowed to specify resource
+                                                      requirements that are lower
+                                                      than previous value but must
+                                                      still be higher than capacity
+                                                      recorded in the status field
+                                                      of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                     properties:
                                                       limits:
                                                         additionalProperties:
@@ -6132,8 +6659,9 @@ spec:
                                                         type: object
                                                     type: object
                                                   selector:
-                                                    description: A label query over
-                                                      volumes to consider for binding.
+                                                    description: selector is a label
+                                                      query over volumes to consider
+                                                      for binding.
                                                     properties:
                                                       matchExpressions:
                                                         description: matchExpressions
@@ -6201,7 +6729,8 @@ spec:
                                                         type: object
                                                     type: object
                                                   storageClassName:
-                                                    description: 'Name of the StorageClass
+                                                    description: 'storageClassName
+                                                      is the name of the StorageClass
                                                       required by the claim. More
                                                       info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                     type: string
@@ -6213,7 +6742,7 @@ spec:
                                                       in claim spec.
                                                     type: string
                                                   volumeName:
-                                                    description: VolumeName is the
+                                                    description: volumeName is the
                                                       binding reference to the PersistentVolume
                                                       backing this claim.
                                                     type: string
@@ -6223,79 +6752,82 @@ spec:
                                             type: object
                                         type: object
                                       fc:
-                                        description: FC represents a Fibre Channel
+                                        description: fc represents a Fibre Channel
                                           resource that is attached to a kubelet's
                                           host machine and then exposed to the pod.
                                         properties:
                                           fsType:
-                                            description: 'Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". Implicitly inferred to
-                                              be "ext4" if unspecified. TODO: how
-                                              do we prevent errors in the filesystem
-                                              from compromising the machine'
+                                            description: 'fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                              TODO: how do we prevent errors in the
+                                              filesystem from compromising the machine'
                                             type: string
                                           lun:
-                                            description: 'Optional: FC target lun
-                                              number'
+                                            description: 'lun is Optional: FC target
+                                              lun number'
                                             format: int32
                                             type: integer
                                           readOnly:
-                                            description: 'Optional: Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.'
+                                            description: 'readOnly is Optional: Defaults
+                                              to false (read/write). ReadOnly here
+                                              will force the ReadOnly setting in VolumeMounts.'
                                             type: boolean
                                           targetWWNs:
-                                            description: 'Optional: FC target worldwide
-                                              names (WWNs)'
+                                            description: 'targetWWNs is Optional:
+                                              FC target worldwide names (WWNs)'
                                             items:
                                               type: string
                                             type: array
                                           wwids:
-                                            description: 'Optional: FC volume world
-                                              wide identifiers (wwids) Either wwids
-                                              or combination of targetWWNs and lun
-                                              must be set, but not both simultaneously.'
+                                            description: 'wwids Optional: FC volume
+                                              world wide identifiers (wwids) Either
+                                              wwids or combination of targetWWNs and
+                                              lun must be set, but not both simultaneously.'
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       flexVolume:
-                                        description: FlexVolume represents a generic
+                                        description: flexVolume represents a generic
                                           volume resource that is provisioned/attached
                                           using an exec based plugin.
                                         properties:
                                           driver:
-                                            description: Driver is the name of the
+                                            description: driver is the name of the
                                               driver to use for this volume.
                                             type: string
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". The default filesystem
-                                              depends on FlexVolume script.
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". The
+                                              default filesystem depends on FlexVolume
+                                              script.
                                             type: string
                                           options:
                                             additionalProperties:
                                               type: string
-                                            description: 'Optional: Extra command
-                                              options if any.'
+                                            description: 'options is Optional: this
+                                              field holds extra command options if
+                                              any.'
                                             type: object
                                           readOnly:
-                                            description: 'Optional: Defaults to false
-                                              (read/write). ReadOnly here will force
-                                              the ReadOnly setting in VolumeMounts.'
+                                            description: 'readOnly is Optional: defaults
+                                              to false (read/write). ReadOnly here
+                                              will force the ReadOnly setting in VolumeMounts.'
                                             type: boolean
                                           secretRef:
-                                            description: 'Optional: SecretRef is reference
-                                              to the secret object containing sensitive
-                                              information to pass to the plugin scripts.
-                                              This may be empty if no secret object
-                                              is specified. If the secret object contains
-                                              more than one secret, all secrets are
-                                              passed to the plugin scripts.'
+                                            description: 'secretRef is Optional: secretRef
+                                              is reference to the secret object containing
+                                              sensitive information to pass to the
+                                              plugin scripts. This may be empty if
+                                              no secret object is specified. If the
+                                              secret object contains more than one
+                                              secret, all secrets are passed to the
+                                              plugin scripts.'
                                             properties:
                                               name:
                                                 description: 'Name of the referent.
@@ -6308,56 +6840,58 @@ spec:
                                         - driver
                                         type: object
                                       flocker:
-                                        description: Flocker represents a Flocker
+                                        description: flocker represents a Flocker
                                           volume attached to a kubelet's host machine.
                                           This depends on the Flocker control service
                                           being running
                                         properties:
                                           datasetName:
-                                            description: Name of the dataset stored
-                                              as metadata -> name on the dataset for
-                                              Flocker should be considered as deprecated
+                                            description: datasetName is Name of the
+                                              dataset stored as metadata -> name on
+                                              the dataset for Flocker should be considered
+                                              as deprecated
                                             type: string
                                           datasetUUID:
-                                            description: UUID of the dataset. This
-                                              is unique identifier of a Flocker dataset
+                                            description: datasetUUID is the UUID of
+                                              the dataset. This is unique identifier
+                                              of a Flocker dataset
                                             type: string
                                         type: object
                                       gcePersistentDisk:
-                                        description: 'GCEPersistentDisk represents
+                                        description: 'gcePersistentDisk represents
                                           a GCE Disk resource that is attached to
                                           a kubelet''s host machine and then exposed
                                           to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         properties:
                                           fsType:
-                                            description: 'Filesystem type of the volume
-                                              that you want to mount. Tip: Ensure
-                                              that the filesystem type is supported
-                                              by the host operating system. Examples:
-                                              "ext4", "xfs", "ntfs". Implicitly inferred
-                                              to be "ext4" if unspecified. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                            description: 'fsType is filesystem type
+                                              of the volume that you want to mount.
+                                              Tip: Ensure that the filesystem type
+                                              is supported by the host operating system.
+                                              Examples: "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                               TODO: how do we prevent errors in the
                                               filesystem from compromising the machine'
                                             type: string
                                           partition:
-                                            description: 'The partition in the volume
-                                              that you want to mount. If omitted,
-                                              the default is to mount by volume name.
-                                              Examples: For volume /dev/sda1, you
-                                              specify the partition as "1". Similarly,
-                                              the volume partition for /dev/sda is
-                                              "0" (or you can leave the property empty).
-                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                            description: 'partition is the partition
+                                              in the volume that you want to mount.
+                                              If omitted, the default is to mount
+                                              by volume name. Examples: For volume
+                                              /dev/sda1, you specify the partition
+                                              as "1". Similarly, the volume partition
+                                              for /dev/sda is "0" (or you can leave
+                                              the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             format: int32
                                             type: integer
                                           pdName:
-                                            description: 'Unique name of the PD resource
-                                              in GCE. Used to identify the disk in
-                                              GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                            description: 'pdName is unique name of
+                                              the PD resource in GCE. Used to identify
+                                              the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             type: string
                                           readOnly:
-                                            description: 'ReadOnly here will force
+                                            description: 'readOnly here will force
                                               the ReadOnly setting in VolumeMounts.
                                               Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                             type: boolean
@@ -6365,7 +6899,7 @@ spec:
                                         - pdName
                                         type: object
                                       gitRepo:
-                                        description: 'GitRepo represents a git repository
+                                        description: 'gitRepo represents a git repository
                                           at a particular revision. DEPRECATED: GitRepo
                                           is deprecated. To provision a container
                                           with a git repo, mount an EmptyDir into
@@ -6374,40 +6908,40 @@ spec:
                                           container.'
                                         properties:
                                           directory:
-                                            description: Target directory name. Must
-                                              not contain or start with '..'.  If
-                                              '.' is supplied, the volume directory
-                                              will be the git repository.  Otherwise,
+                                            description: directory is the target directory
+                                              name. Must not contain or start with
+                                              '..'.  If '.' is supplied, the volume
+                                              directory will be the git repository.  Otherwise,
                                               if specified, the volume will contain
                                               the git repository in the subdirectory
                                               with the given name.
                                             type: string
                                           repository:
-                                            description: Repository URL
+                                            description: repository is the URL
                                             type: string
                                           revision:
-                                            description: Commit hash for the specified
-                                              revision.
+                                            description: revision is the commit hash
+                                              for the specified revision.
                                             type: string
                                         required:
                                         - repository
                                         type: object
                                       glusterfs:
-                                        description: 'Glusterfs represents a Glusterfs
+                                        description: 'glusterfs represents a Glusterfs
                                           mount on the host that shares a pod''s lifetime.
                                           More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                         properties:
                                           endpoints:
-                                            description: 'EndpointsName is the endpoint
+                                            description: 'endpoints is the endpoint
                                               name that details Glusterfs topology.
                                               More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: string
                                           path:
-                                            description: 'Path is the Glusterfs volume
+                                            description: 'path is the Glusterfs volume
                                               path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                             type: string
                                           readOnly:
-                                            description: 'ReadOnly here will force
+                                            description: 'readOnly here will force
                                               the Glusterfs volume to be mounted with
                                               read-only permissions. Defaults to false.
                                               More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -6417,7 +6951,7 @@ spec:
                                         - path
                                         type: object
                                       hostPath:
-                                        description: 'HostPath represents a pre-existing
+                                        description: 'hostPath represents a pre-existing
                                           file or directory on the host machine that
                                           is directly exposed to the container. This
                                           is generally used for system agents or other
@@ -6429,78 +6963,82 @@ spec:
                                           not mount host directories as read/write.'
                                         properties:
                                           path:
-                                            description: 'Path of the directory on
+                                            description: 'path of the directory on
                                               the host. If the path is a symlink,
                                               it will follow the link to the real
                                               path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                             type: string
                                           type:
-                                            description: 'Type for HostPath Volume
+                                            description: 'type for HostPath Volume
                                               Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                             type: string
                                         required:
                                         - path
                                         type: object
                                       iscsi:
-                                        description: 'ISCSI represents an ISCSI Disk
+                                        description: 'iscsi represents an ISCSI Disk
                                           resource that is attached to a kubelet''s
                                           host machine and then exposed to the pod.
                                           More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                         properties:
                                           chapAuthDiscovery:
-                                            description: whether support iSCSI Discovery
-                                              CHAP authentication
+                                            description: chapAuthDiscovery defines
+                                              whether support iSCSI Discovery CHAP
+                                              authentication
                                             type: boolean
                                           chapAuthSession:
-                                            description: whether support iSCSI Session
-                                              CHAP authentication
+                                            description: chapAuthSession defines whether
+                                              support iSCSI Session CHAP authentication
                                             type: boolean
                                           fsType:
-                                            description: 'Filesystem type of the volume
-                                              that you want to mount. Tip: Ensure
-                                              that the filesystem type is supported
-                                              by the host operating system. Examples:
-                                              "ext4", "xfs", "ntfs". Implicitly inferred
-                                              to be "ext4" if unspecified. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                            description: 'fsType is the filesystem
+                                              type of the volume that you want to
+                                              mount. Tip: Ensure that the filesystem
+                                              type is supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                               TODO: how do we prevent errors in the
                                               filesystem from compromising the machine'
                                             type: string
                                           initiatorName:
-                                            description: Custom iSCSI Initiator Name.
-                                              If initiatorName is specified with iscsiInterface
-                                              simultaneously, new iSCSI interface
-                                              <target portal>:<volume name> will be
-                                              created for the connection.
+                                            description: initiatorName is the custom
+                                              iSCSI Initiator Name. If initiatorName
+                                              is specified with iscsiInterface simultaneously,
+                                              new iSCSI interface <target portal>:<volume
+                                              name> will be created for the connection.
                                             type: string
                                           iqn:
-                                            description: Target iSCSI Qualified Name.
+                                            description: iqn is the target iSCSI Qualified
+                                              Name.
                                             type: string
                                           iscsiInterface:
-                                            description: iSCSI Interface Name that
-                                              uses an iSCSI transport. Defaults to
-                                              'default' (tcp).
+                                            description: iscsiInterface is the interface
+                                              Name that uses an iSCSI transport. Defaults
+                                              to 'default' (tcp).
                                             type: string
                                           lun:
-                                            description: iSCSI Target Lun number.
+                                            description: lun represents iSCSI Target
+                                              Lun number.
                                             format: int32
                                             type: integer
                                           portals:
-                                            description: iSCSI Target Portal List.
-                                              The portal is either an IP or ip_addr:port
-                                              if the port is other than default (typically
-                                              TCP ports 860 and 3260).
+                                            description: portals is the iSCSI Target
+                                              Portal List. The portal is either an
+                                              IP or ip_addr:port if the port is other
+                                              than default (typically TCP ports 860
+                                              and 3260).
                                             items:
                                               type: string
                                             type: array
                                           readOnly:
-                                            description: ReadOnly here will force
+                                            description: readOnly here will force
                                               the ReadOnly setting in VolumeMounts.
                                               Defaults to false.
                                             type: boolean
                                           secretRef:
-                                            description: CHAP Secret for iSCSI target
-                                              and initiator authentication
+                                            description: secretRef is the CHAP Secret
+                                              for iSCSI target and initiator authentication
                                             properties:
                                               name:
                                                 description: 'Name of the referent.
@@ -6510,10 +7048,11 @@ spec:
                                                 type: string
                                             type: object
                                           targetPortal:
-                                            description: iSCSI Target Portal. The
-                                              Portal is either an IP or ip_addr:port
-                                              if the port is other than default (typically
-                                              TCP ports 860 and 3260).
+                                            description: targetPortal is iSCSI Target
+                                              Portal. The Portal is either an IP or
+                                              ip_addr:port if the port is other than
+                                              default (typically TCP ports 860 and
+                                              3260).
                                             type: string
                                         required:
                                         - iqn
@@ -6521,26 +7060,27 @@ spec:
                                         - targetPortal
                                         type: object
                                       name:
-                                        description: 'Volume''s name. Must be a DNS_LABEL
-                                          and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        description: 'name of the volume. Must be
+                                          a DNS_LABEL and unique within the pod. More
+                                          info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                         type: string
                                       nfs:
-                                        description: 'NFS represents an NFS mount
+                                        description: 'nfs represents an NFS mount
                                           on the host that shares a pod''s lifetime
                                           More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         properties:
                                           path:
-                                            description: 'Path that is exported by
+                                            description: 'path that is exported by
                                               the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: string
                                           readOnly:
-                                            description: 'ReadOnly here will force
+                                            description: 'readOnly here will force
                                               the NFS export to be mounted with read-only
                                               permissions. Defaults to false. More
                                               info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: boolean
                                           server:
-                                            description: 'Server is the hostname or
+                                            description: 'server is the hostname or
                                               IP address of the NFS server. More info:
                                               https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                             type: string
@@ -6549,98 +7089,100 @@ spec:
                                         - server
                                         type: object
                                       persistentVolumeClaim:
-                                        description: 'PersistentVolumeClaimVolumeSource
+                                        description: 'persistentVolumeClaimVolumeSource
                                           represents a reference to a PersistentVolumeClaim
                                           in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         properties:
                                           claimName:
-                                            description: 'ClaimName is the name of
+                                            description: 'claimName is the name of
                                               a PersistentVolumeClaim in the same
                                               namespace as the pod using this volume.
                                               More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                             type: string
                                           readOnly:
-                                            description: Will force the ReadOnly setting
-                                              in VolumeMounts. Default false.
+                                            description: readOnly Will force the ReadOnly
+                                              setting in VolumeMounts. Default false.
                                             type: boolean
                                         required:
                                         - claimName
                                         type: object
                                       photonPersistentDisk:
-                                        description: PhotonPersistentDisk represents
+                                        description: photonPersistentDisk represents
                                           a PhotonController persistent disk attached
                                           and mounted on kubelets host machine
                                         properties:
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". Implicitly inferred to
-                                              be "ext4" if unspecified.
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           pdID:
-                                            description: ID that identifies Photon
-                                              Controller persistent disk
+                                            description: pdID is the ID that identifies
+                                              Photon Controller persistent disk
                                             type: string
                                         required:
                                         - pdID
                                         type: object
                                       portworxVolume:
-                                        description: PortworxVolume represents a portworx
+                                        description: portworxVolume represents a portworx
                                           volume attached and mounted on kubelets
                                           host machine
                                         properties:
                                           fsType:
-                                            description: FSType represents the filesystem
+                                            description: fSType represents the filesystem
                                               type to mount Must be a filesystem type
                                               supported by the host operating system.
                                               Ex. "ext4", "xfs". Implicitly inferred
                                               to be "ext4" if unspecified.
                                             type: string
                                           readOnly:
-                                            description: Defaults to false (read/write).
-                                              ReadOnly here will force the ReadOnly
-                                              setting in VolumeMounts.
+                                            description: readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           volumeID:
-                                            description: VolumeID uniquely identifies
+                                            description: volumeID uniquely identifies
                                               a Portworx volume
                                             type: string
                                         required:
                                         - volumeID
                                         type: object
                                       projected:
-                                        description: Items for all in one resources
-                                          secrets, configmaps, and downward API
+                                        description: projected items for all in one
+                                          resources secrets, configmaps, and downward
+                                          API
                                         properties:
                                           defaultMode:
-                                            description: Mode bits used to set permissions
-                                              on created files by default. Must be
-                                              an octal value between 0000 and 0777
-                                              or a decimal value between 0 and 511.
-                                              YAML accepts both octal and decimal
-                                              values, JSON requires decimal values
-                                              for mode bits. Directories within the
-                                              path are not affected by this setting.
-                                              This might be in conflict with other
-                                              options that affect the file mode, like
-                                              fsGroup, and the result can be other
-                                              mode bits set.
+                                            description: defaultMode are the mode
+                                              bits used to set permissions on created
+                                              files by default. Must be an octal value
+                                              between 0000 and 0777 or a decimal value
+                                              between 0 and 511. YAML accepts both
+                                              octal and decimal values, JSON requires
+                                              decimal values for mode bits. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.
                                             format: int32
                                             type: integer
                                           sources:
-                                            description: list of volume projections
+                                            description: sources is the list of volume
+                                              projections
                                             items:
                                               description: Projection that may be
                                                 projected along with other supported
                                                 volume types
                                               properties:
                                                 configMap:
-                                                  description: information about the
-                                                    configMap data to project
+                                                  description: configMap information
+                                                    about the configMap data to project
                                                   properties:
                                                     items:
-                                                      description: If unspecified,
+                                                      description: items if unspecified,
                                                         each key-value pair in the
                                                         Data field of the referenced
                                                         ConfigMap will be projected
@@ -6662,26 +7204,26 @@ spec:
                                                           key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: The key to
-                                                              project.
+                                                            description: key is the
+                                                              key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'Optional:
-                                                              mode bits used to set
-                                                              permissions on this
-                                                              file. Must be an octal
-                                                              value between 0000 and
-                                                              0777 or a decimal value
-                                                              between 0 and 511. YAML
-                                                              accepts both octal and
-                                                              decimal values, JSON
-                                                              requires decimal values
-                                                              for mode bits. If not
-                                                              specified, the volume
-                                                              defaultMode will be
-                                                              used. This might be
-                                                              in conflict with other
-                                                              options that affect
+                                                            description: 'mode is
+                                                              Optional: mode bits
+                                                              used to set permissions
+                                                              on this file. Must be
+                                                              an octal value between
+                                                              0000 and 0777 or a decimal
+                                                              value between 0 and
+                                                              511. YAML accepts both
+                                                              octal and decimal values,
+                                                              JSON requires decimal
+                                                              values for mode bits.
+                                                              If not specified, the
+                                                              volume defaultMode will
+                                                              be used. This might
+                                                              be in conflict with
+                                                              other options that affect
                                                               the file mode, like
                                                               fsGroup, and the result
                                                               can be other mode bits
@@ -6689,14 +7231,14 @@ spec:
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: The relative
-                                                              path of the file to
-                                                              map the key to. May
-                                                              not be an absolute path.
-                                                              May not contain the
-                                                              path element '..'. May
-                                                              not start with the string
-                                                              '..'.
+                                                            description: path is the
+                                                              relative path of the
+                                                              file to map the key
+                                                              to. May not be an absolute
+                                                              path. May not contain
+                                                              the path element '..'.
+                                                              May not start with the
+                                                              string '..'.
                                                             type: string
                                                         required:
                                                         - key
@@ -6710,14 +7252,15 @@ spec:
                                                         apiVersion, kind, uid?'
                                                       type: string
                                                     optional:
-                                                      description: Specify whether
-                                                        the ConfigMap or its keys
-                                                        must be defined
+                                                      description: optional specify
+                                                        whether the ConfigMap or its
+                                                        keys must be defined
                                                       type: boolean
                                                   type: object
                                                 downwardAPI:
-                                                  description: information about the
-                                                    downwardAPI data to project
+                                                  description: downwardAPI information
+                                                    about the downwardAPI data to
+                                                    project
                                                   properties:
                                                     items:
                                                       description: Items is a list
@@ -6824,11 +7367,11 @@ spec:
                                                       type: array
                                                   type: object
                                                 secret:
-                                                  description: information about the
-                                                    secret data to project
+                                                  description: secret information
+                                                    about the secret data to project
                                                   properties:
                                                     items:
-                                                      description: If unspecified,
+                                                      description: items if unspecified,
                                                         each key-value pair in the
                                                         Data field of the referenced
                                                         Secret will be projected into
@@ -6850,26 +7393,26 @@ spec:
                                                           key to a path within a volume.
                                                         properties:
                                                           key:
-                                                            description: The key to
-                                                              project.
+                                                            description: key is the
+                                                              key to project.
                                                             type: string
                                                           mode:
-                                                            description: 'Optional:
-                                                              mode bits used to set
-                                                              permissions on this
-                                                              file. Must be an octal
-                                                              value between 0000 and
-                                                              0777 or a decimal value
-                                                              between 0 and 511. YAML
-                                                              accepts both octal and
-                                                              decimal values, JSON
-                                                              requires decimal values
-                                                              for mode bits. If not
-                                                              specified, the volume
-                                                              defaultMode will be
-                                                              used. This might be
-                                                              in conflict with other
-                                                              options that affect
+                                                            description: 'mode is
+                                                              Optional: mode bits
+                                                              used to set permissions
+                                                              on this file. Must be
+                                                              an octal value between
+                                                              0000 and 0777 or a decimal
+                                                              value between 0 and
+                                                              511. YAML accepts both
+                                                              octal and decimal values,
+                                                              JSON requires decimal
+                                                              values for mode bits.
+                                                              If not specified, the
+                                                              volume defaultMode will
+                                                              be used. This might
+                                                              be in conflict with
+                                                              other options that affect
                                                               the file mode, like
                                                               fsGroup, and the result
                                                               can be other mode bits
@@ -6877,14 +7420,14 @@ spec:
                                                             format: int32
                                                             type: integer
                                                           path:
-                                                            description: The relative
-                                                              path of the file to
-                                                              map the key to. May
-                                                              not be an absolute path.
-                                                              May not contain the
-                                                              path element '..'. May
-                                                              not start with the string
-                                                              '..'.
+                                                            description: path is the
+                                                              relative path of the
+                                                              file to map the key
+                                                              to. May not be an absolute
+                                                              path. May not contain
+                                                              the path element '..'.
+                                                              May not start with the
+                                                              string '..'.
                                                             type: string
                                                         required:
                                                         - key
@@ -6898,17 +7441,18 @@ spec:
                                                         apiVersion, kind, uid?'
                                                       type: string
                                                     optional:
-                                                      description: Specify whether
-                                                        the Secret or its key must
-                                                        be defined
+                                                      description: optional field
+                                                        specify whether the Secret
+                                                        or its key must be defined
                                                       type: boolean
                                                   type: object
                                                 serviceAccountToken:
-                                                  description: information about the
-                                                    serviceAccountToken data to project
+                                                  description: serviceAccountToken
+                                                    is information about the serviceAccountToken
+                                                    data to project
                                                   properties:
                                                     audience:
-                                                      description: Audience is the
+                                                      description: audience is the
                                                         intended audience of the token.
                                                         A recipient of a token must
                                                         identify itself with an identifier
@@ -6919,7 +7463,7 @@ spec:
                                                         of the apiserver.
                                                       type: string
                                                     expirationSeconds:
-                                                      description: ExpirationSeconds
+                                                      description: expirationSeconds
                                                         is the requested duration
                                                         of validity of the service
                                                         account token. As the token
@@ -6937,7 +7481,7 @@ spec:
                                                       format: int64
                                                       type: integer
                                                     path:
-                                                      description: Path is the path
+                                                      description: path is the path
                                                         relative to the mount point
                                                         of the file to project the
                                                         token into.
@@ -6949,20 +7493,20 @@ spec:
                                             type: array
                                         type: object
                                       quobyte:
-                                        description: Quobyte represents a Quobyte
+                                        description: quobyte represents a Quobyte
                                           mount on the host that shares a pod's lifetime
                                         properties:
                                           group:
-                                            description: Group to map volume access
+                                            description: group to map volume access
                                               to Default is no group
                                             type: string
                                           readOnly:
-                                            description: ReadOnly here will force
+                                            description: readOnly here will force
                                               the Quobyte volume to be mounted with
                                               read-only permissions. Defaults to false.
                                             type: boolean
                                           registry:
-                                            description: Registry represents a single
+                                            description: registry represents a single
                                               or multiple Quobyte Registry services
                                               specified as a string as host:port pair
                                               (multiple entries are separated with
@@ -6970,17 +7514,17 @@ spec:
                                               for volumes
                                             type: string
                                           tenant:
-                                            description: Tenant owning the given Quobyte
+                                            description: tenant owning the given Quobyte
                                               volume in the Backend Used with dynamically
                                               provisioned Quobyte volumes, value is
                                               set by the plugin
                                             type: string
                                           user:
-                                            description: User to map volume access
+                                            description: user to map volume access
                                               to Defaults to serivceaccount user
                                             type: string
                                           volume:
-                                            description: Volume is a string that references
+                                            description: volume is a string that references
                                               an already created Quobyte volume by
                                               name.
                                             type: string
@@ -6989,47 +7533,47 @@ spec:
                                         - volume
                                         type: object
                                       rbd:
-                                        description: 'RBD represents a Rados Block
+                                        description: 'rbd represents a Rados Block
                                           Device mount on the host that shares a pod''s
                                           lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                         properties:
                                           fsType:
-                                            description: 'Filesystem type of the volume
-                                              that you want to mount. Tip: Ensure
-                                              that the filesystem type is supported
-                                              by the host operating system. Examples:
-                                              "ext4", "xfs", "ntfs". Implicitly inferred
-                                              to be "ext4" if unspecified. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                            description: 'fsType is the filesystem
+                                              type of the volume that you want to
+                                              mount. Tip: Ensure that the filesystem
+                                              type is supported by the host operating
+                                              system. Examples: "ext4", "xfs", "ntfs".
+                                              Implicitly inferred to be "ext4" if
+                                              unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                               TODO: how do we prevent errors in the
                                               filesystem from compromising the machine'
                                             type: string
                                           image:
-                                            description: 'The rados image name. More
-                                              info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            description: 'image is the rados image
+                                              name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           keyring:
-                                            description: 'Keyring is the path to key
+                                            description: 'keyring is the path to key
                                               ring for RBDUser. Default is /etc/ceph/keyring.
                                               More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           monitors:
-                                            description: 'A collection of Ceph monitors.
-                                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            description: 'monitors is a collection
+                                              of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             items:
                                               type: string
                                             type: array
                                           pool:
-                                            description: 'The rados pool name. Default
-                                              is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            description: 'pool is the rados pool name.
+                                              Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                           readOnly:
-                                            description: 'ReadOnly here will force
+                                            description: 'readOnly here will force
                                               the ReadOnly setting in VolumeMounts.
                                               Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: boolean
                                           secretRef:
-                                            description: 'SecretRef is name of the
+                                            description: 'secretRef is name of the
                                               authentication secret for RBDUser. If
                                               provided overrides keyring. Default
                                               is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
@@ -7042,39 +7586,41 @@ spec:
                                                 type: string
                                             type: object
                                           user:
-                                            description: 'The rados user name. Default
-                                              is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                            description: 'user is the rados user name.
+                                              Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                             type: string
                                         required:
                                         - image
                                         - monitors
                                         type: object
                                       scaleIO:
-                                        description: ScaleIO represents a ScaleIO
+                                        description: scaleIO represents a ScaleIO
                                           persistent volume attached and mounted on
                                           Kubernetes nodes.
                                         properties:
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". Default is "xfs".
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Default
+                                              is "xfs".
                                             type: string
                                           gateway:
-                                            description: The host address of the ScaleIO
-                                              API Gateway.
+                                            description: gateway is the host address
+                                              of the ScaleIO API Gateway.
                                             type: string
                                           protectionDomain:
-                                            description: The name of the ScaleIO Protection
-                                              Domain for the configured storage.
+                                            description: protectionDomain is the name
+                                              of the ScaleIO Protection Domain for
+                                              the configured storage.
                                             type: string
                                           readOnly:
-                                            description: Defaults to false (read/write).
-                                              ReadOnly here will force the ReadOnly
-                                              setting in VolumeMounts.
+                                            description: readOnly Defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretRef:
-                                            description: SecretRef references to the
+                                            description: secretRef references to the
                                               secret for ScaleIO user and other sensitive
                                               information. If this is not provided,
                                               Login operation will fail.
@@ -7087,27 +7633,29 @@ spec:
                                                 type: string
                                             type: object
                                           sslEnabled:
-                                            description: Flag to enable/disable SSL
-                                              communication with Gateway, default
+                                            description: sslEnabled Flag enable/disable
+                                              SSL communication with Gateway, default
                                               false
                                             type: boolean
                                           storageMode:
-                                            description: Indicates whether the storage
-                                              for a volume should be ThickProvisioned
+                                            description: storageMode indicates whether
+                                              the storage for a volume should be ThickProvisioned
                                               or ThinProvisioned. Default is ThinProvisioned.
                                             type: string
                                           storagePool:
-                                            description: The ScaleIO Storage Pool
-                                              associated with the protection domain.
+                                            description: storagePool is the ScaleIO
+                                              Storage Pool associated with the protection
+                                              domain.
                                             type: string
                                           system:
-                                            description: The name of the storage system
-                                              as configured in ScaleIO.
+                                            description: system is the name of the
+                                              storage system as configured in ScaleIO.
                                             type: string
                                           volumeName:
-                                            description: The name of a volume already
-                                              created in the ScaleIO system that is
-                                              associated with this volume source.
+                                            description: volumeName is the name of
+                                              a volume already created in the ScaleIO
+                                              system that is associated with this
+                                              volume source.
                                             type: string
                                         required:
                                         - gateway
@@ -7115,70 +7663,70 @@ spec:
                                         - system
                                         type: object
                                       secret:
-                                        description: 'Secret represents a secret that
+                                        description: 'secret represents a secret that
                                           should populate this volume. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         properties:
                                           defaultMode:
-                                            description: 'Optional: mode bits used
-                                              to set permissions on created files
-                                              by default. Must be an octal value between
-                                              0000 and 0777 or a decimal value between
-                                              0 and 511. YAML accepts both octal and
-                                              decimal values, JSON requires decimal
-                                              values for mode bits. Defaults to 0644.
-                                              Directories within the path are not
-                                              affected by this setting. This might
-                                              be in conflict with other options that
-                                              affect the file mode, like fsGroup,
-                                              and the result can be other mode bits
-                                              set.'
+                                            description: 'defaultMode is Optional:
+                                              mode bits used to set permissions on
+                                              created files by default. Must be an
+                                              octal value between 0000 and 0777 or
+                                              a decimal value between 0 and 511. YAML
+                                              accepts both octal and decimal values,
+                                              JSON requires decimal values for mode
+                                              bits. Defaults to 0644. Directories
+                                              within the path are not affected by
+                                              this setting. This might be in conflict
+                                              with other options that affect the file
+                                              mode, like fsGroup, and the result can
+                                              be other mode bits set.'
                                             format: int32
                                             type: integer
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              Secret will be projected into the volume
-                                              as a file whose name is the key and
-                                              content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the Secret,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items If unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -7187,34 +7735,34 @@ spec:
                                               type: object
                                             type: array
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its keys must be defined
+                                            description: optional field specify whether
+                                              the Secret or its keys must be defined
                                             type: boolean
                                           secretName:
-                                            description: 'Name of the secret in the
-                                              pod''s namespace to use. More info:
-                                              https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                            description: 'secretName is the name of
+                                              the secret in the pod''s namespace to
+                                              use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                             type: string
                                         type: object
                                       storageos:
-                                        description: StorageOS represents a StorageOS
+                                        description: storageOS represents a StorageOS
                                           volume attached and mounted on Kubernetes
                                           nodes.
                                         properties:
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". Implicitly inferred to
-                                              be "ext4" if unspecified.
+                                            description: fsType is the filesystem
+                                              type to mount. Must be a filesystem
+                                              type supported by the host operating
+                                              system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           readOnly:
-                                            description: Defaults to false (read/write).
-                                              ReadOnly here will force the ReadOnly
-                                              setting in VolumeMounts.
+                                            description: readOnly defaults to false
+                                              (read/write). ReadOnly here will force
+                                              the ReadOnly setting in VolumeMounts.
                                             type: boolean
                                           secretRef:
-                                            description: SecretRef specifies the secret
+                                            description: secretRef specifies the secret
                                               to use for obtaining the StorageOS API
                                               credentials.  If not specified, default
                                               values will be attempted.
@@ -7227,12 +7775,12 @@ spec:
                                                 type: string
                                             type: object
                                           volumeName:
-                                            description: VolumeName is the human-readable
+                                            description: volumeName is the human-readable
                                               name of the StorageOS volume.  Volume
                                               names are only unique within a namespace.
                                             type: string
                                           volumeNamespace:
-                                            description: VolumeNamespace specifies
+                                            description: volumeNamespace specifies
                                               the scope of the volume within StorageOS.  If
                                               no namespace is specified then the Pod's
                                               namespace will be used.  This allows
@@ -7246,29 +7794,30 @@ spec:
                                             type: string
                                         type: object
                                       vsphereVolume:
-                                        description: VsphereVolume represents a vSphere
+                                        description: vsphereVolume represents a vSphere
                                           volume attached and mounted on kubelets
                                           host machine
                                         properties:
                                           fsType:
-                                            description: Filesystem type to mount.
-                                              Must be a filesystem type supported
-                                              by the host operating system. Ex. "ext4",
-                                              "xfs", "ntfs". Implicitly inferred to
-                                              be "ext4" if unspecified.
+                                            description: fsType is filesystem type
+                                              to mount. Must be a filesystem type
+                                              supported by the host operating system.
+                                              Ex. "ext4", "xfs", "ntfs". Implicitly
+                                              inferred to be "ext4" if unspecified.
                                             type: string
                                           storagePolicyID:
-                                            description: Storage Policy Based Management
-                                              (SPBM) profile ID associated with the
-                                              StoragePolicyName.
+                                            description: storagePolicyID is the storage
+                                              Policy Based Management (SPBM) profile
+                                              ID associated with the StoragePolicyName.
                                             type: string
                                           storagePolicyName:
-                                            description: Storage Policy Based Management
-                                              (SPBM) profile name.
+                                            description: storagePolicyName is the
+                                              storage Policy Based Management (SPBM)
+                                              profile name.
                                             type: string
                                           volumePath:
-                                            description: Path that identifies vSphere
-                                              volume vmdk
+                                            description: volumePath is the path that
+                                              identifies vSphere volume vmdk
                                             type: string
                                         required:
                                         - volumePath
@@ -7277,6 +7826,7 @@ spec:
                                     - name
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 workspaces:
                                   description: Workspaces are the volumes that this
                                     Task requires.
@@ -7296,6 +7846,12 @@ spec:
                                         description: Name is the name by which you
                                           can bind the volume at runtime.
                                         type: string
+                                      optional:
+                                        description: Optional marks a Workspace as
+                                          not being required in TaskRuns. By default
+                                          this field is false and so declared workspaces
+                                          are required.
+                                        type: boolean
                                       readOnly:
                                         description: ReadOnly dictates whether a mounted
                                           volume is writable. By default this field
@@ -7305,6 +7861,7 @@ spec:
                                     - name
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             timeout:
                               description: 'Time after which the TaskRun times out.
@@ -7336,7 +7893,6 @@ spec:
                                     type: string
                                 required:
                                 - name
-                                - workspace
                                 type: object
                               type: array
                           type: object
@@ -7360,6 +7916,11 @@ spec:
                               description: Name is the name of a workspace to be provided
                                 by a PipelineRun.
                               type: string
+                            optional:
+                              description: Optional marks a Workspace as not being
+                                required in PipelineRuns. By default this field is
+                                false and so declared workspaces are required.
+                              type: boolean
                           required:
                           - name
                           type: object
@@ -7678,9 +8239,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -7740,7 +8298,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -7849,9 +8407,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -7908,7 +8464,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -8019,9 +8575,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -8081,7 +8634,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -8190,9 +8743,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -8249,7 +8800,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -8324,6 +8875,26 @@ spec:
                           variables, matching the syntax of Docker links. Optional:
                           Defaults to true.'
                         type: boolean
+                      hostAliases:
+                        description: HostAliases is an optional list of hosts and
+                          IPs that will be injected into the pod's hosts file if specified.
+                          This is only valid for non-hostNetwork pods.
+                        items:
+                          description: HostAlias holds the mapping between IP and
+                            hostnames that will be injected as an entry in the pod's
+                            hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
                       hostNetwork:
                         description: HostNetwork specifies whether the pod may use
                           the node network namespace
@@ -8342,6 +8913,7 @@ spec:
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       nodeSelector:
                         additionalProperties:
                           type: string
@@ -8387,7 +8959,8 @@ spec:
                               in the volume will be owned by FSGroup) 3. The permission
                               bits are OR'd with rw-rw---- \n If unset, the Kubelet
                               will not modify the ownership and permissions of any
-                              volume."
+                              volume. Note that this field cannot be set when spec.os.name
+                              is windows."
                             format: int64
                             type: integer
                           fsGroupChangePolicy:
@@ -8398,14 +8971,16 @@ spec:
                               permissions). It will have no effect on ephemeral volume
                               types such as: secret, configmaps and emptydir. Valid
                               values are "OnRootMismatch" and "Always". If not specified,
-                              "Always" is used.'
+                              "Always" is used. Note that this field cannot be set
+                              when spec.os.name is windows.'
                             type: string
                           runAsGroup:
                             description: The GID to run the entrypoint of the container
                               process. Uses runtime default if unset. May also be
                               set in SecurityContext.  If set in both SecurityContext
                               and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence for that container.
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
@@ -8424,7 +8999,8 @@ spec:
                               if unspecified. May also be set in SecurityContext.  If
                               set in both SecurityContext and PodSecurityContext,
                               the value specified in SecurityContext takes precedence
-                              for that container.
+                              for that container. Note that this field cannot be set
+                              when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
@@ -8433,7 +9009,8 @@ spec:
                               allocate a random SELinux context for each container.  May
                               also be set in SecurityContext.  If set in both SecurityContext
                               and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence for that container.
+                              takes precedence for that container. Note that this
+                              field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -8454,7 +9031,8 @@ spec:
                             type: object
                           seccompProfile:
                             description: The seccomp options to use by the containers
-                              in this pod.
+                              in this pod. Note that this field cannot be set when
+                              spec.os.name is windows.
                             properties:
                               localhostProfile:
                                 description: localhostProfile indicates a profile
@@ -8479,7 +9057,8 @@ spec:
                             description: A list of groups applied to the first process
                               run in each container, in addition to the container's
                               primary GID.  If unspecified, no groups will be added
-                              to any container.
+                              to any container. Note that this field cannot be set
+                              when spec.os.name is windows.
                             items:
                               format: int64
                               type: integer
@@ -8487,7 +9066,8 @@ spec:
                           sysctls:
                             description: Sysctls hold a list of namespaced sysctls
                               used for the pod. Pods with unsupported sysctls (by
-                              the container runtime) might fail to launch.
+                              the container runtime) might fail to launch. Note that
+                              this field cannot be set when spec.os.name is windows.
                             items:
                               description: Sysctl defines a kernel parameter to be
                                 set
@@ -8508,7 +9088,8 @@ spec:
                               all containers. If unspecified, the options within a
                               container's SecurityContext will be used. If set in
                               both SecurityContext and PodSecurityContext, the value
-                              specified in SecurityContext takes precedence.
+                              specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
                                 description: GMSACredentialSpec is where the GMSA
@@ -8585,6 +9166,7 @@ spec:
                               type: string
                           type: object
                         type: array
+                        x-kubernetes-list-type: atomic
                       volumes:
                         description: 'List of volumes that can be mounted by containers
                           belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -8593,123 +9175,128 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS
+                              description: 'awsElasticBlockStore represents an AWS
                                 Disk resource that is attached to a kubelet''s host
                                 machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty).'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the
-                                    ReadOnly property in VolumeMounts to "true". If
-                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource
-                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk
+                              description: azureDisk represents an Azure Data Disk
                                 mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only,
-                                    Read Write.'
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob
-                                    storage
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob
-                                    disks per storage account  Dedicated: single blob
-                                    disk per storage account  Managed: azure managed
-                                    data disk (only in managed availability set).
-                                    defaults to shared'
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service
+                              description: azureFile represents an Azure File Service
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure
-                                    Storage Account Name and Key
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the
+                              description: cephFS represents a Ceph FS mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection
-                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root,
-                                    rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to
-                                    key ring for User, default is /etc/ceph/user.secret
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
                                     More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the authentication secret for User, default is
-                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -8719,31 +9306,32 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name,
-                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached
+                              description: 'cinder represents a cinder volume attached
                                 and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
+                                  description: 'readOnly defaults to false (read/write).
                                     ReadOnly here will force the ReadOnly setting
                                     in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object
-                                    containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -8753,32 +9341,32 @@ spec:
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume
+                                  description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should
+                              description: configMap represents a configMap that should
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
                                     will be projected into the volume as a file whose
                                     name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
@@ -8793,26 +9381,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -8825,28 +9415,28 @@ spec:
                                     uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents
+                              description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver
+                                  description: driver is the name of the CSI driver
                                     that handles this volume. Consult with your admin
                                     for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4",
-                                    "xfs", "ntfs". If not provided, the empty value
-                                    is passed to the associated CSI driver which will
-                                    determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference
+                                  description: nodePublishSecretRef is a reference
                                     to the secret object containing sensitive information
                                     to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
@@ -8863,13 +9453,13 @@ spec:
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration
+                                  description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific
+                                  description: volumeAttributes stores driver-specific
                                     properties that are passed to the CSI driver.
                                     Consult your driver's documentation for supported
                                     values.
@@ -8878,7 +9468,7 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about
+                              description: downwardAPI represents downward API about
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
@@ -8971,32 +9561,33 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory
+                              description: 'emptyDir represents a temporary directory
                                 that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should
-                                    back this directory. The default is "" which means
-                                    to use the node''s default medium. Must be an
-                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required
-                                    for this EmptyDir volume. The size limit is also
-                                    applicable for memory medium. The maximum usage
-                                    on memory medium EmptyDir would be the minimum
-                                    value between the SizeLimit specified here and
-                                    the sum of memory limits of all containers in
-                                    a pod. The default is nil which means that the
-                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is
+                              description: "ephemeral represents a volume that is
                                 handled by a cluster storage driver. The volume's
                                 lifecycle is tied to the pod that defines it - it
                                 will be created before the pod starts, and deleted
@@ -9016,9 +9607,7 @@ spec:
                                 to be used that way - see the documentation of the
                                 driver for more information. \n A pod can use both
                                 types of ephemeral volumes and persistent volumes
-                                at the same time. \n This is a beta feature and only
-                                available when the GenericEphemeralVolume feature
-                                gate is enabled."
+                                at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone
@@ -9058,15 +9647,15 @@ spec:
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired
+                                          description: 'accessModes contains the desired
                                             access modes the volume should have. More
                                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to
-                                            specify either: * An existing VolumeSnapshot
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
                                             If the provisioner or an external controller
@@ -9099,10 +9688,10 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from
-                                            which to populate the volume with data,
-                                            if a non-empty volume is desired. This
-                                            may be any local object from a non-empty
+                                          description: 'dataSourceRef specifies the
+                                            object from which to populate the volume
+                                            with data, if a non-empty volume is desired.
+                                            This may be any local object from a non-empty
                                             API group (non core object) or a PersistentVolumeClaim
                                             object. When this field is specified,
                                             volume binding will only succeed if the
@@ -9124,7 +9713,7 @@ spec:
                                             objects. * While DataSource ignores disallowed
                                             values (dropping them), DataSourceRef   preserves
                                             all values, and generates an error if
-                                            a disallowed value is   specified. (Alpha)
+                                            a disallowed value is   specified. (Beta)
                                             Using this field requires the AnyVolumeDataSource
                                             feature gate to be enabled.'
                                           properties:
@@ -9149,9 +9738,14 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum
-                                            resources the volume should have. More
-                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -9181,8 +9775,8 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -9236,8 +9830,9 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -9246,7 +9841,7 @@ spec:
                                             in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference
+                                          description: volumeName is the binding reference
                                             to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
@@ -9255,74 +9850,75 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource
+                              description: fc represents a Fibre Channel resource
                                 that is attached to a kubelet's host machine and then
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified. TODO: how
                                     do we prevent errors in the filesystem from compromising
                                     the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names
-                                    (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers
-                                    (wwids) Either wwids or combination of targetWWNs
-                                    and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume
+                              description: flexVolume represents a generic volume
                                 resource that is provisioned/attached using an exec
                                 based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to
+                                  description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". The default
-                                    filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if
-                                    any.'
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the secret object containing sensitive information
-                                    to pass to the plugin scripts. This may be empty
-                                    if no secret object is specified. If the secret
-                                    object contains more than one secret, all secrets
-                                    are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -9335,28 +9931,28 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached
+                              description: flocker represents a Flocker volume attached
                                 to a kubelet's host machine. This depends on the Flocker
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata
-                                    -> name on the dataset for Flocker should be considered
-                                    as deprecated
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique
-                                    identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk
+                              description: 'gcePersistentDisk represents a GCE Disk
                                 resource that is attached to a kubelet''s host machine
                                 and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
                                     type is supported by the host operating system.
                                     Examples: "ext4", "xfs", "ntfs". Implicitly inferred
                                     to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -9364,21 +9960,22 @@ spec:
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in
-                                    GCE. Used to identify the disk in GCE. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
@@ -9386,7 +9983,7 @@ spec:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at
+                              description: 'gitRepo represents a git repository at
                                 a particular revision. DEPRECATED: GitRepo is deprecated.
                                 To provision a container with a git repo, mount an
                                 EmptyDir into an InitContainer that clones the repo
@@ -9394,37 +9991,38 @@ spec:
                                 container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain
-                                    or start with '..'.  If '.' is supplied, the volume
-                                    directory will be the git repository.  Otherwise,
-                                    if specified, the volume will contain the git
-                                    repository in the subdirectory with the given
-                                    name.
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount
+                              description: 'glusterfs represents a Glusterfs mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name
-                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path.
+                                  description: 'path is the Glusterfs volume path.
                                     More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs
+                                  description: 'readOnly here will force the Glusterfs
                                     volume to be mounted with read-only permissions.
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
@@ -9433,7 +10031,7 @@ spec:
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file
+                              description: 'hostPath represents a pre-existing file
                                 or directory on the host machine that is directly
                                 exposed to the container. This is generally used for
                                 system agents or other privileged things that are
@@ -9444,71 +10042,73 @@ spec:
                                 directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host.
+                                  description: 'path of the directory on the host.
                                     If the path is a symlink, it will follow the link
                                     to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults
+                                  description: 'type for HostPath Volume Defaults
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource
+                              description: 'iscsi represents an ISCSI Disk resource
                                 that is attached to a kubelet''s host machine and
                                 then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP
-                                    authentication
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP
-                                    authentication
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName
-                                    is specified with iscsiInterface simultaneously,
-                                    new iSCSI interface <target portal>:<volume name>
-                                    will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI
-                                    transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal
-                                    is either an IP or ip_addr:port if the port is
-                                    other than default (typically TCP ports 860 and
-                                    3260).
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly
+                                  description: readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator
-                                    authentication
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -9518,9 +10118,10 @@ spec:
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is
-                                    either an IP or ip_addr:port if the port is other
-                                    than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -9528,24 +10129,24 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and
-                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host
+                              description: 'nfs represents an NFS mount on the host
                                 that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server.
+                                  description: 'path that is exported by the NFS server.
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export
+                                  description: 'readOnly here will force the NFS export
                                     to be mounted with read-only permissions. Defaults
                                     to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address
+                                  description: 'server is the hostname or IP address
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
@@ -9553,132 +10154,133 @@ spec:
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents
+                              description: 'persistentVolumeClaimVolumeSource represents
                                 a reference to a PersistentVolumeClaim in the same
                                 namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  description: 'claimName is the name of a PersistentVolumeClaim
                                     in the same namespace as the pod using this volume.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in
-                                    VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController
+                              description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
                                 machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller
-                                    persistent disk
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume
+                              description: portworxVolume represents a portworx volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type
+                                  description: fSType represents the filesystem type
                                     to mount Must be a filesystem type supported by
                                     the host operating system. Ex. "ext4", "xfs".
                                     Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx
+                                  description: volumeID uniquely identifies a Portworx
                                     volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets,
-                                configmaps, and downward API
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on
-                                    created files by default. Must be an octal value
-                                    between 0000 and 0777 or a decimal value between
-                                    0 and 511. YAML accepts both octal and decimal
-                                    values, JSON requires decimal values for mode
-                                    bits. Directories within the path are not affected
-                                    by this setting. This might be in conflict with
-                                    other options that affect the file mode, like
-                                    fsGroup, and the result can be other mode bits
-                                    set.
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap
-                                          data to project
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              ConfigMap will be projected into the
-                                              volume as a file whose name is the key
-                                              and content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the ConfigMap,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -9693,13 +10295,13 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI
-                                          data to project
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume
@@ -9789,53 +10391,53 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret
-                                          data to project
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              Secret will be projected into the volume
-                                              as a file whose name is the key and
-                                              content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the Secret,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -9850,16 +10452,16 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken
-                                          data to project
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended
+                                            description: audience is the intended
                                               audience of the token. A recipient of
                                               a token must identify itself with an
                                               identifier specified in the audience
@@ -9868,7 +10470,7 @@ spec:
                                               the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the
+                                            description: expirationSeconds is the
                                               requested duration of validity of the
                                               service account token. As the token
                                               approaches expiration, the kubelet volume
@@ -9882,7 +10484,7 @@ spec:
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative
+                                            description: path is the path relative
                                               to the mount point of the file to project
                                               the token into.
                                             type: string
@@ -9893,36 +10495,36 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the
+                              description: quobyte represents a Quobyte mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default
+                                  description: group to map volume access to Default
                                     is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte
+                                  description: readOnly here will force the Quobyte
                                     volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple
+                                  description: registry represents a single or multiple
                                     Quobyte Registry services specified as a string
                                     as host:port pair (multiple entries are separated
                                     with commas) which acts as the central registry
                                     for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume
+                                  description: tenant owning the given Quobyte volume
                                     in the Backend Used with dynamically provisioned
                                     Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults
+                                  description: user to map volume access to Defaults
                                     to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references
+                                  description: volume is a string that references
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
@@ -9930,44 +10532,46 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount
+                              description: 'rbd represents a Rados Block Device mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for
+                                  description: 'keyring is the path to key ring for
                                     RBDUser. Default is /etc/ceph/keyring. More info:
                                     https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication
+                                  description: 'secretRef is name of the authentication
                                     secret for RBDUser. If provided overrides keyring.
                                     Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
@@ -9979,37 +10583,38 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent
+                              description: scaleIO represents a ScaleIO persistent
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Default is
-                                    "xfs".
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API
-                                    Gateway.
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection
-                                    Domain for the configured storage.
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret
+                                  description: secretRef references to the secret
                                     for ScaleIO user and other sensitive information.
                                     If this is not provided, Login operation will
                                     fail.
@@ -10022,26 +10627,26 @@ spec:
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication
-                                    with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a
-                                    volume should be ThickProvisioned or ThinProvisioned.
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated
-                                    with the protection domain.
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured
-                                    in ScaleIO.
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created
-                                    in the ScaleIO system that is associated with
-                                    this volume source.
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -10049,27 +10654,27 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should
+                              description: 'secret represents a secret that should
                                 populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
                                     paths, and unlisted keys will not be present.
                                     If a key is specified which is not present in
@@ -10082,26 +10687,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -10109,30 +10716,31 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys
-                                    must be defined
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume
+                              description: storageOS represents a StorageOS volume
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use
+                                  description: secretRef specifies the secret to use
                                     for obtaining the StorageOS API credentials.  If
                                     not specified, default values will be attempted.
                                   properties:
@@ -10144,12 +10752,12 @@ spec:
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name
+                                  description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
                                     unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope
+                                  description: volumeNamespace specifies the scope
                                     of the volume within StorageOS.  If no namespace
                                     is specified then the Pod's namespace will be
                                     used.  This allows the Kubernetes name scoping
@@ -10161,26 +10769,27 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume
+                              description: vsphereVolume represents a vSphere volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile name.
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume
-                                    vmdk
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -10189,8 +10798,7 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - imagePullSecrets
+                        x-kubernetes-list-type: atomic
                     type: object
                   resources:
                     description: Resources is a list of bindings specifying which
@@ -10239,6 +10847,7 @@ spec:
                                 - value
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             secrets:
                               description: Secrets to fetch to populate some of resource
                                 fields
@@ -10258,6 +10867,7 @@ spec:
                                 - secretName
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             type:
                               type: string
                           required:
@@ -10291,7 +10901,7 @@ spec:
                         pipelineTaskName:
                           type: string
                         taskPodTemplate:
-                          description: PodTemplate holds pod specific configuration
+                          description: Template holds pod specific configuration
                           properties:
                             affinity:
                               description: If specified, the pod's scheduling constraints
@@ -10628,9 +11238,7 @@ spec:
                                                   and null or empty namespaces list
                                                   means "this pod's namespace". An
                                                   empty selector ({}) matches all
-                                                  namespaces. This field is beta-level
-                                                  and is only honored when PodAffinityNamespaceSelector
-                                                  feature is enabled.
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -10698,7 +11306,7 @@ spec:
                                                   selected by namespaceSelector. null
                                                   or empty namespaces list and null
                                                   namespaceSelector means "this pod's
-                                                  namespace"
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -10817,9 +11425,6 @@ spec:
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
-                                              This field is beta-level and is only
-                                              honored when PodAffinityNamespaceSelector
-                                              feature is enabled.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -10882,7 +11487,7 @@ spec:
                                               field and the ones selected by namespaceSelector.
                                               null or empty namespaces list and null
                                               namespaceSelector means "this pod's
-                                              namespace"
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -11004,9 +11609,7 @@ spec:
                                                   and null or empty namespaces list
                                                   means "this pod's namespace". An
                                                   empty selector ({}) matches all
-                                                  namespaces. This field is beta-level
-                                                  and is only honored when PodAffinityNamespaceSelector
-                                                  feature is enabled.
+                                                  namespaces.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -11074,7 +11677,7 @@ spec:
                                                   selected by namespaceSelector. null
                                                   or empty namespaces list and null
                                                   namespaceSelector means "this pod's
-                                                  namespace"
+                                                  namespace".
                                                 items:
                                                   type: string
                                                 type: array
@@ -11193,9 +11796,6 @@ spec:
                                               field. null selector and null or empty
                                               namespaces list means "this pod's namespace".
                                               An empty selector ({}) matches all namespaces.
-                                              This field is beta-level and is only
-                                              honored when PodAffinityNamespaceSelector
-                                              feature is enabled.
                                             properties:
                                               matchExpressions:
                                                 description: matchExpressions is a
@@ -11258,7 +11858,7 @@ spec:
                                               field and the ones selected by namespaceSelector.
                                               null or empty namespaces list and null
                                               namespaceSelector means "this pod's
-                                              namespace"
+                                              namespace".
                                             items:
                                               type: string
                                             type: array
@@ -11335,6 +11935,27 @@ spec:
                                 variables, matching the syntax of Docker links. Optional:
                                 Defaults to true.'
                               type: boolean
+                            hostAliases:
+                              description: HostAliases is an optional list of hosts
+                                and IPs that will be injected into the pod's hosts
+                                file if specified. This is only valid for non-hostNetwork
+                                pods.
+                              items:
+                                description: HostAlias holds the mapping between IP
+                                  and hostnames that will be injected as an entry
+                                  in the pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             hostNetwork:
                               description: HostNetwork specifies whether the pod may
                                 use the node network namespace
@@ -11355,6 +11976,7 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             nodeSelector:
                               additionalProperties:
                                 type: string
@@ -11402,7 +12024,9 @@ spec:
                                     is set (new files created in the volume will be
                                     owned by FSGroup) 3. The permission bits are OR'd
                                     with rw-rw---- \n If unset, the Kubelet will not
-                                    modify the ownership and permissions of any volume."
+                                    modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
@@ -11413,7 +12037,9 @@ spec:
                                     based ownership(and permissions). It will have
                                     no effect on ephemeral volume types such as: secret,
                                     configmaps and emptydir. Valid values are "OnRootMismatch"
-                                    and "Always". If not specified, "Always" is used.'
+                                    and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.'
                                   type: string
                                 runAsGroup:
                                   description: The GID to run the entrypoint of the
@@ -11421,7 +12047,8 @@ spec:
                                     May also be set in SecurityContext.  If set in
                                     both SecurityContext and PodSecurityContext, the
                                     value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
@@ -11442,6 +12069,8 @@ spec:
                                     set in SecurityContext.  If set in both SecurityContext
                                     and PodSecurityContext, the value specified in
                                     SecurityContext takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
@@ -11451,7 +12080,8 @@ spec:
                                     for each container.  May also be set in SecurityContext.  If
                                     set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence
-                                    for that container.
+                                    for that container. Note that this field cannot
+                                    be set when spec.os.name is windows.
                                   properties:
                                     level:
                                       description: Level is SELinux level label that
@@ -11472,7 +12102,8 @@ spec:
                                   type: object
                                 seccompProfile:
                                   description: The seccomp options to use by the containers
-                                    in this pod.
+                                    in this pod. Note that this field cannot be set
+                                    when spec.os.name is windows.
                                   properties:
                                     localhostProfile:
                                       description: localhostProfile indicates a profile
@@ -11498,7 +12129,9 @@ spec:
                                   description: A list of groups applied to the first
                                     process run in each container, in addition to
                                     the container's primary GID.  If unspecified,
-                                    no groups will be added to any container.
+                                    no groups will be added to any container. Note
+                                    that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     format: int64
                                     type: integer
@@ -11507,6 +12140,8 @@ spec:
                                   description: Sysctls hold a list of namespaced sysctls
                                     used for the pod. Pods with unsupported sysctls
                                     (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name
+                                    is windows.
                                   items:
                                     description: Sysctl defines a kernel parameter
                                       to be set
@@ -11528,6 +12163,8 @@ spec:
                                     within a container's SecurityContext will be used.
                                     If set in both SecurityContext and PodSecurityContext,
                                     the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name
+                                    is linux.
                                   properties:
                                     gmsaCredentialSpec:
                                       description: GMSACredentialSpec is where the
@@ -11608,6 +12245,7 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             volumes:
                               description: 'List of volumes that can be mounted by
                                 containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -11617,77 +12255,78 @@ spec:
                                   pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents
+                                    description: 'awsElasticBlockStore represents
                                       an AWS Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty).'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and
-                                          set the ReadOnly property in VolumeMounts
-                                          to "true". If omitted, the default is "false".
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'readOnly value true will force
+                                          the readOnly setting in VolumeMounts. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent
-                                          disk resource in AWS (Amazon EBS volume).
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                        description: 'volumeID is unique ID of the
+                                          persistent disk resource in AWS (Amazon
+                                          EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data
+                                    description: azureDisk represents an Azure Data
                                       Disk mount on the host and bind mount to the
                                       pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read
-                                          Only, Read Write.'
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in
-                                          the blob storage
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the
-                                          blob storage
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is Filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple
-                                          blob disks per storage account  Dedicated:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
                                           single blob disk per storage account  Managed:
                                           azure managed data disk (only in managed
                                           availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
@@ -11696,56 +12335,59 @@ spec:
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File
+                                    description: azureFile represents an Azure File
                                       Service mount on the host and bind mount to
                                       the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains
-                                          Azure Storage Account Name and Key
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
+                                        description: shareName is the azure share
+                                          Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount
+                                    description: cephFS represents a Ceph FS mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection
-                                          of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'monitors is Required: Monitors
+                                          is a collection of Ceph monitors More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted
-                                          root, rather than the full Ceph tree, default
-                                          is /'
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the
-                                          path to key ring for User, default is /etc/ceph/user.secret
-                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretFile is Optional: SecretFile
+                                          is the path to key ring for User, default
+                                          is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the authentication secret for User, default
-                                          is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'secretRef is Optional: SecretRef
+                                          is reference to the authentication secret
+                                          for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -11755,34 +12397,35 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados
-                                          user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                        description: 'user is optional: User is the
+                                          rados user name, default is admin More info:
+                                          https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume
+                                    description: 'cinder represents a cinder volume
                                       attached and mounted on kubelets host machine.
                                       More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Examples: "ext4", "xfs",
-                                          "ntfs". Implicitly inferred to be "ext4"
-                                          if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts. More info:
-                                          https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                        description: 'readOnly defaults to false (read/write).
+                                          ReadOnly here will force the ReadOnly setting
+                                          in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret
-                                          object containing parameters used to connect
-                                          to OpenStack.'
+                                        description: 'secretRef is optional: points
+                                          to a secret object containing parameters
+                                          used to connect to OpenStack.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -11792,32 +12435,33 @@ spec:
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the
+                                        description: 'volumeID used to identify the
                                           volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap
+                                    description: configMap represents a configMap
                                       that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -11834,27 +12478,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -11870,30 +12514,30 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface)
+                                    description: csi (Container Storage Interface)
                                       represents ephemeral storage that is handled
                                       by certain external CSI drivers (Beta feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI
+                                        description: driver is the name of the CSI
                                           driver that handles this volume. Consult
                                           with your admin for the correct name as
                                           registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex.
-                                          "ext4", "xfs", "ntfs". If not provided,
-                                          the empty value is passed to the associated
-                                          CSI driver which will determine the default
-                                          filesystem to apply.
+                                        description: fsType to mount. Ex. "ext4",
+                                          "xfs", "ntfs". If not provided, the empty
+                                          value is passed to the associated CSI driver
+                                          which will determine the default filesystem
+                                          to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference
+                                        description: nodePublishSecretRef is a reference
                                           to the secret object containing sensitive
                                           information to pass to the CSI driver to
                                           complete the CSI NodePublishVolume and NodeUnpublishVolume
@@ -11910,13 +12554,14 @@ spec:
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration
-                                          for the volume. Defaults to false (read/write).
+                                        description: readOnly specifies a read-only
+                                          configuration for the volume. Defaults to
+                                          false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific
+                                        description: volumeAttributes stores driver-specific
                                           properties that are passed to the CSI driver.
                                           Consult your driver's documentation for
                                           supported values.
@@ -11925,7 +12570,7 @@ spec:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API
+                                    description: downwardAPI represents downward API
                                       about the pod that should populate this volume
                                     properties:
                                       defaultMode:
@@ -12026,35 +12671,36 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary
+                                    description: 'emptyDir represents a temporary
                                       directory that shares a pod''s lifetime. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium
-                                          should back this directory. The default
-                                          is "" which means to use the node''s default
-                                          medium. Must be an empty string (default)
-                                          or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                        description: 'medium represents what type
+                                          of storage medium should back this directory.
+                                          The default is "" which means to use the
+                                          node''s default medium. Must be an empty
+                                          string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage
-                                          required for this EmptyDir volume. The size
-                                          limit is also applicable for memory medium.
-                                          The maximum usage on memory medium EmptyDir
-                                          would be the minimum value between the SizeLimit
-                                          specified here and the sum of memory limits
-                                          of all containers in a pod. The default
-                                          is nil which means that the limit is undefined.
-                                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                        description: 'sizeLimit is the total amount
+                                          of local storage required for this EmptyDir
+                                          volume. The size limit is also applicable
+                                          for memory medium. The maximum usage on
+                                          memory medium EmptyDir would be the minimum
+                                          value between the SizeLimit specified here
+                                          and the sum of memory limits of all containers
+                                          in a pod. The default is nil which means
+                                          that the limit is undefined. More info:
+                                          http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   ephemeral:
-                                    description: "Ephemeral represents a volume that
+                                    description: "ephemeral represents a volume that
                                       is handled by a cluster storage driver. The
                                       volume's lifecycle is tied to the pod that defines
                                       it - it will be created before the pod starts,
@@ -12076,9 +12722,7 @@ spec:
                                       - see the documentation of the driver for more
                                       information. \n A pod can use both types of
                                       ephemeral volumes and persistent volumes at
-                                      the same time. \n This is a beta feature and
-                                      only available when the GenericEphemeralVolume
-                                      feature gate is enabled."
+                                      the same time."
                                     properties:
                                       volumeClaimTemplate:
                                         description: "Will be used to create a stand-alone
@@ -12122,16 +12766,16 @@ spec:
                                               are also valid here.
                                             properties:
                                               accessModes:
-                                                description: 'AccessModes contains
+                                                description: 'accessModes contains
                                                   the desired access modes the volume
                                                   should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                                 items:
                                                   type: string
                                                 type: array
                                               dataSource:
-                                                description: 'This field can be used
-                                                  to specify either: * An existing
-                                                  VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                description: 'dataSource field can
+                                                  be used to specify either: * An
+                                                  existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                                   * An existing PVC (PersistentVolumeClaim)
                                                   If the provisioner or an external
                                                   controller can support the specified
@@ -12165,12 +12809,12 @@ spec:
                                                 - name
                                                 type: object
                                               dataSourceRef:
-                                                description: 'Specifies the object
-                                                  from which to populate the volume
-                                                  with data, if a non-empty volume
-                                                  is desired. This may be any local
-                                                  object from a non-empty API group
-                                                  (non core object) or a PersistentVolumeClaim
+                                                description: 'dataSourceRef specifies
+                                                  the object from which to populate
+                                                  the volume with data, if a non-empty
+                                                  volume is desired. This may be any
+                                                  local object from a non-empty API
+                                                  group (non core object) or a PersistentVolumeClaim
                                                   object. When this field is specified,
                                                   volume binding will only succeed
                                                   if the type of the specified object
@@ -12195,7 +12839,7 @@ spec:
                                                   values (dropping them), DataSourceRef   preserves
                                                   all values, and generates an error
                                                   if a disallowed value is   specified.
-                                                  (Alpha) Using this field requires
+                                                  (Beta) Using this field requires
                                                   the AnyVolumeDataSource feature
                                                   gate to be enabled.'
                                                 properties:
@@ -12221,9 +12865,15 @@ spec:
                                                 - name
                                                 type: object
                                               resources:
-                                                description: 'Resources represents
+                                                description: 'resources represents
                                                   the minimum resources the volume
-                                                  should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                                  should have. If RecoverVolumeExpansionFailure
+                                                  feature is enabled users are allowed
+                                                  to specify resource requirements
+                                                  that are lower than previous value
+                                                  but must still be higher than capacity
+                                                  recorded in the status field of
+                                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                                 properties:
                                                   limits:
                                                     additionalProperties:
@@ -12255,8 +12905,8 @@ spec:
                                                     type: object
                                                 type: object
                                               selector:
-                                                description: A label query over volumes
-                                                  to consider for binding.
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
                                                 properties:
                                                   matchExpressions:
                                                     description: matchExpressions
@@ -12316,9 +12966,9 @@ spec:
                                                     type: object
                                                 type: object
                                               storageClassName:
-                                                description: 'Name of the StorageClass
-                                                  required by the claim. More info:
-                                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                                description: 'storageClassName is
+                                                  the name of the StorageClass required
+                                                  by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                                 type: string
                                               volumeMode:
                                                 description: volumeMode defines what
@@ -12327,7 +12977,7 @@ spec:
                                                   when not included in claim spec.
                                                 type: string
                                               volumeName:
-                                                description: VolumeName is the binding
+                                                description: volumeName is the binding
                                                   reference to the PersistentVolume
                                                   backing this claim.
                                                 type: string
@@ -12337,77 +12987,79 @@ spec:
                                         type: object
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource
+                                    description: fc represents a Fibre Channel resource
                                       that is attached to a kubelet's host machine
                                       and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
-                                          TODO: how do we prevent errors in the filesystem
-                                          from compromising the machine'
+                                        description: 'fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified. TODO: how do we prevent
+                                          errors in the filesystem from compromising
+                                          the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
+                                        description: 'lun is Optional: FC target lun
+                                          number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: Defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide
-                                          names (WWNs)'
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide
-                                          identifiers (wwids) Either wwids or combination
-                                          of targetWWNs and lun must be set, but not
-                                          both simultaneously.'
+                                        description: 'wwids Optional: FC volume world
+                                          wide identifiers (wwids) Either wwids or
+                                          combination of targetWWNs and lun must be
+                                          set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume
+                                    description: flexVolume represents a generic volume
                                       resource that is provisioned/attached using
                                       an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver
+                                        description: driver is the name of the driver
                                           to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          The default filesystem depends on FlexVolume
-                                          script.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". The default filesystem depends
+                                          on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options
-                                          if any.'
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false
-                                          (read/write). ReadOnly here will force the
-                                          ReadOnly setting in VolumeMounts.'
+                                        description: 'readOnly is Optional: defaults
+                                          to false (read/write). ReadOnly here will
+                                          force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference
-                                          to the secret object containing sensitive
-                                          information to pass to the plugin scripts.
-                                          This may be empty if no secret object is
-                                          specified. If the secret object contains
-                                          more than one secret, all secrets are passed
-                                          to the plugin scripts.'
+                                        description: 'secretRef is Optional: secretRef
+                                          is reference to the secret object containing
+                                          sensitive information to pass to the plugin
+                                          scripts. This may be empty if no secret
+                                          object is specified. If the secret object
+                                          contains more than one secret, all secrets
+                                          are passed to the plugin scripts.'
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -12420,53 +13072,55 @@ spec:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume
+                                    description: flocker represents a Flocker volume
                                       attached to a kubelet's host machine. This depends
                                       on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as
-                                          metadata -> name on the dataset for Flocker
-                                          should be considered as deprecated
+                                        description: datasetName is Name of the dataset
+                                          stored as metadata -> name on the dataset
+                                          for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is
-                                          unique identifier of a Flocker dataset
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE
+                                    description: 'gcePersistentDisk represents a GCE
                                       Disk resource that is attached to a kubelet''s
                                       host machine and then exposed to the pod. More
                                       info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        description: 'fsType is filesystem type of
+                                          the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume
-                                          that you want to mount. If omitted, the
-                                          default is to mount by volume name. Examples:
-                                          For volume /dev/sda1, you specify the partition
-                                          as "1". Similarly, the volume partition
-                                          for /dev/sda is "0" (or you can leave the
-                                          property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'partition is the partition in
+                                          the volume that you want to mount. If omitted,
+                                          the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify
+                                          the partition as "1". Similarly, the volume
+                                          partition for /dev/sda is "0" (or you can
+                                          leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource
-                                          in GCE. Used to identify the disk in GCE.
-                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                        description: 'pdName is unique name of the
+                                          PD resource in GCE. Used to identify the
+                                          disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
@@ -12474,7 +13128,7 @@ spec:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository
+                                    description: 'gitRepo represents a git repository
                                       at a particular revision. DEPRECATED: GitRepo
                                       is deprecated. To provision a container with
                                       a git repo, mount an EmptyDir into an InitContainer
@@ -12482,39 +13136,39 @@ spec:
                                       EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not
-                                          contain or start with '..'.  If '.' is supplied,
-                                          the volume directory will be the git repository.  Otherwise,
-                                          if specified, the volume will contain the
-                                          git repository in the subdirectory with
-                                          the given name.
+                                        description: directory is the target directory
+                                          name. Must not contain or start with '..'.  If
+                                          '.' is supplied, the volume directory will
+                                          be the git repository.  Otherwise, if specified,
+                                          the volume will contain the git repository
+                                          in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
+                                        description: repository is the URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified
-                                          revision.
+                                        description: revision is the commit hash for
+                                          the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs
+                                    description: 'glusterfs represents a Glusterfs
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint
-                                          name that details Glusterfs topology. More
-                                          info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                        description: 'endpoints is the endpoint name
+                                          that details Glusterfs topology. More info:
+                                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume
+                                        description: 'path is the Glusterfs volume
                                           path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           Glusterfs volume to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
@@ -12524,7 +13178,7 @@ spec:
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing
+                                    description: 'hostPath represents a pre-existing
                                       file or directory on the host machine that is
                                       directly exposed to the container. This is generally
                                       used for system agents or other privileged things
@@ -12535,76 +13189,79 @@ spec:
                                       mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the
+                                        description: 'path of the directory on the
                                           host. If the path is a symlink, it will
                                           follow the link to the real path. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults
+                                        description: 'type for HostPath Volume Defaults
                                           to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource
+                                    description: 'iscsi represents an ISCSI Disk resource
                                       that is attached to a kubelet''s host machine
                                       and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery
-                                          CHAP authentication
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session
-                                          CHAP authentication
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name.
-                                          If initiatorName is specified with iscsiInterface
-                                          simultaneously, new iSCSI interface <target
-                                          portal>:<volume name> will be created for
-                                          the connection.
+                                        description: initiatorName is the custom iSCSI
+                                          Initiator Name. If initiatorName is specified
+                                          with iscsiInterface simultaneously, new
+                                          iSCSI interface <target portal>:<volume
+                                          name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses
-                                          an iSCSI transport. Defaults to 'default'
-                                          (tcp).
+                                        description: iscsiInterface is the interface
+                                          Name that uses an iSCSI transport. Defaults
+                                          to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
+                                        description: lun represents iSCSI Target Lun
+                                          number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The
-                                          portal is either an IP or ip_addr:port if
-                                          the port is other than default (typically
+                                        description: portals is the iSCSI Target Portal
+                                          List. The portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
                                           TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target
-                                          and initiator authentication
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
                                         properties:
                                           name:
                                             description: 'Name of the referent. More
@@ -12614,10 +13271,10 @@ spec:
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal
-                                          is either an IP or ip_addr:port if the port
-                                          is other than default (typically TCP ports
-                                          860 and 3260).
+                                        description: targetPortal is iSCSI Target
+                                          Portal. The Portal is either an IP or ip_addr:port
+                                          if the port is other than default (typically
+                                          TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -12625,26 +13282,26 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL
+                                    description: 'name of the volume. Must be a DNS_LABEL
                                       and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the
+                                    description: 'nfs represents an NFS mount on the
                                       host that shares a pod''s lifetime More info:
                                       https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the
+                                        description: 'path that is exported by the
                                           NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           NFS export to be mounted with read-only
                                           permissions. Defaults to false. More info:
                                           https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP
+                                        description: 'server is the hostname or IP
                                           address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
@@ -12652,99 +13309,101 @@ spec:
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource
+                                    description: 'persistentVolumeClaimVolumeSource
                                       represents a reference to a PersistentVolumeClaim
                                       in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                                        description: 'claimName is the name of a PersistentVolumeClaim
                                           in the same namespace as the pod using this
                                           volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting
-                                          in VolumeMounts. Default false.
+                                        description: readOnly Will force the ReadOnly
+                                          setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a
+                                    description: photonPersistentDisk represents a
                                       PhotonController persistent disk attached and
                                       mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller
-                                          persistent disk
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx
+                                    description: portworxVolume represents a portworx
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem
+                                        description: fSType represents the filesystem
                                           type to mount Must be a filesystem type
                                           supported by the host operating system.
                                           Ex. "ext4", "xfs". Implicitly inferred to
                                           be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies
+                                        description: volumeID uniquely identifies
                                           a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets,
-                                      configmaps, and downward API
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits used to set permissions
-                                          on created files by default. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. Directories
-                                          within the path are not affected by this
-                                          setting. This might be in conflict with
-                                          other options that affect the file mode,
-                                          like fsGroup, and the result can be other
-                                          mode bits set.
+                                        description: defaultMode are the mode bits
+                                          used to set permissions on created files
+                                          by default. Must be an octal value between
+                                          0000 and 0777 or a decimal value between
+                                          0 and 511. YAML accepts both octal and decimal
+                                          values, JSON requires decimal values for
+                                          mode bits. Directories within the path are
+                                          not affected by this setting. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
+                                        description: sources is the list of volume
+                                          projections
                                         items:
                                           description: Projection that may be projected
                                             along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap
-                                                data to project
+                                              description: configMap information about
+                                                the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced ConfigMap will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced ConfigMap
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -12759,11 +13418,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -12781,7 +13441,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -12801,14 +13461,14 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    ConfigMap or its keys must be
-                                                    defined
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI
-                                                data to project
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
                                               properties:
                                                 items:
                                                   description: Items is a list of
@@ -12905,16 +13565,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret
-                                                data to project
+                                              description: secret information about
+                                                the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each
-                                                    key-value pair in the Data field
-                                                    of the referenced Secret will
-                                                    be projected into the volume as
-                                                    a file whose name is the key and
-                                                    content is the value. If specified,
+                                                  description: items if unspecified,
+                                                    each key-value pair in the Data
+                                                    field of the referenced Secret
+                                                    will be projected into the volume
+                                                    as a file whose name is the key
+                                                    and content is the value. If specified,
                                                     the listed keys will be projected
                                                     into the specified paths, and
                                                     unlisted keys will not be present.
@@ -12929,11 +13589,12 @@ spec:
                                                       to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
+                                                        description: key is the key
+                                                          to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode
-                                                          bits used to set permissions
+                                                        description: 'mode is Optional:
+                                                          mode bits used to set permissions
                                                           on this file. Must be an
                                                           octal value between 0000
                                                           and 0777 or a decimal value
@@ -12951,7 +13612,7 @@ spec:
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative
+                                                        description: path is the relative
                                                           path of the file to map
                                                           the key to. May not be an
                                                           absolute path. May not contain
@@ -12971,16 +13632,18 @@ spec:
                                                     apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the
-                                                    Secret or its key must be defined
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
                                                 data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended
+                                                  description: audience is the intended
                                                     audience of the token. A recipient
                                                     of a token must identify itself
                                                     with an identifier specified in
@@ -12990,7 +13653,7 @@ spec:
                                                     of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is
+                                                  description: expirationSeconds is
                                                     the requested duration of validity
                                                     of the service account token.
                                                     As the token approaches expiration,
@@ -13006,7 +13669,7 @@ spec:
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative
+                                                  description: path is the path relative
                                                     to the mount point of the file
                                                     to project the token into.
                                                   type: string
@@ -13017,37 +13680,37 @@ spec:
                                         type: array
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount
+                                    description: quobyte represents a Quobyte mount
                                       on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to
+                                        description: group to map volume access to
                                           Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the
+                                        description: readOnly here will force the
                                           Quobyte volume to be mounted with read-only
                                           permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single
+                                        description: registry represents a single
                                           or multiple Quobyte Registry services specified
                                           as a string as host:port pair (multiple
                                           entries are separated with commas) which
                                           acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte
+                                        description: tenant owning the given Quobyte
                                           volume in the Backend Used with dynamically
                                           provisioned Quobyte volumes, value is set
                                           by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to
+                                        description: user to map volume access to
                                           Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references
+                                        description: volume is a string that references
                                           an already created Quobyte volume by name.
                                         type: string
                                     required:
@@ -13055,46 +13718,47 @@ spec:
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device
+                                    description: 'rbd represents a Rados Block Device
                                       mount on the host that shares a pod''s lifetime.
                                       More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume
-                                          that you want to mount. Tip: Ensure that
-                                          the filesystem type is supported by the
-                                          host operating system. Examples: "ext4",
-                                          "xfs", "ntfs". Implicitly inferred to be
-                                          "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                        description: 'fsType is the filesystem type
+                                          of the volume that you want to mount. Tip:
+                                          Ensure that the filesystem type is supported
+                                          by the host operating system. Examples:
+                                          "ext4", "xfs", "ntfs". Implicitly inferred
+                                          to be "ext4" if unspecified. More info:
+                                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                           TODO: how do we prevent errors in the filesystem
                                           from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info:
-                                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring
+                                        description: 'keyring is the path to key ring
                                           for RBDUser. Default is /etc/ceph/keyring.
                                           More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors.
-                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'monitors is a collection of
+                                          Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default
-                                          is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'pool is the rados pool name.
+                                          Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the
+                                        description: 'readOnly here will force the
                                           ReadOnly setting in VolumeMounts. Defaults
                                           to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication
+                                        description: 'secretRef is name of the authentication
                                           secret for RBDUser. If provided overrides
                                           keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
@@ -13106,38 +13770,39 @@ spec:
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default
-                                          is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                        description: 'user is the rados user name.
+                                          Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent
+                                    description: scaleIO represents a ScaleIO persistent
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Default is "xfs".
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO
-                                          API Gateway.
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection
-                                          Domain for the configured storage.
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly Defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret
+                                        description: secretRef references to the secret
                                           for ScaleIO user and other sensitive information.
                                           If this is not provided, Login operation
                                           will fail.
@@ -13150,26 +13815,27 @@ spec:
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication
-                                          with Gateway, default false
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage
-                                          for a volume should be ThickProvisioned
+                                        description: storageMode indicates whether
+                                          the storage for a volume should be ThickProvisioned
                                           or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated
-                                          with the protection domain.
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system
-                                          as configured in ScaleIO.
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already
-                                          created in the ScaleIO system that is associated
-                                          with this volume source.
+                                        description: volumeName is the name of a volume
+                                          already created in the ScaleIO system that
+                                          is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -13177,25 +13843,26 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that
+                                    description: 'secret represents a secret that
                                       should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on created files by default.
-                                          Must be an octal value between 0000 and
-                                          0777 or a decimal value between 0 and 511.
-                                          YAML accepts both octal and decimal values,
-                                          JSON requires decimal values for mode bits.
-                                          Defaults to 0644. Directories within the
-                                          path are not affected by this setting. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'defaultMode is Optional: mode
+                                          bits used to set permissions on created
+                                          files by default. Must be an octal value
+                                          between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected
+                                          by this setting. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items If unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -13212,27 +13879,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -13242,31 +13909,33 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its keys must be defined
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s
-                                          namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                        description: 'secretName is the name of the
+                                          secret in the pod''s namespace to use. More
+                                          info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS
+                                    description: storageOS represents a StorageOS
                                       volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is the filesystem type
+                                          to mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write).
+                                        description: readOnly defaults to false (read/write).
                                           ReadOnly here will force the ReadOnly setting
                                           in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret
+                                        description: secretRef specifies the secret
                                           to use for obtaining the StorageOS API credentials.  If
                                           not specified, default values will be attempted.
                                         properties:
@@ -13278,12 +13947,12 @@ spec:
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable
+                                        description: volumeName is the human-readable
                                           name of the StorageOS volume.  Volume names
                                           are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the
+                                        description: volumeNamespace specifies the
                                           scope of the volume within StorageOS.  If
                                           no namespace is specified then the Pod's
                                           namespace will be used.  This allows the
@@ -13296,27 +13965,29 @@ spec:
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere
+                                    description: vsphereVolume represents a vSphere
                                       volume attached and mounted on kubelets host
                                       machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must
-                                          be a filesystem type supported by the host
-                                          operating system. Ex. "ext4", "xfs", "ntfs".
-                                          Implicitly inferred to be "ext4" if unspecified.
+                                        description: fsType is filesystem type to
+                                          mount. Must be a filesystem type supported
+                                          by the host operating system. Ex. "ext4",
+                                          "xfs", "ntfs". Implicitly inferred to be
+                                          "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile ID associated with the StoragePolicyName.
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management
-                                          (SPBM) profile name.
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere
-                                          volume vmdk
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -13325,8 +13996,7 @@ spec:
                                 - name
                                 type: object
                               type: array
-                          required:
-                          - imagePullSecrets
+                              x-kubernetes-list-type: atomic
                           type: object
                         taskServiceAccountName:
                           type: string
@@ -13349,26 +14019,27 @@ spec:
                             populate this workspace.
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced ConfigMap will be
-                                projected into the volume as a file whose name is
-                                the key and content is the value. If specified, the
-                                listed keys will be projected into the specified paths,
-                                and unlisted keys will not be present. If a key is
-                                specified which is not present in the ConfigMap, the
-                                volume setup will error unless it is marked optional.
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
                                 Paths must be relative and may not contain the '..'
                                 path or start with '..'.
                               items:
@@ -13376,26 +14047,26 @@ spec:
                                   volume.
                                 properties:
                                   key:
-                                    description: The key to project.
+                                    description: key is the key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -13407,8 +14078,8 @@ spec:
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its keys
-                                must be defined
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
                               type: boolean
                           type: object
                         emptyDir:
@@ -13417,22 +14088,24 @@ spec:
                             Either this OR PersistentVolumeClaim can be used.'
                           properties:
                             medium:
-                              description: 'What type of storage medium should back
-                                this directory. The default is "" which means to use
-                                the node''s default medium. Must be an empty string
-                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Total amount of local storage required
-                                for this EmptyDir volume. The size limit is also applicable
-                                for memory medium. The maximum usage on memory medium
-                                EmptyDir would be the minimum value between the SizeLimit
-                                specified here and the sum of memory limits of all
-                                containers in a pod. The default is nil which means
-                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
@@ -13446,13 +14119,13 @@ spec:
                             Either this OR EmptyDir can be used.
                           properties:
                             claimName:
-                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                              description: 'claimName is the name of a PersistentVolumeClaim
                                 in the same namespace as the pod using this volume.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               type: string
                             readOnly:
-                              description: Will force the ReadOnly setting in VolumeMounts.
-                                Default false.
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
                               type: boolean
                           required:
                           - claimName
@@ -13462,53 +14135,54 @@ spec:
                             this workspace.
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be
-                                relative and may not contain the '..' path or start
-                                with '..'.
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
                                 properties:
                                   key:
-                                    description: The key to project.
+                                    description: key is the key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -13516,12 +14190,12 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: Specify whether the Secret or its keys
-                                must be defined
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
                               type: boolean
                             secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
                         subPath:
@@ -13553,18 +14227,18 @@ spec:
                                 https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                               type: object
                             spec:
-                              description: 'Spec defines the desired characteristics
+                              description: 'spec defines the desired characteristics
                                 of a volume requested by a pod author. More info:
                                 https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 accessModes:
-                                  description: 'AccessModes contains the desired access
+                                  description: 'accessModes contains the desired access
                                     modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
                                 dataSource:
-                                  description: 'This field can be used to specify
+                                  description: 'dataSource field can be used to specify
                                     either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                     * An existing PVC (PersistentVolumeClaim) If the
                                     provisioner or an external controller can support
@@ -13594,14 +14268,14 @@ spec:
                                   - name
                                   type: object
                                 dataSourceRef:
-                                  description: 'Specifies the object from which to
-                                    populate the volume with data, if a non-empty
-                                    volume is desired. This may be any local object
-                                    from a non-empty API group (non core object) or
-                                    a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
+                                  description: 'dataSourceRef specifies the object
+                                    from which to populate the volume with data, if
+                                    a non-empty volume is desired. This may be any
+                                    local object from a non-empty API group (non core
+                                    object) or a PersistentVolumeClaim object. When
+                                    this field is specified, volume binding will only
+                                    succeed if the type of the specified object matches
+                                    some installed volume populator or dynamic provisioner.
                                     This field will replace the functionality of the
                                     DataSource field and as such if both fields are
                                     non-empty, they must have the same value. For
@@ -13616,7 +14290,7 @@ spec:
                                     DataSource ignores disallowed values (dropping
                                     them), DataSourceRef   preserves all values, and
                                     generates an error if a disallowed value is   specified.
-                                    (Alpha) Using this field requires the AnyVolumeDataSource
+                                    (Beta) Using this field requires the AnyVolumeDataSource
                                     feature gate to be enabled.'
                                   properties:
                                     apiGroup:
@@ -13639,8 +14313,12 @@ spec:
                                   - name
                                   type: object
                                 resources:
-                                  description: 'Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  description: 'resources represents the minimum resources
+                                    the volume should have. If RecoverVolumeExpansionFailure
+                                    feature is enabled users are allowed to specify
+                                    resource requirements that are lower than previous
+                                    value but must still be higher than capacity recorded
+                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                   properties:
                                     limits:
                                       additionalProperties:
@@ -13668,8 +14346,8 @@ spec:
                                       type: object
                                   type: object
                                 selector:
-                                  description: A label query over volumes to consider
-                                    for binding.
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -13719,8 +14397,9 @@ spec:
                                       type: object
                                   type: object
                                 storageClassName:
-                                  description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  description: 'storageClassName is the name of the
+                                    StorageClass required by the claim. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                   type: string
                                 volumeMode:
                                   description: volumeMode defines what type of volume
@@ -13728,22 +14407,44 @@ spec:
                                     is implied when not included in claim spec.
                                   type: string
                                 volumeName:
-                                  description: VolumeName is the binding reference
+                                  description: volumeName is the binding reference
                                     to the PersistentVolume backing this claim.
                                   type: string
                               type: object
                             status:
-                              description: 'Status represents the current information/status
+                              description: 'status represents the current information/status
                                 of a persistent volume claim. Read-only. More info:
                                 https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 accessModes:
-                                  description: 'AccessModes contains the actual access
+                                  description: 'accessModes contains the actual access
                                     modes the volume backing the PVC has. More info:
                                     https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                   items:
                                     type: string
                                   type: array
+                                allocatedResources:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: allocatedResources is the storage resource
+                                    within AllocatedResources tracks the capacity
+                                    allocated to a PVC. It may be larger than the
+                                    actual capacity when a volume expansion operation
+                                    is requested. For storage quota, the larger value
+                                    from allocatedResources and PVC.spec.resources
+                                    is used. If allocatedResources is not set, PVC.spec.resources
+                                    alone is used for quota calculation. If a volume
+                                    expansion capacity request is lowered, allocatedResources
+                                    is only lowered if there are no expansion operations
+                                    in progress and if the actual volume capacity
+                                    is equal or lower than the requested capacity.
+                                    This is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                                    feature.
+                                  type: object
                                 capacity:
                                   additionalProperties:
                                     anyOf:
@@ -13751,37 +14452,40 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Represents the actual resources of
-                                    the underlying volume.
+                                  description: capacity represents the actual resources
+                                    of the underlying volume.
                                   type: object
                                 conditions:
-                                  description: Current Condition of persistent volume
-                                    claim. If underlying persistent volume is being
-                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  description: conditions is the current Condition
+                                    of persistent volume claim. If underlying persistent
+                                    volume is being resized then the Condition will
+                                    be set to 'ResizeStarted'.
                                   items:
                                     description: PersistentVolumeClaimCondition contails
                                       details about state of pvc
                                     properties:
                                       lastProbeTime:
-                                        description: Last time we probed the condition.
+                                        description: lastProbeTime is the time we
+                                          probed the condition.
                                         format: date-time
                                         type: string
                                       lastTransitionTime:
-                                        description: Last time the condition transitioned
-                                          from one status to another.
+                                        description: lastTransitionTime is the time
+                                          the condition transitioned from one status
+                                          to another.
                                         format: date-time
                                         type: string
                                       message:
-                                        description: Human-readable message indicating
-                                          details about last transition.
+                                        description: message is the human-readable
+                                          message indicating details about last transition.
                                         type: string
                                       reason:
-                                        description: Unique, this should be a short,
-                                          machine understandable string that gives
-                                          the reason for condition's last transition.
-                                          If it reports "ResizeStarted" that means
-                                          the underlying persistent volume is being
-                                          resized.
+                                        description: reason is a unique, this should
+                                          be a short, machine understandable string
+                                          that gives the reason for condition's last
+                                          transition. If it reports "ResizeStarted"
+                                          that means the underlying persistent volume
+                                          is being resized.
                                         type: string
                                       status:
                                         type: string
@@ -13795,8 +14499,16 @@ spec:
                                     type: object
                                   type: array
                                 phase:
-                                  description: Phase represents the current phase
+                                  description: phase represents the current phase
                                     of PersistentVolumeClaim.
+                                  type: string
+                                resizeStatus:
+                                  description: resizeStatus stores status of resize
+                                    operation. ResizeStatus is not set by default
+                                    but when expansion is complete resizeStatus is
+                                    set to empty string by resize controller or kubelet.
+                                    This is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                                    feature.
                                   type: string
                               type: object
                           type: object
@@ -14118,9 +14830,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14177,7 +14887,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -14281,9 +14991,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -14338,7 +15046,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -14442,9 +15150,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -14501,7 +15207,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -14605,9 +15311,7 @@ spec:
                                     field and the ones listed in the namespaces field.
                                     null selector and null or empty namespaces list
                                     means "this pod's namespace". An empty selector
-                                    ({}) matches all namespaces. This field is beta-level
-                                    and is only honored when PodAffinityNamespaceSelector
-                                    feature is enabled.
+                                    ({}) matches all namespaces.
                                   properties:
                                     matchExpressions:
                                       description: matchExpressions is a list of label
@@ -14662,7 +15366,7 @@ spec:
                                     term is applied to the union of the namespaces
                                     listed in this field and the ones selected by
                                     namespaceSelector. null or empty namespaces list
-                                    and null namespaceSelector means "this pod's namespace"
+                                    and null namespaceSelector means "this pod's namespace".
                                   items:
                                     type: string
                                   type: array
@@ -14694,11 +15398,11 @@ spec:
                         run within a pod.
                       properties:
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
                             to a single $, which allows for escaping the $(VAR_NAME)
                             syntax: i.e. "$$(VAR_NAME)" will produce the string literal
                             "$(VAR_NAME)". Escaped references will never be expanded,
@@ -14709,7 +15413,7 @@ spec:
                           type: array
                         command:
                           description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
+                            The container image''s ENTRYPOINT is used if this is not
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
@@ -14885,7 +15589,7 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                             This field is optional to allow higher level config management
                             to default or override container images in workload controllers
                             like Deployments and StatefulSets.'
@@ -14907,8 +15611,7 @@ spec:
                                 blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
+                                  description: Exec specifies the action to take.
                                   properties:
                                     command:
                                       description: Command is the command line to
@@ -14970,9 +15673,11 @@ spec:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
                                   properties:
                                     host:
                                       description: 'Optional: Host name to connect
@@ -14995,19 +15700,17 @@ spec:
                                 container is terminated due to an API request or management
                                 event such as liveness/startup probe failure, preemption,
                                 resource contention, etc. The handler is not called
-                                if the container crashes or exits. The reason for
-                                termination is passed to the handler. The Pod''s termination
-                                grace period countdown begins before the PreStop hooked
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
                                 is executed. Regardless of the outcome of the handler,
                                 the container will eventually terminate within the
-                                Pod''s termination grace period. Other management
-                                of the container blocks until the hook completes or
-                                until the termination grace period is reached. More
-                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
+                                  description: Exec specifies the action to take.
                                   properties:
                                     command:
                                       description: Command is the command line to
@@ -15069,9 +15772,11 @@ spec:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
                                   properties:
                                     host:
                                       description: 'Optional: Host name to connect
@@ -15096,8 +15801,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -15119,6 +15823,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -15182,9 +15905,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -15287,8 +16009,7 @@ spec:
                             probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -15310,6 +16031,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -15373,9 +16113,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -15457,12 +16196,14 @@ spec:
                                 process. This bool directly controls if the no_new_privs
                                 flag will be set on the container process. AllowPrivilegeEscalation
                                 is true always when the container is: 1) run as Privileged
-                                2) has CAP_SYS_ADMIN'
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
                               type: boolean
                             capabilities:
                               description: The capabilities to add/drop when running
                                 containers. Defaults to the default set of capabilities
-                                granted by the container runtime.
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
                               properties:
                                 add:
                                   description: Added capabilities
@@ -15482,25 +16223,29 @@ spec:
                             privileged:
                               description: Run container in privileged mode. Processes
                                 in privileged containers are essentially equivalent
-                                to root on the host. Defaults to false.
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
                               type: boolean
                             procMount:
                               description: procMount denotes the type of proc mount
                                 to use for the containers. The default is DefaultProcMount
                                 which uses the container runtime defaults for readonly
                                 paths and masked paths. This requires the ProcMountType
-                                feature flag to be enabled.
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
                               description: Whether this container has a read-only
-                                root filesystem. Default is false.
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
                               type: boolean
                             runAsGroup:
                               description: The GID to run the entrypoint of the container
                                 process. Uses runtime default if unset. May also be
                                 set in PodSecurityContext.  If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
                               format: int64
                               type: integer
                             runAsNonRoot:
@@ -15519,6 +16264,8 @@ spec:
                                 if unspecified. May also be set in PodSecurityContext.  If
                                 set in both SecurityContext and PodSecurityContext,
                                 the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
                               format: int64
                               type: integer
                             seLinuxOptions:
@@ -15527,7 +16274,9 @@ spec:
                                 allocate a random SELinux context for each container.  May
                                 also be set in PodSecurityContext.  If set in both
                                 SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
                               properties:
                                 level:
                                   description: Level is SELinux level label that applies
@@ -15550,7 +16299,8 @@ spec:
                               description: The seccomp options to use by this container.
                                 If seccomp options are provided at both the pod &
                                 container level, the container options override the
-                                pod options.
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
                               properties:
                                 localhostProfile:
                                   description: localhostProfile indicates a profile
@@ -15576,7 +16326,8 @@ spec:
                                 all containers. If unspecified, the options from the
                                 PodSecurityContext will be used. If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
                               properties:
                                 gmsaCredentialSpec:
                                   description: GMSACredentialSpec is where the GMSA
@@ -15623,8 +16374,7 @@ spec:
                             https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -15646,6 +16396,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -15709,9 +16478,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -15924,23 +16692,23 @@ spec:
                       creating a pod, and it cannot be modified by updating the pod
                       spec. In order to add an ephemeral container to an existing
                       pod, use the pod's ephemeralcontainers subresource. This field
-                      is alpha-level and is only honored by servers that enable the
-                      EphemeralContainers feature.
+                      is beta-level and available on clusters that haven't disabled
+                      the EphemeralContainers feature gate.
                     items:
-                      description: An EphemeralContainer is a container that may be
-                        added temporarily to an existing pod for user-initiated activities
+                      description: "An EphemeralContainer is a temporary container
+                        that you may add to an existing Pod for user-initiated activities
                         such as debugging. Ephemeral containers have no resource or
                         scheduling guarantees, and they will not be restarted when
-                        they exit or when a pod is removed or restarted. If an ephemeral
-                        container causes a pod to exceed its resource allocation,
-                        the pod may be evicted. Ephemeral containers may not be added
-                        by directly updating the pod spec. They must be added via
-                        the pod's ephemeralcontainers subresource, and they will appear
-                        in the pod spec once added. This is an alpha feature enabled
-                        by the EphemeralContainers feature flag.
+                        they exit or when a Pod is removed or restarted. The kubelet
+                        may evict a Pod if an ephemeral container causes the Pod to
+                        exceed its resource allocation. \n To add an ephemeral container,
+                        use the ephemeralcontainers subresource of an existing Pod.
+                        Ephemeral containers may not be removed or restarted. \n This
+                        is a beta feature available on clusters that haven't disabled
+                        the EphemeralContainers feature gate."
                       properties:
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
+                          description: 'Arguments to the entrypoint. The image''s
                             CMD is used if this is not provided. Variable references
                             $(VAR_NAME) are expanded using the container''s environment.
                             If a variable cannot be resolved, the reference in the
@@ -15955,16 +16723,15 @@ spec:
                           type: array
                         command:
                           description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
-                            provided. Variable references $(VAR_NAME) are expanded
-                            using the container''s environment. If a variable cannot
-                            be resolved, the reference in the input string will be
-                            unchanged. Double $$ are reduced to a single $, which
-                            allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                            will produce the string literal "$(VAR_NAME)". Escaped
-                            references will never be expanded, regardless of whether
-                            the variable exists or not. Cannot be updated. More info:
-                            https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            The image''s ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the
+                            container''s environment. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double
+                            $$ are reduced to a single $, which allows for escaping
+                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                            the string literal "$(VAR_NAME)". Escaped references will
+                            never be expanded, regardless of whether the variable
+                            exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                           items:
                             type: string
                           type: array
@@ -16131,7 +16898,7 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                           type: string
                         imagePullPolicy:
                           description: 'Image pull policy. One of Always, Never, IfNotPresent.
@@ -16149,8 +16916,7 @@ spec:
                                 blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
+                                  description: Exec specifies the action to take.
                                   properties:
                                     command:
                                       description: Command is the command line to
@@ -16212,9 +16978,11 @@ spec:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
                                   properties:
                                     host:
                                       description: 'Optional: Host name to connect
@@ -16237,19 +17005,17 @@ spec:
                                 container is terminated due to an API request or management
                                 event such as liveness/startup probe failure, preemption,
                                 resource contention, etc. The handler is not called
-                                if the container crashes or exits. The reason for
-                                termination is passed to the handler. The Pod''s termination
-                                grace period countdown begins before the PreStop hooked
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
                                 is executed. Regardless of the outcome of the handler,
                                 the container will eventually terminate within the
-                                Pod''s termination grace period. Other management
-                                of the container blocks until the hook completes or
-                                until the termination grace period is reached. More
-                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
+                                  description: Exec specifies the action to take.
                                   properties:
                                     command:
                                       description: Command is the command line to
@@ -16311,9 +17077,11 @@ spec:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
                                   properties:
                                     host:
                                       description: 'Optional: Host name to connect
@@ -16336,8 +17104,7 @@ spec:
                           description: Probes are not allowed for ephemeral containers.
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -16359,6 +17126,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -16422,9 +17208,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -16510,12 +17295,15 @@ spec:
                             - containerPort
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
                         readinessProbe:
                           description: Probes are not allowed for ephemeral containers.
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -16537,6 +17325,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -16600,9 +17407,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -16685,12 +17491,14 @@ spec:
                                 process. This bool directly controls if the no_new_privs
                                 flag will be set on the container process. AllowPrivilegeEscalation
                                 is true always when the container is: 1) run as Privileged
-                                2) has CAP_SYS_ADMIN'
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
                               type: boolean
                             capabilities:
                               description: The capabilities to add/drop when running
                                 containers. Defaults to the default set of capabilities
-                                granted by the container runtime.
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
                               properties:
                                 add:
                                   description: Added capabilities
@@ -16710,25 +17518,29 @@ spec:
                             privileged:
                               description: Run container in privileged mode. Processes
                                 in privileged containers are essentially equivalent
-                                to root on the host. Defaults to false.
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
                               type: boolean
                             procMount:
                               description: procMount denotes the type of proc mount
                                 to use for the containers. The default is DefaultProcMount
                                 which uses the container runtime defaults for readonly
                                 paths and masked paths. This requires the ProcMountType
-                                feature flag to be enabled.
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
                               description: Whether this container has a read-only
-                                root filesystem. Default is false.
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
                               type: boolean
                             runAsGroup:
                               description: The GID to run the entrypoint of the container
                                 process. Uses runtime default if unset. May also be
                                 set in PodSecurityContext.  If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
                               format: int64
                               type: integer
                             runAsNonRoot:
@@ -16747,6 +17559,8 @@ spec:
                                 if unspecified. May also be set in PodSecurityContext.  If
                                 set in both SecurityContext and PodSecurityContext,
                                 the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
                               format: int64
                               type: integer
                             seLinuxOptions:
@@ -16755,7 +17569,9 @@ spec:
                                 allocate a random SELinux context for each container.  May
                                 also be set in PodSecurityContext.  If set in both
                                 SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
                               properties:
                                 level:
                                   description: Level is SELinux level label that applies
@@ -16778,7 +17594,8 @@ spec:
                               description: The seccomp options to use by this container.
                                 If seccomp options are provided at both the pod &
                                 container level, the container options override the
-                                pod options.
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
                               properties:
                                 localhostProfile:
                                   description: localhostProfile indicates a profile
@@ -16804,7 +17621,8 @@ spec:
                                 all containers. If unspecified, the options from the
                                 PodSecurityContext will be used. If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
                               properties:
                                 gmsaCredentialSpec:
                                   description: GMSACredentialSpec is where the GMSA
@@ -16843,8 +17661,7 @@ spec:
                           description: Probes are not allowed for ephemeral containers.
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -16866,6 +17683,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -16929,9 +17765,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -16993,12 +17828,14 @@ spec:
                             EOF. Default is false
                           type: boolean
                         targetContainerName:
-                          description: If set, the name of the container from PodSpec
+                          description: "If set, the name of the container from PodSpec
                             that this ephemeral container targets. The ephemeral container
                             will be run in the namespaces (IPC, PID, etc) of this
-                            container. If not set then the ephemeral container is
-                            run in whatever namespaces are shared for the pod. Note
-                            that the container runtime must support this feature.
+                            container. If not set then the ephemeral container uses
+                            the namespaces configured in the Pod spec. \n The container
+                            runtime must implement support for this feature. If the
+                            runtime does not support namespace targeting then the
+                            result of setting this field is undefined."
                           type: string
                         terminationMessagePath:
                           description: 'Optional: Path at which the file to which
@@ -17047,6 +17884,7 @@ spec:
                           type: array
                         volumeMounts:
                           description: Pod volumes to mount into the container's filesystem.
+                            Subpath mounts are not allowed for ephemeral containers.
                             Cannot be updated.
                           items:
                             description: VolumeMount describes a mounting of a Volume
@@ -17136,8 +17974,7 @@ spec:
                       to secrets in the same namespace to use for pulling any of the
                       images used by this PodSpec. If specified, these secrets will
                       be passed to individual puller implementations for them to use.
-                      For example, in the case of docker, only DockerConfig type secrets
-                      are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                      More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                     items:
                       description: LocalObjectReference contains enough information
                         to let you locate the referenced object inside the same namespace.
@@ -17167,11 +18004,11 @@ spec:
                         run within a pod.
                       properties:
                         args:
-                          description: 'Arguments to the entrypoint. The docker image''s
-                            CMD is used if this is not provided. Variable references
-                            $(VAR_NAME) are expanded using the container''s environment.
-                            If a variable cannot be resolved, the reference in the
-                            input string will be unchanged. Double $$ are reduced
+                          description: 'Arguments to the entrypoint. The container
+                            image''s CMD is used if this is not provided. Variable
+                            references $(VAR_NAME) are expanded using the container''s
+                            environment. If a variable cannot be resolved, the reference
+                            in the input string will be unchanged. Double $$ are reduced
                             to a single $, which allows for escaping the $(VAR_NAME)
                             syntax: i.e. "$$(VAR_NAME)" will produce the string literal
                             "$(VAR_NAME)". Escaped references will never be expanded,
@@ -17182,7 +18019,7 @@ spec:
                           type: array
                         command:
                           description: 'Entrypoint array. Not executed within a shell.
-                            The docker image''s ENTRYPOINT is used if this is not
+                            The container image''s ENTRYPOINT is used if this is not
                             provided. Variable references $(VAR_NAME) are expanded
                             using the container''s environment. If a variable cannot
                             be resolved, the reference in the input string will be
@@ -17358,7 +18195,7 @@ spec:
                             type: object
                           type: array
                         image:
-                          description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                             This field is optional to allow higher level config management
                             to default or override container images in workload controllers
                             like Deployments and StatefulSets.'
@@ -17380,8 +18217,7 @@ spec:
                                 blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
+                                  description: Exec specifies the action to take.
                                   properties:
                                     command:
                                       description: Command is the command line to
@@ -17443,9 +18279,11 @@ spec:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
                                   properties:
                                     host:
                                       description: 'Optional: Host name to connect
@@ -17468,19 +18306,17 @@ spec:
                                 container is terminated due to an API request or management
                                 event such as liveness/startup probe failure, preemption,
                                 resource contention, etc. The handler is not called
-                                if the container crashes or exits. The reason for
-                                termination is passed to the handler. The Pod''s termination
-                                grace period countdown begins before the PreStop hooked
+                                if the container crashes or exits. The Pod''s termination
+                                grace period countdown begins before the PreStop hook
                                 is executed. Regardless of the outcome of the handler,
                                 the container will eventually terminate within the
-                                Pod''s termination grace period. Other management
-                                of the container blocks until the hook completes or
-                                until the termination grace period is reached. More
-                                info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                Pod''s termination grace period (unless delayed by
+                                finalizers). Other management of the container blocks
+                                until the hook completes or until the termination
+                                grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                               properties:
                                 exec:
-                                  description: One and only one of the following should
-                                    be specified. Exec specifies the action to take.
+                                  description: Exec specifies the action to take.
                                   properties:
                                     command:
                                       description: Command is the command line to
@@ -17542,9 +18378,11 @@ spec:
                                   - port
                                   type: object
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
+                                  description: Deprecated. TCPSocket is NOT supported
+                                    as a LifecycleHandler and kept for the backward
+                                    compatibility. There are no validation of this
+                                    field and lifecycle hooks will fail in runtime
+                                    when tcp handler is specified.
                                   properties:
                                     host:
                                       description: 'Optional: Host name to connect
@@ -17569,8 +18407,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -17592,6 +18429,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -17655,9 +18511,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -17760,8 +18615,7 @@ spec:
                             probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -17783,6 +18637,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -17846,9 +18719,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -17930,12 +18802,14 @@ spec:
                                 process. This bool directly controls if the no_new_privs
                                 flag will be set on the container process. AllowPrivilegeEscalation
                                 is true always when the container is: 1) run as Privileged
-                                2) has CAP_SYS_ADMIN'
+                                2) has CAP_SYS_ADMIN Note that this field cannot be
+                                set when spec.os.name is windows.'
                               type: boolean
                             capabilities:
                               description: The capabilities to add/drop when running
                                 containers. Defaults to the default set of capabilities
-                                granted by the container runtime.
+                                granted by the container runtime. Note that this field
+                                cannot be set when spec.os.name is windows.
                               properties:
                                 add:
                                   description: Added capabilities
@@ -17955,25 +18829,29 @@ spec:
                             privileged:
                               description: Run container in privileged mode. Processes
                                 in privileged containers are essentially equivalent
-                                to root on the host. Defaults to false.
+                                to root on the host. Defaults to false. Note that
+                                this field cannot be set when spec.os.name is windows.
                               type: boolean
                             procMount:
                               description: procMount denotes the type of proc mount
                                 to use for the containers. The default is DefaultProcMount
                                 which uses the container runtime defaults for readonly
                                 paths and masked paths. This requires the ProcMountType
-                                feature flag to be enabled.
+                                feature flag to be enabled. Note that this field cannot
+                                be set when spec.os.name is windows.
                               type: string
                             readOnlyRootFilesystem:
                               description: Whether this container has a read-only
-                                root filesystem. Default is false.
+                                root filesystem. Default is false. Note that this
+                                field cannot be set when spec.os.name is windows.
                               type: boolean
                             runAsGroup:
                               description: The GID to run the entrypoint of the container
                                 process. Uses runtime default if unset. May also be
                                 set in PodSecurityContext.  If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is windows.
                               format: int64
                               type: integer
                             runAsNonRoot:
@@ -17992,6 +18870,8 @@ spec:
                                 if unspecified. May also be set in PodSecurityContext.  If
                                 set in both SecurityContext and PodSecurityContext,
                                 the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name
+                                is windows.
                               format: int64
                               type: integer
                             seLinuxOptions:
@@ -18000,7 +18880,9 @@ spec:
                                 allocate a random SELinux context for each container.  May
                                 also be set in PodSecurityContext.  If set in both
                                 SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
+                                specified in SecurityContext takes precedence. Note
+                                that this field cannot be set when spec.os.name is
+                                windows.
                               properties:
                                 level:
                                   description: Level is SELinux level label that applies
@@ -18023,7 +18905,8 @@ spec:
                               description: The seccomp options to use by this container.
                                 If seccomp options are provided at both the pod &
                                 container level, the container options override the
-                                pod options.
+                                pod options. Note that this field cannot be set when
+                                spec.os.name is windows.
                               properties:
                                 localhostProfile:
                                   description: localhostProfile indicates a profile
@@ -18049,7 +18932,8 @@ spec:
                                 all containers. If unspecified, the options from the
                                 PodSecurityContext will be used. If set in both SecurityContext
                                 and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
+                                takes precedence. Note that this field cannot be set
+                                when spec.os.name is linux.
                               properties:
                                 gmsaCredentialSpec:
                                   description: GMSACredentialSpec is where the GMSA
@@ -18096,8 +18980,7 @@ spec:
                             https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                           properties:
                             exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
+                              description: Exec specifies the action to take.
                               properties:
                                 command:
                                   description: Command is the command line to execute
@@ -18119,6 +19002,25 @@ spec:
                                 to 3. Minimum value is 1.
                               format: int32
                               type: integer
+                            grpc:
+                              description: GRPC specifies an action involving a GRPC
+                                port. This is a beta field and requires enabling GRPCContainerProbe
+                                feature gate.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number
+                                    must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: "Service is the name of the service
+                                    to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                    \n If this is not specified, the default behavior
+                                    is defined by gRPC."
+                                  type: string
+                              required:
+                              - port
+                              type: object
                             httpGet:
                               description: HTTPGet specifies the http request to perform.
                               properties:
@@ -18182,9 +19084,8 @@ spec:
                               format: int32
                               type: integer
                             tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
+                              description: TCPSocket specifies an action involving
+                                a TCP port.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to,
@@ -18355,6 +19256,34 @@ spec:
                       https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                     type: object
                     x-kubernetes-map-type: atomic
+                  os:
+                    description: "Specifies the OS of the containers in the pod. Some
+                      pod and container fields are restricted if this is set. \n If
+                      the OS field is set to linux, the following fields must be unset:
+                      -securityContext.windowsOptions \n If the OS field is set to
+                      windows, following fields must be unset: - spec.hostPID - spec.hostIPC
+                      - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile
+                      - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy
+                      - spec.securityContext.sysctls - spec.shareProcessNamespace
+                      - spec.securityContext.runAsUser - spec.securityContext.runAsGroup
+                      - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions
+                      - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities
+                      - spec.containers[*].securityContext.readOnlyRootFilesystem
+                      - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
+                      - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
+                      - spec.containers[*].securityContext.runAsGroup This is a beta
+                      field and requires the IdentifyPodOS feature"
+                    properties:
+                      name:
+                        description: 'Name is the name of the operating system. The
+                          currently supported values are linux and windows. Additional
+                          value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                          Clients should expect to handle additional values and treat
+                          unrecognized values in this field as os: null'
+                        type: string
+                    required:
+                    - name
+                    type: object
                   overhead:
                     additionalProperties:
                       anyOf:
@@ -18371,15 +19300,12 @@ spec:
                       the overhead already set. If RuntimeClass is configured and
                       selected in the PodSpec, Overhead will be set to the value defined
                       in the corresponding RuntimeClass, otherwise it will remain
-                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
-                      This field is beta-level as of Kubernetes v1.18, and is only
-                      honored by servers that enable the PodOverhead feature.'
+                      unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                     type: object
                   preemptionPolicy:
                     description: PreemptionPolicy is the Policy for preempting pods
                       with lower priority. One of Never, PreemptLowerPriority. Defaults
-                      to PreemptLowerPriority if unset. This field is beta-level,
-                      gated by the NonPreemptingPriority feature-gate.
+                      to PreemptLowerPriority if unset.
                     type: string
                   priority:
                     description: The priority value. Various system components use
@@ -18425,8 +19351,7 @@ spec:
                       no RuntimeClass resource matches the named class, the pod will
                       not be run. If unset or empty, the "legacy" RuntimeClass will
                       be used, which is an implicit class with an empty definition
-                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
-                      This is a beta feature as of Kubernetes v1.14.'
+                      that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                     type: string
                   schedulerName:
                     description: If specified, the pod will be dispatched by specified
@@ -18446,7 +19371,8 @@ spec:
                           bit is set (new files created in the volume will be owned
                           by FSGroup) 3. The permission bits are OR'd with rw-rw----
                           \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
+                          permissions of any volume. Note that this field cannot be
+                          set when spec.os.name is windows."
                         format: int64
                         type: integer
                       fsGroupChangePolicy:
@@ -18456,14 +19382,16 @@ spec:
                           support fsGroup based ownership(and permissions). It will
                           have no effect on ephemeral volume types such as: secret,
                           configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified, "Always" is used.'
+                          and "Always". If not specified, "Always" is used. Note that
+                          this field cannot be set when spec.os.name is windows.'
                         type: string
                       runAsGroup:
                         description: The GID to run the entrypoint of the container
                           process. Uses runtime default if unset. May also be set
                           in SecurityContext.  If set in both SecurityContext and
                           PodSecurityContext, the value specified in SecurityContext
-                          takes precedence for that container.
+                          takes precedence for that container. Note that this field
+                          cannot be set when spec.os.name is windows.
                         format: int64
                         type: integer
                       runAsNonRoot:
@@ -18481,6 +19409,8 @@ spec:
                           unspecified. May also be set in SecurityContext.  If set
                           in both SecurityContext and PodSecurityContext, the value
                           specified in SecurityContext takes precedence for that container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
                         format: int64
                         type: integer
                       seLinuxOptions:
@@ -18489,7 +19419,8 @@ spec:
                           SELinux context for each container.  May also be set in
                           SecurityContext.  If set in both SecurityContext and PodSecurityContext,
                           the value specified in SecurityContext takes precedence
-                          for that container.
+                          for that container. Note that this field cannot be set when
+                          spec.os.name is windows.
                         properties:
                           level:
                             description: Level is SELinux level label that applies
@@ -18510,7 +19441,8 @@ spec:
                         type: object
                       seccompProfile:
                         description: The seccomp options to use by the containers
-                          in this pod.
+                          in this pod. Note that this field cannot be set when spec.os.name
+                          is windows.
                         properties:
                           localhostProfile:
                             description: localhostProfile indicates a profile defined
@@ -18533,6 +19465,8 @@ spec:
                         description: A list of groups applied to the first process
                           run in each container, in addition to the container's primary
                           GID.  If unspecified, no groups will be added to any container.
+                          Note that this field cannot be set when spec.os.name is
+                          windows.
                         items:
                           format: int64
                           type: integer
@@ -18540,7 +19474,8 @@ spec:
                       sysctls:
                         description: Sysctls hold a list of namespaced sysctls used
                           for the pod. Pods with unsupported sysctls (by the container
-                          runtime) might fail to launch.
+                          runtime) might fail to launch. Note that this field cannot
+                          be set when spec.os.name is windows.
                         items:
                           description: Sysctl defines a kernel parameter to be set
                           properties:
@@ -18560,7 +19495,8 @@ spec:
                           containers. If unspecified, the options within a container's
                           SecurityContext will be used. If set in both SecurityContext
                           and PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
+                          takes precedence. Note that this field cannot be set when
+                          spec.os.name is linux.
                         properties:
                           gmsaCredentialSpec:
                             description: GMSACredentialSpec is where the GMSA admission
@@ -18740,12 +19676,15 @@ spec:
                             may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                             it is the maximum permitted difference between the number
                             of matching pods in the target topology and the global
-                            minimum. For example, in a 3-zone cluster, MaxSkew is
-                            set to 1, and pods with the same labelSelector spread
-                            as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                            - if MaxSkew is 1, incoming pod can only be scheduled
-                            to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                            would make the ActualSkew(2-0) on zone1(zone2) violate
+                            minimum. The global minimum is the minimum number of matching
+                            pods in an eligible domain or zero if the number of eligible
+                            domains is less than MinDomains. For example, in a 3-zone
+                            cluster, MaxSkew is set to 1, and pods with the same labelSelector
+                            spread as 2/2/1: In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | -
+                            if MaxSkew is 1, incoming pod can only be scheduled to
+                            zone3 to become 2/2/2; scheduling it onto zone1(zone2)
+                            would make the ActualSkew(3-1) on zone1(zone2) violate
                             MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled
                             onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                             it is used to give higher precedence to topologies that
@@ -18753,12 +19692,44 @@ spec:
                             and 0 is not allowed.'
                           format: int32
                           type: integer
+                        minDomains:
+                          description: "MinDomains indicates a minimum number of eligible
+                            domains. When the number of eligible domains with matching
+                            topology keys is less than minDomains, Pod Topology Spread
+                            treats \"global minimum\" as 0, and then the calculation
+                            of Skew is performed. And when the number of eligible
+                            domains with matching topology keys equals or greater
+                            than minDomains, this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less
+                            than minDomains, scheduler won't schedule more than maxSkew
+                            Pods to those domains. If value is nil, the constraint
+                            behaves as if MinDomains is equal to 1. Valid values are
+                            integers greater than 0. When value is not nil, WhenUnsatisfiable
+                            must be DoNotSchedule. \n For example, in a 3-zone cluster,
+                            MaxSkew is set to 2, MinDomains is set to 5 and pods with
+                            the same labelSelector spread as 2/2/2: | zone1 | zone2
+                            | zone3 | |  P P  |  P P  |  P P  | The number of domains
+                            is less than 5(MinDomains), so \"global minimum\" is treated
+                            as 0. In this situation, new pod with the same labelSelector
+                            cannot be scheduled, because computed skew will be 3(3
+                            - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew. \n This is an alpha field and
+                            requires enabling MinDomainsInPodTopologySpread feature
+                            gate."
+                          format: int32
+                          type: integer
                         topologyKey:
                           description: TopologyKey is the key of node labels. Nodes
                             that have a label with this key and identical values are
                             considered to be in the same topology. We consider each
                             <key, value> as a "bucket", and try to put balanced number
-                            of pods into each bucket. It's a required field.
+                            of pods into each bucket. We define a domain as a particular
+                            instance of a topology. Also, we define an eligible domain
+                            as a domain whose nodes match the node selector. e.g.
+                            If TopologyKey is "kubernetes.io/hostname", each Node
+                            is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                            each zone is a domain of that topology. It's a required
+                            field.
                           type: string
                         whenUnsatisfiable:
                           description: 'WhenUnsatisfiable indicates how to deal with
@@ -18768,7 +19739,7 @@ spec:
                             pod in any location,   but giving higher precedence to
                             topologies that would help reduce the   skew. A constraint
                             is considered "Unsatisfiable" for an incoming pod if and
-                            only if every possible node assigment for that pod would
+                            only if every possible node assignment for that pod would
                             violate "MaxSkew" on some topology. For example, in a
                             3-zone cluster, MaxSkew is set to 1, and pods with the
                             same labelSelector spread as 3/1/1: | zone1 | zone2 |
@@ -18797,122 +19768,124 @@ spec:
                         may be accessed by any container in the pod.
                       properties:
                         awsElasticBlockStore:
-                          description: 'AWSElasticBlockStore represents an AWS Disk
+                          description: 'awsElasticBlockStore represents an AWS Disk
                             resource that is attached to a kubelet''s host machine
                             and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty).'
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty).'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Specify "true" to force and set the ReadOnly
-                                property in VolumeMounts to "true". If omitted, the
-                                default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'readOnly value true will force the readOnly
+                                setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: boolean
                             volumeID:
-                              description: 'Unique ID of the persistent disk resource
-                                in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'volumeID is unique ID of the persistent
+                                disk resource in AWS (Amazon EBS volume). More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               type: string
                           required:
                           - volumeID
                           type: object
                         azureDisk:
-                          description: AzureDisk represents an Azure Data Disk mount
+                          description: azureDisk represents an Azure Data Disk mount
                             on the host and bind mount to the pod.
                           properties:
                             cachingMode:
-                              description: 'Host Caching mode: None, Read Only, Read
-                                Write.'
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
                               type: string
                             diskName:
-                              description: The Name of the data disk in the blob storage
+                              description: diskName is the Name of the data disk in
+                                the blob storage
                               type: string
                             diskURI:
-                              description: The URI the data disk in the blob storage
+                              description: diskURI is the URI of data disk in the
+                                blob storage
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is Filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             kind:
-                              description: 'Expected values Shared: multiple blob
-                                disks per storage account  Dedicated: single blob
-                                disk per storage account  Managed: azure managed data
-                                disk (only in managed availability set). defaults
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
                                 to shared'
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                           required:
                           - diskName
                           - diskURI
                           type: object
                         azureFile:
-                          description: AzureFile represents an Azure File Service
+                          description: azureFile represents an Azure File Service
                             mount on the host and bind mount to the pod.
                           properties:
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretName:
-                              description: the name of secret that contains Azure
-                                Storage Account Name and Key
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
                               type: string
                             shareName:
-                              description: Share Name
+                              description: shareName is the azure share Name
                               type: string
                           required:
                           - secretName
                           - shareName
                           type: object
                         cephfs:
-                          description: CephFS represents a Ceph FS mount on the host
+                          description: cephFS represents a Ceph FS mount on the host
                             that shares a pod's lifetime
                           properties:
                             monitors:
-                              description: 'Required: Monitors is a collection of
-                                Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'monitors is Required: Monitors is a collection
+                                of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             path:
-                              description: 'Optional: Used as the mounted root, rather
-                                than the full Ceph tree, default is /'
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: boolean
                             secretFile:
-                              description: 'Optional: SecretFile is the path to key
-                                ring for User, default is /etc/ceph/user.secret More
-                                info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'secretFile is Optional: SecretFile is
+                                the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                authentication secret for User, default is empty.
-                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'secretRef is Optional: SecretRef is reference
+                                to the authentication secret for User, default is
+                                empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -18921,30 +19894,30 @@ spec:
                                   type: string
                               type: object
                             user:
-                              description: 'Optional: User is the rados user name,
-                                default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              description: 'user is optional: User is the rados user
+                                name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                               type: string
                           required:
                           - monitors
                           type: object
                         cinder:
-                          description: 'Cinder represents a cinder volume attached
+                          description: 'cinder represents a cinder volume attached
                             and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Examples:
-                                "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
+                              description: 'readOnly defaults to false (read/write).
                                 ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                 More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: boolean
                             secretRef:
-                              description: 'Optional: points to a secret object containing
-                                parameters used to connect to OpenStack.'
+                              description: 'secretRef is optional: points to a secret
+                                object containing parameters used to connect to OpenStack.'
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -18953,37 +19926,38 @@ spec:
                                   type: string
                               type: object
                             volumeID:
-                              description: 'volume id used to identify the volume
-                                in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'volumeID used to identify the volume in
+                                cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               type: string
                           required:
                           - volumeID
                           type: object
                         configMap:
-                          description: ConfigMap represents a configMap that should
+                          description: configMap represents a configMap that should
                             populate this volume
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
+                              description: 'defaultMode is optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced ConfigMap will be
-                                projected into the volume as a file whose name is
-                                the key and content is the value. If specified, the
-                                listed keys will be projected into the specified paths,
-                                and unlisted keys will not be present. If a key is
-                                specified which is not present in the ConfigMap, the
-                                volume setup will error unless it is marked optional.
+                              description: items if unspecified, each key-value pair
+                                in the Data field of the referenced ConfigMap will
+                                be projected into the volume as a file whose name
+                                is the key and content is the value. If specified,
+                                the listed keys will be projected into the specified
+                                paths, and unlisted keys will not be present. If a
+                                key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional.
                                 Paths must be relative and may not contain the '..'
                                 path or start with '..'.
                               items:
@@ -18991,26 +19965,26 @@ spec:
                                   volume.
                                 properties:
                                   key:
-                                    description: The key to project.
+                                    description: key is the key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -19022,28 +19996,28 @@ spec:
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                             optional:
-                              description: Specify whether the ConfigMap or its keys
-                                must be defined
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
                               type: boolean
                           type: object
                         csi:
-                          description: CSI (Container Storage Interface) represents
+                          description: csi (Container Storage Interface) represents
                             ephemeral storage that is handled by certain external
                             CSI drivers (Beta feature).
                           properties:
                             driver:
-                              description: Driver is the name of the CSI driver that
+                              description: driver is the name of the CSI driver that
                                 handles this volume. Consult with your admin for the
                                 correct name as registered in the cluster.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Ex. "ext4", "xfs",
-                                "ntfs". If not provided, the empty value is passed
-                                to the associated CSI driver which will determine
-                                the default filesystem to apply.
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the
+                                associated CSI driver which will determine the default
+                                filesystem to apply.
                               type: string
                             nodePublishSecretRef:
-                              description: NodePublishSecretRef is a reference to
+                              description: nodePublishSecretRef is a reference to
                                 the secret object containing sensitive information
                                 to pass to the CSI driver to complete the CSI NodePublishVolume
                                 and NodeUnpublishVolume calls. This field is optional,
@@ -19058,13 +20032,13 @@ spec:
                                   type: string
                               type: object
                             readOnly:
-                              description: Specifies a read-only configuration for
-                                the volume. Defaults to false (read/write).
+                              description: readOnly specifies a read-only configuration
+                                for the volume. Defaults to false (read/write).
                               type: boolean
                             volumeAttributes:
                               additionalProperties:
                                 type: string
-                              description: VolumeAttributes stores driver-specific
+                              description: volumeAttributes stores driver-specific
                                 properties that are passed to the CSI driver. Consult
                                 your driver's documentation for supported values.
                               type: object
@@ -19072,7 +20046,7 @@ spec:
                           - driver
                           type: object
                         downwardAPI:
-                          description: DownwardAPI represents downward API about the
+                          description: downwardAPI represents downward API about the
                             pod that should populate this volume
                           properties:
                             defaultMode:
@@ -19162,31 +20136,33 @@ spec:
                               type: array
                           type: object
                         emptyDir:
-                          description: 'EmptyDir represents a temporary directory
+                          description: 'emptyDir represents a temporary directory
                             that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                           properties:
                             medium:
-                              description: 'What type of storage medium should back
-                                this directory. The default is "" which means to use
-                                the node''s default medium. Must be an empty string
-                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'medium represents what type of storage
+                                medium should back this directory. The default is
+                                "" which means to use the node''s default medium.
+                                Must be an empty string (default) or Memory. More
+                                info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               type: string
                             sizeLimit:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Total amount of local storage required
-                                for this EmptyDir volume. The size limit is also applicable
-                                for memory medium. The maximum usage on memory medium
-                                EmptyDir would be the minimum value between the SizeLimit
-                                specified here and the sum of memory limits of all
-                                containers in a pod. The default is nil which means
-                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              description: 'sizeLimit is the total amount of local
+                                storage required for this EmptyDir volume. The size
+                                limit is also applicable for memory medium. The maximum
+                                usage on memory medium EmptyDir would be the minimum
+                                value between the SizeLimit specified here and the
+                                sum of memory limits of all containers in a pod. The
+                                default is nil which means that the limit is undefined.
+                                More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                           type: object
                         ephemeral:
-                          description: "Ephemeral represents a volume that is handled
+                          description: "ephemeral represents a volume that is handled
                             by a cluster storage driver. The volume's lifecycle is
                             tied to the pod that defines it - it will be created before
                             the pod starts, and deleted when the pod is removed. \n
@@ -19204,8 +20180,7 @@ spec:
                             CSI driver is meant to be used that way - see the documentation
                             of the driver for more information. \n A pod can use both
                             types of ephemeral volumes and persistent volumes at the
-                            same time. \n This is a beta feature and only available
-                            when the GenericEphemeralVolume feature gate is enabled."
+                            same time."
                           properties:
                             volumeClaimTemplate:
                               description: "Will be used to create a stand-alone PVC
@@ -19243,18 +20218,18 @@ spec:
                                     also valid here.
                                   properties:
                                     accessModes:
-                                      description: 'AccessModes contains the desired
+                                      description: 'accessModes contains the desired
                                         access modes the volume should have. More
                                         info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                       items:
                                         type: string
                                       type: array
                                     dataSource:
-                                      description: 'This field can be used to specify
-                                        either: * An existing VolumeSnapshot object
-                                        (snapshot.storage.k8s.io/VolumeSnapshot) *
-                                        An existing PVC (PersistentVolumeClaim) If
-                                        the provisioner or an external controller
+                                      description: 'dataSource field can be used to
+                                        specify either: * An existing VolumeSnapshot
+                                        object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller
                                         can support the specified data source, it
                                         will create a new volume based on the contents
                                         of the specified data source. If the AnyVolumeDataSource
@@ -19282,17 +20257,17 @@ spec:
                                       - name
                                       type: object
                                     dataSourceRef:
-                                      description: 'Specifies the object from which
-                                        to populate the volume with data, if a non-empty
-                                        volume is desired. This may be any local object
-                                        from a non-empty API group (non core object)
-                                        or a PersistentVolumeClaim object. When this
-                                        field is specified, volume binding will only
-                                        succeed if the type of the specified object
-                                        matches some installed volume populator or
-                                        dynamic provisioner. This field will replace
-                                        the functionality of the DataSource field
-                                        and as such if both fields are non-empty,
+                                      description: 'dataSourceRef specifies the object
+                                        from which to populate the volume with data,
+                                        if a non-empty volume is desired. This may
+                                        be any local object from a non-empty API group
+                                        (non core object) or a PersistentVolumeClaim
+                                        object. When this field is specified, volume
+                                        binding will only succeed if the type of the
+                                        specified object matches some installed volume
+                                        populator or dynamic provisioner. This field
+                                        will replace the functionality of the DataSource
+                                        field and as such if both fields are non-empty,
                                         they must have the same value. For backwards
                                         compatibility, both fields (DataSource and
                                         DataSourceRef) will be set to the same value
@@ -19305,7 +20280,7 @@ spec:
                                         objects. * While DataSource ignores disallowed
                                         values (dropping them), DataSourceRef   preserves
                                         all values, and generates an error if a disallowed
-                                        value is   specified. (Alpha) Using this field
+                                        value is   specified. (Beta) Using this field
                                         requires the AnyVolumeDataSource feature gate
                                         to be enabled.'
                                       properties:
@@ -19329,9 +20304,13 @@ spec:
                                       - name
                                       type: object
                                     resources:
-                                      description: 'Resources represents the minimum
-                                        resources the volume should have. More info:
-                                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      description: 'resources represents the minimum
+                                        resources the volume should have. If RecoverVolumeExpansionFailure
+                                        feature is enabled users are allowed to specify
+                                        resource requirements that are lower than
+                                        previous value but must still be higher than
+                                        capacity recorded in the status field of the
+                                        claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                       properties:
                                         limits:
                                           additionalProperties:
@@ -19360,8 +20339,8 @@ spec:
                                           type: object
                                       type: object
                                     selector:
-                                      description: A label query over volumes to consider
-                                        for binding.
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -19412,8 +20391,9 @@ spec:
                                           type: object
                                       type: object
                                     storageClassName:
-                                      description: 'Name of the StorageClass required
-                                        by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      description: 'storageClassName is the name of
+                                        the StorageClass required by the claim. More
+                                        info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                       type: string
                                     volumeMode:
                                       description: volumeMode defines what type of
@@ -19422,7 +20402,7 @@ spec:
                                         claim spec.
                                       type: string
                                     volumeName:
-                                      description: VolumeName is the binding reference
+                                      description: volumeName is the binding reference
                                         to the PersistentVolume backing this claim.
                                       type: string
                                   type: object
@@ -19431,32 +20411,34 @@ spec:
                               type: object
                           type: object
                         fc:
-                          description: FC represents a Fibre Channel resource that
+                          description: fc represents a Fibre Channel resource that
                             is attached to a kubelet's host machine and then exposed
                             to the pod.
                           properties:
                             fsType:
-                              description: 'Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified. TODO: how do we prevent errors in the
-                                filesystem from compromising the machine'
+                              description: 'fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified. TODO: how do we prevent
+                                errors in the filesystem from compromising the machine'
                               type: string
                             lun:
-                              description: 'Optional: FC target lun number'
+                              description: 'lun is Optional: FC target lun number'
                               format: int32
                               type: integer
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              description: 'readOnly is Optional: Defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
                               type: boolean
                             targetWWNs:
-                              description: 'Optional: FC target worldwide names (WWNs)'
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
                               items:
                                 type: string
                               type: array
                             wwids:
-                              description: 'Optional: FC volume world wide identifiers
+                              description: 'wwids Optional: FC volume world wide identifiers
                                 (wwids) Either wwids or combination of targetWWNs
                                 and lun must be set, but not both simultaneously.'
                               items:
@@ -19464,35 +20446,37 @@ spec:
                               type: array
                           type: object
                         flexVolume:
-                          description: FlexVolume represents a generic volume resource
+                          description: flexVolume represents a generic volume resource
                             that is provisioned/attached using an exec based plugin.
                           properties:
                             driver:
-                              description: Driver is the name of the driver to use
+                              description: driver is the name of the driver to use
                                 for this volume.
                               type: string
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". The default filesystem depends on FlexVolume
-                                script.
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". The default filesystem
+                                depends on FlexVolume script.
                               type: string
                             options:
                               additionalProperties:
                                 type: string
-                              description: 'Optional: Extra command options if any.'
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
                               type: object
                             readOnly:
-                              description: 'Optional: Defaults to false (read/write).
-                                ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              description: 'readOnly is Optional: defaults to false
+                                (read/write). ReadOnly here will force the ReadOnly
+                                setting in VolumeMounts.'
                               type: boolean
                             secretRef:
-                              description: 'Optional: SecretRef is reference to the
-                                secret object containing sensitive information to
-                                pass to the plugin scripts. This may be empty if no
-                                secret object is specified. If the secret object contains
-                                more than one secret, all secrets are passed to the
-                                plugin scripts.'
+                              description: 'secretRef is Optional: secretRef is reference
+                                to the secret object containing sensitive information
+                                to pass to the plugin scripts. This may be empty if
+                                no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed
+                                to the plugin scripts.'
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -19504,49 +20488,50 @@ spec:
                           - driver
                           type: object
                         flocker:
-                          description: Flocker represents a Flocker volume attached
+                          description: flocker represents a Flocker volume attached
                             to a kubelet's host machine. This depends on the Flocker
                             control service being running
                           properties:
                             datasetName:
-                              description: Name of the dataset stored as metadata
-                                -> name on the dataset for Flocker should be considered
-                                as deprecated
+                              description: datasetName is Name of the dataset stored
+                                as metadata -> name on the dataset for Flocker should
+                                be considered as deprecated
                               type: string
                             datasetUUID:
-                              description: UUID of the dataset. This is unique identifier
-                                of a Flocker dataset
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
                               type: string
                           type: object
                         gcePersistentDisk:
-                          description: 'GCEPersistentDisk represents a GCE Disk resource
+                          description: 'gcePersistentDisk represents a GCE Disk resource
                             that is attached to a kubelet''s host machine and then
                             exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             partition:
-                              description: 'The partition in the volume that you want
-                                to mount. If omitted, the default is to mount by volume
-                                name. Examples: For volume /dev/sda1, you specify
-                                the partition as "1". Similarly, the volume partition
-                                for /dev/sda is "0" (or you can leave the property
-                                empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'partition is the partition in the volume
+                                that you want to mount. If omitted, the default is
+                                to mount by volume name. Examples: For volume /dev/sda1,
+                                you specify the partition as "1". Similarly, the volume
+                                partition for /dev/sda is "0" (or you can leave the
+                                property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               format: int32
                               type: integer
                             pdName:
-                              description: 'Unique name of the PD resource in GCE.
-                                Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'pdName is unique name of the PD resource
+                                in GCE. Used to identify the disk in GCE. More info:
+                                https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
+                              description: 'readOnly here will force the ReadOnly
                                 setting in VolumeMounts. Defaults to false. More info:
                                 https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               type: boolean
@@ -19554,42 +20539,43 @@ spec:
                           - pdName
                           type: object
                         gitRepo:
-                          description: 'GitRepo represents a git repository at a particular
+                          description: 'gitRepo represents a git repository at a particular
                             revision. DEPRECATED: GitRepo is deprecated. To provision
                             a container with a git repo, mount an EmptyDir into an
                             InitContainer that clones the repo using git, then mount
                             the EmptyDir into the Pod''s container.'
                           properties:
                             directory:
-                              description: Target directory name. Must not contain
-                                or start with '..'.  If '.' is supplied, the volume
-                                directory will be the git repository.  Otherwise,
+                              description: directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied,
+                                the volume directory will be the git repository.  Otherwise,
                                 if specified, the volume will contain the git repository
                                 in the subdirectory with the given name.
                               type: string
                             repository:
-                              description: Repository URL
+                              description: repository is the URL
                               type: string
                             revision:
-                              description: Commit hash for the specified revision.
+                              description: revision is the commit hash for the specified
+                                revision.
                               type: string
                           required:
                           - repository
                           type: object
                         glusterfs:
-                          description: 'Glusterfs represents a Glusterfs mount on
+                          description: 'glusterfs represents a Glusterfs mount on
                             the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                           properties:
                             endpoints:
-                              description: 'EndpointsName is the endpoint name that
-                                details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              description: 'endpoints is the endpoint name that details
+                                Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             path:
-                              description: 'Path is the Glusterfs volume path. More
+                              description: 'path is the Glusterfs volume path. More
                                 info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the Glusterfs
+                              description: 'readOnly here will force the Glusterfs
                                 volume to be mounted with read-only permissions. Defaults
                                 to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                               type: boolean
@@ -19598,7 +20584,7 @@ spec:
                           - path
                           type: object
                         hostPath:
-                          description: 'HostPath represents a pre-existing file or
+                          description: 'hostPath represents a pre-existing file or
                             directory on the host machine that is directly exposed
                             to the container. This is generally used for system agents
                             or other privileged things that are allowed to see the
@@ -19609,68 +20595,71 @@ spec:
                             as read/write.'
                           properties:
                             path:
-                              description: 'Path of the directory on the host. If
+                              description: 'path of the directory on the host. If
                                 the path is a symlink, it will follow the link to
                                 the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                             type:
-                              description: 'Type for HostPath Volume Defaults to ""
+                              description: 'type for HostPath Volume Defaults to ""
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                               type: string
                           required:
                           - path
                           type: object
                         iscsi:
-                          description: 'ISCSI represents an ISCSI Disk resource that
+                          description: 'iscsi represents an ISCSI Disk resource that
                             is attached to a kubelet''s host machine and then exposed
                             to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                           properties:
                             chapAuthDiscovery:
-                              description: whether support iSCSI Discovery CHAP authentication
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
                               type: boolean
                             chapAuthSession:
-                              description: whether support iSCSI Session CHAP authentication
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
                               type: boolean
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             initiatorName:
-                              description: Custom iSCSI Initiator Name. If initiatorName
-                                is specified with iscsiInterface simultaneously, new
-                                iSCSI interface <target portal>:<volume name> will
-                                be created for the connection.
+                              description: initiatorName is the custom iSCSI Initiator
+                                Name. If initiatorName is specified with iscsiInterface
+                                simultaneously, new iSCSI interface <target portal>:<volume
+                                name> will be created for the connection.
                               type: string
                             iqn:
-                              description: Target iSCSI Qualified Name.
+                              description: iqn is the target iSCSI Qualified Name.
                               type: string
                             iscsiInterface:
-                              description: iSCSI Interface Name that uses an iSCSI
-                                transport. Defaults to 'default' (tcp).
+                              description: iscsiInterface is the interface Name that
+                                uses an iSCSI transport. Defaults to 'default' (tcp).
                               type: string
                             lun:
-                              description: iSCSI Target Lun number.
+                              description: lun represents iSCSI Target Lun number.
                               format: int32
                               type: integer
                             portals:
-                              description: iSCSI Target Portal List. The portal is
-                                either an IP or ip_addr:port if the port is other
-                                than default (typically TCP ports 860 and 3260).
+                              description: portals is the iSCSI Target Portal List.
+                                The portal is either an IP or ip_addr:port if the
+                                port is other than default (typically TCP ports 860
+                                and 3260).
                               items:
                                 type: string
                               type: array
                             readOnly:
-                              description: ReadOnly here will force the ReadOnly setting
+                              description: readOnly here will force the ReadOnly setting
                                 in VolumeMounts. Defaults to false.
                               type: boolean
                             secretRef:
-                              description: CHAP Secret for iSCSI target and initiator
-                                authentication
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
                               properties:
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -19679,9 +20668,10 @@ spec:
                                   type: string
                               type: object
                             targetPortal:
-                              description: iSCSI Target Portal. The Portal is either
-                                an IP or ip_addr:port if the port is other than default
-                                (typically TCP ports 860 and 3260).
+                              description: targetPortal is iSCSI Target Portal. The
+                                Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and
+                                3260).
                               type: string
                           required:
                           - iqn
@@ -19689,24 +20679,24 @@ spec:
                           - targetPortal
                           type: object
                         name:
-                          description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          description: 'name of the volume. Must be a DNS_LABEL and
+                            unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         nfs:
-                          description: 'NFS represents an NFS mount on the host that
+                          description: 'nfs represents an NFS mount on the host that
                             shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                           properties:
                             path:
-                              description: 'Path that is exported by the NFS server.
+                              description: 'path that is exported by the NFS server.
                                 More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the NFS export
+                              description: 'readOnly here will force the NFS export
                                 to be mounted with read-only permissions. Defaults
                                 to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: boolean
                             server:
-                              description: 'Server is the hostname or IP address of
+                              description: 'server is the hostname or IP address of
                                 the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               type: string
                           required:
@@ -19714,89 +20704,89 @@ spec:
                           - server
                           type: object
                         persistentVolumeClaim:
-                          description: 'PersistentVolumeClaimVolumeSource represents
+                          description: 'persistentVolumeClaimVolumeSource represents
                             a reference to a PersistentVolumeClaim in the same namespace.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                           properties:
                             claimName:
-                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                              description: 'claimName is the name of a PersistentVolumeClaim
                                 in the same namespace as the pod using this volume.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               type: string
                             readOnly:
-                              description: Will force the ReadOnly setting in VolumeMounts.
-                                Default false.
+                              description: readOnly Will force the ReadOnly setting
+                                in VolumeMounts. Default false.
                               type: boolean
                           required:
                           - claimName
                           type: object
                         photonPersistentDisk:
-                          description: PhotonPersistentDisk represents a PhotonController
+                          description: photonPersistentDisk represents a PhotonController
                             persistent disk attached and mounted on kubelets host
                             machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             pdID:
-                              description: ID that identifies Photon Controller persistent
-                                disk
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
                               type: string
                           required:
                           - pdID
                           type: object
                         portworxVolume:
-                          description: PortworxVolume represents a portworx volume
+                          description: portworxVolume represents a portworx volume
                             attached and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: FSType represents the filesystem type to
+                              description: fSType represents the filesystem type to
                                 mount Must be a filesystem type supported by the host
                                 operating system. Ex. "ext4", "xfs". Implicitly inferred
                                 to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             volumeID:
-                              description: VolumeID uniquely identifies a Portworx
+                              description: volumeID uniquely identifies a Portworx
                                 volume
                               type: string
                           required:
                           - volumeID
                           type: object
                         projected:
-                          description: Items for all in one resources secrets, configmaps,
-                            and downward API
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
                           properties:
                             defaultMode:
-                              description: Mode bits used to set permissions on created
-                                files by default. Must be an octal value between 0000
-                                and 0777 or a decimal value between 0 and 511. YAML
-                                accepts both octal and decimal values, JSON requires
-                                decimal values for mode bits. Directories within the
-                                path are not affected by this setting. This might
-                                be in conflict with other options that affect the
-                                file mode, like fsGroup, and the result can be other
-                                mode bits set.
+                              description: defaultMode are the mode bits used to set
+                                permissions on created files by default. Must be an
+                                octal value between 0000 and 0777 or a decimal value
+                                between 0 and 511. YAML accepts both octal and decimal
+                                values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.
                               format: int32
                               type: integer
                             sources:
-                              description: list of volume projections
+                              description: sources is the list of volume projections
                               items:
                                 description: Projection that may be projected along
                                   with other supported volume types
                                 properties:
                                   configMap:
-                                    description: information about the configMap data
-                                      to project
+                                    description: configMap information about the configMap
+                                      data to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           ConfigMap will be projected into the volume
                                           as a file whose name is the key and content
@@ -19813,27 +20803,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -19849,13 +20839,13 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap
-                                          or its keys must be defined
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   downwardAPI:
-                                    description: information about the downwardAPI
-                                      data to project
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
                                     properties:
                                       items:
                                         description: Items is a list of DownwardAPIVolume
@@ -19939,11 +20929,11 @@ spec:
                                         type: array
                                     type: object
                                   secret:
-                                    description: information about the secret data
-                                      to project
+                                    description: secret information about the secret
+                                      data to project
                                     properties:
                                       items:
-                                        description: If unspecified, each key-value
+                                        description: items if unspecified, each key-value
                                           pair in the Data field of the referenced
                                           Secret will be projected into the volume
                                           as a file whose name is the key and content
@@ -19960,27 +20950,27 @@ spec:
                                             within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
+                                              description: key is the key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits used
-                                                to set permissions on this file. Must
-                                                be an octal value between 0000 and
-                                                0777 or a decimal value between 0
-                                                and 511. YAML accepts both octal and
-                                                decimal values, JSON requires decimal
-                                                values for mode bits. If not specified,
-                                                the volume defaultMode will be used.
-                                                This might be in conflict with other
-                                                options that affect the file mode,
-                                                like fsGroup, and the result can be
-                                                other mode bits set.'
+                                              description: 'mode is Optional: mode
+                                                bits used to set permissions on this
+                                                file. Must be an octal value between
+                                                0000 and 0777 or a decimal value between
+                                                0 and 511. YAML accepts both octal
+                                                and decimal values, JSON requires
+                                                decimal values for mode bits. If not
+                                                specified, the volume defaultMode
+                                                will be used. This might be in conflict
+                                                with other options that affect the
+                                                file mode, like fsGroup, and the result
+                                                can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the
-                                                file to map the key to. May not be
-                                                an absolute path. May not contain
+                                              description: path is the relative path
+                                                of the file to map the key to. May
+                                                not be an absolute path. May not contain
                                                 the path element '..'. May not start
                                                 with the string '..'.
                                               type: string
@@ -19996,16 +20986,16 @@ spec:
                                           kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
                                         type: boolean
                                     type: object
                                   serviceAccountToken:
-                                    description: information about the serviceAccountToken
-                                      data to project
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
                                     properties:
                                       audience:
-                                        description: Audience is the intended audience
+                                        description: audience is the intended audience
                                           of the token. A recipient of a token must
                                           identify itself with an identifier specified
                                           in the audience of the token, and otherwise
@@ -20013,7 +21003,7 @@ spec:
                                           to the identifier of the apiserver.
                                         type: string
                                       expirationSeconds:
-                                        description: ExpirationSeconds is the requested
+                                        description: expirationSeconds is the requested
                                           duration of validity of the service account
                                           token. As the token approaches expiration,
                                           the kubelet volume plugin will proactively
@@ -20026,7 +21016,7 @@ spec:
                                         format: int64
                                         type: integer
                                       path:
-                                        description: Path is the path relative to
+                                        description: path is the path relative to
                                           the mount point of the file to project the
                                           token into.
                                         type: string
@@ -20037,35 +21027,35 @@ spec:
                               type: array
                           type: object
                         quobyte:
-                          description: Quobyte represents a Quobyte mount on the host
+                          description: quobyte represents a Quobyte mount on the host
                             that shares a pod's lifetime
                           properties:
                             group:
-                              description: Group to map volume access to Default is
+                              description: group to map volume access to Default is
                                 no group
                               type: string
                             readOnly:
-                              description: ReadOnly here will force the Quobyte volume
+                              description: readOnly here will force the Quobyte volume
                                 to be mounted with read-only permissions. Defaults
                                 to false.
                               type: boolean
                             registry:
-                              description: Registry represents a single or multiple
+                              description: registry represents a single or multiple
                                 Quobyte Registry services specified as a string as
                                 host:port pair (multiple entries are separated with
                                 commas) which acts as the central registry for volumes
                               type: string
                             tenant:
-                              description: Tenant owning the given Quobyte volume
+                              description: tenant owning the given Quobyte volume
                                 in the Backend Used with dynamically provisioned Quobyte
                                 volumes, value is set by the plugin
                               type: string
                             user:
-                              description: User to map volume access to Defaults to
+                              description: user to map volume access to Defaults to
                                 serivceaccount user
                               type: string
                             volume:
-                              description: Volume is a string that references an already
+                              description: volume is a string that references an already
                                 created Quobyte volume by name.
                               type: string
                           required:
@@ -20073,43 +21063,44 @@ spec:
                           - volume
                           type: object
                         rbd:
-                          description: 'RBD represents a Rados Block Device mount
+                          description: 'rbd represents a Rados Block Device mount
                             on the host that shares a pod''s lifetime. More info:
                             https://examples.k8s.io/volumes/rbd/README.md'
                           properties:
                             fsType:
-                              description: 'Filesystem type of the volume that you
-                                want to mount. Tip: Ensure that the filesystem type
-                                is supported by the host operating system. Examples:
+                              description: 'fsType is the filesystem type of the volume
+                                that you want to mount. Tip: Ensure that the filesystem
+                                type is supported by the host operating system. Examples:
                                 "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                                 if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                 TODO: how do we prevent errors in the filesystem from
                                 compromising the machine'
                               type: string
                             image:
-                              description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'image is the rados image name. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             keyring:
-                              description: 'Keyring is the path to key ring for RBDUser.
+                              description: 'keyring is the path to key ring for RBDUser.
                                 Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             monitors:
-                              description: 'A collection of Ceph monitors. More info:
-                                https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               items:
                                 type: string
                               type: array
                             pool:
-                              description: 'The rados pool name. Default is rbd. More
-                                info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'pool is the rados pool name. Default is
+                                rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                             readOnly:
-                              description: 'ReadOnly here will force the ReadOnly
+                              description: 'readOnly here will force the ReadOnly
                                 setting in VolumeMounts. Defaults to false. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: boolean
                             secretRef:
-                              description: 'SecretRef is name of the authentication
+                              description: 'secretRef is name of the authentication
                                 secret for RBDUser. If provided overrides keyring.
                                 Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               properties:
@@ -20120,35 +21111,36 @@ spec:
                                   type: string
                               type: object
                             user:
-                              description: 'The rados user name. Default is admin.
-                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              description: 'user is the rados user name. Default is
+                                admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                               type: string
                           required:
                           - image
                           - monitors
                           type: object
                         scaleIO:
-                          description: ScaleIO represents a ScaleIO persistent volume
+                          description: scaleIO represents a ScaleIO persistent volume
                             attached and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Default is "xfs".
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                               type: string
                             gateway:
-                              description: The host address of the ScaleIO API Gateway.
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
                               type: string
                             protectionDomain:
-                              description: The name of the ScaleIO Protection Domain
-                                for the configured storage.
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly Defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef references to the secret for
+                              description: secretRef references to the secret for
                                 ScaleIO user and other sensitive information. If this
                                 is not provided, Login operation will fail.
                               properties:
@@ -20159,26 +21151,26 @@ spec:
                                   type: string
                               type: object
                             sslEnabled:
-                              description: Flag to enable/disable SSL communication
+                              description: sslEnabled Flag enable/disable SSL communication
                                 with Gateway, default false
                               type: boolean
                             storageMode:
-                              description: Indicates whether the storage for a volume
-                                should be ThickProvisioned or ThinProvisioned. Default
-                                is ThinProvisioned.
+                              description: storageMode indicates whether the storage
+                                for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
                               type: string
                             storagePool:
-                              description: The ScaleIO Storage Pool associated with
-                                the protection domain.
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
                               type: string
                             system:
-                              description: The name of the storage system as configured
-                                in ScaleIO.
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
                               type: string
                             volumeName:
-                              description: The name of a volume already created in
-                                the ScaleIO system that is associated with this volume
-                                source.
+                              description: volumeName is the name of a volume already
+                                created in the ScaleIO system that is associated with
+                                this volume source.
                               type: string
                           required:
                           - gateway
@@ -20186,57 +21178,58 @@ spec:
                           - system
                           type: object
                         secret:
-                          description: 'Secret represents a secret that should populate
+                          description: 'secret represents a secret that should populate
                             this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                           properties:
                             defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
+                              description: 'defaultMode is Optional: mode bits used
+                                to set permissions on created files by default. Must
+                                be an octal value between 0000 and 0777 or a decimal
+                                value between 0 and 511. YAML accepts both octal and
+                                decimal values, JSON requires decimal values for mode
+                                bits. Defaults to 0644. Directories within the path
+                                are not affected by this setting. This might be in
+                                conflict with other options that affect the file mode,
+                                like fsGroup, and the result can be other mode bits
+                                set.'
                               format: int32
                               type: integer
                             items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be
-                                relative and may not contain the '..' path or start
-                                with '..'.
+                              description: items If unspecified, each key-value pair
+                                in the Data field of the referenced Secret will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the Secret, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
                               items:
                                 description: Maps a string key to a path within a
                                   volume.
                                 properties:
                                   key:
-                                    description: The key to project.
+                                    description: key is the key to project.
                                     type: string
                                   mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
+                                    description: 'mode is Optional: mode bits used
+                                      to set permissions on this file. Must be an
+                                      octal value between 0000 and 0777 or a decimal
+                                      value between 0 and 511. YAML accepts both octal
+                                      and decimal values, JSON requires decimal values
+                                      for mode bits. If not specified, the volume
+                                      defaultMode will be used. This might be in conflict
+                                      with other options that affect the file mode,
+                                      like fsGroup, and the result can be other mode
+                                      bits set.'
                                     format: int32
                                     type: integer
                                   path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
+                                    description: path is the relative path of the
+                                      file to map the key to. May not be an absolute
+                                      path. May not contain the path element '..'.
+                                      May not start with the string '..'.
                                     type: string
                                 required:
                                 - key
@@ -20244,30 +21237,30 @@ spec:
                                 type: object
                               type: array
                             optional:
-                              description: Specify whether the Secret or its keys
-                                must be defined
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
                               type: boolean
                             secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secretName is the name of the secret in
+                                the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
                         storageos:
-                          description: StorageOS represents a StorageOS volume attached
+                          description: storageOS represents a StorageOS volume attached
                             and mounted on Kubernetes nodes.
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             readOnly:
-                              description: Defaults to false (read/write). ReadOnly
-                                here will force the ReadOnly setting in VolumeMounts.
+                              description: readOnly defaults to false (read/write).
+                                ReadOnly here will force the ReadOnly setting in VolumeMounts.
                               type: boolean
                             secretRef:
-                              description: SecretRef specifies the secret to use for
+                              description: secretRef specifies the secret to use for
                                 obtaining the StorageOS API credentials.  If not specified,
                                 default values will be attempted.
                               properties:
@@ -20278,12 +21271,12 @@ spec:
                                   type: string
                               type: object
                             volumeName:
-                              description: VolumeName is the human-readable name of
+                              description: volumeName is the human-readable name of
                                 the StorageOS volume.  Volume names are only unique
                                 within a namespace.
                               type: string
                             volumeNamespace:
-                              description: VolumeNamespace specifies the scope of
+                              description: volumeNamespace specifies the scope of
                                 the volume within StorageOS.  If no namespace is specified
                                 then the Pod's namespace will be used.  This allows
                                 the Kubernetes name scoping to be mirrored within
@@ -20295,25 +21288,26 @@ spec:
                               type: string
                           type: object
                         vsphereVolume:
-                          description: VsphereVolume represents a vSphere volume attached
+                          description: vsphereVolume represents a vSphere volume attached
                             and mounted on kubelets host machine
                           properties:
                             fsType:
-                              description: Filesystem type to mount. Must be a filesystem
-                                type supported by the host operating system. Ex. "ext4",
-                                "xfs", "ntfs". Implicitly inferred to be "ext4" if
-                                unspecified.
+                              description: fsType is filesystem type to mount. Must
+                                be a filesystem type supported by the host operating
+                                system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred
+                                to be "ext4" if unspecified.
                               type: string
                             storagePolicyID:
-                              description: Storage Policy Based Management (SPBM)
-                                profile ID associated with the StoragePolicyName.
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
                               type: string
                             storagePolicyName:
-                              description: Storage Policy Based Management (SPBM)
-                                profile name.
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
                               type: string
                             volumePath:
-                              description: Path that identifies vSphere volume vmdk
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
                               type: string
                           required:
                           - volumePath

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/sinker:v20220803-65793402b8
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/status-reconciler:v20220803-65793402b8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/tide:v20220803-65793402b8
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/patches/JsonRFC6902/crier_deployment.yaml
@@ -1,9 +1,6 @@
 ---
 - op: add
   path: /spec/template/spec/containers/0/args/9
-  value: --gcs-workers=0
-- op: add
-  path: /spec/template/spec/containers/0/args/9
   value: --gcs-credentials-file=/etc/gcs/service-account.json
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/4

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20220526-c15dd4997d
+        image: gcr.io/k8s-prow/exporter:v20220803-65793402b8
         imagePullPolicy: Always
         ports:
         - name: metrics


### PR DESCRIPTION
The automated prow bump PR[1] is failing the presubmit deploy test due to the crier pod
failing to start successfully. This change includes the image bumps from that PR and the fix required for a successful deployment. 

Crier was failing to start due to an undefined flag being specified.
Removing the -gcs-workers flag allows crier to start successfully.

```
[root@instance workspace]# kubectl logs -n kubevirt-prow crier-6468d759d6-b5tv5
flag provided but not defined: -gcs-workers
```

Also small update to prow-deploy README to include the correct path to
the kubeconfig.

/cc @kubevirt/prow-job-taskforce 

[1] https://github.com/kubevirt/project-infra/pull/2119