### PR TITLE
kubevirtci, presubmit: Add optional job to check kind-1.23-sriov

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -82,6 +82,88 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
+  - always_run: true
+    annotations:
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-installer-pull-token: "true"
+      rehearsal.allowed: "true"
+      sriov-pod: "true"
+    max_concurrency: 1
+    name: check-up-kind-1.22-sriov
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: sriov-pod-multi
+                    operator: In
+                    values:
+                      - "true"
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/bash
+            - -ce
+            - |
+              trap "echo teardown && make cluster-down" EXIT SIGINT
+              make cluster-up
+              ./cluster-up/cluster/kind/check-cluster-up.sh
+          env:
+            - name: KUBEVIRT_PROVIDER
+              value: kind-1.22-sriov
+            - name: KUBEVIRT_NUM_NODES
+              value: "3"
+            - name: RUN_KUBEVIRT_CONFORMANCE
+              value: "true"
+            - name: SONOBUOY_EXTRA_ARGS
+              value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
+          image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+          name: ""
+          resources:
+            requests:
+              memory: 15Gi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: modules
+              readOnly: true
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            - mountPath: /dev/vfio/
+              name: vfio
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      priorityClassName: sriov
+      volumes:
+        - hostPath:
+            path: /lib/modules
+            type: Directory
+          name: modules
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+        - hostPath:
+            path: /dev/vfio/
+            type: Directory
+          name: vfio
   - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -82,7 +82,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     cluster: prow-workloads
@@ -96,7 +96,7 @@ presubmits:
       rehearsal.allowed: "true"
       sriov-pod: "true"
     max_concurrency: 1
-    name: check-up-kind-1.22-sriov
+    name: check-up-kind-1.23-sriov
     spec:
       affinity:
         podAntiAffinity:
@@ -126,7 +126,7 @@ presubmits:
               ./cluster-up/cluster/kind/check-cluster-up.sh
           env:
             - name: KUBEVIRT_PROVIDER
-              value: kind-1.22-sriov
+              value: kind-1.23-sriov
             - name: KUBEVIRT_NUM_NODES
               value: "3"
             - name: RUN_KUBEVIRT_CONFORMANCE


### PR DESCRIPTION
https://github.com/kubevirt/kubevirtci/pull/897 adds a kind-1.23-sriov provider.

Add an optional pre-submit job, in order to check `kind-1.23-sriov`.