### PR TITLE
Add flakefinder rewrite to GCS bucket

### DIFF
--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
   - manifests/local/cherrypicker_deployment.yaml
   - manifests/local/cherrypicker_service.yaml
   - manifests/local/deck-ingress.yaml
+  - manifests/local/flakefinder-rewrite-ingress.yaml
   - manifests/local/gcsweb-deployment.yaml
   - manifests/local/gcsweb-ingress.yaml
   - manifests/local/gcsweb-service.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/flakefinder-rewrite-ingress.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/flakefinder-rewrite-ingress.yaml
@@ -1,0 +1,31 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: google-storage-buckets
+spec:
+  type: ExternalName
+  externalName: storage.googleapis.com
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+    nginx.ingress.kubernetes.io/rewrite-target: /kubevirt-prow/reports/flakefinder/$2
+  name: flakefinder-rewrite
+  namespace: default
+spec:
+  ingressClassName: public-iks-k8s-nginx
+  tls:
+  - hosts:
+    - flakefinder.ci.kubevirt.io
+    secretName: flakefinder-tls
+  rules:
+  - host: flakefinder.ci.kubevirt.io
+    http:
+      paths:
+      - path: /(/|$)(.*)
+        backend:
+          serviceName: google-storage-buckets
+          servicePort: 443


### PR DESCRIPTION
We want to rewrite URLs 

https://flakefinder.ci.kubevirt.io/index.html

into 

https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/index.html