### PR TITLE
Enable reporting on ARM64 presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -965,7 +965,6 @@ presubmits:
     optional: true
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:
@@ -1561,7 +1560,6 @@ presubmits:
     optional: true
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
The ARM64 based KubeVirt presubmit lanes have been reasonably stable recently[1][2]. Reporting these on the KubeVirt PRs would give valuable feedback to the contributors.

[1] https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-arm64 
[2] https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-unit-test-arm64

/cc @zhlhahaha @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>