### PR TITLE
presubmit, ksd: Update image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Update image, because the newer image has increased timeout waiting for podman socket.

Error here
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubesecondarydns/38/pull-kubesecondarydns-e2e-k8s/1599692018617946112