### PR TITLE
common-instancetypes: Add basic functional test coverage

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -22,3 +22,38 @@ presubmits:
         resources:
           requests:
             memory: "1Gi"
+  - name: pull-common-instancetypes-kubevirt-functest
+    branches:
+      - main
+    always_run: false
+    run_if_changed: ./common*bundle.yaml
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - "/bin/sh"
+        - "-c"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+        image: quay.io/kubevirtci/bootstrap:v20221116-f8c83d3
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external


### PR DESCRIPTION
This change adds a basic func test prow job for common-instancetypes that deploys KubeVirt from HEAD, deploys common-instancetypes and then exercises the various validation code paths by creating VirtualMachines for each instance type and preference available in the environment.

Future test coverage could start these VirtualMachines and exercise the runtime VirtualMachineInstance code paths but this should be enough for now ahead of KubeVirt `v0.59.0` and common-instancetypes `v0.1.0` being cut.