### PR TITLE
Add workaround for cri-o version 1.24

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.23,1.24,1.25,1.26"
+            value: "1.24,1.25,1.26"
         command: ["/bin/sh", "-ce"]
         args:
           - |

--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -22,6 +22,13 @@ mirror_crio_repo_for_version () {
         CRIO_SUBDIR=":cri-o:$1"
         REPOID="${BASE_REPOID}_cri-o_$1"
     fi
+    # cri-o builds > v1.24.1 are broken for Centos_8_Stream
+    # cri-o > v1.24.2 is required to avoid https://github.com/cri-o/cri-o/issues/5889
+    # Use CentOS_8 build for cri-o v1.24
+    if [[ $1 = 1.24 ]]
+    then
+        OS="CentOS_8"
+    fi
     curl -L -o $REPOID.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable$CRIO_SUBDIR/$OS/devel:kubic:libcontainers:stable$CRIO_SUBDIR.repo
     reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR -n --repoid=$REPOID --download-metadata
 }

--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -28,6 +28,8 @@ mirror_crio_repo_for_version () {
     if [[ $1 = 1.24 ]]
     then
         OS="CentOS_8"
+    else
+        OS="CentOS_8_Stream"
     fi
     curl -L -o $REPOID.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable$CRIO_SUBDIR/$OS/devel:kubic:libcontainers:stable$CRIO_SUBDIR.repo
     reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR -n --repoid=$REPOID --download-metadata


### PR DESCRIPTION
The CentOS Stream 8 builds for cri-o 1.24 look to be failing.
The repo only has up to 1.24.1[1] which still hits this intermittent issue[2] which is fixed in 1.24.2.

Use the CentOS 8 build as a workaround for this.

Also remove cri-o 1.23 from kubevirt mirror. 

[1] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/CentOS_8_Stream/x86_64/
[2] https://github.com/cri-o/cri-o/issues/5889


/cc @dhiller 