### PR TITLE
Increase retention period for lower resolution data in Thanos

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -389,8 +389,8 @@ spec:
         - --delete-delay=48h
         - --deduplication.replica-label=replica
         - --retention.resolution-raw=21d
-        - --retention.resolution-5m=21d
-        - --retention.resolution-1h=21d
+        - --retention.resolution-5m=45d
+        - --retention.resolution-1h=180d
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:


### PR DESCRIPTION
Increase retention period for 5 minutes resolution data to 45 days and and 180 days for 1 hour resolution.

This will give us a good overview of the infrastructure over the past 180 days.

As compaction has been halted for the past few months the previous 21 days retention limit has not been enforced.
```
level=error ts=2022-09-17T09:14:25.183977714Z caller=compact.go:458 msg="critical error detected; halting" err="compaction: group 0@129772796
23947480160: block with not healthy index found /var/thanos/compact/compact/0@12977279623947480160/01FX852DEYQ9N639AH29KA46A9; Compaction level 1; Labels: map[cluster:prow-workloads prometheus:monitoring/prometheus-stack-kube-prom-prometheus prometheus_replica:prometheus-prometheus
-stack-kube-prom-prometheus-0]: 2/229719 series have an average of 1.000 out-of-order chunks: 1.000 of these are exact duplicates (in terms o
f data and time range)"
```

/cc @dhiller @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>