### PR TITLE
Move publish-kubevirtci prowjob back to using dind

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-podman-in-container-enabled: "true"
+        preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -43,7 +43,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang:v20220906-4f60dd3
+        - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"


### PR DESCRIPTION
Clusters have been failing to come up on the hco test lanes[1]. There looks to be an issue with the providers that have been published with podman which breaks scp to the nodes.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_hyperconverged-cluster-operator/2092/pull-hyperconverged-cluster-operator-e2e-k8s-1.23/1572554341003300864

/cc @oshoval @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>