### PR TITLE
Temporarily move pinc jobs to prow-workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -748,7 +748,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -776,7 +776,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -806,7 +806,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -836,7 +836,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -866,7 +866,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -894,7 +894,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -953,7 +953,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -994,7 +994,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1022,7 +1022,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1050,7 +1050,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1079,7 +1079,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1620,7 +1620,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -832,7 +832,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -861,7 +861,7 @@ presubmits:
   - always_run: false
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -892,7 +892,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -922,7 +922,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       rehearsal.allowed: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -982,7 +982,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1011,7 +1011,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1073,7 +1073,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -1113,7 +1113,7 @@ presubmits:
         secret:
           secretName: kubevirtci-coveralls-token
   - always_run: true
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -1154,7 +1154,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1183,7 +1183,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1212,7 +1212,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1242,7 +1242,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1640,7 +1640,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s


### PR DESCRIPTION
The docker image proxy is currently down on the ibm-prow-jos cluster - temporarily move the jobs that rely on this proxy to the prow-workloads cluster.

This should be changed back once the docker image proxy is back up.

/cc @dhiller 

Signed-off-by: Brian Carey <bcarey@redhat.com>