### PR TITLE
Make kubevirt fossa check optional due to failures

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1123,6 +1123,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-fossa
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
The kubevirt fossa presubmit check is failing constantly[1]. Fossa support have been contacted about the issue.

The failing fossa presubmit is blocking merges and batch merges to the kubevirt/kubevirt repo - updating this job to be optional.

[1] https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-fossa

/cc @dhiller @EdDev @enp0s3 

Signed-off-by: Brian Carey <bcarey@redhat.com>