### PR TITLE
Toggling wiki to 'true' for the community repo

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -277,7 +277,7 @@ orgs:
         allow_rebase_merge: false
         description: Community content
         has_projects: false
-        has_wiki: false
+        has_wiki: true
       containerized-data-importer:
         description: Data Import Service for kubernetes, designed with kubevirt in mind.
         has_projects: true


### PR DESCRIPTION
I'd like to use the wiki feature for the Community repo to support an events page, which will require relatively frequent updates. 

Signed-off-by: Andrew Burden <aburden@redhat.com>