### PR TITLE
Add csv output to kubevirt get

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -1000,7 +1000,8 @@ postsubmits:
           - -c
           args:
           - |
-            bazel run //robots/cmd/kubevirt:kubevirt -- get presubmits --job-config-path-kubevirt-presubmits $(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --github-token-path '' --output-file /tmp/presubmits.html
+            # we fetch presubmits for kubevirt/kubevirt branches main and release-0.59
+            bazel run //robots/cmd/kubevirt:kubevirt -- get presubmits --job-config-path-kubevirt-presubmits $(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --job-config-path-kubevirt-presubmits $(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml --github-token-path '' --output-file /tmp/presubmits.html
             bazel run //robots/cmd/kubevirt:kubevirt -- get periodics --job-config-path-kubevirt-periodics $(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml --github-token-path '' --output-file /tmp/periodics.html
             gsutil cp /tmp/presubmits.html /tmp/periodics.html gs://kubevirt-prow/reports/e2ejobs/kubevirt/kubevirt
           resources:

--- a/robots/pkg/kubevirt/cmd/get/BUILD.bazel
+++ b/robots/pkg/kubevirt/cmd/get/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
     embedsrcs = [
         "periodics.gohtml",
         "presubmits.gohtml",
+        "periodics.gocsv",
+        "presubmits.gocsv",
     ],
     importpath = "kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/get",
     visibility = ["//visibility:public"],

--- a/robots/pkg/kubevirt/cmd/get/periodics.gocsv
+++ b/robots/pkg/kubevirt/cmd/get/periodics.gocsv
@@ -1,0 +1,28 @@
+{{- /*
+  This file is part of the KubeVirt project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Copyright 2023 Red Hat, Inc.
+*/ -}}
+{{- /* gotype: kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/get.PeriodicsData */ -}}
+"Job Name","Env","Cron","Interval","Description"
+{{ range $row, $periodic := $.Periodics -}}
+    "{{ $periodic.Name }}","
+    {{- range $container := $periodic.Spec.Containers }}
+        {{- range $env := $container.Env }}{{ $env.Name}}: {{$env.Value}}; {{ end -}}
+    {{ end -}}","
+    {{- $periodic.Cron }}","
+    {{- $periodic.Interval }}","
+    {{- index $.CronDescriptions $periodic.Name }}"
+{{ end }}

--- a/robots/pkg/kubevirt/cmd/get/presubmits.gocsv
+++ b/robots/pkg/kubevirt/cmd/get/presubmits.gocsv
@@ -1,0 +1,29 @@
+{{- /*
+  This file is part of the KubeVirt project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Copyright 2023 Red Hat, Inc.
+*/ -}}
+{{- /* gotype: kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/get.presubmits */ -}}
+"Job Name","Env","AlwaysRun","Optional","RunIfChanged","SkipIfOnlyChanged"
+{{ range $row, $presubmit := . -}}
+    "{{ $presubmit.Name }}","
+    {{- range $container := $presubmit.Spec.Containers }}
+        {{- range $env := $container.Env }}{{ $env.Name}}: {{$env.Value}}; {{ end -}}
+    {{ end -}}","
+    {{- if $presubmit.AlwaysRun }}☑{{ else }}☐{{ end }}","
+    {{- if $presubmit.Optional }}☑{{ else }}☐{{ end }}","
+    {{- $presubmit.RunIfChanged }}","
+    {{- $presubmit.SkipIfOnlyChanged }}"
+{{ end }}


### PR DESCRIPTION
Adds flag `--output-format` where allowed values are `html` and `csv`, according to the flag value an output file in that format is generated.

Also adds the support for multiple presubmit config files and modifies the postsubmit generating [presubmits.html](https://storage.googleapis.com/kubevirt-prow/reports/e2ejobs/kubevirt/kubevirt/presubmits.html) and [periodics.html](https://storage.googleapis.com/kubevirt-prow/reports/e2ejobs/kubevirt/kubevirt/periodics.html) to use files for main and release-0.59.

Screenshots (**please note the 0.59 suffixes that mark the release branch jobs**):

![image](https://user-images.githubusercontent.com/809335/219352795-985b18d6-f40f-46da-a6c6-c6ab59838c66.png)

![image](https://user-images.githubusercontent.com/809335/219353410-57ab7883-baca-442c-ab14-4513147fadba.png)
