### PR TITLE
Add preset for podman shared images store

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -142,6 +142,7 @@ periodics:
   labels:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sysprep
   spec:
@@ -413,6 +414,7 @@ periodics:
   labels:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     vgpu: "true"
   max_concurrency: 1
   name: periodic-kubevirt-e2e-kind-1.23-vgpu
@@ -868,6 +870,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sig-performance
   reporter_config:
     slack:
@@ -930,6 +933,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
   reporter_config:
@@ -978,6 +982,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
   reporter_config:
@@ -1027,6 +1032,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sig-performance-realtime
   reporter_config:
     slack:
@@ -1092,6 +1098,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.23-sig-network
   reporter_config:
@@ -1138,6 +1145,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.23-sig-storage
   reporter_config:
@@ -1184,6 +1192,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.23-sig-compute
   reporter_config:
@@ -1230,6 +1239,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.23-operator
   reporter_config:
@@ -1278,6 +1288,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.24-sig-compute-migrations
   reporter_config:
@@ -1328,6 +1339,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.24-sig-network
   reporter_config:
@@ -1374,6 +1386,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.24-sig-storage
   reporter_config:
@@ -1420,6 +1433,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.24-sig-compute
   reporter_config:
@@ -1466,6 +1480,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.24-operator
   reporter_config:
@@ -1512,6 +1527,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sig-network
   reporter_config:
@@ -1558,6 +1574,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sig-storage
   reporter_config:
@@ -1604,6 +1621,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sig-compute
   reporter_config:
@@ -1650,6 +1668,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.25-sig-operator
   reporter_config:
@@ -1696,6 +1715,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.26-sig-network
   reporter_config:
@@ -1742,6 +1762,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.26-sig-storage
   reporter_config:
@@ -1788,6 +1809,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.26-sig-compute
   reporter_config:
@@ -1834,6 +1856,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-k8s-1.26-sig-operator
   reporter_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -14,6 +14,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
@@ -93,6 +94,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
@@ -134,6 +136,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-root
@@ -174,6 +177,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-network-root
@@ -214,6 +218,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-storage-root
@@ -254,6 +259,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 2
     name: pull-kubevirt-e2e-k8s-1.25-sig-performance
@@ -315,6 +321,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-operator-root
@@ -355,6 +362,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016
@@ -549,6 +557,7 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       vgpu: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-kind-1.23-vgpu-root
@@ -629,6 +638,7 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-check-tests-for-flakes
@@ -1133,6 +1143,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
@@ -1172,6 +1183,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
@@ -1210,6 +1222,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
@@ -1252,6 +1265,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
@@ -1294,6 +1308,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
@@ -1340,6 +1355,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime
     optional: true
@@ -1378,6 +1394,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime-root
     optional: true
@@ -1512,6 +1529,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-network
@@ -1582,6 +1600,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-storage
@@ -1620,6 +1639,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-sig-compute
@@ -1658,6 +1678,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-operator
@@ -1696,6 +1717,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-swap-enabled
@@ -1738,6 +1760,7 @@ presubmits:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
     name: pull-kubevirt-e2e-k8s-1.23-sig-monitoring
     run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
     skip_branches:
@@ -1775,6 +1798,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.23-single-node
@@ -1824,6 +1848,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-network
@@ -1863,6 +1888,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-psa-sig-network
     optional: true
@@ -1901,6 +1927,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-storage
@@ -1939,6 +1966,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute
@@ -1977,6 +2005,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-operator
@@ -2016,6 +2045,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
     optional: true
@@ -2055,6 +2085,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
     optional: true
@@ -2093,6 +2124,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-sig-network
@@ -2131,6 +2163,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-sig-storage
@@ -2169,6 +2202,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-sig-compute
@@ -2207,6 +2241,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-sig-operator
@@ -2315,6 +2350,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-network
@@ -2354,6 +2390,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-storage
@@ -2393,6 +2430,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-compute
@@ -2432,6 +2470,7 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-operator

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -457,6 +457,17 @@ presets:
   - name: podman-data
     mountPath: /var/lib/containers
 - labels:
+    preset-podman-shared-images: "true"
+  volumes:
+  - name: podman-shared-images
+    hostPath:
+      path: /var/lib/shared-images
+      type: Directory
+  volumeMounts:
+  - name: podman-shared-images
+    mountPath: /var/lib/shared-images
+    readOnly: true
+- labels:
     preset-docker-mirror: "true"
   volumes:
   - name: docker-config


### PR DESCRIPTION
This preset will allow the e2e jobs to access the shared image store which will include the kubevirtci node images so the jobs will no longer have to spend time downloading the images.

Signed-off-by: Brian Carey <bcarey@redhat.com>