### PR TITLE
enable credentials for windows lane for release-0.58 configs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -386,6 +386,7 @@ presubmits:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-dind-enabled: "true"
+      preset-gcs-credentials: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 1


### PR DESCRIPTION
This should resolve the [issues](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/8896/pull-kubevirt-e2e-windows2016-0.58/1615019446710046720) we have with fetching the windows image in release-0.58

Also refers to [#9062](https://github.com/kubevirt/kubevirt/pull/9062)
/cc @brianmcarey @dhiller 

Signed-off-by: enp0s3 <ibezukh@redhat.com>