### PR TITLE
Increase memory request/limit for publish of shared images

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -172,9 +172,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "1Gi"
+                memory: "4Gi"
               limits:
-                memory: "1Gi"
+                memory: "4Gi"
     - name: publish-kubekins-e2e-image
       always_run: false
       run_if_changed: "images/kubekins-e2e/.*"


### PR DESCRIPTION
The job is failing due to a lack of resources[1] and it succeeeds locally using phaino. Increasing the memory request for the job.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-shared-images-controller-image/1600798705781313536

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>