### PR TITLE
Increase node memory for 0.58 performance lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -316,7 +316,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 11G
+          value: 12G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -328,7 +328,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 52Gi
+            memory: 56Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
The sig-performance lane for the 0.58 release is seeing the same issue with insufficient memory on the nodes [1].

This backports the memory increase[2] to the 0.58 release.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8785/pull-kubevirt-e2e-k8s-1.22-sig-performance-0.58/1592806770189799424 
[2] https://github.com/kubevirt/project-infra/pull/2442

/cc @dhiller @lyarwood 

Signed-off-by: Brian Carey <bcarey@redhat.com>