### PR TITLE
Fix prow binary pathes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -498,7 +498,7 @@ periodics:
     - name: peribolos
       image: gcr.io/k8s-prow/peribolos:v20221117-3815e13b72
       command:
-      - /app/prow/cmd/peribolos/app.binary
+      - /ko-app/peribolos
       args:
       - --github-endpoint=http://ghproxy
       - --github-endpoint=https://api.github.com

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
-      - /app/robots/commenter/app.binary
+      - /ko-app/commenter
       args:
       - |-
         --query=is:pr
@@ -54,7 +54,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
-      - /app/robots/commenter/app.binary
+      - /ko-app/commenter
       args:
       - |-
         --query=org:kubevirt
@@ -83,7 +83,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
-      - /app/robots/commenter/app.binary
+      - /ko-app/commenter
       args:
       - |-
         --query=org:kubevirt
@@ -111,7 +111,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
-      - /app/robots/commenter/app.binary
+      - /ko-app/commenter
       args:
       - |-
         --query=org:kubevirt
@@ -143,7 +143,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20221117-3815e13b72
       command:
-      - /app/robots/commenter/app.binary
+      - /ko-app/commenter
       args:
       - |-
         --query=org:kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -964,7 +964,7 @@ postsubmits:
         containers:
         - image: gcr.io/k8s-prow/configurator:v20221117-3815e13b72
           command:
-          - /app/testgrid/cmd/configurator/app.binary
+          - /ko-app/configurator
           args:
           - --prow-config=github/ci/prow-deploy/files/config.yaml
           - --prow-job-config=github/ci/prow-deploy/files/jobs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -784,7 +784,7 @@ presubmits:
       containers:
       - name: label-sync
         image: gcr.io/k8s-prow/label_sync:v20221117-3815e13b72
-        command: [ "/app/label_sync/app.binary" ]
+        command: [ "/ko-app/label_sync" ]
         args:
         - --config=github/ci/prow-deploy/files/labels.yaml
         - --confirm=false
@@ -807,7 +807,7 @@ presubmits:
       containers:
       - name: label-sync
         image: gcr.io/k8s-prow/label_sync:v20221117-3815e13b72
-        command: [ "/app/label_sync/app.binary" ]
+        command: [ "/ko-app/label_sync" ]
         args:
         - --config=github/ci/prow-deploy/files/labels.yaml
         - --confirm=false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -752,7 +752,7 @@ presubmits:
       - name: peribolos
         image: gcr.io/k8s-prow/peribolos:v20221117-3815e13b72
         command:
-        - /app/prow/cmd/peribolos/app.binary
+        - /ko-app/peribolos
         args:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com


### PR DESCRIPTION
Update pathes for binaries of peribolos and commenter, since the pathes have changed when we introduced the new images, reducing in failures of a number of jobs. Examples:

* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-org-github-config-updater/1601162006000308224
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-stale/1601165277557428224

/cc @brianmcarey @xpivarc 