### PR TITLE
Reenable reporting for FOSSA presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1047,10 +1047,8 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-fossa
-    optional: true
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
Since the FOSSA check has stabilized we can enable reporting for it again.

https://prow.ci.kubevirt.io/?repo=kubevirt%2Fkubevirt&job=*fossa*

/cc @brianmcarey @xpivarc @enp0s3 @acardace 