### PR TITLE
Increase thanos data retention for 1hr resolution to 1 year

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -390,7 +390,7 @@ spec:
         - --deduplication.replica-label=replica
         - --retention.resolution-raw=7d
         - --retention.resolution-5m=30d
-        - --retention.resolution-1h=90d
+        - --retention.resolution-1h=365d
         env:
         - name: OBJSTORE_CONFIG
           valueFrom:


### PR DESCRIPTION
Data retained in the thanos bucket has been greatly reduced so the data retention period for the 1hr resolution can be increased to 1 year

This will allow better visibility of trends over time.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>