### PR TITLE
kccm: Add more owners

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -602,6 +602,9 @@ orgs:
           - nirarg
           - davidvossel
           - rmohr
+          - mfranczy
+          - rhrazdil
+          - qinqon
         repos:
           cloud-provider-kubevirt: admin
       maintainers:


### PR DESCRIPTION
Marcin, Radim and Quique need to be marked as OWNERS at the project since they are maintainers.