### PR TITLE
Mirror istio images 1.15

### DIFF
--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -1,8 +1,8 @@
 docker.io,library/registry:2.7.1,quay.io/kubevirtci
 docker.io,kindest/node:v1.23.4,quay.io/kubevirtci
 docker.io,grafana/grafana:7.5.4,quay.io/kubevirtci
-docker.io,istio/install-cni:1.10.0,quay.io/kubevirtci
-docker.io,istio/operator:1.10.0,quay.io/kubevirtci
-docker.io,istio/pilot:1.10.0,quay.io/kubevirtci
-docker.io,istio/proxyv2:1.10.0,quay.io/kubevirtci
+docker.io,istio/install-cni:1.15.0,quay.io/kubevirtci
+docker.io,istio/operator:1.15.0,quay.io/kubevirtci
+docker.io,istio/pilot:1.15.0,quay.io/kubevirtci
+docker.io,istio/proxyv2:1.15.0,quay.io/kubevirtci
 docker.io,rpardini/docker-registry-proxy:0.6.2,quay.io/kubevirtci


### PR DESCRIPTION
This version is needed in order
to support kubernetes 1.25

Signed-off-by: L. Pivarc <lpivarc@redhat.com>