### PR TITLE
common-instancetypes: Switch merge_method to merge

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -113,7 +113,7 @@ tide:
     kubevirt/node-maintenance-operator: merge
     kubevirt/ansible-kubevirt-modules: squash
     kubevirt/hyperconverged-cluster-operator: squash
-    kubevirt/common-instancetypes: squash
+    kubevirt/common-instancetypes: merge
     kubevirt/common-templates: squash
     kubevirt/kvm-info-nfd-plugin: squash
     kubevirt/cpu-nfd-plugin: squash


### PR DESCRIPTION
Moves the project away from squash given the tendency for multiple commit PRs and squash causing a loss of a clean history in the repository.