### PR TITLE
Add check-provision job for 1.25-fips

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -476,6 +476,33 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    optional: true
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 2
+    name: check-provision-k8s-1.25-fips
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.25-fips && ../provision.sh
+        image: quay.io/kubevirtci/golang:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 14Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
     decorate: true


### PR DESCRIPTION
This is a copy of the 1.24-psa job, with just the path and the name changed