### PR TITLE
Add new presubmit for kubevirtci 1.26 provider, update creator to manually create presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -101,69 +101,69 @@ presubmits:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: sriov-pod
-                    operator: In
-                    values:
-                      - "true"
-              topologyKey: kubernetes.io/hostname
-            - labelSelector:
-                matchExpressions:
-                  - key: sriov-pod-multi
-                    operator: In
-                    values:
-                      - "true"
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/bash
-            - -ce
-            - |
-              trap "echo teardown && make cluster-down" EXIT SIGINT
-              make cluster-up
-              ./cluster-up/cluster/kind/check-cluster-up.sh
-          env:
-            - name: KUBEVIRT_PROVIDER
-              value: kind-1.23-sriov
-            - name: KUBEVIRT_NUM_NODES
-              value: "3"
-            - name: RUN_KUBEVIRT_CONFORMANCE
-              value: "true"
-            - name: SONOBUOY_EXTRA_ARGS
-              value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
-          image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
-          name: ""
-          resources:
-            requests:
-              memory: 15Gi
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-            - mountPath: /dev/vfio/
-              name: vfio
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - |
+          trap "echo teardown && make cluster-down" EXIT SIGINT
+          make cluster-up
+          ./cluster-up/cluster/kind/check-cluster-up.sh
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.23-sriov
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "true"
+        - name: SONOBUOY_EXTRA_ARGS
+          value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
+        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        name: ""
+        resources:
+          requests:
+            memory: 15Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
       nodeSelector:
         hardwareSupport: sriov-nic
       priorityClassName: sriov
       volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-        - hostPath:
-            path: /dev/vfio/
-            type: Directory
-          name: vfio
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
   - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
@@ -183,69 +183,69 @@ presubmits:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: sriov-pod
-                    operator: In
-                    values:
-                      - "true"
-              topologyKey: kubernetes.io/hostname
-            - labelSelector:
-                matchExpressions:
-                  - key: sriov-pod-multi
-                    operator: In
-                    values:
-                      - "true"
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/bash
-            - -ce
-            - |
-              trap "echo teardown && make cluster-down" EXIT SIGINT
-              make cluster-up
-              ./cluster-up/cluster/kind/check-cluster-up.sh
-          env:
-            - name: KUBEVIRT_PROVIDER
-              value: kind-1.25-sriov
-            - name: KUBEVIRT_NUM_NODES
-              value: "3"
-            - name: RUN_KUBEVIRT_CONFORMANCE
-              value: "true"
-            - name: SONOBUOY_EXTRA_ARGS
-              value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
-          image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
-          name: ""
-          resources:
-            requests:
-              memory: 15Gi
-          securityContext:
-            privileged: true
-          volumeMounts:
-            - mountPath: /lib/modules
-              name: modules
-              readOnly: true
-            - mountPath: /sys/fs/cgroup
-              name: cgroup
-            - mountPath: /dev/vfio/
-              name: vfio
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - |
+          trap "echo teardown && make cluster-down" EXIT SIGINT
+          make cluster-up
+          ./cluster-up/cluster/kind/check-cluster-up.sh
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.25-sriov
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "true"
+        - name: SONOBUOY_EXTRA_ARGS
+          value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
+        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        name: ""
+        resources:
+          requests:
+            memory: 15Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
       nodeSelector:
         hardwareSupport: sriov-nic
       priorityClassName: sriov
       volumes:
-        - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
-            path: /sys/fs/cgroup
-            type: Directory
-          name: cgroup
-        - hostPath:
-            path: /dev/vfio/
-            type: Directory
-          name: vfio
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
   - always_run: true
     cluster: prow-workloads
     decorate: true
@@ -270,7 +270,7 @@ presubmits:
                   operator: In
                   values:
                   - "true"
-              topologyKey: "kubernetes.io/hostname"
+              topologyKey: kubernetes.io/hostname
             weight: 100
       containers:
       - command:
@@ -289,7 +289,8 @@ presubmits:
         - name: RUN_KUBEVIRT_CONFORMANCE
           value: "true"
         - name: SONOBUOY_EXTRA_ARGS
-          value: "--plugin-env kubevirt-conformance.E2E_FOCUS=MediatedDevices --plugin-env kubevirt-conformance.E2E_SKIP=QUARANTINE"
+          value: --plugin-env kubevirt-conformance.E2E_FOCUS=MediatedDevices --plugin-env
+            kubevirt-conformance.E2E_SKIP=QUARANTINE
         image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
         name: ""
         resources:
@@ -325,8 +326,8 @@ presubmits:
     cluster: prow-workloads
     decorate: true
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-gocli
     optional: true
@@ -352,8 +353,8 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.22
     spec:
@@ -378,8 +379,8 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.23
     spec:
@@ -404,8 +405,8 @@ presubmits:
     decoration_config:
       timeout: 20m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-alpine-with-test-tooling
     spec:
@@ -450,16 +451,16 @@ presubmits:
           type: Directory
         name: devices
   - always_run: false
-    optional: true
     cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.24-psa
+    optional: true
     spec:
       containers:
       - command:
@@ -482,8 +483,8 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.24
     spec:
@@ -508,8 +509,8 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 2
     name: check-provision-k8s-1.24-ipv6
     spec:
@@ -534,8 +535,8 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.25
     spec:
@@ -545,6 +546,33 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.25 && ../provision.sh
+        image: quay.io/kubevirtci/golang:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 1
+    name: check-provision-k8s-1.26
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.26 && ../provision.sh
         image: quay.io/kubevirtci/golang:v20221116-f8c83d3
         name: ""
         resources:

