### PR TITLE
Update sig-compute-realtime to use 1.24, add root

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1504,7 +1504,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
+    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1517,7 +1517,47 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-compute-realtime
+          value: k8s-1.24-sig-compute-realtime
+        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime-root
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.24-sig-compute-realtime
+        - name: FEATURE_GATES
+          value: Root
         image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
         name: ""
         resources:


### PR DESCRIPTION
Bumps the pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime to use 1.24 provider, also adds a
pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime-root lane.

/cc @jordigilh @brianmcarey 