### PR TITLE
Update publish-kubevirtci to use podman in container setup

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-dind-enabled: "true"
+        preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -43,7 +43,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        - image: quay.io/kubevirtci/golang:v20220906-4f60dd3
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"


### PR DESCRIPTION
`publish-kubevirtci` was moved to use the legacy dind bootstrap due to issue with dependent containers (https://github.com/kubevirt/project-infra/pull/2312)

This issue should be resolved by https://github.com/kubevirt/kubevirtci/pull/875

/cc @enp0s3 @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>