### PR TITLE
add new repository test-benchmarks

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -473,6 +473,10 @@ orgs:
         default_branch: main
         description: Operator which deploys kubevirt-tekton-tasks in cluster
         has_projects: true
+      test-benchmarks:
+        default_branch: main
+        description: setup to create reproducible benchmarks tests with containers and KubeVirt VMs
+        has_projects: true
       test-infra-containers:
         description: All containers which are useful for testing (tgtd, cinder, ceph, gluster, ...)
         has_projects: true
@@ -813,6 +817,11 @@ orgs:
         privacy: closed
         repos:
           tekton-tasks-operator: write
+      test-benchmarks-maintainers:
+        maintainers:
+          - alicefr
+        repos:
+          test-benchmarks: admin
       web-ui-maintainers:
         description: ""
         maintainers:


### PR DESCRIPTION
Create new repository test-benchmarks in KubeVirt to store the benchmark tests.

Currently, the code is hosted in my github account: 
  https://github.com/alicefr/kubevirt-test-vm

Moving the repository offers a better visibility and hopefully other users can find this useful and contribute to it.