### PR TITLE
presubmit, kubevirtci: Switch to check-up-kind-1.23-sriov

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubevirt/kubevirtci:
-  - always_run: true
+  - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     cluster: prow-workloads
@@ -82,7 +82,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: false
+  - always_run: true
     annotations:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     cluster: prow-workloads


### PR DESCRIPTION
Following #2477, this PR enables the new `check-up-kind-1.23-sriov` job instead of the old `check-up-kind-1.22-sriov` job.

It checks that creating a SR-IOV cluster succeeds and runs Kubevirt SR-IOV tests suite with a given kubevirt/kubevirtci PR changes.

Signed-off-by: Or Mergi <ormergi@redhat.com>