### PR TITLE
Update the performance lanes to use the 1.25 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -143,7 +143,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.22-sysprep
+  name: periodic-kubevirt-e2e-k8s-1.25-sysprep
   spec:
     containers:
     - command:
@@ -954,7 +954,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
-  name: periodic-kubevirt-e2e-k8s-1.22-sig-performance
+  name: periodic-kubevirt-e2e-k8s-1.25-sig-performance
   reporter_config:
     slack:
       job_states_to_report: []
@@ -977,7 +977,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.22
+        value: k8s-1.25
       - name: KUBEVIRT_STORAGE
         value: hpp
       - name: KUBEVIRT_MEMORY_SIZE
@@ -1299,7 +1299,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
-  name: periodic-kubevirt-e2e-k8s-1.22-sig-performance-realtime
+  name: periodic-kubevirt-e2e-k8s-1.25-sig-performance-realtime
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1319,7 +1319,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make realtime-perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.22
+        value: k8s-1.25
       - name: KUBEVIRT_STORAGE
         value: rook-ceph-default
       - name: KUBEVIRT_MEMORY_SIZE

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -256,7 +256,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-shared-images: "true"
     max_concurrency: 2
-    name: pull-kubevirt-e2e-k8s-1.22-sig-performance
+    name: pull-kubevirt-e2e-k8s-1.25-sig-performance
     optional: true
     run_if_changed: ^pkg/virt-api/.*|^pkg/virt-handler/.*|^pkg/virt-controller/.*|^pkg/virt-launcher/.*
     skip_branches:
@@ -280,7 +280,7 @@ presubmits:
           FUNC_TEST_ARGS="--no-color --seed=42" make perftest
         env:
         - name: KUBEVIRT_PROVIDER
-          value: k8s-1.22
+          value: k8s-1.25
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
@@ -1999,7 +1999,7 @@ presubmits:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
-    name: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
+    name: pull-kubevirt-e2e-k8s-1.23-sig-monitoring
     run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
     skip_branches:
     - release-\d+\.\d+
@@ -2012,7 +2012,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-monitoring
+          value: k8s-1.23-sig-monitoring
         - name: KUBEVIRT_NUM_NODES
           value: "2"
         image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3


### PR DESCRIPTION
The 1.22 provider will no longer be supported soon so updating lanes to use the 1.25 kubernetes provider

@rthallisey  - this change may impact the performance metrics. 

The periodic sysprep lane (periodic-kubevirt-e2e-k8s-1.22-sysprep) is actually using the 1.25 already [1] - updating name to better reflect what is running. 

Update the sig-monitoring lane to 1.23 as there were issues with 1.24/1.25 [2]

/cc @dhiller @rthallisey 

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.22-sysprep/1595930288540618752#1:build-log.txt%3A365
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2487/rehearsal-pull-kubevirt-e2e-k8s-1.25-sig-monitoring/1600155780672131072

Signed-off-by: Brian Carey <bcarey@redhat.com>