### PR TITLE
Only publish common-instancetypes image when it changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
@@ -1,6 +1,8 @@
 postsubmits:
   kubevirt/common-instancetypes:
     - name: publish-common-instancetypes-builder
+      always_run: false
+      run_if_changed: "image/.*"
       branches:
         - main
       decorate: true
@@ -13,7 +15,6 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       annotations:
         testgrid-create-test-group: "false"
-        rehearsal.allowed: "false"
       cluster: prow-workloads
       spec:
         nodeSelector:


### PR DESCRIPTION
A new image should only be published when a change to the builder image is merged.

/cc @lyarwood @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>