### PR TITLE
Enable the windows e2e presubmit lane for all kubevirt PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -347,8 +347,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    optional: true
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits


### PR DESCRIPTION
This was previously disabled due to being unable to access the remote vm images[1]

These images have been mirrored to a Kubevirt GCS bucket and should always be available now.

[1] https://github.com/kubevirt/project-infra/pull/2520

/cc @enp0s3 @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>