### PR TITLE
images_to_mirror: Add kind node image v1.25.2

### DIFF
--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -1,5 +1,6 @@
 docker.io,library/registry:2.7.1,quay.io/kubevirtci
 docker.io,kindest/node:v1.23.4,quay.io/kubevirtci
+docker.io,kindest/node:v1.25.2,quay.io/kubevirtci
 docker.io,grafana/grafana:7.5.4,quay.io/kubevirtci
 docker.io,istio/install-cni:1.15.0,quay.io/kubevirtci
 docker.io,istio/operator:1.15.0,quay.io/kubevirtci


### PR DESCRIPTION
Mirror kind node image v1.25.2 in order to use it in kubevirtci kind-1.25-sriov provider [1].

[1] https://github.com/kubevirt/kubevirtci/pull/893

Signed-off-by: Orel Misan <omisan@redhat.com>