### PR TITLE
cnao: add multus-dynamic-networks functests to presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -293,3 +293,36 @@ presubmits:
               - "/bin/sh"
               - "-c"
               - "automation/check-patch.e2e-macvtap-cni-functests.sh"
+    - name: pull-e2e-cnao-multus-dynamic-networks-functests
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+      always_run: false
+      optional: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "29Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-multus-dynamic-networks-controller-functests.sh"


### PR DESCRIPTION
This PR adds the `multus-dynamic-networks-controller` [e2e tests](https://github.com/maiqueb/multus-dynamic-networks-controller/blob/main/e2e/e2e_test.go) as a late to CNAO presubmits.
