### PR TITLE
Make fossa lane in CDI always run and required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -394,8 +394,8 @@ presubmits:
   - name: pull-containerized-data-importer-fossa
     skip_branches:
       - release-\d+\.\d+
-    always_run: false
-    optional: true
+    always_run: true
+    optional: false
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs


### PR DESCRIPTION
fossa issues have been solved, we can now reliably run it against our repo.

Signed-off-by: Alexander Wels <awels@redhat.com>