### PR TITLE
Increase memory request of publish-kubevirtci job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -64,4 +64,4 @@ postsubmits:
             name: devices
           resources:
             requests:
-              memory: "8Gi"
+              memory: "29Gi"


### PR DESCRIPTION
There looks to be performance issues with the publish-kubevirtci job when the workloads cluster is heavily loaded

https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/publish-kubevirtci

Increasing the memory request to match the regular e2e jobs should guarantee a certain level of compute resources for the job.

/cc @oshoval @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>