### PR TITLE
Improve flakefinder test name layout

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
       testgrid-create-test-group: "false"
     spec:
       containers:
-        - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+        - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -42,7 +42,7 @@ periodics:
     decorate: true
     spec:
       containers:
-        - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+        - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json
@@ -77,7 +77,7 @@ periodics:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+        - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/gcs/service-account.json

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -31,7 +31,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -52,7 +52,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -10,7 +10,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -32,7 +32,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:
@@ -54,7 +54,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       command:
       - "/app/robots/cmd/flakefinder/app.binary"
       args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -20,7 +20,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+      image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       name: ""
       resources: {}
 - annotations:
@@ -44,7 +44,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+      image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       name: ""
       resources: {}
 - annotations:
@@ -68,7 +68,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+      image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       name: ""
       resources: {}
 - annotations:
@@ -120,7 +120,7 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+      image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       name: ""
       resources: {}
 - annotations:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -42,7 +42,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
@@ -77,7 +77,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/flakefinder:v20221007-a2417698
+    - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json

--- a/robots/cmd/flake-report-creator/cmd/BUILD.bazel
+++ b/robots/cmd/flake-report-creator/cmd/BUILD.bazel
@@ -7,6 +7,10 @@ go_library(
         "prow.go",
         "root.go",
     ],
