### PR TITLE
Fix: make pull-kubevirt-verify-go-mod required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -828,7 +828,7 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
@@ -841,7 +841,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-verify-go-mod
-    run_if_changed: ^vendor/.*|^staging/.*|go\.mod$|go\.sum$
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Fix for https://github.com/kubevirt/project-infra/pull/2193.

In the above PR, this line was added to the lane definition:
```yaml
run_if_changed: ^vendor/.*|^staging/.*|go\.mod$|go\.sum$
```

As @rmohr had [pointed out](https://github.com/kubevirt/project-infra/pull/2193#discussion_r970671141), we can have one of the two: either required, or selective run. Since we want this lane to be required, we should remove the selective run option.