### PR TITLE
Increase thanos compact cpu and memory limits

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -422,11 +422,11 @@ spec:
           periodSeconds: 5
         resources:
           limits:
+            cpu: 0.82
+            memory: 620Mi
+          requests:
             cpu: 0.42
             memory: 420Mi
-          requests:
-            cpu: 0.123
-            memory: 123Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/thanos/compact


### PR DESCRIPTION
From monitoring the thanos compact pod, it can be seen that the CPU[1] and memory[2] usage consistently hits the limits allowed. Increasing these limits should improve the compaction performance.

The pod is being killed due to being out of memory:
```
kubectl get pods -n monitoring | grep compact
thanos-compact-0                                         1/1     Running   22 (9m39s ago)   5d
```
```
kubectl describe pod -n monitoring thanos-compact-0 | grep Reason
      Reason:    OOMKilled
```

[1]
![Screenshot from 2022-10-12 08-56-38](https://user-images.githubusercontent.com/21010464/195286023-5d552f54-17ad-40a0-bb3c-cbe48cdb0ec0.png)

[2]
![Screenshot from 2022-10-12 08-56-57](https://user-images.githubusercontent.com/21010464/195286223-238d329e-f43d-4964-a672-70d6ce96fe2b.png)


/cc @xpivarc @dhiller @brybacki 


Signed-off-by: Brian Carey <bcarey@redhat.com>