### PR TITLE
Add circuit breaker to flake-report-creator

### DIFF
--- a/hack/flake-report-creator.sh
+++ b/hack/flake-report-creator.sh
@@ -6,7 +6,7 @@ docker run -v /etc/pki:/etc/pki -v /etc/ssl:/etc/ssl \
         -e GOOGLE_APPLICATION_CREDENTIALS="$GOOGLE_APPLICATION_CREDENTIALS" \
         -v "${tmp_dir}:/tmp:Z" \
         --network host \
-        quay.io/kubevirtci/flake-report-creator:v20220823-fe8793d0 \
+        quay.io/kubevirtci/flake-report-creator:v20221104-9aec1ec5 \
         --overwrite --outputFile=/tmp/report.html \
         "$@"
 

--- a/robots/pkg/circuitbreaker/BUILD.bazel
+++ b/robots/pkg/circuitbreaker/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["circuitbreaker.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/circuitbreaker",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["circuitbreaker_test.go"],
+    deps = [
+        ":go_default_library",
+        "@com_github_onsi_ginkgo//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+    ],
+)

--- a/robots/pkg/circuitbreaker/BUILD.bazel
+++ b/robots/pkg/circuitbreaker/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["circuitbreaker.go"],
     importpath = "kubevirt.io/project-infra/robots/pkg/circuitbreaker",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
 )
 
 go_test(

--- a/robots/pkg/circuitbreaker/circuitbreaker.go
+++ b/robots/pkg/circuitbreaker/circuitbreaker.go
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package circuitbreaker
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// CircuitBreaker is a minimal implementation of the [circuit breaker pattern].
+//
+// [circuit breaker pattern]: https://martinfowler.com/bliki/CircuitBreaker.html
+type CircuitBreaker struct {
+	mutex      sync.Mutex
+	lastErr    error
+	open       bool
+	occurred   time.Time
+	retryAfter time.Duration
+}
+
+func NewCircuitBreaker(retryAfter time.Duration) *CircuitBreaker {
+	if retryAfter <= 0 {
+		panic(fmt.Errorf("retryAfter <= 0: %v", retryAfter))
+	}
+	return &CircuitBreaker{retryAfter: retryAfter}
+}
+
+// WrapRetryableFunc wraps the target retry.RetryableFunc into a new function that transforms the result of the original
+// call into the state for the circuit breaker, which is then updated accordingly.
+//
+// If the circuit breaker is closed, the wrapped function will be called. If the wrapped function returns an error,
+// the time of the occurrence and the error will be recorded, and the circuit breaker will be opened.
+// If the circuit breaker is open, the wrapped function will only be called if the retryAfter period has been reached,
+// otherwise the last occurred error will be returned directly. If the wrapped function is called and does not return
+// an error, the circuit breaker will be closed.
+func (g *CircuitBreaker) WrapRetryableFunc(retryableFunc func() error) func() error {
+	return func() error {
+		if shouldStayOpen, lastErr := g.isOpenAndNotFeasibleForRetry(); shouldStayOpen {
+			return lastErr
+		}
+		err := retryableFunc()
+		g.updateState(err)
+		return err
+	}
+}
+
+func (g *CircuitBreaker) isOpenAndNotFeasibleForRetry() (bool, error) {
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+	return g.open && !g.occurred.Add(g.retryAfter).Before(time.Now()), g.lastErr
+}
+
+func (g *CircuitBreaker) updateState(err error) {
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+	if err != nil {
+		g.open = true
+		g.occurred = time.Now()
+	} else {
+		g.open = false
+	}
+	g.lastErr = err
+}

--- a/robots/pkg/circuitbreaker/circuitbreaker.go
+++ b/robots/pkg/circuitbreaker/circuitbreaker.go
@@ -77,11 +77,11 @@ func (g *CircuitBreaker) isRetryBlocked() bool {
 }
 
 func (g *CircuitBreaker) updateState(err error) {
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
 	if g.isRetryBlocked() {
 		return
 	}
-	g.mutex.Lock()
-	defer g.mutex.Unlock()
 	if err != nil && g.shouldOpen(err) {
 		g.open = true
 		g.blockedUntil = time.Now().Add(g.retryAfter)

--- a/robots/pkg/circuitbreaker/circuitbreaker_test.go
+++ b/robots/pkg/circuitbreaker/circuitbreaker_test.go
@@ -1,0 +1,225 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package circuitbreaker_test
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"kubevirt.io/project-infra/robots/pkg/circuitbreaker"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "jenkins suite")
+}
+
+var _ = Describe("circuitbreaker.go", func() {
+
+	When("creating", func() {
+
+		It("should panic on non positive retryAfter", func() {
+			Expect(func() { circuitbreaker.NewCircuitBreaker(0) }).To(Panic())
+		})
+
+		It("should return a breaker if the retry interval is positive", func() {
+			Expect(circuitbreaker.NewCircuitBreaker(time.Millisecond)).To(Not(BeNil()))
+		})
+
+	})
+
+	When("calling with one instance", func() {
+
+		var circuitBreaker *circuitbreaker.CircuitBreaker
+		retryAfter := 10 * time.Millisecond
+
+		BeforeEach(func() {
+			circuitBreaker = circuitbreaker.NewCircuitBreaker(retryAfter)
+		})
+
+		It("should call the target", func() {
+			mockRetryableFunc := &MockRetryableFunc{errors: []error{nil}}
+			retryableFunc := circuitBreaker.WrapRetryableFunc(mockRetryableFunc.target())
+			retryableFunc()
+			Expect(mockRetryableFunc.calls).To(BeEquivalentTo(1))
+		})
+
+		It("should not call the target a second time before the retry period has passed", func() {
+			mockRetryableFunc := &MockRetryableFunc{errors: []error{fmt.Errorf("test"), nil}}
+			retryableFunc := circuitBreaker.WrapRetryableFunc(mockRetryableFunc.target())
+			retryableFunc()
+			retryableFunc()
+			Expect(mockRetryableFunc.calls).To(BeEquivalentTo(1))
+		})
+
+		It("should call the target a second time after retry period has passed", func() {
+			mockRetryableFunc := &MockRetryableFunc{errors: []error{fmt.Errorf("test"), nil}}
+			retryableFunc := circuitBreaker.WrapRetryableFunc(mockRetryableFunc.target())
+			retryableFunc()
+			time.Sleep(retryAfter)
+			retryableFunc()
+			Expect(mockRetryableFunc.calls).To(BeEquivalentTo(2))
+		})
+
+	})
+
+	When("calling with two instances", func() {
+
+		var circuitBreaker *circuitbreaker.CircuitBreaker
+		retryAfter := 10 * time.Millisecond
+
+		BeforeEach(func() {
+			circuitBreaker = circuitbreaker.NewCircuitBreaker(retryAfter)
+		})
+
+		It("should not call the second target if the call to first target failed", func() {
+			targetFuncA := &MockRetryableFunc{errors: []error{fmt.Errorf("test")}}
+			targetFuncB := &MockRetryableFunc{errors: []error{nil}}
+			retryableFuncA := circuitBreaker.WrapRetryableFunc(targetFuncA.target())
+			retryableFuncB := circuitBreaker.WrapRetryableFunc(targetFuncB.target())
+			retryableFuncA()
+			retryableFuncB()
+			Expect(targetFuncA.calls).To(BeEquivalentTo(1))
+			Expect(targetFuncB.calls).To(BeEquivalentTo(0))
+		})
+
+		It("should call the second target after retry period has passed", func() {
+			targetFuncA := &MockRetryableFunc{errors: []error{fmt.Errorf("test")}}
+			targetFuncB := &MockRetryableFunc{errors: []error{nil}}
+			retryableFuncA := circuitBreaker.WrapRetryableFunc(targetFuncA.target())
+			retryableFuncB := circuitBreaker.WrapRetryableFunc(targetFuncB.target())
+			retryableFuncA()
+			time.Sleep(retryAfter)
+			retryableFuncB()
+			Expect(targetFuncA.calls).To(BeEquivalentTo(1))
+			Expect(targetFuncB.calls).To(BeEquivalentTo(1))
+		})
+
+	})
+
+	When("calling with go routines", func() {
+
+		var circuitBreaker *circuitbreaker.CircuitBreaker
+		retryAfter := 10 * time.Millisecond
+
+		BeforeEach(func() {
+			circuitBreaker = circuitbreaker.NewCircuitBreaker(retryAfter)
+		})
+
+		It("should call only one target func in case of error", func() {
+			numberOfThreads := 4
+			var wg sync.WaitGroup
+			wg.Add(numberOfThreads)
+			var targetFuncs []*MockRetryableFunc
+			for i := 0; i < numberOfThreads; i++ {
+				targetFunc := &MockRetryableFunc{errors: []error{fmt.Errorf("test")}}
+				targetFuncs = append(targetFuncs, targetFunc)
+				go func(targetFunc *MockRetryableFunc) {
+					defer wg.Done()
+					_ = circuitBreaker.WrapRetryableFunc(targetFunc.target())()
+				}(targetFunc)
+			}
+			wg.Wait()
+			totalCalls := 0
+			for i := 0; i < numberOfThreads; i++ {
+				totalCalls += targetFuncs[i].calls
+			}
+			Expect(totalCalls).To(BeEquivalentTo(1))
+		})
+
+		It("should call all four target funcs in case of no error", func() {
+			numberOfThreads := 4
+			var wg sync.WaitGroup
+			wg.Add(numberOfThreads)
+			var targetFuncs []*MockRetryableFunc
+			for i := 0; i < numberOfThreads; i++ {
+				targetFunc := &MockRetryableFunc{errors: []error{nil}}
+				targetFuncs = append(targetFuncs, targetFunc)
+				go func(index int, targetFunc *MockRetryableFunc) {
+					defer wg.Done()
+					_ = circuitBreaker.WrapRetryableFunc(targetFunc.target())()
+				}(i, targetFunc)
+			}
+			wg.Wait()
+			totalCalls := 0
+			for i := 0; i < numberOfThreads; i++ {
+				totalCalls += targetFuncs[i].calls
+			}
+			Expect(totalCalls).To(BeEquivalentTo(4))
+		})
+
+		It("should call all four target funcs in case of the first caller errors and the others wait long enough", func() {
+			numberOfThreads := 4
+			var wg sync.WaitGroup
+			wg.Add(numberOfThreads)
+
+			// while the first call of target func happens directly and returns an error...
+			var targetFuncs []*MockRetryableFunc
+			targetFunc := &MockRetryableFunc{errors: []error{fmt.Errorf("test")}}
+			targetFuncs = append(targetFuncs, targetFunc)
+			go func(targetFunc *MockRetryableFunc) {
+				defer wg.Done()
+				_ = circuitBreaker.WrapRetryableFunc(targetFunc.target())()
+			}(targetFunc)
+
+			// ...the remaining functions all wait twice the retryAfter period before they call the target func
+			for i := 1; i < numberOfThreads; i++ {
+				targetFunc := &MockRetryableFunc{errors: []error{nil}}
+				targetFuncs = append(targetFuncs, targetFunc)
+				go func(index int, targetFunc *MockRetryableFunc) {
+					defer wg.Done()
+					time.Sleep(2 * retryAfter)
+					_ = circuitBreaker.WrapRetryableFunc(targetFunc.target())()
+				}(i, targetFunc)
+			}
+
+			wg.Wait()
+
+			// this should result in all functions being called
+			totalCalls := 0
+			for i := 0; i < numberOfThreads; i++ {
+				totalCalls += targetFuncs[i].calls
+			}
+			Expect(totalCalls).To(BeEquivalentTo(4))
+		})
+
+	})
+
+})
+
+// MockRetryableFunc is a mock that returns a func implementing RetryableFunc, which can return different error values
+// and count the number of times the func got called.
+type MockRetryableFunc struct {
+	calls  int
+	errors []error
+}
+
+// target returns a RetryableFunc that for each consecutive call returns the next element
+// from the slice, thereafter it increments the counter indicating the number of times the target func got called by one.
+func (m *MockRetryableFunc) target() func() error {
+	return func() error {
+		err := m.errors[m.calls]
+		m.calls++
+		return err
+	}
+}

--- a/robots/pkg/jenkins/BUILD.bazel
+++ b/robots/pkg/jenkins/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,8 +6,22 @@ go_library(
     importpath = "kubevirt.io/project-infra/robots/pkg/jenkins",
     visibility = ["//visibility:public"],
     deps = [
+        "//robots/pkg/circuitbreaker:go_default_library",
         "@com_github_avast_retry_go//:go_default_library",
         "@com_github_bndr_gojenkins//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["builds_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//robots/pkg/circuitbreaker:go_default_library",
+        "@com_github_bndr_gojenkins//:go_default_library",
+        "@com_github_onsi_ginkgo//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/robots/pkg/jenkins/builds.go
+++ b/robots/pkg/jenkins/builds.go
@@ -214,6 +214,10 @@ func getBuildFromGetterWithRetry(buildDataGetter BuildDataGetter, buildNumber in
 		}),
 		retry.Delay(retryDelay),
 		retry.MaxJitter(maxJitter),
+		// We are using FixedDelay here since we only want to wait for the specified amount of
+		// time per each retry with a random jitter value, since the default retry.BackOffDelay would
+		// multiply the wait time on each retry
+		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
 	)
 	return build, statusCode, err
 }

