### PR TITLE
kubevirt, presubmits: Add psa-sig-network lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2120,6 +2120,45 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.24-psa-sig-network
+    optional: true
+    skip_branches:
+      - release-\d+\.\d+
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -c
+            - automation/test.sh
+          env:
+            - name: TARGET
+              value: k8s-1.24-psa-sig-network
+          image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+          name: ""
+          resources:
+            requests:
+              memory: 29Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - always_run: true
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2285,9 +2285,9 @@ presubmits:
     labels:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
     optional: true
@@ -2324,9 +2324,9 @@ presubmits:
     labels:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
     optional: true


### PR DESCRIPTION
This PR adds a new lane `pull-kubevirt-e2e-k8s-1.24-psa-sig-network`