### PR TITLE
Add reference to project-infra repo for multiarch periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -219,6 +219,11 @@ periodics:
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    work_dir: true
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"


### PR DESCRIPTION
This periodic job is currently failing[1] as it can't find the files
required to build the multiarch bootstrap. Adding an extra ref to the
project-infra repo and setting it as the working directory.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-publish-multiarch-bootstrap-image/1563549538193510400

/cc @dhiller @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>