### PR TITLE
Build CDI builder using buildah

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -187,7 +187,7 @@ postsubmits:
           - "-ce"
           - |
             cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
-            make builder-push
+            CDI_CONTAINER_BUILDCMD=buildah make builder-push
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Right now CDI will only use buildah as a build command if podman is also
used, but in that case we won't build multi-arch images.

Force buildah so we can get arm64 images as well.