### PR TITLE
Update libguetfs periodics

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -35,7 +35,7 @@ periodics:
           url=https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance
           bucket_dir="kubevirt-prow/devel/release/kubevirt/libguestfs-appliance"
           ./create-libguestfs-appliance.sh
-          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version.txt).tar.xz || gsutil cp ./output/appliance-*.tar.xz gs://$bucket_dir/
+          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version.txt) || gsutil cp ./output/libguestfs-appliance-*.tar.xz gs://$bucket_dir/
           gsutil cp ./output/latest-version.txt gs://$bucket_dir/
       # docker-in-docker needs privileged mode
       securityContext:


### PR DESCRIPTION
The https://github.com/kubevirt/libguestfs-appliance/pull/15 changed the file name from appliance to libguestfs appliance and the latest-version.txt contains also the tarball suffix.

Signed-off-by: Alice Frosi <afrosi@redhat.com>