### PR TITLE
Change CDI image postsubmits back to dind

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -75,7 +75,7 @@ periodics:
     grace_period: 5m
   max_concurrency: 1
   labels:
-    preset-podman-in-container-enabled: "true"
+    preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
@@ -89,7 +89,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+    - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -14,12 +14,12 @@ postsubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-podman-in-container-enabled: "true"
+      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -52,12 +52,12 @@ postsubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-podman-in-container-enabled: "true"
+      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -170,14 +170,14 @@ postsubmits:
       timeout: 3h
       grace_period: 5m
     labels:
-      preset-podman-in-container-enabled: "true"
+      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt


### PR DESCRIPTION
There has been an issue with pushing CDI images since the change to podman - change back to the legacy bootstrap image and dind until issue is resolved.

/cc @awels @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>