### PR TITLE
Add gcs credentials to windows related e2e jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -141,6 +141,7 @@ periodics:
     repo: kubevirt
   labels:
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -361,6 +361,7 @@ presubmits:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"


### PR DESCRIPTION
The windows VM test images will be hosted in a private GCS bucket so these jobs will require these credentials.

/cc @dhiller @dominikholler @xpivarc 

Signed-off-by: Brian Carey <bcarey@redhat.com>