### PR TITLE
[sig-performance] Increase node memory and job memory request

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -920,7 +920,7 @@ periodics:
       - name: KUBEVIRT_STORAGE
         value: hpp
       - name: KUBEVIRT_MEMORY_SIZE
-        value: 11G
+        value: 12G
       - name: KUBEVIRT_NUM_NODES
         value: "4"
       - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -932,7 +932,7 @@ periodics:
       resources:
         requests:
           cpu: "12"
-          memory: 52Gi
+          memory: 56Gi
       securityContext:
         privileged: true
     nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -290,7 +290,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 11G
+          value: 12G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -302,7 +302,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 52Gi
+            memory: 56Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
sig-performance lanes have been failing consistently[1] - this is due to
insufficient memory on the nodes to schedule the full amount of vms.

```
 {
                        "type": "PodScheduled",
                        "status": "False",
                        "lastProbeTime": null,
                        "lastTransitionTime": "2022-11-08T10:23:13Z",
                        "reason": "Unschedulable",
                        "message": "0/4 nodes are available: 4 Insufficient memory."
```

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sig-performance/1589920378929549312


Signed-off-by: Brian Carey <bcarey@redhat.com>