### PR TITLE
Update multiarch bootstrap build to podman

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -226,12 +226,12 @@ periodics:
     work_dir: true
   max_concurrency: 1
   labels:
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-kubevirtci-quay-credential: "true"
   cluster: prow-workloads
   spec:
     containers:
-      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+      - image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"


### PR DESCRIPTION
This was previously set to use docker as there was no `--amend` flag available when using `podman manifest create` [1]. This is now available in the latest bootstrap image.

/cc @enp0s3 @dhiller 

[1] https://github.com/kubevirt/project-infra/pull/2271

Signed-off-by: Brian Carey <bcarey@redhat.com>