### PR TITLE
Set 1.26 lanes to gating

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2525,7 +2525,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-network
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2565,7 +2564,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2605,7 +2603,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-compute
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2645,7 +2642,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-operator
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Since the 1.26 periodics look good, and we don't see any issues on the 1.26 presubmits either, we can make the lanes for 1.26 gating.

See testgrid dashboard here: https://testgrid.k8s.io/kubevirt-periodics

/cc @brianmcarey @rthallisey 