### PR TITLE
Set check-up-kind-1.23-vgpu to optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -177,6 +177,7 @@ presubmits:
       vgpu: "true"
     max_concurrency: 1
     name: check-up-kind-1.23-vgpu
+    optional: true
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
The lane is very flaky, and thus steadily blocking merges.

See: https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/check-up-kind-1.23-vgpu

/cc @brianmcarey @xpivarc 