### PR TITLE
Update PSA jobs and use new way to enable it

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1864,7 +1864,7 @@ presubmits:
       preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-psa-sig-network
+    name: pull-kubevirt-e2e-k8s-1.25-psa-sig-network
     optional: true
     skip_branches:
       - release-\d+\.\d+
@@ -1876,8 +1876,10 @@ presubmits:
             - -c
             - automation/test.sh
           env:
+            - name: KUBEVIRT_PSA
+              value: "true"
             - name: TARGET
-              value: k8s-1.24-psa-sig-network
+              value: k8s-1.25-sig-network
           image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
           name: ""
           resources:
@@ -2017,7 +2019,7 @@ presubmits:
       preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
+    name: pull-kubevirt-e2e-k8s-1.25-psa-sig-compute
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -2029,8 +2031,10 @@ presubmits:
         - -c
         - automation/test.sh
         env:
+        - name: KUBEVIRT_PSA
+          value: "true"
         - name: TARGET
-          value: k8s-1.24-psa-sig-compute
+          value: k8s-1.25-sig-compute
         image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
         name: ""
         resources:
@@ -2056,7 +2060,7 @@ presubmits:
       preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
+    name: pull-kubevirt-e2e-k8s-1.25-psa-sig-storage
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -2068,8 +2072,10 @@ presubmits:
         - -c
         - automation/test.sh
         env:
+        - name: KUBEVIRT_PSA
+          value: "true"
         - name: TARGET
-          value: k8s-1.24-psa-sig-storage
+          value: k8s-1.25-sig-storage
         image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
         name: ""
         resources:


### PR DESCRIPTION
Update PSA lanes to 1.25 and use a new way to enable PSA rather than the dedicated provider.