### PR TITLE
bootstrap files: Add bind-utils

### DIFF
--- a/images/bootstrap-legacy/Dockerfile
+++ b/images/bootstrap-legacy/Dockerfile
@@ -54,6 +54,7 @@ RUN dnf install -y \
     sudo \
     buildah \
     qemu-user-static \
+    bind-utils \
     wget &&\
   dnf -y clean all
 

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -54,6 +54,7 @@ RUN dnf install -y \
     sudo \
     buildah \
     qemu-user-static \
+    bind-utils \
     wget \
     python3-jinja2 &&\
   dnf -y clean all


### PR DESCRIPTION
Needed for `nslookup` which is used by `KubeSecondaryDNS`.

Signed-off-by: Or Shoval <oshoval@redhat.com>