### PR TITLE
Add openssh-server to bootstrap image

### DIFF
--- a/images/bootstrap-legacy/Dockerfile
+++ b/images/bootstrap-legacy/Dockerfile
@@ -43,6 +43,7 @@ RUN dnf install -y \
     libvirt-devel \
     make \
     mercurial \
+    openssh-server\
     patch \
     protobuf-compiler \
     python3-devel \
@@ -114,5 +115,7 @@ RUN git config --global --add safe.directory '*'
 # .bazelrc files if bazel remote caching is enabled
 COPY ["entrypoint.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
         "/usr/local/bin/"]
+
+RUN ssh-keygen -A
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/bootstrap-legacy/runner.sh
+++ b/images/bootstrap-legacy/runner.sh
@@ -152,6 +152,9 @@ export SOURCE_DATE_EPOCH
 # run setup mixins
 for file in $(find /etc/setup.mixin.d/ -maxdepth 1 -name '*.sh' -print -quit); do source $file; done
 
+# start sshd
+/usr/sbin/sshd
+
 # actually start bootstrap and the job
 set -o xtrace
 "$@"

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -43,6 +43,7 @@ RUN dnf install -y \
     libvirt-devel \
     make \
     mercurial \
+    openssh-server\
     patch \
     protobuf-compiler \
     python3-devel \
@@ -119,5 +120,7 @@ RUN git config --global --add safe.directory '*'
 # .bazelrc files if bazel remote caching is enabled
 COPY ["entrypoint.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
         "/usr/local/bin/"]
+
+RUN ssh-keygen -A
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -137,6 +137,9 @@ export SOURCE_DATE_EPOCH
 # run setup mixins
 for file in $(find /etc/setup.mixin.d/ -maxdepth 1 -name '*.sh' -print -quit); do source $file; done
 
+# start sshd
+/usr/sbin/sshd
+
 # actually start bootstrap and the job
 set -o xtrace
 "$@"


### PR DESCRIPTION
`scp` command requires running openssh-server to works with sftp
We cannot use `systemctl start sshd` since `System has not been booted with systemd as init system`.
For this, we need to generate the keys and start the process manually.

required by: https://github.com/kubevirt/kubevirt/pull/8410

/cc @brianmcarey 