### PR TITLE
Update kubevirt.github.io jobs to use new container

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -12,9 +12,9 @@ periodics:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: docker.io/library/ruby
+        - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f
           env:
             - name: NOKOGIRI_USE_SYSTEM_LIBRARIES
               value: "true"
           command: ["/bin/sh", "-c"]
-          args: ["/usr/local/bin/bundle install && bundle exec rake -- -u"]
+          args: ["bundle exec rake -- -u"]

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
@@ -19,13 +19,13 @@ postsubmits:
       securityContext:
         runAsUser: 0
       containers:
-      - image: quay.io/kubevirtci/ruby:v20210628-647402e
+      - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f
         env:
         - name: GIT_AUTHOR_NAME
           value: kubevirt-bot
         - name: GIT_AUTHOR_EMAIL
           value: kubevirtbot@redhat.com
-        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+        command: [ "/usr/bin/bash", "-c" ]
         args:
         - |
           set -ex
@@ -38,7 +38,7 @@ postsubmits:
             git config user.name "$GIT_AUTHOR_NAME"
           )
           WORK_DIR=$(cd ../gh-pages && pwd)
-          bundle install && make build
+          make build
           BUILD_DIR=$(pwd)/_site
           cd ${WORK_DIR}
           find . -mindepth 1 -maxdepth 1 -regextype egrep -not -regex '\./(\.git.*|\.nojekyll)' -print0 | xargs -0 rm -rf

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -7,12 +7,12 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-      - image: docker.io/library/ruby
+      - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f
         env:
         - name: NOKOGIRI_USE_SYSTEM_LIBRARIES
           value: "true"
         command: [ "/bin/sh", "-c" ]
-        args: [ "/usr/local/bin/bundle install && bundle exec rake" ]
+        args: [ "bundle exec rake" ]
   - name: pull-kubevirt.github.io-build
     branches:
     - ^main$
@@ -25,9 +25,9 @@ presubmits:
       securityContext:
         runAsUser: 0
       containers:
-      - image: quay.io/kubevirtci/ruby:v20210628-647402e
-        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+      - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f
+        command: [ "/usr/bin/bash", "-c" ]
         args:
         - |
           set -ex
-          bundle install && make build
+          make build


### PR DESCRIPTION
Signed-off-by: cwilkers <cwilkers@redhat.com>

@dhiller I am not 100% sure that I am not losing something by taking "runner.sh" out of the equation here, but it looks like something that is only needed for bootstrap containers doing big Go builds.

