### PR TITLE
Update bootstrap images to use Fedora 37

### DIFF
--- a/images/bootstrap-legacy/Dockerfile
+++ b/images/bootstrap-legacy/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:36
+FROM fedora:37
 
 WORKDIR /workspace
 RUN mkdir -p /workspace

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:36
+FROM fedora:37
 
 WORKDIR /workspace
 RUN mkdir -p /workspace

--- a/images/golang/Dockerfile
+++ b/images/golang/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH
 FROM bootstrap-$ARCH
 
-ENV GIMME_GO_VERSION=1.17.8
+ENV GIMME_GO_VERSION=1.19.2
 
 # Cache latest stable golang version
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme


### PR DESCRIPTION
Fedora 37 has been released for over a month now[1] and looks stable enough
so we can update the bootstrap images to F37.

The kubevirt builder image is using golang version 1.19.2 [2] - this golang
bootstrap image should default to the same.

[1] https://fedoramagazine.org/announcing-fedora-37/
[2] https://github.com/kubevirt/kubevirt/blob/297edbe21961c7a3ef462f94f4eeead0520ec043/hack/builder/Dockerfile#L7

/cc @dhiller @enp0s3 

