### PR TITLE
Correct pushgateway url

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -86,7 +86,7 @@ periodics:
     containers:
     - args:
       - |
-        go run robots/cmd/push-flakefinder-results/main.go --pushgateway-url=http://pushgateway
+        go run robots/cmd/push-flakefinder-results/main.go --pushgateway-url=http://pushgateway.kubevirt-prow
       command: [ "/usr/local/bin/runner.sh", "/bin/bash", "-ce" ]
       env:
       - name: GIMME_GO_VERSION


### PR DESCRIPTION
We need to add the namespace to the service url since all prow job pods are running in `kubevirt-prow-jobs` while pushgateway service is inside `kubevirt-prow` namespace.

Successful run here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-push-kubevirt-flakefinder-report-values/1575811694112804864

/cc @xpivarc @enp0s3 

FYI @brianmcarey 