--- a/robots/pkg/jenkins/builds_test.go
+++ b/robots/pkg/jenkins/builds_test.go
@@ -1,0 +1,128 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package jenkins
+
+import (
+	"fmt"
+	"github.com/bndr/gojenkins"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestJenkins(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "jenkins suite")
+}
+
+type SimpleMockBuildDataGetter struct {
+	callCounter int
+	build       []*gojenkins.Build
+	err         []error
+}
+
+func (d *SimpleMockBuildDataGetter) GetBuild(buildNumber int64) (build *gojenkins.Build, err error) {
+	build, err = d.build[d.callCounter], d.err[d.callCounter]
+	d.callCounter++
+	return build, err
+}
+
+type DurationBasedMockBuildDataGetter struct {
+	callCounter   uint32
+	start         time.Time
+	durationIndex []time.Duration
+	build         []*gojenkins.Build
+	err           []error
+}
+
+func (d *DurationBasedMockBuildDataGetter) GetBuild(buildNumber int64) (build *gojenkins.Build, err error) {
+	atomic.AddUint32(&d.callCounter, 1)
+	for index, durationInterval := range d.durationIndex {
+		if time.Now().Before(d.start.Add(durationInterval)) {
+			return d.build[index], d.err[index]
+		}
+	}
+	panic(fmt.Errorf("no interval was matching!"))
+}
+
+func (d *DurationBasedMockBuildDataGetter) GetCallCounter() uint32 {
+	return d.callCounter
+}
+
+var _ = Describe("builds.go", func() {
+
+	BeforeEach(func() {
+		retryDelay = 100 * time.Millisecond
+		maxJitter = 10 * time.Millisecond
+	})
+
+	When("retrying", func() {
+
+		entry := logrus.WithField("dummy", "blah")
+
+		It("should return build directly", func() {
+			expectedBuild := &gojenkins.Build{}
+			build, statusCode, err := getBuildFromGetterWithRetry(&SimpleMockBuildDataGetter{build: []*gojenkins.Build{expectedBuild}, err: []error{nil}}, int64(42), entry)
+			Expect(build).To(BeIdenticalTo(expectedBuild))
+			Expect(statusCode).To(BeEquivalentTo(0))
+			Expect(err).To(BeNil())
+		})
+
+		It("should return nil if 404", func() {
+			err2 := fmt.Errorf("404")
+			build, statusCode, err := getBuildFromGetterWithRetry(&SimpleMockBuildDataGetter{build: []*gojenkins.Build{nil}, err: []error{err2}}, int64(42), entry)
+			Expect(build).To(BeNil())
+			Expect(statusCode).To(BeEquivalentTo(http.StatusNotFound))
+			Expect(err).To(BeIdenticalTo(err2))
+		})
+
+		It("should return build after one retry with gateway timeout", func() {
+			expectedBuild := &gojenkins.Build{}
+			build, statusCode, err := getBuildFromGetterWithRetry(&SimpleMockBuildDataGetter{build: []*gojenkins.Build{nil, expectedBuild}, err: []error{fmt.Errorf("504"), nil}}, int64(42), entry)
+			Expect(build).To(BeIdenticalTo(expectedBuild))
+			Expect(statusCode).To(BeEquivalentTo(http.StatusGatewayTimeout))
+			Expect(err).To(BeNil())
+		})
+
+		PIt("should only call the service twice after 504 happened", func() {
+			expectedBuild := &gojenkins.Build{}
+			buildDataGetter := &DurationBasedMockBuildDataGetter{start: time.Now(), durationIndex: []time.Duration{200 * time.Millisecond, 400 * time.Millisecond}, build: []*gojenkins.Build{nil, expectedBuild}, err: []error{fmt.Errorf("504"), nil}}
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				_, _, _ = getBuildFromGetterWithRetry(buildDataGetter, int64(42), entry)
+			}()
+			go func() {
+				defer wg.Done()
+				_, _, _ = getBuildFromGetterWithRetry(buildDataGetter, int64(42), entry)
+			}()
+			wg.Wait()
+			Eventually(buildDataGetter.GetCallCounter()).Should(BeEquivalentTo(uint32(2)))
+		})
+
+	})
+
+})

