### PR TITLE
Make the performance job voting and running per commit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -240,7 +240,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -255,9 +255,9 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-shared-images: "true"
-    max_concurrency: 2
+    max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.25-sig-performance
-    run_if_changed: ^pkg/virt-api/.*|^pkg/virt-handler/.*|^pkg/virt-controller/.*|^pkg/virt-launcher/.*
+    run_if_changed: ^cmd/.*|^rpm/.*|^tests/performance/.*|^hack/perftests.sh|^tools/perfscale-audit/.*|^bazel/.*|^third_party/.*|^staging/src/.*|^api/.*|^pkg/virt-.*|^pkg/controlller/.*
     skip_branches:
     - release-\d+\.\d+
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -240,7 +240,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -257,7 +257,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 2
     name: pull-kubevirt-e2e-k8s-1.25-sig-performance
-    optional: true
     run_if_changed: ^pkg/virt-api/.*|^pkg/virt-handler/.*|^pkg/virt-controller/.*|^pkg/virt-launcher/.*
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
https://groups.google.com/g/kubevirt-dev/c/zdgrOmJcodc/m/72-MqVwzGQAJ

The performance job has been stable for many months so I think its time to make it voting.

This job is designed to catch the following issues on a new PR:
1) Performance regression (slow phase transitions)
2) Scale regression (too many http requests)
3) control-plane mem increase

Catching these issues in an MR would allow the author to add a release note documenting a performance change.