### PR TITLE
Add topologyKey to podAntiAffinity rules of vgpu

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -406,6 +406,7 @@ periodics:
                 operator: In
                 values:
                 - "true"
+            topologyKey: "kubernetes.io/hostname"
     containers:
     - command:
       - /usr/local/bin/runner.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -617,6 +617,7 @@ presubmits:
                   operator: In
                   values:
                   - "true"
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - command:
         - /usr/local/bin/runner.sh
@@ -687,6 +688,7 @@ presubmits:
                   operator: In
                   values:
                   - "true"
+              topologyKey: "kubernetes.io/hostname"
       containers:
       - command:
         - /usr/local/bin/runner.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -106,7 +106,7 @@ presubmits:
                   operator: In
                   values:
                   - "true"
-              topologyKey: ""
+              topologyKey: "kubernetes.io/hostname"
             weight: 100
       containers:
       - command:


### PR DESCRIPTION
Updated all vgpu jobs podAntiAffinity to have a topologyKey value, since it's required.

Started modified periodics with added topologyKey, seems to work: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-kind-1.23-vgpu/1562838672078802944

/cc @brianmcarey 