### PR TITLE
kubesecondarydns, presubmit: Fix e2e lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -35,6 +35,5 @@ presubmits:
               - |
                 make cluster-up
                 make cluster-sync
-                make create-nodeport
                 make functest
 


### PR DESCRIPTION
`make create-nodeport` is already done as part of cluster-sync.
No need to do it twice.

Signed-off-by: Or Shoval <oshoval@redhat.com>