### PR TITLE
Add /var/log/audit path to Arm64 e2e periodic lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -647,6 +647,12 @@ periodics:
           memory: 16Gi
       securityContext:
         privileged: true
+      volumeMounts:
+      - mountPath: /var/log/audit
+        name: audit
+    volumes:
+    - emptyDir: {}
+      name: audit
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"


### PR DESCRIPTION
The ARM64 e2e lane has been failing recently[1] due to kind being unable to find /var/log/audit - add an emptyDir to the job definition to stop this failing.

Test run of this config change here - https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-kind-e2e-test-ARM64/1617917479961497600

[1] https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-kind-e2e-test-ARM64

/cc @zhlhahaha @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>