### PR TITLE
Update pr-creator image to latest

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -61,7 +61,7 @@ presubmits:
     - release-\d+\.\d+
     spec:
       containers:
-      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
         command: ["/bin/sh", "-ce"]
         args:
         - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -62,7 +62,7 @@ periodics:
   cluster: prow-workloads
   spec:
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+    - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
       command: ["/bin/sh", "-c"]
       args:
       - |
@@ -94,7 +94,7 @@ periodics:
   cluster: prow-workloads
   spec:
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+    - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
       command: ["/bin/sh", "-c"]
       args:
       - GIT_ASKPASS=/usr/local/bin/git-askpass.sh git-pr.sh -c "./hack/bump-cdi.sh" -r kubevirtci -b bump-cdi -T main -p $(pwd)

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -351,7 +351,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
         command: ["/bin/sh"]
         args:
           - "-c"
@@ -383,7 +383,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
         command: ["/bin/sh"]
         args:
           - "-ce"
@@ -425,7 +425,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
         env:
         command: ["/bin/sh"]
         args:
@@ -455,7 +455,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
         command: ["/bin/sh"]
         args:
           - "-ce"
@@ -567,7 +567,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
         command: [ "/bin/sh" , "-c" ]
         args:
           - |
@@ -596,7 +596,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+    - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
       env:
       command: [ "/bin/sh" , "-c" ]
       args:
@@ -627,7 +627,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+    - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
       env:
       command: [ "/bin/sh" , "-c" ]
       args:
@@ -658,7 +658,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+    - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
       env:
       command: [ "/bin/sh" , "-c" ]
       args:
@@ -722,7 +722,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20210920-0ef32ec
+    - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
       command:
       - /usr/local/bin/runner.sh
       - /bin/sh


### PR DESCRIPTION
Updating to latest pr-creator is necessary, as the cached bazel version seems to get corrupt after 1 year due to bad logic: https://github.com/bazelbuild/bazel/issues/14355

This leads to failing jobs like this one: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-cluster-minorversion-updater/1574742168902307840#1:build-log.txt%3A43

/cc @brianmcarey @xpivarc 