### PR TITLE
kubevirtci, k8s-1.26-ipv6: Remove presubmit job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -404,59 +404,6 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
-    max_concurrency: 2
-    name: check-provision-k8s-1.25-ipv6
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.25-ipv6 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20221222-8f66e7e
-        name: ""
-        resources:
-          requests:
-            memory: 14Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 2
-    name: check-provision-k8s-1.26-ipv6
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.26-ipv6 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20221222-8f66e7e
-        name: ""
-        resources:
-          requests:
-            memory: 14Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.25
     spec:


### PR DESCRIPTION
As part of the effort to make the provider robust, we need to remove the presubmit job of the legacy
standalone single stack provider.

Needed for https://github.com/kubevirt/kubevirtci/pull/954

