### PR TITLE
Update autoowners image builder to golang 1.18

### DIFF
--- a/images/autoowners/Dockerfile
+++ b/images/autoowners/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /go/src/github.com/openshift/ci-tools/
 RUN mkdir -p /go/src/github.com/openshift/ && \
@@ -7,7 +7,7 @@ RUN mkdir -p /go/src/github.com/openshift/ && \
     cd ci-tools/ && \
     env GOPROXY=off GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /go/bin/autoowners ./cmd/autoowners/...
 
-FROM gcr.io/k8s-prow/git:v20200605-44f6c96
+FROM gcr.io/k8s-prow/git:v20220523-6026203ca9
 
 COPY --from=builder /go/bin/autoowners /usr/bin/autoowners
 


### PR DESCRIPTION
The autoowners image build fails when using golang:1.16 as builder base
image. Upgrading to golang:1.18 leads to a successful build.

Example failure: 
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2260/rehearsal-build-autoowners-image/1559886806290272256

/cc @dhiller @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>