### PR TITLE
Add image bump for prowjobs to hack/bump-prow.sh

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
+    - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -52,7 +52,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
+    - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -81,7 +81,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
+    - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -109,7 +109,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
+    - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -141,7 +141,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20210720-5548472063
+    - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -496,7 +496,7 @@ periodics:
   spec:
     containers:
     - name: peribolos
-      image: gcr.io/k8s-prow/peribolos:v20210115-603a3a062d
+      image: gcr.io/k8s-prow/peribolos:v20221117-3815e13b72
       command:
       - /app/prow/cmd/peribolos/app.binary
       args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -932,7 +932,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-        - image: gcr.io/k8s-prow/configurator:v20210526-1d9416cb76
+        - image: gcr.io/k8s-prow/configurator:v20221117-3815e13b72
           command:
           - /app/testgrid/cmd/configurator/app.binary
           args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20220325-bc0e092550
+      - image: gcr.io/k8s-prow/checkconfig:v20221117-3815e13b72
         args:
         - "/ko-app/checkconfig"
         - "--config-path"
@@ -724,7 +724,7 @@ presubmits:
     spec:
       containers:
       - name: peribolos
-        image: gcr.io/k8s-prow/peribolos:v20210115-603a3a062d
+        image: gcr.io/k8s-prow/peribolos:v20221117-3815e13b72
         command:
         - /app/prow/cmd/peribolos/app.binary
         args:
@@ -757,7 +757,7 @@ presubmits:
     spec:
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20200623-9f5410055c
+        image: gcr.io/k8s-prow/label_sync:v20221117-3815e13b72
         command: [ "/app/label_sync/app.binary" ]
         args:
         - --config=github/ci/prow-deploy/files/labels.yaml
@@ -780,7 +780,7 @@ presubmits:
     spec:
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20200623-9f5410055c
+        image: gcr.io/k8s-prow/label_sync:v20221117-3815e13b72
         command: [ "/app/label_sync/app.binary" ]
         args:
         - --config=github/ci/prow-deploy/files/labels.yaml

--- a/hack/bump-prow.sh
+++ b/hack/bump-prow.sh
@@ -53,6 +53,12 @@ bump_base_manifests_local_images(){
     find ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/base/manifests/local -type f -name '*.yaml' | xargs sed -i "s!image: gcr.io/k8s-prow/\(.*\):.*!image: gcr.io/k8s-prow/\\1:${latest_prow_tag}!"
 }
 
+bump_job_images(){
+    local latest_prow_tag=$1
+
+    find ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/files/jobs -type f -name '*.yaml' | xargs sed -i "s!image: gcr.io/k8s-prow/\(.*\):.*!image: gcr.io/k8s-prow/\\1:${latest_prow_tag}!"
+}
+
 main(){
     copy_files
 
@@ -67,6 +73,7 @@ main(){
     bump_utility_images "${latest_prow_tag}"
     bump_exporter "${latest_prow_tag}"
     bump_base_manifests_local_images "${latest_prow_tag}"
+    bump_job_images "${latest_prow_tag}"
 }
 
 main "${@}"


### PR DESCRIPTION
Adds the bumping of the prow images inside the job definitions to `hack/bump-prow.sh`.

Note: also sets the job images to the currently used version.

/cc @xpivarc @enp0s3 