### PR TITLE
Use legacy image for jobs that push images using bazel

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -164,7 +164,7 @@ periodics:
     repo: kubevirt
     workdir: true
   labels:
-    preset-podman-in-container-enabled: "true"
+    preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
@@ -220,7 +220,7 @@ periodics:
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
-      image: quay.io/kubevirtci/golang:v20220829-40e8aca
+      image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
       name: ""
       resources:
         requests:
@@ -242,7 +242,7 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
-    preset-podman-in-container-enabled: "true"
+    preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
@@ -294,7 +294,7 @@ periodics:
         value: quay.io/kubevirt
       - name: BUILD_ARCH
         value: crossbuild-aarch64
-      image: quay.io/kubevirtci/bootstrap:v20220829-40e8aca
+      image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
       name: ""
       resources:
         requests:
@@ -594,7 +594,7 @@ periodics:
   labels:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
-    preset-podman-in-container-enabled: "true"
+    preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
@@ -647,7 +647,7 @@ periodics:
         value: crossbuild-aarch64
       - name: KUBEVIRT_E2E_FOCUS
         value: arm64
-      image: quay.io/kubevirtci/bootstrap:v20220829-40e8aca
+      image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
       name: ""
       resources:
         requests:
@@ -736,7 +736,7 @@ periodics:
         value: Always
       - name: PERFSCALE_WORKLOAD
         value: tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-burst-100.yaml
-      image: quay.io/kubevirtci/golang:v20220829-40e8aca
+      image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
       name: ""
       resources:
         requests:
@@ -834,7 +834,7 @@ periodics:
         value: tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-burst-400.yaml
       - name: PERFSCALE_WORKLOAD_SIX_HUNDRED
         value: tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-burst-600.yaml
-      image: quay.io/kubevirtci/golang:v20220829-40e8aca
+      image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
       name: ""
       resources:
         requests:


### PR DESCRIPTION
Pushing images using bazel fails when run from the podman bootstrap
image. It fails with a 400 bad request[1]. Updating these jobs back to
using the legacy image until issue is resolved.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-main/1566954990545670144#1:build-log.txt%3A3

/cc @xpivarc @enp0s3 @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>