### PR TITLE
csi-driver postsubmit: update container image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -23,14 +23,21 @@ postsubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e@sha256:8c80c98d035a0f285ad49b964e5d0b62004844f3340407367841618e80e1503c
+          - image: quay.io/kubevirtci/golang:v20220728-1410a63
+            env:
+              - name: REPO
+                value: quay.io/kubevirt
+              - name: IMAGE
+                value: csi-driver
+              - name: TAG
+                value: latest
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
               - >
-                cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin &&
-                make push REPO=quay.io/kubevirt IMAGE=csi-driver TAG=latest
+                cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin=true &&
+                make push
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
postsubmit job used very old image and failed on 
```
vendor/github.com/openshift/build-machinery-go/make/targets/golang/../../lib/golang.mk:22: *** `go` is required with minimal version "1.13.4", detected version "1.12.9". You can override this check by using `make GO_REQUIRED_MIN_VERSION:=`.  Stop.
```
https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/publish-csi-driver

The image is updated so it contains newer toolbox. 

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>