### PR TITLE
kubevirt, presubmits: run pull-kubevirt-unit-test-arm64 on Arm Cluster 2

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -935,7 +935,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-arm64-workloads
+    cluster: prow-arm64-workloads-2
     decorate: true
     decoration_config:
       grace_period: 5m0s


### PR DESCRIPTION
Currently Both pull-kubevirt-unit-test-arm64 and pull-kubevirt-e2e-arm64, this may lead to memory run out. Allocate pull-kubevirt-unit-test-arm64 jobs to Arm Cluster 2