### PR TITLE
Revert prow due to issue with applying sriov labels to pods

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20221020-6d9d0a69a3"
-        initupload: "gcr.io/k8s-prow/initupload:v20221020-6d9d0a69a3"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20221020-6d9d0a69a3"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20221020-6d9d0a69a3"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20221013-86c528dbe3"
+        initupload: "gcr.io/k8s-prow/initupload:v20221013-86c528dbe3"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20221013-86c528dbe3"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20221013-86c528dbe3"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20221005-95ee1a9f65"
-        initupload: "gcr.io/k8s-prow/initupload:v20221005-95ee1a9f65"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20221005-95ee1a9f65"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20221005-95ee1a9f65"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220929-df51d670b0"
+        initupload: "gcr.io/k8s-prow/initupload:v20220929-df51d670b0"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220929-df51d670b0"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220929-df51d670b0"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220929-df51d670b0"
-        initupload: "gcr.io/k8s-prow/initupload:v20220929-df51d670b0"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220929-df51d670b0"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220929-df51d670b0"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220922-e4d87dae72"
+        initupload: "gcr.io/k8s-prow/initupload:v20220922-e4d87dae72"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220922-e4d87dae72"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220922-e4d87dae72"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20221013-86c528dbe3"
-        initupload: "gcr.io/k8s-prow/initupload:v20221013-86c528dbe3"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20221013-86c528dbe3"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20221013-86c528dbe3"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20221005-95ee1a9f65"
+        initupload: "gcr.io/k8s-prow/initupload:v20221005-95ee1a9f65"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20221005-95ee1a9f65"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20221005-95ee1a9f65"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220922-e4d87dae72"
-        initupload: "gcr.io/k8s-prow/initupload:v20220922-e4d87dae72"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220922-e4d87dae72"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220922-e4d87dae72"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220915-cd08dd395d"
+        initupload: "gcr.io/k8s-prow/initupload:v20220915-cd08dd395d"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220915-cd08dd395d"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220915-cd08dd395d"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20221020-6d9d0a69a3
+              image: gcr.io/k8s-prow/branchprotector:v20221013-86c528dbe3
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20221013-86c528dbe3
+              image: gcr.io/k8s-prow/branchprotector:v20221005-95ee1a9f65
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20221005-95ee1a9f65
+              image: gcr.io/k8s-prow/branchprotector:v20220929-df51d670b0
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20220929-df51d670b0
+              image: gcr.io/k8s-prow/branchprotector:v20220922-e4d87dae72
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20220922-e4d87dae72
+              image: gcr.io/k8s-prow/branchprotector:v20220915-cd08dd395d
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/cherrypicker:v20221013-86c528dbe3
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/cherrypicker:v20220929-df51d670b0
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/cherrypicker:v20220922-e4d87dae72
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/cherrypicker:v20221005-95ee1a9f65
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/cherrypicker:v20220915-cd08dd395d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221013-86c528dbe3
+              image: gcr.io/k8s-prow/label_sync:v20221005-95ee1a9f65
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220929-df51d670b0
+              image: gcr.io/k8s-prow/label_sync:v20220922-e4d87dae72
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221020-6d9d0a69a3
+              image: gcr.io/k8s-prow/label_sync:v20221013-86c528dbe3
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221005-95ee1a9f65
+              image: gcr.io/k8s-prow/label_sync:v20220929-df51d670b0
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220922-e4d87dae72
+              image: gcr.io/k8s-prow/label_sync:v20220915-cd08dd395d
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221013-86c528dbe3
+              image: gcr.io/k8s-prow/label_sync:v20221005-95ee1a9f65
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220929-df51d670b0
+              image: gcr.io/k8s-prow/label_sync:v20220922-e4d87dae72
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221020-6d9d0a69a3
+              image: gcr.io/k8s-prow/label_sync:v20221013-86c528dbe3
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20221005-95ee1a9f65
+              image: gcr.io/k8s-prow/label_sync:v20220929-df51d670b0
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20220922-e4d87dae72
+              image: gcr.io/k8s-prow/label_sync:v20220915-cd08dd395d
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/crier:v20220929-df51d670b0
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/crier:v20221013-86c528dbe3
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/crier:v20221005-95ee1a9f65
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/crier:v20220922-e4d87dae72
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/crier:v20220915-cd08dd395d
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/deck:v20220929-df51d670b0
         imagePullPolicy: Always
         ports:
         - name: http

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/deck:v20220922-e4d87dae72
         imagePullPolicy: Always
         ports:
         - name: http

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/deck:v20221013-86c528dbe3
         imagePullPolicy: Always
         ports:
         - name: http

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/deck:v20221005-95ee1a9f65
         imagePullPolicy: Always
         ports:
         - name: http

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/deck:v20220915-cd08dd395d
         imagePullPolicy: Always
         ports:
         - name: http

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/ghproxy:v20220922-e4d87dae72
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/ghproxy:v20221013-86c528dbe3
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/ghproxy:v20220929-df51d670b0
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/ghproxy:v20221005-95ee1a9f65
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/ghproxy:v20220915-cd08dd395d
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/hook:v20221013-86c528dbe3
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/hook:v20220929-df51d670b0
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/hook:v20221005-95ee1a9f65
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/hook:v20220922-e4d87dae72
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/hook:v20220915-cd08dd395d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/horologium:v20221005-95ee1a9f65
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/horologium:v20221013-86c528dbe3
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/horologium:v20220929-df51d670b0
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/horologium:v20220922-e4d87dae72
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/horologium:v20220915-cd08dd395d
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/needs-rebase:v20221013-86c528dbe3
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/needs-rebase:v20220929-df51d670b0
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/needs-rebase:v20221005-95ee1a9f65
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/needs-rebase:v20220922-e4d87dae72
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/needs-rebase:v20220915-cd08dd395d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/prow-controller-manager:v20221005-95ee1a9f65
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220929-df51d670b0
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/prow-controller-manager:v20221013-86c528dbe3
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220922-e4d87dae72
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220915-cd08dd395d
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -143,17 +143,6 @@ spec:
                       that contains a git http.cookiefile, which should be used during
                       the cloning process.
                     type: string
