### PR TITLE
Adding kind/ labels to help categorise release notes

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -117,6 +117,12 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - name: kind/deprecation
+      description: Indicates the PR/issue deprecates a feature that will be removed in a subsequent release.
+      color: fdeb7e
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: 9192ff
       description: Categorizes as a Hacktoberfest contribution
       name: hacktoberfest


### PR DESCRIPTION
Adding labels as per https://github.com/kubevirt/kubevirt/pull/8752/files

I noticed that there is currently a `release-note-action-required` label already here.
Maybe the `kind/action-required` is not necessary if we want to continue with that, however does it make sense for consistency sake to have these labels all as `kind/` ? Both from the POV of a contributor remembering to add relevant labels to their PR and also from kubevirt-bot automation.

Signed-off-by: Andrew Burden <aburden@redhat.com>