### PR TITLE
Reduce memory for external execution

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1640,7 +1640,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Jobs that use external provider dont require
29Gi memory as the ones that use KubevirtCI

Signed-off-by: L. Pivarc <lpivarc@redhat.com>