### PR TITLE
Allow mirror images job to run privileged

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -1089,7 +1089,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
       spec:
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220816-91d8af2
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command: ["/bin/sh"]
           args:
           - -c
@@ -1103,3 +1103,5 @@ postsubmits:
               memory: "200Mi"
             limits:
               memory: "200Mi"
+          securityContext:
+            privileged: true


### PR DESCRIPTION
Since the post-project-infra-mirror-images-from-docker-hub was updated to use the new podman bootstrap image, it fails trying to mount /var/lib/containers/storage/overlay due to permission issues[1]. Allowing the job to run as privileged allows the job to complete successfully.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-mirror-images-from-docker-hub/1579426531975892992

/cc @xpivarc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>