### PR TITLE
Correct regex to not include release branches

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -375,7 +375,7 @@ presubmits:
               memory: "29Gi"
   - name: pull-containerized-data-importer-fossa
     skip_branches:
-      - release-\d+\.\d+
+      - release-v\d+\.\d+
     always_run: true
     optional: false
     annotations:


### PR DESCRIPTION
CDI names its releases release-v1.something, not release-1.something

Fixes CI failure seen here: https://github.com/kubevirt/containerized-data-importer/pull/2462