### PR TITLE
kubevirtci, presubmit: Increase max_concurrency

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -188,7 +188,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    max_concurrency: 1
+    max_concurrency: 2
     name: check-provision-k8s-1.22
     spec:
       containers:
@@ -240,7 +240,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    max_concurrency: 1
+    max_concurrency: 2
     name: check-provision-k8s-1.23
     spec:
       containers:
@@ -308,7 +308,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    max_concurrency: 1
+    max_concurrency: 2
     name: check-provision-k8s-1.24
     spec:
       containers:
@@ -334,7 +334,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    max_concurrency: 1
+    max_concurrency: 2
     name: check-provision-k8s-1.24-ipv6
     optional: false
     spec:


### PR DESCRIPTION
Waiting for results when max_concurrency is 1 takes a lot of time,
increase it to 2.
