### PR TITLE
Switch check-provision-1.22 to optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -347,7 +347,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     cluster: prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
The 1.22 provider is in the process of being retired - we should not be running an extra presubmit per PR.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>