### PR TITLE
Flakefinder: add json export

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       testgrid-create-test-group: "false"
     spec:
       containers:
-        - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+        - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -42,7 +42,7 @@ periodics:
     decorate: true
     spec:
       containers:
-        - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+        - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -77,7 +77,7 @@ periodics:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+        - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -31,7 +31,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -52,7 +52,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -32,7 +32,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -54,7 +54,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -20,7 +20,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+      image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       name: ""
       resources: {}
 - annotations:
@@ -44,7 +44,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+      image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       name: ""
       resources: {}
 - annotations:
@@ -68,7 +68,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+      image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       name: ""
       resources: {}
 - annotations:
@@ -95,7 +95,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+      image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       name: ""
       resources: {}
 - annotations:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -42,7 +42,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -77,7 +77,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20220505-8aeca1a5
+    - image: quay.io/kubevirtci/flakefinder:v20220929-25d205de
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/pkg/flakefinder/BUILD.bazel
+++ b/robots/pkg/flakefinder/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "@com_github_google_go_github_v28//github:go_default_library",
+        "@com_github_joshdk_go_junit//:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_ginkgo//extensions/table:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/robots/pkg/flakefinder/report_data.go
+++ b/robots/pkg/flakefinder/report_data.go
@@ -9,15 +9,15 @@ import (
 )
 
 type Params struct {
-	StartOfReport   string
-	EndOfReport     string
-	Headers         []string
-	Tests           []string
-	Data            map[string]map[string]*Details
-	PrNumbers       []int
-	Org             string
-	Repo            string
-	FailuresForJobs map[string]*JobFailures
+	StartOfReport   string                         `json:"startOfReport"`
+	EndOfReport     string                         `json:"endOfReport"`
+	Headers         []string                       `json:"headers"`
+	Tests           []string                       `json:"tests"`
+	Data            map[string]map[string]*Details `json:"data"`
+	PrNumbers       []int                          `json:"prNumbers"`
+	Org             string                         `json:"org"`
+	Repo            string                         `json:"repo"`
+	FailuresForJobs map[string]*JobFailures        `json:"failuresForJobs"`
 }
 
 type Details struct {


### PR DESCRIPTION
As a basis and preliminary step for creating an issue automation for the flakiest tests we need a parseable export. Therefore we add creating a json file that contains the report data.

/cc @brianmcarey @xpivarc @enp0s3 