--- a/robots/pkg/jenkins/builds_test.go
+++ b/robots/pkg/jenkins/builds_test.go
@@ -138,10 +138,10 @@ var _ = Describe("builds.go", func() {
 				}()
 			}
 			wg.Wait()
-			Expect(buildDataGetter.GetCallCounter()).To(BeNumerically("<=", uint32(numberOfThreads+1)))
+			Expect(buildDataGetter.GetCallCounter()).To(BeEquivalentTo(uint32(numberOfThreads + 1)))
 		})
 
-		It("each of the getters should not be called more than twice", func() {
+		It("should not call any of the getters more than twice", func() {
 			numberOfThreads := 5
 			var wg sync.WaitGroup
 			wg.Add(numberOfThreads)
@@ -160,7 +160,7 @@ var _ = Describe("builds.go", func() {
 			}
 		})
 
-		It("should call the service even in case of 503 twice per thread, since the circuit only opens on 504", func() {
+		It("should call the service only once per thread in case of 503, since the circuit only opens on 504, and 503 is not valid for retry", func() {
 			buildDataGetter := &DurationBasedMockBuildDataGetter{start: time.Now(), durationIndex: []time.Duration{100 * time.Millisecond, 1000 * time.Millisecond}, build: []*gojenkins.Build{nil, {}}, err: []error{fmt.Errorf("%d", http.StatusServiceUnavailable), nil}}
 			var wg sync.WaitGroup
 			numberOfThreads := 5
@@ -172,7 +172,7 @@ var _ = Describe("builds.go", func() {
 				}()
 			}
 			wg.Wait()
-			Expect(buildDataGetter.GetCallCounter()).To(BeNumerically("<=", uint32(numberOfThreads*2)))
+			Expect(buildDataGetter.GetCallCounter()).To(BeEquivalentTo(uint32(numberOfThreads)))
 		})
 
 	})

--- a/robots/pkg/jenkins/builds_test.go
+++ b/robots/pkg/jenkins/builds_test.go
@@ -77,9 +77,6 @@ var _ = Describe("builds.go", func() {
 	BeforeEach(func() {
 		retryDelay = 150 * time.Millisecond
 		maxJitter = 10 * time.Millisecond
-		if retryDelay <= 0 {
-			panic(fmt.Errorf("retryAfter <= 0: %v", retryDelay))
-		}
 		circuitBreakerBuildDataGetter = circuitbreaker.NewCircuitBreaker(retryDelay, openOnStatusGateWayTimeout)
 	})
 


### PR DESCRIPTION
* Create a minimal circuitbreaker implementation that avoids stressing the Jenkins with requests in case the service returns 504 status indicating it is not healthy.
* To make the use case testable, create new interface BuildDataGetter for
dependency injection with default implementation. Extract method that
uses the interface while preserving the original. Use this interface for mock testing.
* Add test for parallel execution that assures that
the service is not called more often than wanted.

Note: the retry and jitter values were extended since the feedback was that the Jenkins services requires around 1-2 minutes to recover, therefore an extra minute to give it a bit more time.

TODOs:
- [x] [update the flake-report-creator image to use the new version](https://github.com/kubevirt/project-infra/pull/2414/files#diff-11d9dded96f1181674711c876b472f2e1eb22e1f430a666c3ac0d26a89e2fda0R9)

/cc @fossedihelm @xpivarc 