### PR TITLE
Fix rehearse plugin to rebase on target main branch

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -200,10 +200,9 @@ func (h *GitHubEventsHandler) handlePullRequestUpdateEvent(log *logrus.Entry, ev
 }
 
 func (h *GitHubEventsHandler) handleRehearsalForPR(log *logrus.Entry, pr *github.PullRequest, eventGUID string) {
-	repoName := "kubevirt/project-infra"
-	repo, org, err := gitv2.OrgRepo(repoName)
+	repo, org, err := gitv2.OrgRepo(pr.Base.Repo.FullName)
 	if err != nil {
-		log.WithError(err).Errorf("Could not parse repo name: %s", repoName)
+		log.WithError(err).Errorf("Could not parse repo name: %s", pr.Base.Repo.FullName)
 		return
 	}
 	log.Infoln("Generating git client")
@@ -220,7 +219,7 @@ func (h *GitHubEventsHandler) handleRehearsalForPR(log *logrus.Entry, pr *github
 		return
 	}
 	log.Infoln("Getting diff")
-	changedFiles, err := git.Diff("origin/main", "HEAD")
+	changedFiles, err := git.Diff(pr.Base.SHA, "HEAD")
 	if err != nil {
 		log.WithError(err).Error("Could not calculate diff for PR.")
 		return
@@ -238,10 +237,10 @@ func (h *GitHubEventsHandler) handleRehearsalForPR(log *logrus.Entry, pr *github
 			"Could not load job configs from head ref: %s", "HEAD")
 	}
 
-	baseConfigs, err := h.loadConfigsAtRef(changedJobConfigs, git, "origin/main")
+	baseConfigs, err := h.loadConfigsAtRef(changedJobConfigs, git, pr.Base.SHA)
 	if err != nil {
 		log.WithError(err).Errorf(
-			"Could not load job configs from base ref: %s", "origin/main")
+			"Could not load job configs from base ref: %s", pr.Base.SHA)
 	}
 	log.Infoln("Base configs:", baseConfigs)
 

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20221028-gd04a62ff
+          image: quay.io/kubevirtci/rehearse:v20221101-04a62ff
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20221101-04a62ff
+          image: quay.io/kubevirtci/rehearse:v20221102-h7a62ff
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
No changed files were being discovered as there was no diff between
`HEAD` and `main` after the PR commits were merged into the user's main
branch of their fork. 

```
	err = git.MergeAndCheckout(pr.Base.Ref, string(github.MergeSquash), pr.Head.SHA)
	if err != nil {
		log.WithError(err).Error("Could not rebase the PR on the target branch.")
		return
	}
	log.Infoln("Getting diff")
        changedFiles, err := git.Diff("HEAD", pr.Base.Ref)
```

After the merge `HEAD` and `pr.Base.Ref` (`main`) were the same so no diff could be found. 

```
time="2022-11-01T02:16:04Z" level=info msg="Merging \"b2f0217ff25ca28dc097a33fc0e422ad195a4d59\" using the \"squash\" strategy" client=git org=zhlhahaha repo=project-infra
time="2022-11-01T02:16:04Z" level=info msg="Getting diff" event-guid=204ee140-598b-11ed-857a-e788fbddd802
time="2022-11-01T02:16:04Z" level=info msg="Finding the differences between \"HEAD\" and \"main\"" client=git org=zhlhahaha repo=project-infra
time="2022-11-01T02:16:04Z" level=info msg="Changed files: []" event-guid=204ee140-598b-11ed-857a-e788fbddd802
time="2022-11-01T02:16:04Z" level=info msg="Changed job configs: []" event-guid=204ee140-598b-11ed-857a-e788fbddd802
```

Update to use kubevirt/project-infra as target repo as the user's fork
may have an outdated main branch and the PR will be targeting main
branch of kubevirt/project-infra

Fixes #791

/cc @dhiller @xpivarc 