### PR TITLE
Bump migration lanes to use 1.24 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1459,7 +1459,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.23-sig-compute-migrations
+  name: periodic-kubevirt-e2e-k8s-1.24-sig-compute-migrations
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1476,7 +1476,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.23-sig-compute-migrations
+        value: k8s-1.24-sig-compute-migrations
       - name: KUBEVIRT_NUM_NODES
         value: "3"
       - name: KUBEVIRT_STORAGE

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1376,7 +1376,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
+    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1388,7 +1388,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-compute-migrations
+          value: k8s-1.24-sig-compute-migrations
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: KUBEVIRT_STORAGE
@@ -1460,7 +1460,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
+    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1472,7 +1472,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23-sig-compute-migrations
+          value: k8s-1.24-sig-compute-migrations
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: KUBEVIRT_STORAGE


### PR DESCRIPTION
As stated we don't currently test migration with 1.24. So therefore we bump to use 1.24 for migration from 1.22, also we bump non root from 1.23 to 1.24.

/cc @xpivarc @brianmcarey @enp0s3 