### PR TITLE
Fix periodic sysprep name to use 1.22

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -118,7 +118,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.19-sysprep
+  name: periodic-kubevirt-e2e-k8s-1.22-sysprep
   spec:
     containers:
     - command:


### PR DESCRIPTION
Since it's using the default provider, which is 1.22 currently, we
update the periodic name.

See https://github.com/kubevirt/kubevirtci/blob/7aa6748dc9ed5db081ec44301b5cb96118a4dfa3/cluster-up/hack/common.sh#L20