### PR TITLE
Add alert for critical halting error in thanos compact

### DIFF
--- a/github/ci/services/loki/manifests/common/rules.yaml
+++ b/github/ci/services/loki/manifests/common/rules.yaml
@@ -46,3 +46,15 @@ data:
             namespace: "monitoring"
           annotations:
             description: "High rate of failed writes to CI Search persistent volumes"
+      - name: ThanosLogAlerts
+        rules:
+          alert: ThanosCompactHalted
+          expr: |
+            rate({app="thanos-compact, namespace="monitoring"} |= "critical error detected; halting" [5m])
+            > 0
+          for: 10m
+          labels:
+            severity: "critical"
+            namespace: "monitoring"
+          annotations:
+            description: "Thanos compaction has halted. Please investigate."


### PR DESCRIPTION
Adding a Loki alert  to alert when the thanos compaction is halted due to an error occuring similar to the following:

```
level=error ts=2022-09-17T09:14:25.183977714Z caller=compact.go:458 msg="critical error detected; halting" err="compaction: group 0@129772796
23947480160: block with not healthy index found /var/thanos/compact/compact/0@12977279623947480160/01FX852DEYQ9N639AH29KA46A9; Compaction level 1; Labels: map[cluster:prow-workloads prometheus:monitoring/prometheus-stack-kube-prom-prometheus prometheus_replica:prometheus-prometheus
-stack-kube-prom-prometheus-0]: 2/229719 series have an average of 1.000 out-of-order chunks: 1.000 of these are exact duplicates (in terms o
f data and time range)"
```

The retention limits are not applied if compaction is halted [1]. 

/cc @dhiller @xpivarc

[1] https://thanos.io/v0.28/components/compact.md/#enforcing-retention-of-data
Signed-off-by: Brian Carey <bcarey@redhat.com>