### PR TITLE
Update remaining jobs to use podman

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
       grace_period: 5m
     max_concurrency: 6
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -52,7 +52,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -55,7 +55,7 @@ periodics:
     repo: kubevirt
     base_ref: main
   labels:
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -409,7 +409,7 @@ presubmits:
     run_if_changed: "github/ci/prow-deploy/.*"
     decorate: true
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"


### PR DESCRIPTION
There were some jobs that use images that are built from the bootstrap
image. These images were rebuilt recently and the jobs were updated[1] so these jobs now require the
podman preset to be enabled.

[1] https://github.com/kubevirt/project-infra/pull/2531

Signed-off-by: Brian Carey <bcarey@redhat.com>