### PR TITLE
hco,presubmit: Update golang bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -14,15 +14,15 @@ presubmits:
       grace_period: 5m
     max_concurrency: 6
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
+      preset-podman-shared-images: "true"
     cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20230103-9f4e101
+      - image: quay.io/kubevirtci/golang:v20221222-8f66e7e
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -48,15 +48,15 @@ presubmits:
       grace_period: 5m
     max_concurrency: 6
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
+      preset-podman-shared-images: "true"
     cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20230103-9f4e101
+      - image: quay.io/kubevirtci/golang:v20221222-8f66e7e
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"


### PR DESCRIPTION
This image uses podman
The old image has problems suddenly with docker
`Error: statfs /var/run/docker.sock: no such file or directory`
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_hyperconverged-cluster-operator/2198/pull-hyperconverged-cluster-operator-e2e-k8s-1.24/1610587959369666560

We need to use podman anyhow.
Previous image is based on an old image, if all is passing with the new one no need to keep it.

Signed-off-by: Or Shoval <oshoval@redhat.com>