### PR TITLE
Reduce length of image tag to be looked for

### DIFF
--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -18,7 +18,7 @@ else
 fi
 
 IMAGE_NAME="$1"
-latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("v[0-9]+-[a-z0-9]+") )' | tail -1)
+latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("^v[0-9]+-[a-z0-9]{7,8}$") )' | tail -1)
 if [ -z "$latest_image_tag" ]; then
     echo "Couldn't find latest_image_tag"
     exit 1


### PR DESCRIPTION
Don't consider the platform based images, use the general image tags instead.

See https://github.com/kubevirt/project-infra/pull/2472/files#diff-12f4d5cb56d6eb2ad6984f4302f785e8fb92bd0aebf262c3ee4c765b42864d40R17

/cc @brianmcarey @xpivarc @enp0s3 