### PR TITLE
Fix bootstrap image version for arm64 workloads

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -640,7 +640,7 @@ periodics:
         value: "1"
       - name: KUBEVIRT_E2E_FOCUS
         value: arm64
-      image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+      image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
       name: ""
       resources:
         requests:
@@ -674,7 +674,7 @@ periodics:
       - /bin/sh
       - -c
       - make test
-      image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+      image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
       name: ""
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -973,7 +973,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
         name: ""
         resources:
           requests:
@@ -1577,7 +1577,7 @@ presubmits:
           value: "1"
         - name: KUBEVIRT_E2E_FOCUS
           value: arm64
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20221119-67aebd9
         name: ""
         resources:
           requests:


### PR DESCRIPTION
The image tag of the arm64 based jobs were updated to an image that does not support arm64. This updates theses jobs to the latest bootstrap image that supports arm64.

/cc @zhlhahaha @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>