### PR TITLE
Add K8s-1.23 SR-IOV lane jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -564,6 +564,88 @@ periodics:
         type: Directory
       name: vfio
 - annotations:
+    k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 0 22, 11 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 30m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-dind-enabled: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.23-sriov
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  spec:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+            - key: sriov-pod
+              operator: In
+              values:
+              - "true"
+          topologyKey: kubernetes.io/hostname
+        - labelSelector:
+            matchExpressions:
+            - key: sriov-pod-multi
+              operator: In
+              values:
+              - "true"
+          topologyKey: kubernetes.io/hostname
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -ce
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: kind-1.23-sriov
+      image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+      name: ""
+      resources:
+        requests:
+          memory: 29Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /lib/modules
+        name: modules
+        readOnly: true
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+      - mountPath: /dev/vfio/
+        name: vfio
+    nodeSelector:
+      hardwareSupport: sriov-nic
+    priorityClassName: sriov
+    volumes:
+    - hostPath:
+        path: /lib/modules
+        type: Directory
+      name: modules
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - hostPath:
+        path: /dev/vfio/
+        type: Directory
+      name: vfio
+- annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
   cron: 15 22 * * 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -617,6 +617,85 @@ presubmits:
           path: /var/log/audit
           type: Directory
         name: audit
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 30m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "true"
+      preset-dind-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      rehearsal.allowed: "true"
+      sriov-pod: "true"
+    max_concurrency: 10
+    name: pull-kubevirt-e2e-kind-1.23-sriov
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.23-sriov
+        image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      priorityClassName: sriov
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
   - always_run: true
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -460,7 +460,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -617,7 +617,7 @@ presubmits:
           path: /var/log/audit
           type: Directory
         name: audit
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni


### PR DESCRIPTION
This PR adds new periodic and presubmit jobs for testing Kubevirt SR-IOV tests on k8s-1.23 cluster (using the new SR-IOV kubecirtci provider kubevirt/kubevirtci#897).
And use the new jobs instead of the old ones (i.e: use pull-kubevirt-e2e-kind-1.23-sriov instead of pull-kubevirt-e2e-kind-1.22-sriov).

Note to reviewer: 
- Since only two SR-IOV jobs can runs simontanuasly its necessary to pick only SR-IOV lane (e.g: `pull-kubevirt-e2e-kind-1.23-sriov`).
- The new `kind-1.23-sriov` periodic job will start after `kind-1.22-sriov` perodic job.
We can remove it as soon as we see that the new periodic job is stable.