### PR TITLE
Switch non-root sriov presubmit to optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -425,7 +425,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       priorityClassName: windows
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -442,7 +442,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
-    optional: false
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -507,7 +507,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -526,7 +526,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.22-sriov
-    optional: true
+    optional: false
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
The non-root sriov presubmit lane has been failing consistently.[1] This issue has not been seen in the periodic sriov lane which runs rootful [2[. The issue looks to be non-root specific.

Updating the non-root sriov presubmit to optional and the rootful sriov presubmit to required. This allows us to keep testing sriov without blocking unrelated PRs while investigation into non-root issue is ongoing.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8477/pull-kubevirt-e2e-kind-1.22-sriov-nonroot/1570718990223806464
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sriov/1570719846792957952

/cc @xpivarc @dhiller @EdDev 

Signed-off-by: Brian Carey <bcarey@redhat.com>