### PR TITLE
Increase the size of thanos compact volume

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -449,7 +449,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: 20Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Increasing the size of the persistent volume used by the thanos compact pod to 20GB

No space left errors have been halting the compaction process.
```
level=error ts=2022-09-26T12:55:05.816703454Z caller=compact.go:458 msg="critical error detected; halting" err="compaction: group 0@12977279623947480160: compact blocks [/var/thanos/compact/compact/0@12977279623947480160/01FCQGRHFN4C6PVPDW54D30SC3 /var/thanos/compact/compact/0@12977279623947480160/01FCQH1XER3VH9YY90R80TV3FS /var/thanos/compact/compact/0@12977279623947480160/01FCQHBTPM1ZHQV3HW1ZFFGEA9 /var/thanos/compact/compact/0@12977279623947480160/01FCQHK1YYPVQZ41GC9GST4HG9 /var/thanos/compact/compact/0@12977279623947480160/01FCQHTEKXB0BCC8Y73TDZPPBB /var/thanos/compact/compact/0@12977279623947480160/01FCQJ2KVZYC7TZ67H9B4CFY44]: 2 errors: populate block: write chunks: preallocate: no space left on device; sync /var/thanos/compact/compact/0@12977279623947480160/01GDWXGWE015G9QJHA8H360EE7.tmp-for-creation/chunks/000004: file already closed"
```

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>