### PR TITLE
Update multiarch publish jobs to use legacy bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -226,7 +226,7 @@ periodics:
   cluster: prow-workloads
   spec:
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -91,12 +91,12 @@ postsubmits:
       decorate: true
       max_concurrency: 1
       labels:
-        preset-podman-in-container-enabled: "true"
+        preset-dind-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220816-91d8af2
+          - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"


### PR DESCRIPTION
The version of podman in the latest bootstrap image does not have the
`--amend` flag availabe when using `podman manifest create`. This causes the
publish_multiarch_image.sh to fail [1].

This flag looks like it will be available in the next podman release[2] so
just moving these jobs back to using DinD until the flag is available

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-bootstrap-image/1561665301555187712
[2] https://github.com/containers/podman/pull/15350

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>