### PR TITLE
Update CDI prow jobs to use the podman bootrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -75,7 +75,7 @@ periodics:
     grace_period: 5m
   max_concurrency: 1
   labels:
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
@@ -89,7 +89,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+    - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -14,12 +14,12 @@ postsubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+      - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -52,12 +52,12 @@ postsubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+      - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -88,13 +88,13 @@ postsubmits:
       timeout: 3h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "false"
       preset-github-credentials: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+      - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -129,13 +129,13 @@ postsubmits:
       timeout: 3h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "false"
       preset-github-credentials: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+      - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -170,14 +170,14 @@ postsubmits:
       timeout: 3h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+      - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -12,11 +12,11 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -40,12 +40,12 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -69,12 +69,12 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -98,12 +98,12 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -130,14 +130,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -164,14 +164,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -198,14 +198,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -234,14 +234,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -270,14 +270,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -304,14 +304,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -338,14 +338,14 @@ presubmits:
     max_concurrency: 6
     cluster: prow-workloads
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        - image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -371,7 +371,7 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
@@ -383,7 +383,7 @@ presubmits:
         env:
         - name: FOSSA_TOKEN_FILE
           value: /root/.docker/secrets/fossa/token
-        image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
+        image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         name: ""
         resources:
           requests:


### PR DESCRIPTION
An issue with rsync failures and podman was identified and the CDI prowjobs were moved back to using dind[1]. The rsync failures were caused by the rsync container not being cleaned up correctly and a fix has been created for this issue[2].

This change depends on https://github.com/kubevirt/containerized-data-importer/pull/2448 being merged

/cc @awels  @maya-r 

[1] https://github.com/kubevirt/project-infra/commit/a2e6419e36d8c3c4303585a1ea256e94d5b0a236 
[2] https://github.com/kubevirt/containerized-data-importer/pull/2448