### PR TITLE
Move build of multiarch bootstrap to weekly periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -211,7 +211,39 @@ periodics:
           - "/app/robots/cmd/indexpagecreator/app.binary"
         args:
           - --dry-run=false
-
+- name: periodic-publish-multiarch-bootstrap-image
+  cron: "30 15 * * 6"
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 5h0m0s
+  max_concurrency: 1
+  labels:
+    preset-dind-enabled: "true"
+    preset-kubevirtci-quay-credential: "true"
+  cluster: prow-workloads
+  spec:
+    containers:
+      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/bash"
+          - "-c"
+          - |
+            cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+            cd images
+            ./publish_multiarch_image.sh bootstrap quay.io kubevirtci
+            ./publish_multiarch_image.sh -l golang quay.io kubevirtci
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+          limits:
+            memory: "8Gi"
 - name: periodic-kubevirt-mirror-uploader
   cron: "05 7 * * *"
   max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -83,20 +83,17 @@ postsubmits:
                 memory: "1Gi"
               limits:
                 memory: "1Gi"
-    - name: publish-multiarch-bootstrap-image
+    - name: publish-bootstrap-image
       always_run: false
       run_if_changed: "images/golang/.*|images/bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
-      decoration_config:
-        grace_period: 5m0s
-        timeout: 5h0m0s
       max_concurrency: 1
       labels:
         preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: prow-workloads
+      cluster: ibm-prow-jobs
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -107,16 +104,16 @@ postsubmits:
               - |
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
-                ./publish_multiarch_image.sh bootstrap quay.io kubevirtci
-                ./publish_multiarch_image.sh -l golang quay.io kubevirtci
+                ./publish_image.sh bootstrap quay.io kubevirtci
+                ./publish_image.sh golang quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
               requests:
-                memory: "8Gi"
+                memory: "1Gi"
               limits:
-                memory: "8Gi"
+                memory: "1Gi"
     - name: publish-bootstrap-legacy-images
       always_run: false
       run_if_changed: "images/golang-legacy/.*|images/bootstrap-legacy/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -85,18 +85,15 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
-  - name: build-multiarch-bootstrap-image
+  - name: build-bootstrap-image
     always_run: false
     run_if_changed: "images/bootstrap/.*|images/golang/.*"
     decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 5h0m0s
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: prow-workloads
+    cluster: ibm-prow-jobs
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -106,16 +103,16 @@ presubmits:
             - "-ce"
             - |
               cd images
-              ./publish_multiarch_image.sh -b bootstrap quay.io kubevirtci
-              ./publish_multiarch_image.sh -b -l golang quay.io kubevirtci
+              ./publish_image.sh -b bootstrap quay.io kubevirtci
+              ./publish_image.sh -b golang quay.io kubevirtci
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
             requests:
-              memory: "8Gi"
+              memory: "1Gi"
             limits:
-              memory: "8Gi"
+              memory: "1Gi"
   - name: build-bootstrap-legacy-images
     always_run: false
     run_if_changed: "images/bootstrap-legacy/.*|images/golang-legacy/.*"


### PR DESCRIPTION
Since the addition of the arm64 bootstrap image builds the presubmit and
postsubmit prowjobs take between 4 to 5 hours[1]. This can cause
issues when trying to merge updates to the bootstrap image.

This change moves the publishing of the arm64 images to a weekly
periodic job and returns the bootstrap presubmit and postsubmit jobs to
just build the x64_86 variant of the images.

[1] https://github.com/kubevirt/project-infra/issues/2252

/cc @dhiller @zhlhahaha @oshoval 

Signed-off-by: Brian Carey <bcarey@redhat.com>