### PR TITLE
Update podman socket path in bootstrap image to match kubevirtci defaults

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -76,13 +76,13 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
         export HTTP_PROXY=${CONTAINER_HTTP_PROXY}
         export HTTPS_PROXY=${CONTAINER_HTTPS_PROXY}
 	export KIND_EXPERIMENTAL_PROVIDER="podman"
-	mkdir -p ${XDG_RUNTIME_DIR}/podman
+	mkdir -p /run/podman
         podman system service \
                -t 0 \
-               unix:///${XDG_RUNTIME_DIR}/podman/podman.sock \
+               unix:///run/podman/podman.sock \
                >/var/log/podman.log 2>&1 &
         echo "${!}" > /var/run/podman.pid
-	ln -s ${XDG_RUNTIME_DIR}/podman/podman.sock /var/run/docker.sock
+	ln -s /run/podman/podman.sock /var/run/docker.sock
 	# Set podman short-name-mode to permissive
 	sed -i 's/short-name-mode="enforcing"/short-name-mode="permissive"/g' /etc/containers/registries.conf
     )
@@ -91,7 +91,7 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
     MAX_WAIT=5
     while true; do
         # wait for podman socket to be ready
-        curl --unix-socket "${XDG_RUNTIME_DIR}/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1 && break
+        curl --unix-socket "/run/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1 && break
         if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
             WAIT_N=$((WAIT_N+1))
             echo "Waiting for podman socket to be ready, sleeping for ${WAIT_N} seconds."


### PR DESCRIPTION
kubevirtci was updated to look for an environment variable
`KUBEVIRTCI_PODMAN_SOCKET` which defaults to `/run/podman/podman.sock` [1]

The bootstrap image should set up the podman socket at the same path as
the default so that it is always found.

[1] https://github.com/kubevirt/kubevirtci/pull/833

/cc @oshoval @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>