### PR TITLE
Bump sig compute migration lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1290,7 +1290,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.24-sig-compute-migrations
+  name: periodic-kubevirt-e2e-k8s-1.25-sig-compute-migrations
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1307,7 +1307,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.24-sig-compute-migrations
+        value: k8s-1.25-sig-compute-migrations
       - name: KUBEVIRT_NUM_NODES
         value: "3"
       - name: KUBEVIRT_STORAGE

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1225,7 +1225,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
+    name: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations-root
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1238,6 +1238,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-compute-migrations
+        - name: FEATURE_GATES
+          value: Root
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: KUBEVIRT_STORAGE
@@ -1268,7 +1270,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations-nonroot
+    name: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1285,10 +1287,6 @@ presubmits:
           value: "3"
         - name: KUBEVIRT_STORAGE
           value: rook-ceph-default
-        - name: FEATURE_GATES
-          value: NonRoot
-        - name: KUBEVIRT_NONROOT
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1268,49 +1268,6 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.23-sig-compute-migrations
-        - name: KUBEVIRT_NUM_NODES
-          value: "3"
-        - name: KUBEVIRT_STORAGE
-          value: rook-ceph-default
-        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
     skip_branches:
     - release-\d+\.\d+

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1225,7 +1225,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
+    name: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1237,7 +1237,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.24-sig-compute-migrations
+          value: k8s-1.25-sig-compute-migrations
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: KUBEVIRT_STORAGE
@@ -1268,7 +1268,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
+    name: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations-nonroot
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1280,7 +1280,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.24-sig-compute-migrations
+          value: k8s-1.25-sig-compute-migrations
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: KUBEVIRT_STORAGE


### PR DESCRIPTION
Remove 1.23 migration presubmit lane, bump 1.24 (root and nonroot) to 1.25. Also bump periodic lane.

/cc @brianmcarey @fossedihelm @iholder101 @jean-edouard 