### PR TITLE
Disable Istio tests on Kubernetes 1.26

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1366,7 +1366,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-ipv6-sig-network
+          value: k8s-1.26-ipv6-sig-network-no-istio
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
@@ -2183,7 +2183,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-network
+          value: k8s-1.26-sig-network-no-istio
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2426,7 +2426,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-centos9-sig-network
+          value: k8s-1.26-centos9-sig-network-no-istio
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:


### PR DESCRIPTION
This is a temporary patch that disables Istio on Kubernetes 1.26. This allows us to move most of the tests to CentOS 9 while Istio, which is currently broken on CentOS 9, stays tested on Kubernetes 1.25 and 1.24.

Must be merged together with https://github.com/kubevirt/kubevirt/pull/9157.