### PR TITLE
Make new k8s e2e suite lane mandatory for kubevirt csi driver

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -185,8 +185,8 @@ presubmits:
       annotations:
         fork-per-release: "true"
         testgrid-dashboards: kubevirt-csi-driver-presubmits
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       skip_report: false
       decorate: true
       decoration_config:


### PR DESCRIPTION
Signed-off-by: Alexander Wels <awels@redhat.com>