### PR TITLE
Add antiaffinity rules to bm9 for publish and alpine

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -22,6 +22,15 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       cluster: prow-workloads
       spec:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+              - matchExpressions:
+                - key: kubernetes.io/hostname
+                  operator: NotIn
+                  values:
+                  - bare-metal-9
         nodeSelector:
           type: bare-metal-external
         volumes:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -245,6 +245,15 @@ presubmits:
     max_concurrency: 1
     name: check-provision-alpine-with-test-tooling
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: NotIn
+                values:
+                - bare-metal-9
       containers:
       - command:
         - /usr/local/bin/runner.sh


### PR DESCRIPTION
The jobs check-provision-alpine-with-test-tooling and publish-kubevirtci
are getting stuck regularly on bm9. We add an antiaffinity until the
problem is resolved.

/cc @brianmcarey 