### PR TITLE
Set check-provision-k8s-1.26-centos9 to required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -422,7 +422,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -448,7 +448,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
As the 1.26 CentOS 9 provider is the provider that testing will be carried out against in kubevirt[1] - the check-provision job should be set to required.

The 1.26 CentOS 8 provider will be removed shortly so a check-provision job should not be required there. 

[1] https://github.com/kubevirt/project-infra/pull/2610

/cc @dhiller @enp0s3 