### PR TITLE
Update kubvirt builder image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
       decorate: true
       spec:
         containers:
-          - image: quay.io/kubevirt/builder:2203011706-a6a84d038
+          - image: quay.io/kubevirt/builder:2212180911-8818abcfa
             command: [ "/bin/sh" , "-c" ]
             args:
               - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -596,7 +596,7 @@ periodics:
       - -c
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main -R
-      image: quay.io/kubevirt/builder:2203011706-a6a84d038
+      image: quay.io/kubevirt/builder:2212180911-8818abcfa
       name: ""
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -239,7 +239,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder:2203011706-a6a84d038
+      - image: quay.io/kubevirt/builder:2212180911-8818abcfa
         command: ["/bin/sh"]
         args:
           - "-c"
@@ -277,7 +277,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder:2203011706-a6a84d038
+      - image: quay.io/kubevirt/builder:2212180911-8818abcfa
         command: ["/bin/sh"]
         args:
           - "-c"
@@ -500,7 +500,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder:2203011706-a6a84d038
+      - image: quay.io/kubevirt/builder:2212180911-8818abcfa
         command: ["/bin/sh"]
         args:
           - "-c"

--- a/hack/update-jobs-with-latest-image.sh
+++ b/hack/update-jobs-with-latest-image.sh
@@ -18,7 +18,7 @@ else
 fi
 
 IMAGE_NAME="$1"
-latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("^v[0-9]+-[a-z0-9]{7,8}$") )' | tail -1)
+latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("^v?[0-9]+-[a-z0-9]{7,9}$") )' | tail -1)
 if [ -z "$latest_image_tag" ]; then
     echo "Couldn't find latest_image_tag"
     exit 1


### PR DESCRIPTION
Updates the kubevirt builder image for jobs, since i.e. bump-kubevirt-rpms-weekly is [failing](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/bump-kubevirt-rpms-weekly/1614748255260774400) due to bazel being too old.

Also adjusts the bump-image script to work for kubevirt builder image tags.