### PR TITLE
Add CI plugin config for test-benchmarks

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -127,6 +127,7 @@ tide:
     kubevirt/qe-tools: merge
     kubevirt/cloud-provider-kubevirt: merge
     kubevirt/secrets: merge
+    kubevirt/test-benchmarks: merge
 
   queries:
   - repos:
@@ -148,6 +149,7 @@ tide:
     - kubevirt/qe-tools
     - kubevirt/cloud-provider-kubevirt
     - kubevirt/secrets
+    - kubevirt/test-benchmarks
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -499,6 +499,7 @@ triggers:
   - kubevirt/qe-tools
   - kubevirt/cloud-provider-kubevirt
   - kubevirt/secrets
+  - kubevirt/test-benchmarks
 - repos:
   - virtblocks/virtblocks
 - repos:
@@ -545,6 +546,7 @@ approve:
   - kubevirt/kubevirt-velero-plugin
   - kubevirt/qe-tools
   - kubevirt/cloud-provider-kubevirt
+  - kubevirt/test-benchmarks
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -596,6 +598,7 @@ lgtm:
   - kubevirt/qe-tools
   - kubevirt/cloud-provider-kubevirt
   - kubevirt/secrets
+  - kubevirt/test-benchmarks
   review_acts_as_lgtm: true
 
 override:


### PR DESCRIPTION
The tide, trigger, lgtm and approve plugins are missing config for repo kubevirt/test-benchmarks. See [prow plugin docs](https://prow.k8s.io/plugins) and [kubevirt merge automation docs](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md).

Closes #2399

/cc @alicefr @brianmcarey 