### PR TITLE
Increase thanos-compact pvc to 100Gi due to out space error

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -449,7 +449,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 40Gi
+          storage: 100Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The compaction process gets halted due to the persistent volume running out of space. Increasing the volume size to 100Gi should help this issue.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>