### PR TITLE
Revert "Add newline to commit msg for bump prow jobs (#2466)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -542,7 +542,7 @@ periodics:
         command: ["/bin/sh"]
         args:
           - "-c"
-          - hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main -B "Bump Prow \n /cc @kubevirt/prow-job-taskforce"
+          - hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main -B "Bump Prow /cc @kubevirt/prow-job-taskforce"
         resources:
           requests:
             memory: "200Mi"
@@ -730,7 +730,7 @@ periodics:
       args:
       - |
         if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
-          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B "Bump Prow Job images \n /cc @kubevirt/prow-job-taskforce"
+          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B "Bump Prow Job images /cc @kubevirt/prow-job-taskforce"
         fi
       resources:
         requests:


### PR DESCRIPTION
This reverts commit 8fe75668f8088e3c3a37daba279a4e0e04a382ec.

The newline character did not result in a new line in the PR description so it did not have the desired effect[1]. Revert back to previous commit message.

/cc @dhiller 

[1] https://github.com/kubevirt/project-infra/pull/2472#issue-1456714984

