### PR TITLE
Install Material theme to user-guide container

### DIFF
--- a/images/kubevirt-user-guide/Dockerfile
+++ b/images/kubevirt-user-guide/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /src && cd /src && \
     npm install -g markdownlint-cli casperjs phantomjs-prebuilt yaspeller && \
     cd /src && bundle install && bundle update && cd && \
     pip install --upgrade pip && \
-    pip install mkdocs mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin && \
+    pip install mkdocs mkdocs-material mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin && \
     gem list && \
     rpm -e --nodeps libX11 libX11-common libXrender libXft && \
     dnf erase -y @development-tools gcc qt5-srpm-macros \

--- a/images/kubevirt-user-guide/Dockerfile
+++ b/images/kubevirt-user-guide/Dockerfile
@@ -1,5 +1,5 @@
 # BASE
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:37
 
 ENV LC_ALL=en_US.UTF-8
 


### PR DESCRIPTION
In order to support https://github.com/kubevirt/user-guide/pull/633, this patch adds mkdocs-material theme to the list of packages installed to the user-guide build container.