### PR TITLE
Revert "Move capk e2e prowjob back to using dind (#2456)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 11
     name: pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e
@@ -22,7 +22,7 @@ presubmits:
         - /bin/sh
         - -c
         - make functest
-        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        image: quay.io/kubevirtci/golang:v20221105-0d76701
         name: ""
         resources:
           requests:


### PR DESCRIPTION
This reverts commit d86c52f5cc6677d0a055ab6fc024f1787b418dbf.

Issues with running this job under podman have been identified and should be fixed by:
https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/pull/208

/cc @dhiller @nunnatsa @qinqon 