### PR TITLE
Set enable CI report for test-benchmarks

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
       - main
     always_run: true
     optional: true
-    skip_report: true
+    skip_report: false
     decorate: true
     decoration_config:
       timeout: 3h


### PR DESCRIPTION
Currently, the CI results are not reported on PRs for the test-benchmarks repo.

Signed-off-by: Alice Frosi <afrosi@redhat.com>