### PR TITLE
Switch merge_methods of kubevirt/common-templates and kubevirt/containerdisks to merge

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -114,7 +114,7 @@ tide:
     kubevirt/ansible-kubevirt-modules: squash
     kubevirt/hyperconverged-cluster-operator: squash
     kubevirt/common-instancetypes: merge
-    kubevirt/common-templates: squash
+    kubevirt/common-templates: merge
     kubevirt/kvm-info-nfd-plugin: squash
     kubevirt/cpu-nfd-plugin: squash
     kubevirt/node-labeller: squash

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -89,7 +89,7 @@ tide:
     kubevirt/libguestfs-appliance: merge
     kubevirt/containerized-data-importer: squash
     kubevirt/cluster-api-provider-kubevirt: merge
-    kubevirt/containerdisks: squash
+    kubevirt/containerdisks: merge
     kubevirt/kubevirt: merge
     kubevirt/machine-remediation-operator: squash
     kubevirt/project-infra: squash


### PR DESCRIPTION
Switch `merge_methods` of `kubevirt/common-templates` and `kubevirt/containerdisks` to `merge` to avoid the loss of a clean history in the repository when merging multiple commit PRs. (similar to https://github.com/kubevirt/project-infra/pull/2573)