### PR TITLE
Add vm-console-proxy repository to kubevirt organization

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -507,6 +507,12 @@ orgs:
         description: VM monitoring application based on WSGI, libvirt, flask and gevent, inspired by cAdvisor.
         has_projects: false
         has_wiki: false
+      vm-console-proxy:
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        default_branch: main
+        description: Proxy for VM console connection.
+        has_projects: false
       vm-import-operator:
         allow_rebase_merge: false
         allow_squash_merge: false
@@ -751,6 +757,7 @@ orgs:
           must-gather: write
           node-maintenance-operator: write
           ssp-operator: write
+          vm-console-proxy: write
       ovirt-bot:
         description: ""
         maintainers:
@@ -840,6 +847,14 @@ orgs:
           - alicefr
         repos:
           test-benchmarks: admin
+      vm-console-proxy-maintainers:
+        description: "Maintainers of vm-console-proxy repository"
+        privacy: closed
+        maintainers:
+          - akrejcir
+          - dominikholler
+        repos:
+          vm-console-proxy: admin
       web-ui-maintainers:
         description: ""
         maintainers:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -130,6 +130,7 @@ tide:
     kubevirt/cloud-provider-kubevirt: merge
     kubevirt/secrets: merge
     kubevirt/test-benchmarks: merge
+    kubevirt/vm-console-proxy: merge
 
   queries:
   - repos:
@@ -188,6 +189,7 @@ tide:
     - kubevirt/ssp-operator
     - kubevirt/must-gather
     - kubevirt/csi-driver
+    - kubevirt/vm-console-proxy
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -400,6 +400,14 @@ plugins:
     - owners-label
     - trigger
 
+  kubevirt/vm-console-proxy:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
   kubevirt/vm-import-operator:
     plugins:
     - approve
@@ -517,6 +525,7 @@ triggers:
   - kubevirt/cloud-provider-kubevirt
   - kubevirt/secrets
   - kubevirt/test-benchmarks
+  - kubevirt/vm-console-proxy
 - repos:
   - virtblocks/virtblocks
 - repos:
@@ -566,6 +575,7 @@ approve:
   - kubevirt/qe-tools
   - kubevirt/cloud-provider-kubevirt
   - kubevirt/test-benchmarks
+  - kubevirt/vm-console-proxy
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -620,6 +630,7 @@ lgtm:
   - kubevirt/cloud-provider-kubevirt
   - kubevirt/secrets
   - kubevirt/test-benchmarks
+  - kubevirt/vm-console-proxy
   review_acts_as_lgtm: true
 
 override:


### PR DESCRIPTION
It is a proxy that provides access to VM's VNC, and uses a time limited token for authentication.

Currently the project is in my personal repository: https://github.com/akrejcir/vm-console-proxy