### PR TITLE
Make 1.26 CentOS Stream 9 based provider default for gating 1.26 lanes, remove explicit centos9 lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2184,6 +2184,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-network
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.26-centos9
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2225,6 +2227,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-storage
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.26-centos9
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2266,6 +2270,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-compute
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.26-centos9
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2307,6 +2313,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-operator-upgrade
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.26-centos9
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2346,6 +2354,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-operator-configuration
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.26-centos9
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
@@ -2387,166 +2397,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    optional: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-centos9-sig-network
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.26-centos9-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    optional: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-centos9-sig-storage
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.26-centos9-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    optional: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-centos9-sig-compute
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.26-centos9-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    optional: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-centos9-sig-operator
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.26-centos9-sig-operator
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2309,6 +2309,9 @@ presubmits:
           value: k8s-1.26-centos9-sig-operator-upgrade
         - name: KUBEVIRT_PSA
           value: "true"
+        # FIXME: remove after 0.59 release
+        - name: PREVIOUS_RELEASE_TAG
+          value: v0.59.0-rc.0
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2307,6 +2307,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator-upgrade
+        - name: KUBEVIRT_PSA
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2183,7 +2183,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-centos9-sig-network
+          value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2183,9 +2183,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-network
-        - name: KUBEVIRT_PROVIDER
-          value: k8s-1.26-centos9
+          value: k8s-1.26-centos9-sig-network
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2226,9 +2224,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-storage
-        - name: KUBEVIRT_PROVIDER
-          value: k8s-1.26-centos9
+          value: k8s-1.26-centos9-sig-storage
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2269,9 +2265,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-compute
-        - name: KUBEVIRT_PROVIDER
-          value: k8s-1.26-centos9
+          value: k8s-1.26-centos9-sig-compute
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2312,9 +2306,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-operator-upgrade
-        - name: KUBEVIRT_PROVIDER
-          value: k8s-1.26-centos9
+          value: k8s-1.26-centos9-sig-operator-upgrade
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2353,9 +2345,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-operator-configuration
-        - name: KUBEVIRT_PROVIDER
-          value: k8s-1.26-centos9
+          value: k8s-1.26-centos9-sig-operator-configuration
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e


### PR DESCRIPTION
Since we want to have CentOS Stream 9 as default node OS, and PSA enabled, and this should be our only merge gate, we explicitly set the centos9 for the 1.26 default gating sig lanes, and remove the centos9 lanes entirely.

/cc @acardace @enp0s3 @fabiand @fossedihelm @phoracek @xpivarc 