### PR TITLE
Setup registry auth file for podman bootstrap

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -124,6 +124,12 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
 fi
 
+# Set up Container Registry Auth file
+mkdir -p "${HOME}/containers" && echo "{}" > "${HOME}/containers/auth.json"
+export REGISTRY_AUTH_FILE="${HOME}/containers/auth.json"
+# Bazel push expects credentials to be available at ${HOME}/.docker/config.json
+mkdir "${HOME}/.docker" && ln -s "${REGISTRY_AUTH_FILE}" "${HOME}/.docker/config.json"
+
 # Use a reproducible build date based on the most recent git commit timestamp.
 SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
 export SOURCE_DATE_EPOCH


### PR DESCRIPTION
An issue occurred when trying to push images using bazel[1]. Bazel failed
to find the registry credentials as `${HOME}/.docker/config.json` no longer
existed. This change sets a path for the podman authfile and
then symlinks it to `${HOME}/.docker/config.json` to allow the
bazel push to succeed.

/cc @xpivarc @dhiller 

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-main/1566592579221327872#1:build-log.txt%3A812

Signed-off-by: Brian Carey <bcarey@redhat.com>