### PR TITLE
Increase thanos compact PVC to 40Gi

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -449,7 +449,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 20Gi
+          storage: 40Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The compact process is hitting an error due to a full disk which is causing the compaction to halt and the data retention limits not to be enforced.

Increasing the size of the PVC to 40Gi.

/cc @dhiller @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>