### PR TITLE
DNM/WIP Add skip_if_only_changed regex to skip jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1,2242 +1,2289 @@
 presubmits:
   kubevirt/kubevirt:
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
-    run_if_changed: pkg/virt-handler/cgroup/.*
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-compute
-        - name: KUBEVIRT_CGROUPV2
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
-      preset-gcs-credentials: "true"
-      preset-github-credentials: "true"
-    max_concurrency: 1
-    name: pull-kubevirtci-bump-kubevirt
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
-        command: ["/bin/sh", "-ce"]
-        args:
-        - |
-          HEAD=$(git ls-remote --heads https://github.com/kubevirt/kubevirt.git | grep refs/heads/main | cut -f1)
-          git reset --hard $HEAD
-          export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-          git-pr.sh -c "make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -T main
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "8Gi"
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
-    run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-storage
-        - name: KUBEVIRT_CGROUPV2
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-nonroot
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-compute
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-network-nonroot
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-network
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-storage-nonroot
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-storage
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-storage
-        - name: CDI_DV_GC
-          value: "0"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 2
-    name: pull-kubevirt-e2e-k8s-1.22-sig-performance
-    optional: true
-    run_if_changed: ^pkg/virt-api/.*|^pkg/virt-handler/.*|^pkg/virt-controller/.*|^pkg/virt-launcher/.*
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - |
-          # Build the perfscale-audit binary
-          make bazel-build
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
+      run_if_changed: pkg/virt-handler/cgroup/.*
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-compute
+              - name: KUBEVIRT_CGROUPV2
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h
+      labels:
+        preset-dind-enabled: "true"
+        preset-docker-mirror: "true"
+        preset-gcs-credentials: "true"
+        preset-github-credentials: "true"
+      max_concurrency: 1
+      name: pull-kubevirtci-bump-kubevirt
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/pr-creator:v20220927-5a02fb7
+            command: ["/bin/sh", "-ce"]
+            args:
+              - |
+                HEAD=$(git ls-remote --heads https://github.com/kubevirt/kubevirt.git | grep refs/heads/main | cut -f1)
+                git reset --hard $HEAD
+                export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+                git-pr.sh -c "make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -T main
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "8Gi"
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
+      run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-storage
+              - name: KUBEVIRT_CGROUPV2
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-compute-nonroot
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-compute
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-network-nonroot
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-network
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-storage-nonroot
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-storage
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-storage
+              - name: CDI_DV_GC
+                value: "0"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 2
+      name: pull-kubevirt-e2e-k8s-1.22-sig-performance
+      optional: true
+      run_if_changed: ^pkg/virt-api/.*|^pkg/virt-handler/.*|^pkg/virt-controller/.*|^pkg/virt-launcher/.*
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - |
+                # Build the perfscale-audit binary
+                make bazel-build
 
-          # Create k8s cluster
-          make cluster-up
+                # Create k8s cluster
+                make cluster-up
 
-          # Push and deploy kubevirt
-          make cluster-sync
+                # Push and deploy kubevirt
+                make cluster-sync
 
-          FUNC_TEST_ARGS="--no-color --seed=42" make perftest
-        env:
-        - name: KUBEVIRT_PROVIDER
-          value: k8s-1.22
-        - name: KUBEVIRT_STORAGE
-          value: hpp
-        - name: KUBEVIRT_MEMORY_SIZE
-          value: 11G
-        - name: KUBEVIRT_NUM_NODES
-          value: "4"
-        - name: KUBEVIRT_DEPLOY_PROMETHEUS
-          value: "true"
-        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
-          value: --prometheus-port 30007
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            cpu: "12"
-            memory: 52Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-operator-nonroot
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - ' automation/test.sh'
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-operator
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 2h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 1
-    name: pull-kubevirt-e2e-windows2016
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: windows2016
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-      priorityClassName: windows
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 30m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      sriov-pod: "true"
-    max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
-    optional: false
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod-multi
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: kind-1.22-sriov
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /dev/vfio/
-          name: vfio
-      nodeSelector:
-        hardwareSupport: sriov-nic
-      priorityClassName: sriov
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - hostPath:
-          path: /dev/vfio/
-          type: Directory
-        name: vfio
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 30m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-      rehearsal.allowed: "true"
-      sriov-pod: "true"
-    max_concurrency: 10
-    name: pull-kubevirt-e2e-kind-1.22-sriov
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod-multi
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: kind-1.22-sriov
-        image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /dev/vfio/
-          name: vfio
-      nodeSelector:
-        hardwareSupport: sriov-nic
-      priorityClassName: sriov
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - hostPath:
-          path: /dev/vfio/
-          type: Directory
-        name: vfio
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 30m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      vgpu: "true"
-    max_concurrency: 1
-    name: pull-kubevirt-e2e-kind-1.23-vgpu
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: vgpu
-                  operator: In
-                  values:
-                  - "true"
-              topologyKey: "kubernetes.io/hostname"
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - |
-          automation/test.sh
-        env:
-        - name: TARGET
-          value: kind-1.23-vgpu
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 18Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /dev/vfio/
-          name: vfio
-        - mountPath: /var/log/audit
-          name: audit
-      nodeSelector:
-        hardwareSupport: gpu
-      priorityClassName: vgpu
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - hostPath:
-          path: /dev/vfio/
-          type: Directory
-        name: vfio
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 30m0s
-      timeout: 4h0m0s
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      vgpu: "true"
-    max_concurrency: 1
-    name: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: vgpu
-                  operator: In
-                  values:
-                  - "true"
-              topologyKey: "kubernetes.io/hostname"
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - |
-          automation/test.sh
-        env:
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        - name: TARGET
-          value: kind-1.23-vgpu
-        image: quay.io/kubevirtci/golang:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 18Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /dev/vfio/
-          name: vfio
-        - mountPath: /var/log/audit
-          name: audit
-      nodeSelector:
-        hardwareSupport: gpu
-      priorityClassName: vgpu
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - hostPath:
-          path: /dev/vfio/
-          type: Directory
-        name: vfio
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-check-tests-for-flakes
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-generate
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-verify-rpms
-    optional: true
-    run_if_changed: WORKSPACE
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-verify-go-mod
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make deps-sync && hack/verify-generate.sh
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      rehearsal.allowed: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-gosec
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-build
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-build-arm64
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        env:
-        - name: BUILD_ARCH
-          value: crossbuild-aarch64
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-unit-test
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - make test
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 10m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-goveralls
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then
-          make goveralls; fi
-        env:
-        - name: COVERALLS_TOKEN_FILE
-          value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /root/.docker/secrets/coveralls
-          name: kubevirtci-coveralls
-          readOnly: true
-      volumes:
-      - name: kubevirtci-coveralls
-        secret:
-          secretName: kubevirtci-coveralls-token
-  - always_run: true
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 10m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-fossa
-    optional: true
-    skip_report: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - make fossa
-        env:
-        - name: FOSSA_TOKEN_FILE
-          value: /root/.docker/secrets/fossa/token
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /root/.docker/secrets/fossa
-          name: kubevirtci-fossa
-          readOnly: true
-      volumes:
-      - name: kubevirtci-fossa
-        secret:
-          secretName: kubevirtci-fossa-token
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-apidocs
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-client-python
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-manifests
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt"
-          && make olm-verify
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-prom-rules-verify
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-check-unassigned-tests
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - hack/check-unassigned-tests.sh
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-network
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.22-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-ipv6-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-storage
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.22-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-compute
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.22-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-compute-migrations
-        - name: KUBEVIRT_NUM_NODES
-          value: "3"
-        - name: KUBEVIRT_STORAGE
-          value: rook-ceph-default
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-compute-migrations
-        - name: KUBEVIRT_NUM_NODES
-          value: "3"
-        - name: KUBEVIRT_STORAGE
-          value: rook-ceph-default
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-compute-migrations
-        - name: KUBEVIRT_NUM_NODES
-          value: "3"
-        - name: KUBEVIRT_STORAGE
-          value: rook-ceph-default
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-operator
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.22-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.22-sig-compute-realtime
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    extra_refs:
-    - base_ref: main
-      org: kubevirt
-      repo: project-infra
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-github-credentials: "true"
-      preset-kubevirtci-quay-credential: "true"
-      preset-shared-images: "true"
-    max_concurrency: 1
-    name: pull-kubevirt-e2e-arm64
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - |
-          # install yq
-          curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
-          chmod +x ./yq && mv ./yq /usr/local/bin/yq
+                FUNC_TEST_ARGS="--no-color --seed=42" make perftest
+            env:
+              - name: KUBEVIRT_PROVIDER
+                value: k8s-1.22
+              - name: KUBEVIRT_STORAGE
+                value: hpp
+              - name: KUBEVIRT_MEMORY_SIZE
+                value: 11G
+              - name: KUBEVIRT_NUM_NODES
+                value: "4"
+              - name: KUBEVIRT_DEPLOY_PROMETHEUS
+                value: "true"
+              - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+                value: --prometheus-port 30007
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                cpu: "12"
+                memory: 52Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-operator-nonroot
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - ' automation/test.sh'
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-operator
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 2h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 1
+      name: pull-kubevirt-e2e-windows2016
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: windows2016
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+        priorityClassName: windows
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 30m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-unnested: "true"
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        sriov-pod: "true"
+      max_concurrency: 10
+      name: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
+      optional: false
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: sriov-pod
+                      operator: In
+                      values:
+                        - "true"
+                topologyKey: kubernetes.io/hostname
+              - labelSelector:
+                  matchExpressions:
+                    - key: sriov-pod-multi
+                      operator: In
+                      values:
+                        - "true"
+                topologyKey: kubernetes.io/hostname
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/bash
+              - -ce
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: kind-1.22-sriov
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - mountPath: /sys/fs/cgroup
+                name: cgroup
+              - mountPath: /dev/vfio/
+                name: vfio
+        nodeSelector:
+          hardwareSupport: sriov-nic
+        priorityClassName: sriov
+        volumes:
+          - hostPath:
+              path: /lib/modules
+              type: Directory
+            name: modules
+          - hostPath:
+              path: /sys/fs/cgroup
+              type: Directory
+            name: cgroup
+          - hostPath:
+              path: /dev/vfio/
+              type: Directory
+            name: vfio
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 30m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-unnested: "true"
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+        rehearsal.allowed: "true"
+        sriov-pod: "true"
+      max_concurrency: 10
+      name: pull-kubevirt-e2e-kind-1.22-sriov
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        affinity:
+          podAntiAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                    - key: sriov-pod
+                      operator: In
+                      values:
+                        - "true"
+                topologyKey: kubernetes.io/hostname
+              - labelSelector:
+                  matchExpressions:
+                    - key: sriov-pod-multi
+                      operator: In
+                      values:
+                        - "true"
+                topologyKey: kubernetes.io/hostname
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/bash
+              - -ce
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: kind-1.22-sriov
+            image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - mountPath: /sys/fs/cgroup
+                name: cgroup
+              - mountPath: /dev/vfio/
+                name: vfio
+        nodeSelector:
+          hardwareSupport: sriov-nic
+        priorityClassName: sriov
+        volumes:
+          - hostPath:
+              path: /lib/modules
+              type: Directory
+            name: modules
+          - hostPath:
+              path: /sys/fs/cgroup
+              type: Directory
+            name: cgroup
+          - hostPath:
+              path: /dev/vfio/
+              type: Directory
+            name: vfio
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 30m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        vgpu: "true"
+      max_concurrency: 1
+      name: pull-kubevirt-e2e-kind-1.23-vgpu
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: vgpu
+                        operator: In
+                        values:
+                          - "true"
+                  topologyKey: "kubernetes.io/hostname"
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/bash
+              - -ce
+              - |
+                automation/test.sh
+            env:
+              - name: TARGET
+                value: kind-1.23-vgpu
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 18Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - mountPath: /sys/fs/cgroup
+                name: cgroup
+              - mountPath: /dev/vfio/
+                name: vfio
+              - mountPath: /var/log/audit
+                name: audit
+        nodeSelector:
+          hardwareSupport: gpu
+        priorityClassName: vgpu
+        volumes:
+          - hostPath:
+              path: /lib/modules
+              type: Directory
+            name: modules
+          - hostPath:
+              path: /sys/fs/cgroup
+              type: Directory
+            name: cgroup
+          - hostPath:
+              path: /dev/vfio/
+              type: Directory
+            name: vfio
+          - hostPath:
+              path: /var/log/audit
+              type: Directory
+            name: audit
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 30m0s
+        timeout: 4h0m0s
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        vgpu: "true"
+      max_concurrency: 1
+      name: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: vgpu
+                        operator: In
+                        values:
+                          - "true"
+                  topologyKey: "kubernetes.io/hostname"
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/bash
+              - -ce
+              - |
+                automation/test.sh
+            env:
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+              - name: TARGET
+                value: kind-1.23-vgpu
+            image: quay.io/kubevirtci/golang:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 18Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /lib/modules
+                name: modules
+                readOnly: true
+              - mountPath: /sys/fs/cgroup
+                name: cgroup
+              - mountPath: /dev/vfio/
+                name: vfio
+              - mountPath: /var/log/audit
+                name: audit
+        nodeSelector:
+          hardwareSupport: gpu
+        priorityClassName: vgpu
+        volumes:
+          - hostPath:
+              path: /lib/modules
+              type: Directory
+            name: modules
+          - hostPath:
+              path: /sys/fs/cgroup
+              type: Directory
+            name: cgroup
+          - hostPath:
+              path: /dev/vfio/
+              type: Directory
+            name: vfio
+          - hostPath:
+              path: /var/log/audit
+              type: Directory
+            name: audit
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-check-tests-for-flakes
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-generate
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-verify-rpms
+      optional: true
+      run_if_changed: WORKSPACE
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-verify-go-mod
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make deps-sync && hack/verify-generate.sh
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        rehearsal.allowed: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-gosec
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      skip_report: true
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-build
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-build-arm64
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+            env:
+              - name: BUILD_ARCH
+                value: crossbuild-aarch64
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-unit-test
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - make test
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 10m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-goveralls
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then make goveralls; fi
+            env:
+              - name: COVERALLS_TOKEN_FILE
+                value: /root/.docker/secrets/coveralls/token
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 8Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /root/.docker/secrets/coveralls
+                name: kubevirtci-coveralls
+                readOnly: true
+        volumes:
+          - name: kubevirtci-coveralls
+            secret:
+              secretName: kubevirtci-coveralls-token
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 10m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-fossa
+      optional: true
+      skip_report: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - make fossa
+            env:
+              - name: FOSSA_TOKEN_FILE
+                value: /root/.docker/secrets/fossa/token
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /root/.docker/secrets/fossa
+                name: kubevirtci-fossa
+                readOnly: true
+        volumes:
+          - name: kubevirtci-fossa
+            secret:
+              secretName: kubevirtci-fossa-token
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-apidocs
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-client-python
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-manifests
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt" && make olm-verify
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-prom-rules-verify
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-check-unassigned-tests
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - hack/check-unassigned-tests.sh
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.22-sig-network
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.22-sig-network
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-ipv6-sig-network
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.22-sig-storage
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.22-sig-storage
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.22-sig-compute
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.22-sig-compute
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-compute-migrations
+              - name: KUBEVIRT_NUM_NODES
+                value: "3"
+              - name: KUBEVIRT_STORAGE
+                value: rook-ceph-default
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-compute-migrations
+              - name: KUBEVIRT_NUM_NODES
+                value: "3"
+              - name: KUBEVIRT_STORAGE
+                value: rook-ceph-default
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-compute-migrations
+              - name: KUBEVIRT_NUM_NODES
+                value: "3"
+              - name: KUBEVIRT_STORAGE
+                value: rook-ceph-default
+              - name: FEATURE_GATES
+                value: NonRoot
+              - name: KUBEVIRT_NONROOT
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.22-operator
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.22-sig-operator
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.22-sig-compute-realtime
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      extra_refs:
+        - base_ref: main
+          org: kubevirt
+          repo: project-infra
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-github-credentials: "true"
+        preset-kubevirtci-quay-credential: "true"
+        preset-shared-images: "true"
+      max_concurrency: 1
+      name: pull-kubevirt-e2e-arm64
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - |
+                # install yq
+                curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+                chmod +x ./yq && mv ./yq /usr/local/bin/yq
 
-          # get kubectl
-          curl -L "https://dl.k8s.io/release/v1.19.7/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
-          chmod +x /usr/local/bin/kubectl
+                # get kubectl
+                curl -L "https://dl.k8s.io/release/v1.19.7/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+                chmod +x /usr/local/bin/kubectl
 
-          # get kubeconfig
-          source ../project-infra/hack/manage-secrets.sh
-          decrypt_secrets
-          extract_secret 'kubeconfigARM' /kubeconfig
+                # get kubeconfig
+                source ../project-infra/hack/manage-secrets.sh
+                decrypt_secrets
+                extract_secret 'kubeconfigARM' /kubeconfig
 
-          # login quay.io
-          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                # login quay.io
+                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
 
-          # run the test
-          automation/test.sh
-        env:
-        - name: TARGET
-          value: external
-        - name: KUBEVIRT_PROVIDER
-          value: external
-        - name: DOCKER_PREFIX
-          value: quay.io/kubevirtci
-        - name: DOCKER_TAG
-          value: aarch64_test
-        - name: KUBECONFIG
-          value: /kubeconfig
-        - name: kubectl
-          value: /usr/local/bin/kubectl
-        - name: IMAGE_PULL_POLICY
-          value: Always
-        - name: BUILD_ARCH
-          value: crossbuild-aarch64
-        - name: KUBEVIRT_E2E_FOCUS
-          value: arm64
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /etc/pgp
-          name: pgp-bot-key
-          readOnly: true
-      nodeSelector:
-        type: bare-metal-external
-      volumes:
-      - name: pgp-bot-key
-        secret:
-          secretName: pgp-bot-key
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: build-kubevirt-builder
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -ce
-        - |
-          make builder-build
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-network
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-    cluster: ibm-prow-jobs
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-code-lint
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - |
-          make lint
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 4Gi
-        securityContext:
-          privileged: true
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-storage
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-compute
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-operator
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-swap-enabled
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23
-        - name: KUBEVIRT_E2E_FOCUS
-          value: SwapTest
-        - name: KUBEVIRT_SWAP_ON
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
-    run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.22-sig-monitoring
-        - name: KUBEVIRT_NUM_NODES
-          value: "2"
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-single-node
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23
-        - name: KUBEVIRT_E2E_FOCUS
-          value: .*
-        - name: KUBEVIRT_NUM_NODES
-          value: "1"
-        - name: KUBEVIRT_INFRA_REPLICAS
-          value: "1"
-        - name: KUBEVIRT_WITH_CNAO
-          value: "true"
-        - name: KUBEVIRT_STORAGE
-          value: rook-ceph-default
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 15Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-network
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-storage
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-compute
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-operator
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    optional: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-psa-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    optional: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.24-psa-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
+                # run the test
+                automation/test.sh
+            env:
+              - name: TARGET
+                value: external
+              - name: KUBEVIRT_PROVIDER
+                value: external
+              - name: DOCKER_PREFIX
+                value: quay.io/kubevirtci
+              - name: DOCKER_TAG
+                value: aarch64_test
+              - name: KUBECONFIG
+                value: /kubeconfig
+              - name: kubectl
+                value: /usr/local/bin/kubectl
+              - name: IMAGE_PULL_POLICY
+                value: Always
+              - name: BUILD_ARCH
+                value: crossbuild-aarch64
+              - name: KUBEVIRT_E2E_FOCUS
+                value: arm64
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 8Gi
+            securityContext:
+              privileged: true
+            volumeMounts:
+              - mountPath: /etc/pgp
+                name: pgp-bot-key
+                readOnly: true
+        nodeSelector:
+          type: bare-metal-external
+        volumes:
+          - name: pgp-bot-key
+            secret:
+              secretName: pgp-bot-key
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: build-kubevirt-builder
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -ce
+              - |
+                make builder-build
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-sig-network
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-network
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+      cluster: ibm-prow-jobs
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-code-lint
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - |
+                make lint
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 4Gi
+            securityContext:
+              privileged: true
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-sig-storage
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-storage
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-sig-compute
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-compute
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-operator
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23-sig-operator
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-swap-enabled
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      skip_report: true
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23
+              - name: KUBEVIRT_E2E_FOCUS
+                value: SwapTest
+              - name: KUBEVIRT_SWAP_ON
+                value: "true"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+      name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
+      run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.22-sig-monitoring
+              - name: KUBEVIRT_NUM_NODES
+                value: "2"
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.23-single-node
+      optional: true
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.23
+              - name: KUBEVIRT_E2E_FOCUS
+                value: .*
+              - name: KUBEVIRT_NUM_NODES
+                value: "1"
+              - name: KUBEVIRT_INFRA_REPLICAS
+                value: "1"
+              - name: KUBEVIRT_WITH_CNAO
+                value: "true"
+              - name: KUBEVIRT_STORAGE
+                value: rook-ceph-default
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 15Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-network
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-network
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-storage
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-storage
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-sig-compute
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-compute
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: true
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-operator
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-sig-operator
+            image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      optional: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 7h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-psa-sig-compute
+            image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
+    - always_run: false
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-presubmits
+      cluster: prow-workloads
+      decorate: true
+      optional: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 4h0m0s
+      labels:
+        preset-bazel-cache: "true"
+        preset-bazel-unnested: "true"
+        preset-dind-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      max_concurrency: 11
+      name: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -c
+              - automation/test.sh
+            env:
+              - name: TARGET
+                value: k8s-1.24-psa-sig-storage
+            image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+            name: ""
+            resources:
+              requests:
+                memory: 29Gi
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+      skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$


### PR DESCRIPTION
DNM/WIP as there must be a better way to mass edit these jobs, any feedback would be welcome!

I've used yq to add skip_if_only_changed to jobs without run_if_changed set using the following command:
```
$ docker run -i --rm -v $(pwd):/work mikefarah/yq -i '. | with(.presubmits.kubevirt/kubevirt[]; with(select(.run_if_changed == null); .skip_if_only_changed = "^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$"))' /work/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
```

This appears to give the desired result but jq reorders the contents so the diff is awful:
```
$ docker run -i --rm -v $(pwd):/work mikefarah/yq '.presubmits.kubevirt/kubevirt[] | pick(["name", "run_if_changed", "skip_if_only_changed"])' /work/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml 
name: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
run_if_changed: pkg/virt-handler/cgroup/.*
name: pull-kubevirtci-bump-kubevirt
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
name: pull-kubevirt-e2e-k8s-1.24-sig-compute-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-network-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-storage-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-sig-performance
run_if_changed: ^pkg/virt-api/.*|^pkg/virt-handler/.*|^pkg/virt-controller/.*|^pkg/virt-launcher/.*
name: pull-kubevirt-e2e-k8s-1.24-operator-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-windows2016
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-kind-1.22-sriov
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-kind-1.23-vgpu
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-check-tests-for-flakes
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-generate
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-verify-rpms
run_if_changed: WORKSPACE
name: pull-kubevirt-verify-go-mod
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-gosec
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-build
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-build-arm64
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-unit-test
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-goveralls
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-fossa
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-apidocs
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-client-python
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-manifests
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-prom-rules-verify
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-check-unassigned-tests
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-sig-network
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-sig-storage
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-sig-compute
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-operator
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-arm64
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: build-kubevirt-builder
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-sig-network
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-code-lint
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-sig-storage
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-sig-compute
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-operator
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.23-swap-enabled
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
name: pull-kubevirt-e2e-k8s-1.23-single-node
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-network
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-storage
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-sig-compute
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-operator
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$
name: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
skip_if_only_changed: ^docs/|\\.(md|adoc)$|^(README|LICENSE|OWNERS|OWNERS_ALIASES)$

```