### PR TITLE
Increase memory requests of bootstrap image build jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -129,9 +129,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "1Gi"
+              memory: "4Gi"
             limits:
-              memory: "1Gi"
+              memory: "4Gi"
   - name: build-bootstrap-legacy-images
     always_run: false
     run_if_changed: "images/bootstrap-legacy/.*|images/golang-legacy/.*"
@@ -156,9 +156,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "1Gi"
+              memory: "4Gi"
             limits:
-              memory: "1Gi"
+              memory: "4Gi"
   - name: build-kubekins-e2e-image
     always_run: false
     run_if_changed: "images/kubekins-e2e/.*"


### PR DESCRIPTION
The presubmit jobs which test the building of the bootstrap container images look to be failing due to low memory.

https://github.com/kubevirt/project-infra/pull/2501

/cc @oshoval @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>