### PR TITLE
Remove check-provision job for 1.22-ipv6 as provider no longer exists

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -206,32 +206,6 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    max_concurrency: 1
-    name: check-provision-k8s-1.22-ipv6
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.22-ipv6 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20220728-1410a63
-        name: ""
-        resources:
-          requests:
-            memory: 14Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
     decorate: true


### PR DESCRIPTION
The 1.22-ipv6 provider was removed from the kubevirtci repo[1]

[1] https://github.com/kubevirt/kubevirtci/commit/203b112e3114966f6f87c1fabb5499711701b54c

/cc @oshoval @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>