### PR TITLE
Allow for only amd64 image builds in mulitarch image script

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -104,8 +104,8 @@ postsubmits:
               - |
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
-                ./publish_image.sh bootstrap quay.io kubevirtci
-                ./publish_image.sh golang quay.io kubevirtci
+                ./publish_multiarch_image.sh -a bootstrap quay.io kubevirtci
+                ./publish_multiarch_image.sh -a -l golang quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -103,8 +103,8 @@ presubmits:
             - "-ce"
             - |
               cd images
-              ./publish_image.sh -b bootstrap quay.io kubevirtci
-              ./publish_image.sh -b golang quay.io kubevirtci
+              ./publish_multiarch_image.sh -a -b bootstrap quay.io kubevirtci
+              ./publish_multiarch_image.sh -a -b -l golang quay.io kubevirtci
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/images/publish_multiarch_image.sh
+++ b/images/publish_multiarch_image.sh
@@ -4,8 +4,11 @@ archs=(amd64 arm64)
 main() {
     local build_only local_base_image
     local_base_image=false
-    while getopts "blh" opt; do
+    while getopts "ablh" opt; do
         case "$opt" in
+	    a)
+		archs=(amd64)
+		;;
             b)
                 build_only=true
                 ;;
@@ -56,6 +59,7 @@ help() {
     Build and publish multiarch infra images.
 
     OPTIONS
+        -a  Build only amd64 image
         -h  Show this help message and exit.
         -b  Only build the image and exit. Do not publish the built image.
         -l  Use local base image


### PR DESCRIPTION
Building the bootstrap image using the original `publish_image.sh` script
no longer works due to missing `ARCH` arg[1].

This update allows for just building amd64 images using the
`publish_multiarch_image.sh` script.

/cc @zhlhahaha @dhiller @xpivarc 

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-bootstrap-image/1561635282061627392

Signed-off-by: Brian Carey <bcarey@redhat.com>