--- a/robots/cmd/kubevirtci-presubmit-creator/main.go
+++ b/robots/cmd/kubevirtci-presubmit-creator/main.go
@@ -44,11 +44,15 @@ type options struct {
 	TokenPath                        string
 	endpoint                         string
 	jobConfigPathKubevirtciPresubmit string
+	k8sReleaseSemver                 string
 }
 
 func (o *options) Validate() error {
 	if _, err := os.Stat(o.jobConfigPathKubevirtciPresubmit); os.IsNotExist(err) {
 		return fmt.Errorf("jobConfigPathKubevirtciPresubmit is required: %v", err)
+	}
+	if o.k8sReleaseSemver != "" && !querier.SemVerMinorRegex.MatchString(o.k8sReleaseSemver) {
+		return fmt.Errorf("k8s-release-semver does not match SemVerMinorRegex: %s", o.k8sReleaseSemver)
 	}
 	return nil
 }
@@ -60,6 +64,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.jobConfigPathKubevirtciPresubmit, "job-config-path-kubevirtci-presubmit", "", "The directory of the k8s providers")
+	fs.StringVar(&o.k8sReleaseSemver, "k8s-release-semver", "", "The semver of the k8s release to create a presubmit for")
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to parse args: %v", err))
@@ -103,22 +108,32 @@ func main() {
 		}
 	}
 
+	var latestReleaseSemver *querier.SemVer
+
+	if o.k8sReleaseSemver == "" {
+		releases, _, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
+		if err != nil {
+			log.Panicln(err)
+		}
+		releases = querier.ValidReleases(releases)
+		if len(releases) == 0 {
+			log.Info("No release found, nothing to do.")
+			os.Exit(0)
+		}
+		latestReleaseSemver = querier.ParseRelease(releases[0])
+	} else {
+		majorMinor := querier.SemVerMinorRegex.FindStringSubmatch(o.k8sReleaseSemver)
+		latestReleaseSemver = &querier.SemVer{
+			Major: majorMinor[1],
+			Minor: majorMinor[2],
+			Patch: "0",
+		}
+	}
+
 	jobConfig, err := config.ReadJobConfig(o.jobConfigPathKubevirtciPresubmit)
 	if err != nil {
 		log.Panicln(err)
 	}
-
-	releases, _, err := client.Repositories.ListReleases(ctx, "kubernetes", "kubernetes", nil)
-	if err != nil {
-		log.Panicln(err)
-	}
-	releases = querier.ValidReleases(releases)
-	if len(releases) == 0 {
-		log.Info("No release found, nothing to do.")
-		os.Exit(0)
-	}
-
-	latestReleaseSemver := querier.ParseRelease(releases[0])
 
 	newJobConfig, exists := AddNewPresubmitIfNotExists(jobConfig, latestReleaseSemver)
 	if exists && !o.dryRun {
@@ -177,7 +192,7 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 			Name:           fmt.Sprintf("check-provision-k8s-%s.%s", semver.Major, semver.Minor),
 			MaxConcurrency: 1,
 			Labels: map[string]string{
-				"preset-dind-enabled":  "true",
+				"preset-dind-enabled":        "true",
 				"preset-docker-mirror-proxy": "true",
 			},
 			Cluster: "prow-workloads",

--- a/robots/cmd/kubevirtci-presubmit-creator/main.go
+++ b/robots/cmd/kubevirtci-presubmit-creator/main.go
@@ -192,8 +192,8 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 			Name:           fmt.Sprintf("check-provision-k8s-%s.%s", semver.Major, semver.Minor),
 			MaxConcurrency: 1,
 			Labels: map[string]string{
-				"preset-dind-enabled":        "true",
-				"preset-docker-mirror-proxy": "true",
+				"preset-docker-mirror-proxy":         "true",
+				"preset-podman-in-container-enabled": "true",
 			},
 			Cluster: "prow-workloads",
 			Spec: &v1.PodSpec{
@@ -202,7 +202,7 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 				},
 				Containers: []v1.Container{
 					{
-						Image: "quay.io/kubevirtci/golang:v20210316-d295087",
+						Image: "quay.io/kubevirtci/golang:v20221116-f8c83d3",
 						Command: []string{
 							"/usr/local/bin/runner.sh",
 							"/bin/sh",

--- a/robots/pkg/jenkins/builds_test.go
+++ b/robots/pkg/jenkins/builds_test.go
@@ -123,21 +123,6 @@ var _ = Describe("builds.go", func() {
 			Expect(err).To(BeNil())
 		})
 
-		It("should only call the service once after 504 happened, then once per each thread after service is available again", func() {
-			buildDataGetter := &DurationBasedMockBuildDataGetter{start: time.Now(), durationIndex: []time.Duration{100 * time.Millisecond, 1000 * time.Millisecond}, build: []*gojenkins.Build{nil, {}}, err: []error{fmt.Errorf("%d", http.StatusGatewayTimeout), nil}}
-			var wg sync.WaitGroup
-			numberOfThreads := 5
-			wg.Add(numberOfThreads)
-			for i := 0; i < numberOfThreads; i++ {
-				go func() {
-					defer wg.Done()
-					_, _, _ = getBuildFromGetterWithRetry(buildDataGetter, int64(42), entry)
-				}()
-			}
-			wg.Wait()
-			Expect(buildDataGetter.GetCallCounter()).To(BeEquivalentTo(uint32(numberOfThreads + 1)))
-		})
-
 		It("should not call any of the getters more than twice", func() {
 			numberOfThreads := 5
 			var wg sync.WaitGroup


### PR DESCRIPTION
Adds the new presubmit for the new 1.26 provider in kubevirtci.

It also adds the flag `k8s-release-semver` to the kubevirtci-presubmit-creator so we can create new presubmits for arbitrary versions. This skips the lookup for the latest kubernetes version.

/cc @Barakmor1 @brianmcarey 