### PR TITLE
Set PSA enabled for all 1.26 CentOS Stream 9 lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1795,6 +1795,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network
+      - name: KUBEVIRT_PSA
+        value: "true"
       image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
       name: ""
       resources:
@@ -1938,6 +1940,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
+      - name: KUBEVIRT_PSA
+        value: "true"
       image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
       name: ""
       resources:
@@ -2081,6 +2085,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-compute
+      - name: KUBEVIRT_PSA
+        value: "true"
       image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
       name: ""
       resources:
@@ -2224,6 +2230,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
+      - name: KUBEVIRT_PSA
+        value: "true"
       image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2628,6 +2628,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network
+        - name: KUBEVIRT_PSA
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2668,6 +2670,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
+        - name: KUBEVIRT_PSA
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2708,6 +2712,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-compute
+        - name: KUBEVIRT_PSA
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2748,6 +2754,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator
+        - name: KUBEVIRT_PSA
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:


### PR DESCRIPTION
Since our goal will be to have the gating lanes on CentOS Stream 9 with PSA enabled, let's enable it on all CentOS Stream 9 lanes, periodic and presubmit

/cc @brianmcarey @acardace @enp0s3 @xpivarc 