### PR TITLE
Use legacy dind setup for publish-kubevirtci prowjob

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-podman-in-container-enabled: "true"
+        preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -34,7 +34,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang:v20220829-40e8aca
+        - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"


### PR DESCRIPTION
The publish-kubevirtci job is failing due to issue with cleaning up
containers[1]. This issue was not seen when using the dind setup. Updating
this job to use the legacy image until the logic is in place to
correctly cleanup the containers.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1565349289993965568

/cc @dhiller @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>