### PR TITLE
Use correct provider name for operator lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1862,7 +1862,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.25-operator
+  name: periodic-kubevirt-e2e-k8s-1.25-sig-operator
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1879,7 +1879,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.25-operator
+        value: k8s-1.25-sig-operator
       image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2376,7 +2376,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.25-operator
+    name: pull-kubevirt-e2e-k8s-1.25-sig-operator
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -2389,7 +2389,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.25-operator
+          value: k8s-1.25-sig-operator
         image: quay.io/kubevirtci/bootstrap:v20220906-4f60dd3
         name: ""
         resources:


### PR DESCRIPTION
Since we are using sig-operator in k8s <= 1.24 already, let's update the
lane names to reflect reality for 1.25.

The update of the sig name for the automation will be done in a separate
PR.

NOTE: we are NOT updating the lanes for 1.24 <= to avoid losing
information in the testgrid dashboard!

/cc @enp0s3 @xpivarc