-                  default_memory_request:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: DefaultMemoryRequest is the default requested memory
-                      on a test container. If SetLimitEqualsMemoryRequest is also
-                      true then the Limit will also be set the same as this request.
-                      Could be overridden by memory request defined explicitly on
-                      prowjob.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
                   default_service_account_name:
                     description: DefaultServiceAccountName is the name of the Kubernetes
                       service account that should be used by the pod if one is not

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -360,10 +360,6 @@ spec:
                     description: S3CredentialsSecret is the name of the Kubernetes
                       secret that holds blob storage push credentials.
                     type: string
-                  set_limit_equals_memory_request:
-                    description: SetLimitEqualsMemoryRequest sets memory limit equal
-                      to request.
-                    type: boolean
                   skip_cloning:
                     description: SkipCloning determines if we should clone source
                       code in the initcontainers for jobs that specify refs

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/sinker:v20220929-df51d670b0
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/sinker:v20221005-95ee1a9f65
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/sinker:v20221013-86c528dbe3
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/sinker:v20220922-e4d87dae72
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/sinker:v20220915-cd08dd395d
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/status-reconciler:v20221005-95ee1a9f65
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/status-reconciler:v20220922-e4d87dae72
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/status-reconciler:v20220929-df51d670b0
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/status-reconciler:v20221013-86c528dbe3
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/status-reconciler:v20220915-cd08dd395d
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/tide:v20220922-e4d87dae72
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/tide:v20221013-86c528dbe3
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/tide:v20220929-df51d670b0
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/tide:v20221005-95ee1a9f65
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/tide:v20220915-cd08dd395d
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20221020-6d9d0a69a3
+        image: gcr.io/k8s-prow/exporter:v20221013-86c528dbe3
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20220929-df51d670b0
+        image: gcr.io/k8s-prow/exporter:v20220922-e4d87dae72
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20221013-86c528dbe3
+        image: gcr.io/k8s-prow/exporter:v20221005-95ee1a9f65
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20221005-95ee1a9f65
+        image: gcr.io/k8s-prow/exporter:v20220929-df51d670b0
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20220922-e4d87dae72
+        image: gcr.io/k8s-prow/exporter:v20220915-cd08dd395d
         imagePullPolicy: Always
         ports:
         - name: metrics


### PR DESCRIPTION
Theres an issue[1] with sriov pods not getting the labels applied correctly. This causes a clash with sriov pods being scheduled together as the anti-affinity can no longer work correctly.

https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8597/pull-kubevirt-e2e-kind-1.22-sriov/1584691345816031232/podinfo.json

[1] https://github.com/kubevirt/kubevirt/issues/8656

/cc @dhiller @oshoval @rmohr 