### PR TITLE
ksd: Update image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -348,7 +348,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
+          - image: quay.io/kubevirtci/bootstrap:v20221205-e30b34a
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
+          - image: quay.io/kubevirtci/bootstrap:v20221205-e30b34a
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
The new image includes bind-utils
which is needed because we use nslookup as part of e2e.

Signed-off-by: Or Shoval <oshoval@redhat.com>