### PR TITLE
Update 1.26 periodics to use 1.26 CentOS 9 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1899,6 +1899,9 @@ periodics:
         value: "true"
       - name: KUBEVIRT_PSA
         value: "true"
+      # FIXME: remove after 0.59 release
+      - name: PREVIOUS_RELEASE_TAG
+        value: v0.59.0-rc.0
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -1948,6 +1951,9 @@ periodics:
         value: "true"
       - name: KUBEVIRT_PSA
         value: "true"
+      # FIXME: remove after 0.59 release
+      - name: PREVIOUS_RELEASE_TAG
+        value: v0.59.0-rc.0
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
       - name: FEATURE_GATES

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1056,6 +1056,8 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
       - name: KUBEVIRT_CGROUPV2
@@ -1202,6 +1204,8 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-compute
@@ -1746,6 +1750,8 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -1793,6 +1799,8 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -1839,6 +1847,8 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
@@ -1889,6 +1899,8 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-compute
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -1935,6 +1947,8 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-compute
@@ -1985,6 +1999,8 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2031,6 +2047,8 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1024,57 +1024,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 23 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-sig-storage-cgroupsv2
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
-      - name: TARGET
-        value: k8s-1.26-centos9-sig-storage
-      - name: KUBEVIRT_CGROUPV2
-        value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
   cron: 30 21 * * *
   decorate: true
   decoration_config:
@@ -1158,57 +1107,6 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.25-sig-compute
-      - name: KUBEVIRT_CGROUPV2
-        value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 30 21 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-sig-compute-cgroupsv2
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
-      - name: TARGET
-        value: k8s-1.26-centos9-sig-compute
       - name: KUBEVIRT_CGROUPV2
         value: "true"
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1057,7 +1057,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-storage
+        value: k8s-1.26-centos9-sig-storage
       - name: KUBEVIRT_CGROUPV2
         value: "true"
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -1204,7 +1204,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-compute
+        value: k8s-1.26-centos9-sig-compute
       - name: KUBEVIRT_CGROUPV2
         value: "true"
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -1747,53 +1747,6 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 30 1,17 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-centos9-sig-network
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
         value: k8s-1.26-centos9-sig-network
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
@@ -1841,7 +1794,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-storage
+        value: k8s-1.26-centos9-sig-storage
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
@@ -1888,56 +1841,9 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-storage
+        value: k8s-1.26-centos9-sig-storage
       - name: FEATURE_GATES
         value: Root
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 40 2,18 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-centos9-sig-storage
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.26-centos9-sig-storage
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
@@ -1984,7 +1890,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-compute
+        value: k8s-1.26-centos9-sig-compute
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
@@ -2031,56 +1937,9 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-compute
+        value: k8s-1.26-centos9-sig-compute
       - name: FEATURE_GATES
         value: Root
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 50 3,19 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-centos9-sig-compute
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.26-centos9-sig-compute
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
@@ -2127,7 +1986,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-operator
+        value: k8s-1.26-centos9-sig-operator
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
@@ -2174,56 +2033,9 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.26-sig-operator
+        value: k8s-1.26-centos9-sig-operator
       - name: FEATURE_GATES
         value: Root
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
-      name: ""
-      resources:
-        requests:
-          memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 0 6,22 * * *
-  decorate: true
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-centos9-sig-operator
-  reporter_config:
-    slack:
-      job_states_to_report: []
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.26-centos9-sig-operator
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:


### PR DESCRIPTION
Testing is no longer required against the 1.26 CentOS 8 provider[1]

Updating the 1.26 periodics to use the CentOS 9 provider and remove specifice CentOS 9 periodics.

/cc @xpivarc @dhiller 