### PR TITLE
Use golang builder for functional test lane. 

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20220728-1410a63
+          - image: quay.io/kubevirtci/golang:v20220823-3fed276
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -95,7 +95,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+          - image: quay.io/kubevirtci/golang:v20220823-3fed276
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"


### PR DESCRIPTION
Update unit test lane to latest golang builder

Signed-off-by: Alexander Wels <awels@redhat.com>