### PR TITLE
Fix pod antiaffinity for check-up-kind-1.23-vgpu

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -131,16 +131,17 @@ presubmits:
           name: vfio
       nodeSelector:
         hardwareSupport: gpu
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-              - key: vgpu
-                operator: In
-                values:
-                - "true"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: vgpu
+                  operator: In
+                  values:
+                  - "true"
       volumes:
       - hostPath:
           path: /lib/modules


### PR DESCRIPTION
Element was missing, see #2282 where yaml modification tried to remove
the part. Also see here for correct definition:
https://github.com/kubevirt/project-infra/blob/b8ddb38f5e598465347daa21abb8fb439adc9a55/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml#L19

/cc @brianmcarey @xpivarc 