### PR TITLE
Update kubevirt periodics job and project-infra to 1.19

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -92,7 +92,7 @@ periodics:
       - -ce
       env:
       - name: GIMME_GO_VERSION
-        value: "1.16"
+        value: "1.19"
       image: quay.io/kubevirtci/golang:v20221222-8f66e7e
       name: ""
       resources: {}

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -758,7 +758,7 @@ periodics:
     - image: quay.io/kubevirtci/golang:v20221222-8f66e7e
       env:
       - name: GIMME_GO_VERSION
-        value: "1.16"
+        value: "1.19"
       command:
       - "/usr/local/bin/runner.sh"
       - "/bin/sh"


### PR DESCRIPTION
Since go was updated to 1.19 by #2362 yesterday we need to adjust `GIMME_GO_VERSION` for two jobs.

Examples:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-check-prow-jobconfigs/1620707968225906688#1:build-log.txt%3A4
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-push-kubevirt-flakefinder-report-values/1620594217694793728#1:build-log.txt%3A4

/cc @brianmcarey @enp0s3 @xpivarc 