### PR TITLE
Set 1.26 lanes to run on every PR

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -62,26 +62,26 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.24-sig-compute-cgroupsv2
     run_if_changed: pkg/virt-handler/cgroup/.*
     skip_branches:
-      - release-\d+\.\d+
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/sh
-            - -c
-            - automation/test.sh
-          env:
-            - name: TARGET
-              value: k8s-1.24-sig-compute
-            - name: KUBEVIRT_CGROUPV2
-              value: "true"
-          image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
-          name: ""
-          resources:
-            requests:
-              memory: 29Gi
-          securityContext:
-            privileged: true
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.24-sig-compute
+        - name: KUBEVIRT_CGROUPV2
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         type: bare-metal-external
   - always_run: false
@@ -104,26 +104,26 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.25-sig-compute-cgroupsv2
     run_if_changed: pkg/virt-handler/cgroup/.*
     skip_branches:
-      - release-\d+\.\d+
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/sh
-            - -c
-            - automation/test.sh
-          env:
-            - name: TARGET
-              value: k8s-1.25-sig-compute
-            - name: KUBEVIRT_CGROUPV2
-              value: "true"
-          image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
-          name: ""
-          resources:
-            requests:
-              memory: 29Gi
-          securityContext:
-            privileged: true
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.25-sig-compute
+        - name: KUBEVIRT_CGROUPV2
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         type: bare-metal-external
   - always_run: false
@@ -136,10 +136,10 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"
+      preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirtci-bump-kubevirt
     skip_branches:
@@ -226,26 +226,26 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.24-sig-storage-cgroupsv2
     run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
     skip_branches:
-      - release-\d+\.\d+
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/sh
-            - -c
-            - automation/test.sh
-          env:
-            - name: TARGET
-              value: k8s-1.24-sig-storage
-            - name: KUBEVIRT_CGROUPV2
-              value: "true"
-          image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
-          name: ""
-          resources:
-            requests:
-              memory: 29Gi
-          securityContext:
-            privileged: true
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.24-sig-storage
+        - name: KUBEVIRT_CGROUPV2
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         type: bare-metal-external
   - always_run: false
@@ -268,26 +268,26 @@ presubmits:
     name: pull-kubevirt-e2e-k8s-1.25-sig-storage-cgroupsv2
     run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
     skip_branches:
-      - release-\d+\.\d+
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/sh
-            - -c
-            - automation/test.sh
-          env:
-            - name: TARGET
-              value: k8s-1.25-sig-storage
-            - name: KUBEVIRT_CGROUPV2
-              value: "true"
-          image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
-          name: ""
-          resources:
-            requests:
-              memory: 29Gi
-          securityContext:
-            privileged: true
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.25-sig-storage
+        - name: KUBEVIRT_CGROUPV2
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         type: bare-metal-external
   - always_run: true
@@ -1337,7 +1337,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1355,6 +1354,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2009,33 +2009,33 @@ presubmits:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
+      preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-psa-sig-network
     optional: true
     skip_branches:
-      - release-\d+\.\d+
+    - release-\d+\.\d+
     spec:
       containers:
-        - command:
-            - /usr/local/bin/runner.sh
-            - /bin/sh
-            - -c
-            - automation/test.sh
-          env:
-            - name: KUBEVIRT_PSA
-              value: "true"
-            - name: TARGET
-              value: k8s-1.25-sig-network
-          image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
-          name: ""
-          resources:
-            requests:
-              memory: 29Gi
-          securityContext:
-            privileged: true
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: TARGET
+          value: k8s-1.25-sig-network
+        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
       nodeSelector:
         type: bare-metal-external
   - always_run: true
@@ -2168,9 +2168,9 @@ presubmits:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
+      preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-psa-sig-compute
     optional: true
@@ -2210,9 +2210,9 @@ presubmits:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
+      preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-psa-sig-storage
     optional: true
@@ -2357,7 +2357,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -2375,6 +2374,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2507,7 +2507,7 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -2547,7 +2547,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -2587,7 +2587,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -2627,7 +2627,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1638,7 +1638,7 @@ presubmits:
             memory: 29Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1709,7 +1709,7 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1748,7 +1748,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1787,7 +1787,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/robots/pkg/kubevirt/cmd/remove/always_run.go
+++ b/robots/pkg/kubevirt/cmd/remove/always_run.go
@@ -36,6 +36,7 @@ import (
 
 type removeAlwaysRunOptions struct {
 	jobConfigPathKubevirtPresubmits string
+	force                           bool
 }
 
 func (o removeAlwaysRunOptions) Validate() error {
@@ -82,6 +83,7 @@ func RemoveAlwaysRunCommand() *cobra.Command {
 
 func init() {
 	removeAlwaysRunCommand.PersistentFlags().StringVar(&removeAlwaysRunOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The directory of the kubevirt presubmit job definitions")
+	removeAlwaysRunCommand.PersistentFlags().BoolVar(&removeAlwaysRunOpts.force, "force", false, "skip check of always_run, disable right away")
 }
 
 func runAlwaysRunCommand(cmd *cobra.Command, args []string) error {
@@ -113,10 +115,12 @@ func runAlwaysRunCommand(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	result, message := ensureSigJobsDoAlwaysRun(jobConfig, latestMinorReleases[0])
-	if result != ALL_JOBS_DO_ALWAYS_RUN {
-		log.Log().Infof("Not all presubmits for k8s %s do run always, nothing to do.\n%s", latestMinorReleases[0], message)
-		return nil
+	if !removeAlwaysRunOpts.force {
+		result, message := ensureSigJobsDoAlwaysRun(jobConfig, latestMinorReleases[0])
+		if result != ALL_JOBS_DO_ALWAYS_RUN {
+			log.Log().Infof("Not all presubmits for k8s %s do run always, nothing to do.\n%s", latestMinorReleases[0], message)
+			return nil
+		}
 	}
 
 	targetReleaseSemver := latestMinorReleases[3]


### PR DESCRIPTION
Now that the periodics for 1.26 seem to pass we want to run the presubmits on every PR.

Also disable running the 1.23 sig lanes on every PR. Add a `force` flag to the automation to skip the check for this.

/cc @brianmcarey @jean-edouard @rthallisey 