### PR TITLE
Bump common-instancetypes-builder

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-      - image: quay.io/kubevirtci/common-instancetypes-builder:v20221104-ae4ae31
+      - image: quay.io/kubevirtci/common-instancetypes-builder:v20221104-3adec0b
         command:
         - "/bin/bash"
         - "-c"


### PR DESCRIPTION
/cc @brianmcarey 

shellcheck was recently introduced to the image [1], bump so we can start to use it in prow job.

[1] https://github.com/kubevirt/common-instancetypes/pull/10