### PR TITLE
Update CDI image postsubmits to use podman

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -75,7 +75,7 @@ periodics:
     grace_period: 5m
   max_concurrency: 1
   labels:
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
@@ -89,7 +89,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+    - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -14,12 +14,12 @@ postsubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -52,12 +52,12 @@ postsubmits:
       timeout: 1h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "false"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -170,14 +170,14 @@ postsubmits:
       timeout: 3h
       grace_period: 5m
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt


### PR DESCRIPTION
There was an issue with pushing CDI images when the prowjobs were running with the podman in container setup. This issue was due to bazel push expecting the registry auth information to exist under the docker location.

This change depends on a PR[1] in CDI which makes the required registry auth config available in the builder container that pushes the images

This reverts commit d751dca8ff84463a950a7c78486f5f17aba92502.

[1] https://github.com/kubevirt/containerized-data-importer/pull/2479

/cc @awels @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>