### PR TITLE
Cleanup of 1.23 kubevirt presubmit lanes and add 1.26 periodic root lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1947,6 +1947,55 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
+  cron: 10 2,18 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.26-sig-storage-root
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.26-sig-storage
+      - name: FEATURE_GATES
+        value: Root
+      image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+      name: ""
+      resources:
+        requests:
+          memory: 29Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
   cron: 40 2,18 * * *
   decorate: true
   decoration_config:
@@ -2041,6 +2090,55 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
+  cron: 20 3,19 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.26-sig-compute-root
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.26-sig-compute
+      - name: FEATURE_GATES
+        value: Root
+      image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+      name: ""
+      resources:
+        requests:
+          memory: 29Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
   cron: 50 3,19 * * *
   decorate: true
   decoration_config:
@@ -2122,6 +2220,55 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-sig-operator
+      image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+      name: ""
+      resources:
+        requests:
+          memory: 29Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 30 6,22 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.26-sig-operator-root
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.26-sig-operator
+      - name: FEATURE_GATES
+        value: Root
       image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -556,7 +556,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       priorityClassName: windows
-  - always_run: false
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -713,7 +713,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
+    name: pull-kubevirt-e2e-k8s-1.26-sig-compute-cgroupsv2
     run_if_changed: pkg/virt-handler/cgroup/.*
     skip_branches:
     - release-\d+\.\d+
@@ -30,7 +30,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23-sig-compute
+          value: k8s-1.26-sig-compute
         - name: KUBEVIRT_CGROUPV2
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
@@ -181,7 +181,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
+    name: pull-kubevirt-e2e-k8s-1.26-sig-storage-cgroupsv2
     run_if_changed: pkg/virt-handler/cgroup/.*|pkg/virt-handler/hotplug-disk/.*|pkg/hotplug-disk/.*|cmd/virt-chroot/cgroup.go
     skip_branches:
     - release-\d+\.\d+
@@ -194,7 +194,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23-sig-storage
+          value: k8s-1.26-sig-storage
         - name: KUBEVIRT_CGROUPV2
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
@@ -1686,7 +1686,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-swap-enabled
+    name: pull-kubevirt-e2e-k8s-1.26-swap-enabled
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1700,7 +1700,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23
+          value: k8s-1.26
         - name: KUBEVIRT_E2E_FOCUS
           value: SwapTest
         - name: KUBEVIRT_SWAP_ON
@@ -1727,7 +1727,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
-    name: pull-kubevirt-e2e-k8s-1.23-sig-monitoring
+    name: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
     run_if_changed: ^pkg/monitoring/.*|tests/monitoring/.*$
     skip_branches:
     - release-\d+\.\d+
@@ -1740,7 +1740,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23-sig-monitoring
+          value: k8s-1.26-sig-monitoring
         - name: KUBEVIRT_NUM_NODES
           value: "2"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
@@ -1767,7 +1767,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.23-single-node
+    name: pull-kubevirt-e2e-k8s-1.26-single-node
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1780,7 +1780,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.23
+          value: k8s-1.26
         - name: KUBEVIRT_E2E_FOCUS
           value: .*
         - name: KUBEVIRT_NUM_NODES


### PR DESCRIPTION
This PR includes a couple of changes to cleanup the presubmits lanes and also added periodic lanes to test rootful kubevirt. 

- [Swap rootful vgpu lane for nonroot lane](https://github.com/kubevirt/project-infra/commit/72d3a15fde22fbd30d7bf05ec4f84c6df59b9ee2)
-  [Add periodic 1.26 root test lanes](https://github.com/kubevirt/project-infra/commit/463313e781a164800ac148819b9873e2f0d3359a)
-  [Bump remaining lanes that use the 1.23 provider](https://github.com/kubevirt/project-infra/commit/d827f31ecd3c63336ee7f80cb83d144133df8d2f)

/cc @dhiller @xpivarc 