### PR TITLE
Move capk e2e prowjob back to using dind

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
+      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 11
     name: pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e
@@ -22,7 +22,7 @@ presubmits:
         - /bin/sh
         - -c
         - make functest
-        image: quay.io/kubevirtci/golang:v20221105-0d76701
+        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
         name: ""
         resources:
           requests:


### PR DESCRIPTION
There is an issue with some of the Dockerfiles in the capk repository that breaks podman[1].

Moving the job back to dind to unblock the CI while issue is being investigated

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubernetes-sigs_cluster-api-provider-kubevirt/208/pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e/1592088855954067456#1:build-log.txt%3A422

/cc @nunnatsa @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>