+    embedsrcs = [
+        "jenkins-report-template.gohtml",
+        "prow-report-template.gohtml",
+    ],
     importpath = "kubevirt.io/project-infra/robots/cmd/flake-report-creator/cmd",
     visibility = ["//visibility:public"],
     deps = [
@@ -24,7 +28,11 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["jenkins_test.go"],
+    srcs = [
+        "cmd_suite_test.go",
+        "jenkins_test.go",
+        "prow_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//robots/pkg/flakefinder:go_default_library",

--- a/robots/cmd/flake-report-creator/cmd/cmd_suite_test.go
+++ b/robots/cmd/flake-report-creator/cmd/cmd_suite_test.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+type expecter interface {
+	contains(content string, t *testing.T)
+}
+
+type expectation struct {
+	expectedToBeContained string
+}
+
+func (e *expectation) contains(content string, t *testing.T) {
+	if !strings.Contains(content, e.expectedToBeContained) {
+		t.Errorf("Expected contained: %q, actual %q", e.expectedToBeContained, content)
+	}
+}
+
+func expectContains(expectedToBeContained string) expectation {
+	return expectation{expectedToBeContained: expectedToBeContained}
+}

--- a/robots/cmd/flake-report-creator/cmd/jenkins-report-template.gohtml
+++ b/robots/cmd/flake-report-creator/cmd/jenkins-report-template.gohtml
@@ -1,0 +1,275 @@
+{{- /*
+
+    This file is part of the KubeVirt project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Copyright 2023 Red Hat, Inc.
+
+*/ -}}
+
+{{- /* gotype: kubevirt.io/project-infra/robots/cmd/flake-report-creator/cmd.JenkinsReportParams */ -}}
+
+<html lang="en">
+<head>
+    <title>flakefinder report</title>
+    <meta charset="UTF-8"/>
+    <!--suppress CssUnusedSymbol -->
+    <style>
+        table, th, td {
+            border: 1px solid black;
+        }
+
+        .yellow, .threesigma {
+            background-color: #ffff80;
+        }
+
+        .almostgreen, .twosigma {
+            background-color: #dfff80;
+        }
+
+        .green, .onesigma {
+            background-color: #9fff80;
+        }
+
+        .red, .foursigma {
+            background-color: #ff8080;
+        }
+
+        .orange {
+            background-color: #ffbf80;
+        }
+
+        .unimportant {
+        }
+
+        .tests_passed {
+            color: #226c18;
+            font-weight: bold;
+        }
+
+        .tests_failed {
+            color: #8a1717;
+            font-weight: bold;
+        }
+
+        .tests_skipped {
+            color: #535453;
+            font-weight: bold;
+        }
+
+        .center {
+            text-align: center
+        }
+
+        .right {
+            text-align: right;
+            width: 100%;
+        }
+
+        .popup {
+            position: relative;
+            display: inline-block;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
+        .popup .popuptext {
+            display: none;
+            width: 220px;
+            background-color: #555;
+            text-align: center;
+            border-radius: 6px;
+            padding: 8px 8px;
+            position: absolute;
+            z-index: 1;
+            left: 50%;
+            margin-left: -110px;
+        }
+
+        .popup .popuptextjoblist {
+            display: none;
+            width: 350px;
+            background-color: #FFFFFF;
+            text-align: center;
+            border-radius: 6px;
+            padding: 8px 8px;
+            position: absolute;
+            z-index: 1;
+            left: 100%;
+            margin-left: -350px;
+        }
+
+        .popup:hover .popuptext {
+            display: block;
+            -webkit-animation: fadeIn 1s;
+            animation: fadeIn 1s;
+        }
+
+        .popup:hover .popuptextjoblist {
+            display: block;
+            -webkit-animation: fadeIn 1s;
+            animation: fadeIn 1s;
+        }
+
+        .nowrap {
+            white-space: nowrap;
+        }
+
+        @-webkit-keyframes fadeIn {
+            from {
+                opacity: 0;
+            }
+            to {
+                opacity: 1;
+            }
+        }
+
+        @keyframes fadeIn {
+            from {
+                opacity: 0;
+            }
+            to {
+                opacity: 1;
+            }
+        }
+    </style>
+</head>
+<body>
+<h1>flakefinder report</h1>
+
+<div>
+    Data range from {{ $.StartOfReport }} till {{ $.EndOfReport }}<br/>
+</div>
+
+<div id="jobRatings" class="popup right">
+    <u>list of job ratings</u>
+    <div class="popuptextjoblist right" id="targetRatingsForJobs">
+        <table width="100%">
+            {{- range $key, $jobRating := $.JobNamesToRatings }}
+                <tr class="unimportant">
+                    <td>
+                        <a href="{{ $.JenkinsBaseURL }}/job/{{$key}}"><span title="job">{{$key}}</span></a>
+                    </td>
+                    <td>
+                        <div><span title="number of completed builds">{{ .TotalCompletedBuilds }}</span></div>
+                    </td>
+                    <td>
+                        <div><span title="mean">{{ printf "%.2f" .Mean }}</span></div>
+                    </td>
+                    <td>
+                        <div><span title="standard deviation">{{ printf "%.2f" .StandardDeviation }}</span></div>
+                    </td>
+                </tr>
+                {{- range $buildNo := .BuildNumbers }}
+                    <tr class="unimportant">{{ with $buildData := (index (index $.JobNamesToRatings $key).BuildNumbersToData $buildNo) }}
+                            <td>
+                            </td>
+                            <td>
+                                <a href="{{ $.JenkinsBaseURL }}/job/{{$key}}/{{$buildNo}}"><span
+                                            title="job build number">{{$buildNo}}</span></a>
+                            </td>
+                            <td>
+                                <div class="tests_failed"><span
+                                            title="test failures">{{ $buildData.Failures }}</span>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="{{ if le $buildData.Sigma 1.0 }}onesigma{{ else if le $buildData.Sigma 2.0 }}twosigma{{ else if le $buildData.Sigma 3.0 }}threesigma{{ else }}foursigma{{ end }}">
+                                    <span title="&sigma; rating">{{ $buildData.Sigma }}</span></div>
+                            </td>
+                        {{ end }}</tr>{{ end }}{{ end }}
+        </table>
+    </div>
+</div>
+
+{{ if not .Headers }}
+    <div>No failing tests! 🙂</div>
+{{ else }}
+    <div id="failuresForJobs" class="popup right">
+        <u>list of job runs</u>
+        <div class="popuptextjoblist right" id="targetfailuresForJobs">
+            <table width="100%">
+                {{- range $key, $jobFailures := $.FailuresForJobs }}
+                    <tr class="unimportant">
+                        <td>
+                            <a href="{{ $.JenkinsBaseURL }}/job/{{.Job}}"><span title="job">{{.Job}}</span></a>
+                        </td>
+                        <td>
+                            <a href="{{ $.JenkinsBaseURL }}/job/{{.Job}}/{{.BuildNumber}}"><span
+                                        title="job build number">{{.BuildNumber}}</span></a>
+                        </td>
+                        <td>
+                            <div class="tests_failed"><span title="test failures">{{ .Failures }}</span></div>
+                        </td>
+                        <td>
+                            <div>
+                                <span title="&sigma; rating">{{ (index (index $.JobNamesToRatings .Job).BuildNumbersToData .BuildNumber).Sigma }}</span>
+                            </div>
+                        </td>
+                    </tr>{{ end }}
+            </table>
+        </div>
+    </div>
+
+
+    <table>
+        <tr>
+            <td></td>
+            <td></td>
+            {{ range $header := $.Headers -}}
+                <td><a href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/">{{ $header }}</a></td>
+            {{- end }}
+        </tr>
+        {{ range $row, $test := $.Tests -}}
+            <tr>
+                <td>
+                    <div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a></div>
+                </td>
+                <td>{{ $test }}</td>
+                {{ range $col, $header := $.Headers -}}
+                    {{ if not (index $.Data $test $header) -}}
+                        <td class="center">
+                            N/A
+                        </td>
+                    {{- else -}}
+                        <td class="{{ (index $.Data $test $header).Severity }} center">
+                            <div id="r{{$row}}c{{$col}}" class="popup">
+                                <span class="tests_failed"
+                                      title="failed tests">{{ (index $.Data $test $header).Failed }}</span>/<span
+                                        class="tests_passed"
+                                        title="passed tests">{{ (index $.Data $test $header).Succeeded }}</span>/<span
+                                        class="tests_skipped"
+                                        title="skipped tests">{{ (index $.Data $test $header).Skipped }}</span>{{ if (index $.Data $test $header).Jobs }}
+                            <div class="popuptext" id="targetr{{$row}}c{{$col}}">
+                                {{ range $Job := (index $.Data $test $header).Jobs -}}
+                                    <div class="{{.Severity}} nowrap"><a
+                                                href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/{{.BuildNumber}}">{{.BuildNumber}}</a>
+                                        (<span class="tests_failed"
+                                               title="failed tests in job run">{{ (index $.FailuresForJobs (printf "%s-%d" $header .BuildNumber)).Failures }}</span>)
+                                    </div>
+                                {{- end }}
+                            </div>{{ end }}
+                            </div>
+                        </td>
+                    {{- end }}
+                {{- end }}
+            </tr>
+        {{- end }}
+    </table>
+{{ end -}}
+
+</body>
+</html>

--- a/robots/cmd/flake-report-creator/cmd/jenkins.go
+++ b/robots/cmd/flake-report-creator/cmd/jenkins.go
@@ -22,6 +22,7 @@ package cmd
 import (
 	"context"
 	"crypto/tls"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"kubevirt.io/project-infra/robots/pkg/flakefinder/build"
@@ -46,222 +47,11 @@ const (
 	defaultJenkinsBaseUrl        = "https://main-jenkins-csb-cnvqe.apps.ocp-c1.prod.psi.redhat.com/"
 	defaultJenkinsJobNamePattern = "^test-kubevirt-cnv-4.10-(compute|network|operator|storage)(-[a-z0-9]+)?$"
 	defaultArtifactFileNameRegex = "^(xunit_results|((merged|partial)\\.)?junit\\.functest(\\.[0-9]+)?)\\.xml$"
-	JenkinsReportTemplate        = `
-<html>
-<head>
-    <title>flakefinder report</title>
-    <meta charset="UTF-8">
-		<style>
-			table, th, td {
-				border: 1px solid black;
-			}
-			.yellow, .threesigma {
-				background-color: #ffff80;
-			}
-			.almostgreen, .twosigma {
-				background-color: #dfff80;
-			}
-			.green, .onesigma {
-				background-color: #9fff80;
-			}
-			.red, .foursigma {
-				background-color: #ff8080;
-			}
-			.orange {
-				background-color: #ffbf80;
-			}
-			.unimportant {
-			}
-			.tests_passed {
-				color: #226c18;
-				font-weight: bold;
-			}
-			.tests_failed {
-				color: #8a1717;
-				font-weight: bold;
-			}
-			.tests_skipped {
-				color: #535453;
-				font-weight: bold;
-			}
-			.center {
-				text-align:center
-			}
-			.right {
-				text-align: right;
-				width: 100%;
-			}
-
-			.popup {
-				position: relative;
-				display: inline-block;
-				-webkit-user-select: none;
-				-moz-user-select: none;
-				-ms-user-select: none;
-				user-select: none;
-			}
-
-			.popup .popuptext {
-				display: none;
-				width: 220px;
-				background-color: #555;
-				text-align: center;
-				border-radius: 6px;
-				padding: 8px 8px;
-				position: absolute;
-				z-index: 1;
-				left: 50%;
-				margin-left: -110px;
-			}
-
-            .popup .popuptextjoblist {
-                display: none;
-                width: 350px;
-                background-color: #FFFFFF;
-                text-align: center;
-                border-radius: 6px;
-                padding: 8px 8px;
-                position: absolute;
-                z-index: 1;
-                left: 100%;
-                margin-left: -350px;
-            }
-
-			.popup:hover .popuptext {
-				display: block;
-				-webkit-animation: fadeIn 1s;
-				animation: fadeIn 1s;
-			}
-
-			.popup:hover .popuptextjoblist {
-				display: block;
-				-webkit-animation: fadeIn 1s;
-				animation: fadeIn 1s;
-			}
-
-			.nowrap {
-				white-space: nowrap;
-			}
-
-			@-webkit-keyframes fadeIn {
-				from {opacity: 0;}
-				to {opacity: 1;}
-			}
-
-			@keyframes fadeIn {
-				from {opacity: 0;}
-				to {opacity:1 ;}
-			}
-		</style>
-	</meta>
-</head>
-<body>
-<h1>flakefinder report</h1>
-
-<div>
-	Data range from {{ $.StartOfReport }} till {{ $.EndOfReport }}<br/>
-</div>
-
-{{ if not .Headers }}
-	<div>No failing tests! 🙂</div>
-{{ else }}
-<div id="jobRatings" class="popup right" >
-	<u>list of job ratings</u>
-	<div class="popuptextjoblist right" id="targetRatingsForJobs">
-		<table width="100%">
-			{{ range $key, $jobRating := $.JobNamesToRatings }}<tr class="unimportant">
-				<td>
-					<a href="{{ $.JenkinsBaseURL }}/job/{{$key}}"><span title="job">{{$key}}</span></a>
-				</td>
-				<td>
-					<div><span title="number of completed builds">{{ .TotalCompletedBuilds }}</span></div>
-				</td>
-				<td>
-					<div><span title="mean">{{ printf "%.2f" .Mean }}</span></div>
-				</td>
-				<td>
-					<div><span title="standard deviation">{{ printf "%.2f" .StandardDeviation }}</span></div>
-				</td>
-			</tr>
-			{{ range $buildNo := .BuildNumbers }}<tr class="unimportant">{{ with $buildData := (index (index $.JobNamesToRatings $key).BuildNumbersToData $buildNo) }}
-				<td>
-				</td>
-				<td>
-					<a href="{{ $.JenkinsBaseURL }}/job/{{$key}}/{{$buildNo}}"><span title="job build number">{{$buildNo}}</span></a>
-				</td>
-				<td>
-					<div class="tests_failed"><span title="test failures">{{ $buildData.Failures }}</span></div>
-				</td>
-				<td>
-					<div class="{{ if le $buildData.Sigma 1.0 }}onesigma{{ else if le $buildData.Sigma 2.0 }}twosigma{{ else if le $buildData.Sigma 3.0 }}threesigma{{ else }}foursigma{{ end }}"><span title="&sigma; rating">{{ $buildData.Sigma }}</span></div>
-				</td>
-			{{ end }}</tr>{{ end }}{{ end }}
-		</table>
-	</div>
-</div>
-<div id="failuresForJobs" class="popup right" >
-	<u>list of job runs</u>
-	<div class="popuptextjoblist right" id="targetfailuresForJobs">
-		<table width="100%">
-			{{ range $key, $jobFailures := $.FailuresForJobs }}<tr class="unimportant">
-				<td>
-					<a href="{{ $.JenkinsBaseURL }}/job/{{.Job}}"><span title="job">{{.Job}}</span></a>
-				</td>
-				<td>
-					<a href="{{ $.JenkinsBaseURL }}/job/{{.Job}}/{{.BuildNumber}}"><span title="job build number">{{.BuildNumber}}</span></a>
-				</td>
-				<td>
-					<div class="tests_failed"><span title="test failures">{{ .Failures }}</span></div>
-				</td>
-				<td>
-					<div><span title="&sigma; rating">{{ (index (index $.JobNamesToRatings .Job).BuildNumbersToData .BuildNumber).Sigma }}</span></div>
-				</td>
-			</tr>{{ end }}
-		</table>
-	</div>
-</div>
-
-
-<table>
-    <tr>
-        <td></td>
-        <td></td>
-        {{ range $header := $.Headers }}
-        <td><a href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/">{{ $header }}</a></td>
-        {{ end }}
-    </tr>
-    {{ range $row, $test := $.Tests }}
-    <tr>
-        <td><div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a></div></td>
-        <td>{{ $test }}</td>
-        {{ range $col, $header := $.Headers }}
-	        {{if not (index $.Data $test $header) }}
-        <td class="center">
-            N/A
-        </td>
-			{{else}}
-        <td class="{{ (index $.Data $test $header).Severity }} center">
-            <div id="r{{$row}}c{{$col}}" class="popup" >
-                <span class="tests_failed" title="failed tests">{{ (index $.Data $test $header).Failed }}</span>/<span class="tests_passed" title="passed tests">{{ (index $.Data $test $header).Succeeded }}</span>/<span class="tests_skipped" title="skipped tests">{{ (index $.Data $test $header).Skipped }}</span>{{ if (index $.Data $test $header).Jobs }}
-                <div class="popuptext" id="targetr{{$row}}c{{$col}}">
-                    {{ range $Job := (index $.Data $test $header).Jobs }}
-                    <div class="{{.Severity}} nowrap"><a href="{{ $.JenkinsBaseURL }}/job/{{ $header }}/{{.BuildNumber}}">{{.BuildNumber}}</a> (<span class="tests_failed" title="failed tests in job run">{{ (index $.FailuresForJobs (printf "%s-%d" $header .BuildNumber)).Failures }}</span>)</div>
-                    {{ end }}
-                </div>{{ end }}
-            </div>
-        </td>
-            {{end}}
-        {{ end }}
-    </tr>
-    {{ end }}
-</table>
-{{ end }}
-
-</body>
-</html>
-`
-	jenkinsShortUsage = "flake-report-creator jenkins creates reports from junit xml artifact files generated during jenkins builds"
+	jenkinsShortUsage            = "flake-report-creator jenkins creates reports from junit xml artifact files generated during jenkins builds"
 )
+
+//go:embed jenkins-report-template.gohtml
+var jenkinsReportTemplate string
 
 var (
 	fileNameRegex  = regexp.MustCompile(defaultArtifactFileNameRegex)
@@ -543,7 +333,7 @@ func writeReportToFile(startOfReport time.Time, endOfReport time.Time, reports [
 		jobNamesToRatings[rating.Name] = rating
 	}
 
-	writeHTMLReportToOutputFile(outputFile, JenkinsReportTemplate, JenkinsReportParams{Params: parameters, JenkinsBaseURL: opts.endpoint, JobNamesToRatings: jobNamesToRatings})
+	writeHTMLReportToOutputFile(outputFile, jenkinsReportTemplate, JenkinsReportParams{Params: parameters, JenkinsBaseURL: opts.endpoint, JobNamesToRatings: jobNamesToRatings})
 
 	writeJSONToOutputFile(strings.TrimSuffix(outputFile, ".html")+".json", parameters)
 }

--- a/robots/cmd/flake-report-creator/cmd/prow-report-template.gohtml
+++ b/robots/cmd/flake-report-creator/cmd/prow-report-template.gohtml
@@ -1,0 +1,125 @@
+{{- /*
+
+    This file is part of the KubeVirt project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Copyright 2023 Red Hat, Inc.
+
+*/ -}}
+
+{{- /* gotype: kubevirt.io/project-infra/robots/cmd/flake-report-creator/cmd.SimpleReportParams */ -}}
+
+<html lang="en">
+<head>
+    <title>flakefinder report</title>
+    <meta charset="UTF-8"/>
+    <!--suppress CssUnusedSymbol -->
+    <style>
+        table, th, td {
+            border: 1px solid black;
+        }
+
+        .yellow {
+            background-color: #ffff80;
+        }
+
+        .almostgreen {
+            background-color: #dfff80;
+        }
+
+        .green {
+            background-color: #9fff80;
+        }
+
+        .red {
+            background-color: #ff8080;
+        }
+
+        .orange {
+            background-color: #ffbf80;
+        }
+
+        .unimportant {
+        }
+
+        .tests_passed {
+            color: #226c18;
+            font-weight: bold;
+        }
+
+        .tests_failed {
+            color: #8a1717;
+            font-weight: bold;
+        }
+
+        .tests_skipped {
+            color: #535453;
+            font-weight: bold;
+        }
+
+        .center {
+            text-align: center
+        }
+
+        .right {
+            text-align: right;
+            width: 100%;
+        }
+    </style>
+</head>
+<body>
+<h1>flakefinder report</h1>
+
+<div>
+    Data since {{ $.StartOfReport }}<br/>
+    Bucket: {{ $.BucketName }}<br/>
+    Pathes: {{ range $path := $.JobDataPathes }}<code>{{ $path }},</code>{{ end }}
+</div>
+<table>
+    <tr>
+        <td></td>
+        <td></td>
+        {{ range $header := $.Headers }}
+            <td>{{ $header }}</td>
+        {{ end }}
+    </tr>
+    {{ range $row, $test := $.Tests }}
+        <tr>
+            <td>
+                <div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a></div>
+            </td>
+            <td>{{ $test }}</td>
+            {{ range $col, $header := $.Headers }}
+                {{if not (index $.Data $test $header) }}
+                    <td class="center">
+                        N/A
+                    </td>
+                {{else}}
+                    <td class="{{ (index $.Data $test $header).Severity }} center">
+                        <div id="r{{$row}}c{{$col}}">
+                            <span class="tests_failed"
+                                  title="failed tests">{{ (index $.Data $test $header).Failed }}</span>/<span
+                                    class="tests_passed"
+                                    title="passed tests">{{ (index $.Data $test $header).Succeeded }}</span>/<span
+                                    class="tests_skipped"
+                                    title="skipped tests">{{ (index $.Data $test $header).Skipped }}</span>
+                        </div>
+                    </td>
+                {{end}}
+            {{ end }}
+        </tr>
+    {{ end }}
+</table>
+</body>
+</html>

--- a/robots/cmd/flakefinder/index.go
+++ b/robots/cmd/flakefinder/index.go
@@ -127,10 +127,12 @@ func WriteReportIndexPage(reportDirGcsObjects []string, reportIndexObjectWriter 
 //
 // Assumptions: input data sorted in alphanumeric desc order, i.e.
 // [
-// 	"flakefinder-2019-08-24-672h.html",
-//	"flakefinder-2019-08-24-168h.html",
-//	"flakefinder-2019-08-24-024h.html",
-//  ...
+//
+//		"flakefinder-2019-08-24-672h.html",
+//		"flakefinder-2019-08-24-168h.html",
+//		"flakefinder-2019-08-24-024h.html",
+//	 ...
+//
 // ]
 //
 // Note: legacy format "flakefinder-2019-08-24.html" is allowed, missing duration leads to taking this for weekly (168h)

--- a/robots/cmd/flakefinder/main.go
+++ b/robots/cmd/flakefinder/main.go
@@ -137,14 +137,15 @@ func main() {
 }
 
 // BuildReportOutputPath creates the path to which the report will get written, considering also if we are in
-// preview mode, so that existing production reports will not be overwritten. I.e considering
-// options{
-//		reportOutputChildPath: "kubevirt/kubevirt"
-//		isPreview:			   true
-// }
+// preview mode, so that existing production reports will not be overwritten. I.e. considering
+//
+//	options{
+//			reportOutputChildPath: "kubevirt/kubevirt"
+//			isPreview:			   true
+//	}
+//
 // will lead to
 // "reports/flakefinder/preview/kubevirt/kubevirt"
-//
 func BuildReportOutputPath(o options) string {
 	outputPath := flakefinder.ReportsPath
 	if o.isPreview {

--- a/robots/cmd/flakefinder/report.gohtml
+++ b/robots/cmd/flakefinder/report.gohtml
@@ -152,12 +152,19 @@
         }
 
         span.testAttribute {
-            font-weight: bold;
             color: white;
             padding: 3px 6px;
             border-radius: 8px;
             text-align: center;
-            margin: 0px;
+            margin-right: 1px;
+        }
+
+        span.testAttributeName {
+            font-style: italic;
+        }
+
+        span.testAttributeValue {
+            font-weight: bold;
         }
 
         div.testAttribute {
@@ -245,11 +252,14 @@
                 </td>
                 <td>{{- if (index $.TestAttributes $test) }}
                         <div class="testAttribute">
-                            {{- range $testAttribute := (index $.TestAttributes $test) }}
-                                <span class="testAttribute testAttributeType{{ $testAttribute.AttributeType }}">{{ $testAttribute.Name }}{{ if $testAttribute.Value }}:{{ $testAttribute.Value }}{{ end }}</span>
-                            {{- end }}
+                            {{- range $testAttribute := (index $.TestAttributes $test) -}}
+                                <span class="testAttribute testAttributeType{{ $testAttribute.AttributeType }}"><span class="testAttribute testAttributeName">{{ $testAttribute.Name }}</span>
+                                    {{- if $testAttribute.Value }}:<span class="testAttribute testAttributeValue">{{ $testAttribute.Value }}</span>{{ end -}}
+                                </span>
+                            {{- end -}}
                         </div>{{- end }}
                     {{ if (index $.BareTestNames $test) }}{{- index $.BareTestNames $test -}}{{ else }}{{- $test -}}{{ end }}
+                    <div hidden id="testName{{$row}}">{{- $test -}}</div><button title="Copy full test name to clipboard" class="clipboard" onclick="handleCopyTextFromArea('testName{{- $row -}}')">📋</button>
                 </td>
                 {{- range $col, $header := $.Headers -}}
                     {{- if not (index $.Data $test $header) }}
@@ -307,6 +317,12 @@
     function popup(id) {
         var popup = document.getElementById("target" + id);
         popup.classList.toggle("show");
+    }
+
+    function handleCopyTextFromArea(id) {
+        let hiddenDiv = document.getElementById(id);
+        let text = hiddenDiv.innerText || hiddenDiv.textContent;
+        navigator.clipboard.writeText(text)
     }
 </script>
 <div>

--- a/robots/cmd/flakefinder/report.gohtml
+++ b/robots/cmd/flakefinder/report.gohtml
@@ -127,6 +127,43 @@
             animation: fadeIn 1s;
         }
 
+        .testAttributeType0 {
+            background-color: red;
+        }
+
+        .testAttributeType1 {
+            background-color: indianred;
+        }
+
+        .testAttributeType2 {
+            background-color: darkorange;
+        }
+
+        .testAttributeType3 {
+            background-color: lightseagreen;
+        }
+
+        .testAttributeType4 {
+            background-color: forestgreen;
+        }
+
+        .testAttributeType5 {
+            background-color: dimgray;
+        }
+
+        span.testAttribute {
+            font-weight: bold;
+            color: white;
+            padding: 3px 6px;
+            border-radius: 8px;
+            text-align: center;
+            margin: 0px;
+        }
+
+        div.testAttribute {
+            margin: 2px 0px;
+        }
+
         /* Add animation (fade in the popup) */
         @-webkit-keyframes fadeIn {
             from {
@@ -206,13 +243,20 @@
                 <td>
                     <div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a></div>
                 </td>
-                <td>{{ $test }}</td>
-                {{ range $col, $header := $.Headers }}
-                    {{if not (index $.Data $test $header) }}
+                <td>{{- if (index $.TestAttributes $test) }}
+                        <div class="testAttribute">
+                            {{- range $testAttribute := (index $.TestAttributes $test) }}
+                                <span class="testAttribute testAttributeType{{ $testAttribute.AttributeType }}">{{ $testAttribute.Name }}{{ if $testAttribute.Value }}:{{ $testAttribute.Value }}{{ end }}</span>
+                            {{- end }}
+                        </div>{{- end }}
+                    {{ if (index $.BareTestNames $test) }}{{- index $.BareTestNames $test -}}{{ else }}{{- $test -}}{{ end }}
+                </td>
+                {{- range $col, $header := $.Headers -}}
+                    {{- if not (index $.Data $test $header) }}
                         <td class="center">
                             N/A
                         </td>
-                    {{else}}
+                    {{- else }}
                         <td class="{{ (index $.Data $test $header).Severity }} center"
                             title="{{ $test }}&#10;{{ $header }}">
                             <div id="r{{$row}}c{{$col}}" onClick="popup(this.id)" class="popup">

--- a/robots/cmd/flakefinder/report.gohtml
+++ b/robots/cmd/flakefinder/report.gohtml
@@ -152,11 +152,12 @@
         }
 
         span.testAttribute {
+            display: inline-block;
             color: white;
             padding: 3px 6px;
             border-radius: 8px;
             text-align: center;
-            margin-right: 1px;
+            margin: 1px 1px 0px 0px;
         }
 
         span.testAttributeName {
@@ -259,7 +260,7 @@
                             {{- end -}}
                         </div>{{- end }}
                     {{ if (index $.BareTestNames $test) }}{{- index $.BareTestNames $test -}}{{ else }}{{- $test -}}{{ end }}
-                    <div hidden id="testName{{$row}}">{{- $test -}}</div><button title="Copy full test name to clipboard" class="clipboard" onclick="handleCopyTextFromArea('testName{{- $row -}}')">📋</button>
+                    <div hidden="" id="testName{{$row}}">{{- $test -}}</div><button title="Copy full test name to clipboard" class="clipboard" onclick="handleCopyTextFromArea('testName{{- $row -}}')">📋</button>
                 </td>
                 {{- range $col, $header := $.Headers -}}
                     {{- if not (index $.Data $test $header) }}

--- a/robots/cmd/flakefinder/report.gohtml
+++ b/robots/cmd/flakefinder/report.gohtml
@@ -1,6 +1,27 @@
+{{- /*
+
+    This file is part of the KubeVirt project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Copyright 2023 Red Hat, Inc.
+
+*/ -}}
+
 {{- /* gotype: kubevirt.io/project-infra/robots/pkg/flakefinder.Params */ -}}
+
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>{{ $.Org }}/{{ $.Repo }} - flakefinder report</title>
     <meta charset="UTF-8"/>
@@ -146,7 +167,7 @@
     <div id="failuresForJobs" onClick="popup(this.id)" class="popup right">
         <u>list of job runs</u>
         <div class="popuptextjoblist right" id="targetfailuresForJobs">
-            <table width="100%">
+            <table>
                 {{ range $key, $jobFailures := $.FailuresForJobs }}
                     <tr class="unimportant">
                         <td>
@@ -205,7 +226,7 @@
                                     <table>
                                         {{ range $Job := (index $.Data $test $header).Jobs }}
                                             <tr>
-                                                <td class="{{.Severity}} nowrap" width="100%">
+                                                <td class="{{.Severity}} nowrap">
                                                     {{ if ne .PR 0 }}
                                                         <a href="https://prow.ci.kubevirt.io/view/gcs/kubevirt-prow/pr-logs/pull/{{ $.Org }}_{{ $.Repo }}/{{.PR}}/{{.Job}}/{{.BuildNumber}}">{{.BuildNumber}}</a>
                                                     {{ else if .BatchPRs }}

--- a/robots/cmd/flakefinder/report.gohtml
+++ b/robots/cmd/flakefinder/report.gohtml
@@ -1,3 +1,4 @@
+{{- /* gotype: kubevirt.io/project-infra/robots/pkg/flakefinder.Params */ -}}
 <!DOCTYPE html>
 <html>
 <head>
@@ -128,7 +129,6 @@
 <body>
 
 <h1>flakefinder report for {{ $.Org }}/{{ $.Repo }}</h1>
-{{- /* gotype: kubevirt.io/project-infra/robots/pkg/flakefinder.Params */ -}}
 <div>
     Data range from {{ $.StartOfReport }} till {{ $.EndOfReport }}
 </div>

--- a/robots/cmd/flakefinder/report_test.go
+++ b/robots/cmd/flakefinder/report_test.go
@@ -37,6 +37,15 @@ var _ = Describe("report.go", func() {
 
 	})
 
+	const (
+		testName1 = "[release-blocker][Serial][test_id:4217]t1"
+		testName2 = "[QUARANTINE][test_id:1742]t2"
+		testName3 = "[sig-compute][some-unimportant-label]t3"
+		jobNameA  = "a"
+		jobNameB  = "b"
+		jobNameC  = "c"
+	)
+
 	When("rendering report data", func() {
 
 		var buffer bytes.Buffer
@@ -52,9 +61,57 @@ var _ = Describe("report.go", func() {
 		}
 
 		prepareWithDefaultParams := func() {
-			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23",
+			parameters := flakefinder.Params{
+				Data: map[string]map[string]*flakefinder.Details{
+					testName1: {
+						jobNameA: &flakefinder.Details{
+							Failed:    4,
+							Succeeded: 1,
+							Skipped:   2,
+							Severity:  "red",
+							Jobs:      []*flakefinder.Job{}},
+					},
+					testName2: {
+						jobNameB: &flakefinder.Details{
+							Failed:    1,
+							Succeeded: 5,
+							Skipped:   1,
+							Severity:  "red",
+							Jobs:      []*flakefinder.Job{}},
+					},
+					testName3: {
+						jobNameC: &flakefinder.Details{
+							Failed:    9,
+							Succeeded: 3,
+							Skipped:   1,
+							Severity:  "red",
+							Jobs:      []*flakefinder.Job{}},
+					},
+				},
+				Headers: []string{jobNameA, jobNameB, jobNameC},
+				Tests:   []string{testName1, testName2, testName3},
+				TestAttributes: map[string]flakefinder.TestAttributes{
+					testName1: flakefinder.NewTestAttributes(testName1),
+					testName2: flakefinder.NewTestAttributes(testName2),
+					testName3: flakefinder.NewTestAttributes(testName3),
+				},
+				BareTestNames: map[string]string{
+					testName1: flakefinder.GetBareTestName(testName1),
+					testName2: flakefinder.GetBareTestName(testName2),
+					testName3: flakefinder.GetBareTestName(testName3),
+				},
+				EndOfReport: "2019-08-23",
+				Org:         Org,
+				Repo:        Repo,
+				PrNumbers:   []int{17, 42},
+			}
+
+			prepareBuffer(parameters)
+		}
+
+		prepareWithNoFailingTests := func() {
+			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{},
+				Headers: []string{}, Tests: []string{}, EndOfReport: "2019-08-23",
 				Org: Org, Repo: Repo,
 				PrNumbers: []int{17, 42},
 			}
@@ -69,16 +126,18 @@ var _ = Describe("report.go", func() {
 
 		It("has rows", func() {
 			prepareWithDefaultParams()
-			Expect(buffer.String()).To(ContainSubstring("<td>t1</td>"))
-			Expect(buffer.String()).To(ContainSubstring("<td>t2</td>"))
-			Expect(buffer.String()).To(ContainSubstring("<td>t3</td>"))
+			Expect(buffer.String()).To(ContainSubstring(flakefinder.NewTestAttributes(testName1)[0].Name))
+			Expect(buffer.String()).To(ContainSubstring("<div class=\"testAttribute\""))
+			Expect(buffer.String()).To(ContainSubstring(testName1))
+			Expect(buffer.String()).To(ContainSubstring(testName2))
+			Expect(buffer.String()).To(ContainSubstring(testName3))
 		})
 
 		It("has columns", func() {
 			prepareWithDefaultParams()
-			Expect(buffer.String()).To(ContainSubstring("<td>a</td>"))
-			Expect(buffer.String()).To(ContainSubstring("<td>b</td>"))
-			Expect(buffer.String()).To(ContainSubstring("<td>c</td>"))
+			Expect(buffer.String()).To(ContainSubstring(fmt.Sprintf("<td>%s</td>", jobNameA)))
+			Expect(buffer.String()).To(ContainSubstring(fmt.Sprintf("<td>%s</td>", jobNameB)))
+			Expect(buffer.String()).To(ContainSubstring(fmt.Sprintf("<td>%s</td>", jobNameC)))
 		})
 
 		It("has one filled test cell", func() {
@@ -98,35 +157,26 @@ var _ = Describe("report.go", func() {
 			Expect(buffer.String()).To(ContainSubstring("#42"))
 		})
 
+		It("creates valid html with default params", func() {
+			prepareWithDefaultParams()
+			Expect(validation.HTMLValidator{}.IsValid(buffer.Bytes())).To(BeNil())
+		})
+
 		It("shows no errors if no failing tests", func() {
-			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{},
-				Headers: []string{}, Tests: []string{}, EndOfReport: "2019-08-23",
-				Org: Org, Repo: Repo,
-				PrNumbers: []int{17, 42},
-			}
-
-			prepareBuffer(parameters)
-
+			prepareWithNoFailingTests()
 			Expect(buffer.String()).To(ContainSubstring("No failing tests!"))
 		})
 
 		It("shows pr ids if no failing tests", func() {
-			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{},
-				Headers: []string{}, Tests: []string{}, EndOfReport: "2019-08-23",
-				Org: Org, Repo: Repo,
-				PrNumbers: []int{17, 42},
-			}
-
-			prepareBuffer(parameters)
-
+			prepareWithNoFailingTests()
 			Expect(buffer.String()).To(ContainSubstring("#17"))
 			Expect(buffer.String()).To(ContainSubstring("#42"))
 		})
 
 		DescribeTable("title contains repo and org", func(org, repo string) {
 			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
+				"t1": {jobNameA: &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{}}},
+			}, Headers: []string{jobNameA, "b", "c"}, Tests: []string{"t1", "t2", testName3}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
 
 			prepareBuffer(parameters)
 
@@ -139,10 +189,10 @@ var _ = Describe("report.go", func() {
 
 		DescribeTable("prow link contains repo and org", func(org, repo string) {
 			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
+				"t1": {jobNameA: &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
 					{BuildNumber: 1742, Severity: "red", PR: 1427, Job: "testblah"},
 				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
+			}, Headers: []string{jobNameA, "b", "c"}, Tests: []string{"t1", "t2", testName3}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
 
 			prepareBuffer(parameters)
 
@@ -155,10 +205,10 @@ var _ = Describe("report.go", func() {
 
 		DescribeTable("GitHub link contains repo and org", func(org, repo string) {
 			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
+				"t1": {jobNameA: &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
 					{BuildNumber: 1742, Severity: "red", PR: 1427, Job: "testblah"},
 				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
+			}, Headers: []string{jobNameA, "b", "c"}, Tests: []string{"t1", "t2", testName3}, EndOfReport: "2019-08-23", Org: org, Repo: repo}
 
 			prepareBuffer(parameters)
 
@@ -171,10 +221,10 @@ var _ = Describe("report.go", func() {
 
 		It("shows job header table", func() {
 			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
+				"t1": {jobNameA: &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
 					{BuildNumber: 1742, Severity: "red", PR: 1427, Job: "testblah"},
 				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: "kubevirt", Repo: "kubevirt",
+			}, Headers: []string{jobNameA, "b", "c"}, Tests: []string{"t1", "t2", testName3}, EndOfReport: "2019-08-23", Org: "kubevirt", Repo: "kubevirt",
 				FailuresForJobs: map[string]*flakefinder.JobFailures{
 					"1742": {
 						BuildNumber: 1742,
@@ -200,10 +250,10 @@ var _ = Describe("report.go", func() {
 
 		It("shows batch job PRs", func() {
 			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
+				"t1": {jobNameA: &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
 					{BuildNumber: 1742, Severity: "red", BatchPRs: []int{1427, 1737}, Job: "testblah"},
 				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: "kubevirt", Repo: "kubevirt",
+			}, Headers: []string{jobNameA, "b", "c"}, Tests: []string{"t1", "t2", testName3}, EndOfReport: "2019-08-23", Org: "kubevirt", Repo: "kubevirt",
 				FailuresForJobs: map[string]*flakefinder.JobFailures{
 					"1742": {
 						BuildNumber: 1742,
@@ -228,33 +278,6 @@ var _ = Describe("report.go", func() {
 			Expect(buffer.String()).To(ContainSubstring("k8s-1.19-whocares"))
 		})
 
-		It("creates valid html", func() {
-			parameters := flakefinder.Params{Data: map[string]map[string]*flakefinder.Details{
-				"t1": {"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
-					{BuildNumber: 1742, Severity: "red", BatchPRs: []int{1427, 1737}, Job: "testblah"},
-				}}},
-			}, Headers: []string{"a", "b", "c"}, Tests: []string{"t1", "t2", "t3"}, EndOfReport: "2019-08-23", Org: "kubevirt", Repo: "kubevirt",
-				FailuresForJobs: map[string]*flakefinder.JobFailures{
-					"1742": {
-						BuildNumber: 1742,
-						BatchPRs:    []int{1427, 1737},
-						Job:         "k8s-1.18-whatever",
-						Failures:    66,
-					},
-					"4217": {
-						BuildNumber: 4217,
-						PR:          42,
-						Job:         "k8s-1.19-whocares",
-						Failures:    66,
-					},
-				},
-			}
-
-			prepareBuffer(parameters)
-
-			Expect(validation.HTMLValidator{}.IsValid(buffer.Bytes())).To(BeNil())
-		})
-
 	})
 
 	When("rendering report csv", func() {
@@ -266,7 +289,7 @@ var _ = Describe("report.go", func() {
 			data := CSVParams{
 				Data: map[string]map[string]*flakefinder.Details{
 					"t1": {
-						"a": &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
+						jobNameA: &flakefinder.Details{Failed: 4, Succeeded: 1, Skipped: 2, Severity: "red", Jobs: []*flakefinder.Job{
 							{
 								BuildNumber: 1742,
 								Severity:    "red",
@@ -276,8 +299,8 @@ var _ = Describe("report.go", func() {
 						"b": &flakefinder.Details{Failed: 5, Succeeded: 2, Skipped: 3, Severity: "yellow", Jobs: []*flakefinder.Job{}},
 					},
 					"t2": {
-						"a": &flakefinder.Details{Failed: 8, Succeeded: 2, Skipped: 4, Severity: "cyan", Jobs: []*flakefinder.Job{}},
-						"b": &flakefinder.Details{Failed: 9, Succeeded: 3, Skipped: 5, Severity: "blue", Jobs: []*flakefinder.Job{}},
+						jobNameA: &flakefinder.Details{Failed: 8, Succeeded: 2, Skipped: 4, Severity: "cyan", Jobs: []*flakefinder.Job{}},
+						"b":      &flakefinder.Details{Failed: 9, Succeeded: 3, Skipped: 5, Severity: "blue", Jobs: []*flakefinder.Job{}},
 					},
 				},
 			}

--- a/robots/cmd/flakefinder/report_test.go
+++ b/robots/cmd/flakefinder/report_test.go
@@ -40,7 +40,7 @@ var _ = Describe("report.go", func() {
 	const (
 		testName1 = "[release-blocker][Serial][test_id:4217]t1"
 		testName2 = "[QUARANTINE][test_id:1742]t2"
-		testName3 = "[sig-compute][some-unimportant-label]t3"
+		testName3 = "[sig-compute][some-unimportant-label][some-label][some-label][some-label][some-label][some-label][some-label][some-label][some-label][some-label][some-label]t3"
 		jobNameA  = "a"
 		jobNameB  = "b"
 		jobNameC  = "c"

--- a/robots/pkg/flakefinder/report_data_test.go
+++ b/robots/pkg/flakefinder/report_data_test.go
@@ -430,6 +430,9 @@ var _ = Describe("report_data.go", func() {
 					EndOfReport:   endOfReport.Format(time.RFC3339),
 					Headers:       []string{"job"},
 					Tests:         []string{"test3"},
+					TestAttributes: map[string]TestAttributes{
+						"test3": nil,
+					},
 					Data: map[string]map[string]*Details{
 						"test3": {
 							"job": {
@@ -511,6 +514,9 @@ var _ = Describe("report_data.go", func() {
 					EndOfReport:   endOfReport.Format(time.RFC3339),
 					Headers:       []string{"job"},
 					Tests:         []string{"test3"},
+					TestAttributes: map[string]TestAttributes{
+						"test3": nil,
+					},
 					Data: map[string]map[string]*Details{
 						"test3": {
 							"job": {
@@ -532,6 +538,153 @@ var _ = Describe("report_data.go", func() {
 					},
 				}))
 		})
+
+		It("adds test attributes for failing tests", func() {
+			startOfReport := time.Now().Add(minusDay)
+			endOfReport := time.Now()
+			Expect(CreateFlakeReportData(
+				[]*JobResult{
+					{
+						Job: "job",
+						JUnit: []junit.Suite{
+							{
+								Name:       "suite",
+								Package:    "",
+								Properties: nil,
+								Tests: []junit.Test{
+									{
+										Name:       "test1",
+										Classname:  "",
+										Duration:   0,
+										Status:     junit.StatusPassed,
+										Error:      nil,
+										Properties: nil,
+									},
+									{
+										Name:       "test2",
+										Classname:  "",
+										Duration:   0,
+										Status:     junit.StatusSkipped,
+										Error:      nil,
+										Properties: nil,
+									},
+									{
+										Name:       "[Serial]test3[sig-compute]",
+										Classname:  "",
+										Duration:   0,
+										Status:     junit.StatusFailed,
+										Error:      nil,
+										Properties: nil,
+									},
+								},
+								SystemOut: "",
+								SystemErr: "",
+								Totals:    junit.Totals{},
+							},
+						},
+						BuildNumber: buildNumber,
+						PR:          pr,
+						BatchPRs:    nil,
+					},
+				},
+				[]int{pr},
+				endOfReport,
+				org,
+				repo,
+				startOfReport,
+			)).To(BeEquivalentTo(
+				Params{
+					StartOfReport: startOfReport.Format(time.RFC3339),
+					EndOfReport:   endOfReport.Format(time.RFC3339),
+					Headers:       []string{"job"},
+					Tests:         []string{"[Serial]test3[sig-compute]"},
+					TestAttributes: map[string]TestAttributes{
+						"[Serial]test3[sig-compute]": {
+							{Name: "Serial", Value: "", AttributeType: 2},
+							{Name: "sig-compute", Value: "", AttributeType: 3},
+						},
+					},
+					Data: map[string]map[string]*Details{
+						"[Serial]test3[sig-compute]": {
+							"job": {
+								Succeeded: 0,
+								Skipped:   0,
+								Failed:    1,
+								Severity:  "red",
+								Jobs: []*Job{
+									{BuildNumber: buildNumber, Severity: "red", PR: pr, BatchPRs: nil, Job: "job"},
+								},
+							},
+						},
+					},
+					PrNumbers: []int{pr},
+					Org:       org,
+					Repo:      repo,
+					FailuresForJobs: map[string]*JobFailures{
+						fmt.Sprintf("job-%d", buildNumber): {BuildNumber: buildNumber, PR: pr, BatchPRs: nil, Job: "job", Failures: 1},
+					},
+				}))
+		})
+
 	})
+
+	DescribeTable("Extracting TestAttributes", func(testName string, expected TestAttributes) {
+		Expect(NewTestAttributes(testName)).To(BeEquivalentTo(expected))
+	},
+		Entry("empty", "", nil),
+		Entry("serial", "[Serial]", TestAttributes{
+			{
+				Name:          "Serial",
+				Value:         "",
+				AttributeType: TestAttributeTypeSerial,
+			},
+		}),
+		Entry("sig", "[sig-storage]", TestAttributes{
+			{
+				Name:          "sig-storage",
+				Value:         "",
+				AttributeType: TestAttributeTypeSIG,
+			},
+		}),
+		Entry("test id", "[test_id:1742]", TestAttributes{
+			{
+				Name:          "test_id",
+				Value:         "1742",
+				AttributeType: TestAttributeTypeTestID,
+			},
+		}),
+		Entry("quarantine", "[QUARANTINE]", TestAttributes{
+			{
+				Name:          "QUARANTINE",
+				Value:         "",
+				AttributeType: TestAttributeTypeQuarantine,
+			},
+		}),
+		Entry("release-blocker", "[release-blocker]", TestAttributes{
+			{
+				Name:          "release-blocker",
+				Value:         "",
+				AttributeType: TestAttributeTypeReleaseBlocker,
+			},
+		}),
+		Entry("complex test name", "[Serial][sig-operator]Operator [rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should update kubevirt [release-blocker][test_id:3145]from previous release to target tested release by patching KubeVirt CR", TestAttributes{
+			{
+				Name:          "release-blocker",
+				Value:         "",
+				AttributeType: 0,
+			},
+			{Name: "Serial", Value: "", AttributeType: 2},
+			{Name: "sig-operator", Value: "", AttributeType: 3},
+			{Name: "test_id", Value: "3145", AttributeType: 4},
+			{Name: "rfe_id", Value: "2291", AttributeType: 5},
+			{Name: "crit", Value: "high", AttributeType: 5},
+			{
+				Name:          "vendor",
+				Value:         "cnv-qe@redhat.com",
+				AttributeType: 5,
+			},
+			{Name: "level", Value: "component", AttributeType: 5},
+		}),
+	)
 
 })

--- a/robots/pkg/flakefinder/report_data_test.go
+++ b/robots/pkg/flakefinder/report_data_test.go
@@ -452,6 +452,7 @@ var _ = Describe("report_data.go", func() {
 					FailuresForJobs: map[string]*JobFailures{
 						fmt.Sprintf("job-%d", buildNumber): {BuildNumber: buildNumber, PR: pr, BatchPRs: nil, Job: "job", Failures: 1},
 					},
+					BareTestNames: map[string]string{"test3": "test3"},
 				}))
 		})
 
@@ -536,6 +537,7 @@ var _ = Describe("report_data.go", func() {
 					FailuresForJobs: map[string]*JobFailures{
 						fmt.Sprintf("job-%d", buildNumber): {BuildNumber: buildNumber, PR: 0, BatchPRs: []int{pr}, Job: "job", Failures: 1},
 					},
+					BareTestNames: map[string]string{"test3": "test3"},
 				}))
 		})
 
@@ -623,6 +625,9 @@ var _ = Describe("report_data.go", func() {
 					FailuresForJobs: map[string]*JobFailures{
 						fmt.Sprintf("job-%d", buildNumber): {BuildNumber: buildNumber, PR: pr, BatchPRs: nil, Job: "job", Failures: 1},
 					},
+					BareTestNames: map[string]string{
+						"[Serial]test3[sig-compute]": "test3",
+					},
 				}))
 		})
 
@@ -685,6 +690,13 @@ var _ = Describe("report_data.go", func() {
 			},
 			{Name: "level", Value: "component", AttributeType: 5},
 		}),
+	)
+
+	DescribeTable("Getting bare test names", func(testName string, expected string) {
+		Expect(GetBareTestName(testName)).To(BeEquivalentTo(expected))
+	},
+		Entry("empty", "", ""),
+		Entry("complex test name", "[Serial][sig-operator]Operator [rfe_id:2291][crit:high][vendor:cnv-qe@redhat.com][level:component]should update kubevirt [release-blocker][test_id:3145]from previous release to target tested release by patching KubeVirt CR", "Operator should update kubevirt from previous release to target tested release by patching KubeVirt CR"),
 	)
 
 })


### PR DESCRIPTION
Improve readability of test names by extracting attributes/tags and showing them as labels above the test name. Also improve readability for valued tags like `test_id:1742` by separation of attribute name and value.

![image](https://user-images.githubusercontent.com/809335/212143306-ef963d5e-c1d1-4f87-a2ef-6ad202fba470.png)


![image](https://user-images.githubusercontent.com/809335/212143185-05b761bb-23fc-4830-8cef-b991d5bbde46.png)

Example report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/preview/flakefinder-2023-01-11-024h.html

/cc @brianmcarey @enp0s3 