### PR TITLE
Switch non-root sriov lane back to required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -428,7 +428,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       priorityClassName: windows
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -445,7 +445,6 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -510,7 +509,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -529,7 +528,7 @@ presubmits:
       sriov-pod: "true"
     max_concurrency: 10
     name: pull-kubevirt-e2e-kind-1.22-sriov
-    optional: false
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
This reverts commit a4b49f65c2f9f82cd28c0a2467106a323a074b43.

The issue was not related to nonroot but to pods being mislabelled by prow. Switch the non-root lane back to being required.

/cc @EdDev @oshoval 

Signed-off-by: Brian Carey <bcarey@redhat.com>