### PR TITLE
Make kubevirt-csi-driver sanity lane mandatory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -79,8 +79,8 @@ presubmits:
       annotations:
         fork-per-release: "true"
         testgrid-create-test-group: "false"
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       skip_report: false
       decorate: true
       decoration_config:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>