### PR TITLE
Make prow-bump use pr-creator image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -500,7 +500,7 @@ periodics:
     securityContext:
       runAsUser: 0
     containers:
-      - image: quay.io/kubevirt/builder:2212180911-8818abcfa
+      - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
         command: ["/bin/sh"]
         args:
           - "-c"


### PR DESCRIPTION
Using kubevirt builder as job image is a waste of resources, we use pr-creator instead.

Successful run here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-bump/1614981981030846464 