### PR TITLE
bootstrap: add j2 to the img

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -54,7 +54,8 @@ RUN dnf install -y \
     sudo \
     buildah \
     qemu-user-static \
-    wget &&\
+    wget \
+    python3-jinja2 &&\
   dnf -y clean all
 
 # Install gcloud


### PR DESCRIPTION
j2 is required to template the multus-cni e2e test manifests, which are not pushed into the multus repo.

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>