### PR TITLE
Mirror istioctl 1.15

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -693,7 +693,7 @@ periodics:
           - name: BUCKET_DIR
             value: kubevirtci-istioctl-mirror
           - name: ISTIO_VERSIONS
-            value: "1.10.0,1.13.0,1.14.0"
+            value: "1.10.0,1.13.0,1.14.0,1.15.0"
         command: ["/bin/sh", "-c"]
         args:
           - ./hack/mirror-istioctl.sh


### PR DESCRIPTION
This version is needed in order
to support kubernetes 1.25

Signed-off-by: L. Pivarc <lpivarc@redhat.com>