### PR TITLE
Add daemonset for shared images to prow-workloads cluster

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - resources/metrics-server.yaml
   - resources/priority-classes.yaml
   - resources/place-holder.yaml
+  - resources/shared-images-controller.yaml
   - ../../components/docker-mirror-proxy/base
   - ../../components/greenhouse/base
 

--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/shared-images-controller.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/shared-images-controller.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: shared-images-controller
+  namespace: kubevirt-prow
+  labels:
+    name: shared-images-controller
+spec:
+  selector:
+    matchLabels:
+      name: shared-images-controller
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: shared-images-controller
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: shared-images-controller
+        image: quay.io/kubevirtci/shared-images-controller:v20221208-a669d6f
+        command: [ "/usr/local/bin/runner.sh", "/shared-images-controller"]
+        resources:
+          requests:
+            memory: 2Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/shared-images
+          name: shared-images
+      volumes:
+      - hostPath:
+          path: /var/lib/shared-images
+          type: DirectoryOrCreate
+        name: shared-images


### PR DESCRIPTION
This daemonset is responsible for maintaining the shared image store on
each node in the workloads cluster. It will download the latest
kubevirtci node images and remove any old images that are no longer
required. The e2e jobs will mount this directory as a read only shared
image store.

/cc @enp0s3 @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>