### PR TITLE
single stack providers: Use the robust provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1081,7 +1081,9 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.25-ipv6-sig-network
+          value: k8s-1.25-sig-network
+        - name: KUBEVIRT_SINGLE_STACK
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
@@ -1121,7 +1123,9 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-ipv6-sig-network
+          value: k8s-1.26-sig-network
+        - name: KUBEVIRT_SINGLE_STACK
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:


### PR DESCRIPTION
Instead using the old k8s-x-ipv6 provider,
use the new one which supports both dual stack
and single stack.

Depends on https://github.com/kubevirt/kubevirtci/pull/954 - done.
Need to be tested with the [bump](https://github.com/kubevirt/kubevirt/pull/9375) and merge both together.

