### PR TITLE
Switch kubevirtci prowjobs to use podman in container setup

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang:v20220823-3fed276
+        - image: quay.io/kubevirtci/golang:v20220829-40e8aca
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-dind-enabled: "true"
+        preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -34,7 +34,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang:v20220728-1410a63
+        - image: quay.io/kubevirtci/golang:v20220823-3fed276
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-installer-pull-token: "true"
       rehearsal.allowed: "true"
@@ -51,7 +51,7 @@ presubmits:
           value: "true"
         - name: SONOBUOY_EXTRA_ARGS
           value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:
@@ -88,7 +88,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-installer-pull-token: "true"
       rehearsal.allowed: "true"
@@ -125,9 +125,8 @@ presubmits:
         - name: RUN_KUBEVIRT_CONFORMANCE
           value: "true"
         - name: SONOBUOY_EXTRA_ARGS
-          value: --plugin-env kubevirt-conformance.E2E_FOCUS=MediatedDevices --plugin-env
-            kubevirt-conformance.E2E_SKIP=QUARANTINE
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+          value: "--plugin-env kubevirt-conformance.E2E_FOCUS=MediatedDevices --plugin-env kubevirt-conformance.E2E_SKIP=QUARANTINE"
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:
@@ -162,7 +161,7 @@ presubmits:
     cluster: prow-workloads
     decorate: true
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-gocli
@@ -174,7 +173,7 @@ presubmits:
         - /bin/bash
         - -c
         - cd cluster-provision/gocli/ && make all container
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220816-91d8af2
         name: ""
         resources:
           requests:
@@ -189,7 +188,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.22
@@ -200,7 +199,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.22 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:
@@ -215,7 +214,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.23
@@ -226,7 +225,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.23 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:
@@ -241,7 +240,7 @@ presubmits:
     decoration_config:
       timeout: 20m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-provision-alpine-with-test-tooling
@@ -253,7 +252,7 @@ presubmits:
         - -c
         - dnf install -y genisoimage libvirt && cd cluster-provision/images/vm-image-builder
           && ./create-containerdisk.sh alpine-cloud-init
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:
@@ -283,7 +282,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.24
@@ -294,7 +293,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.24 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:
@@ -309,7 +308,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.24-ipv6
@@ -320,7 +319,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.24-ipv6 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
+        image: quay.io/kubevirtci/golang:v20220823-3fed276
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
+      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-installer-pull-token: "true"
       rehearsal.allowed: "true"
@@ -51,7 +51,7 @@ presubmits:
           value: "true"
         - name: SONOBUOY_EXTRA_ARGS
           value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
         name: ""
         resources:
           requests:
@@ -88,7 +88,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
+      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-installer-pull-token: "true"
       rehearsal.allowed: "true"
@@ -126,7 +126,7 @@ presubmits:
           value: "true"
         - name: SONOBUOY_EXTRA_ARGS
           value: "--plugin-env kubevirt-conformance.E2E_FOCUS=MediatedDevices --plugin-env kubevirt-conformance.E2E_SKIP=QUARANTINE"
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
         name: ""
         resources:
           requests:
@@ -173,7 +173,7 @@ presubmits:
         - /bin/bash
         - -c
         - cd cluster-provision/gocli/ && make all container
-        image: quay.io/kubevirtci/golang:v20220816-91d8af2
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:
@@ -199,7 +199,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.22 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:
@@ -225,7 +225,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.23 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:
@@ -252,7 +252,7 @@ presubmits:
         - -c
         - dnf install -y genisoimage libvirt && cd cluster-provision/images/vm-image-builder
           && ./create-containerdisk.sh alpine-cloud-init
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:
@@ -293,7 +293,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.24 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:
@@ -319,7 +319,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.24-ipv6 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220823-3fed276
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:
@@ -334,7 +334,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.25
@@ -346,7 +346,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.25 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20210316-d295087
+        image: quay.io/kubevirtci/golang:v20220829-40e8aca
         name: ""
         resources:
           requests:


### PR DESCRIPTION
Update the kubevirtci prowjobs to use the new podman based bootstrap image. 

There is an outstanding issue with running sonobuoy on the kind based lanes that are deployed with podman so these lanes have been updated to use the legacy image for now. 