### PR TITLE
ksd: remove the release-note plugin from ksd

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -135,6 +135,7 @@ tide:
   - repos:
     - kubevirt/libguestfs-appliance
     - kubevirt/project-infra
+    - kubevirt/kubesecondarydns
     - kubevirt/cluster-api-provider-kubevirt
     - kubevirt/machine-remediation-operator
     - kubevirt/kubevirtci
@@ -171,7 +172,6 @@ tide:
     - k8snetworkplumbingwg/ovs-cni
     - kubevirt/macvtap-cni
     - kubevirt/cluster-network-addons-operator
-    - kubevirt/kubesecondarydns
     - kubevirt/bridge-marker
     - nmstate/kubernetes-nmstate
     - k8snetworkplumbingwg/kubemacpool

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -134,7 +134,6 @@ plugins:
     - approve
     - lgtm
     - owners-label
-    - release-note
     - trigger
 
   kubevirt/common-instancetypes:


### PR DESCRIPTION
KubeSecondaryDNS is already using a builtin github action to create the release notes based on PR titles.
In this repository we don't need to manually add another custom collectible note to the PR description,
hence remove the plugin that expects it.