### PR TITLE
Update bazel remote cache flag to --remote_cache

### DIFF
--- a/images/bootstrap/create_bazel_cache_rcs.sh
+++ b/images/bootstrap/create_bazel_cache_rcs.sh
@@ -82,7 +82,7 @@ make_bazel_rc () {
     cache_id="$(get_workspace),$(hash_toolchains)"
     local cache_url
     cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
-    echo "build --remote_http_cache=${cache_url}"
+    echo "build --remote_cache=${cache_url}"
 }
 
 # https://docs.bazel.build/versions/master/user-manual.html#bazelrc


### PR DESCRIPTION
Basel --remote_http_cache has been deprecated

Update it to --remote_cache to reduce some noise in the job logs[1]

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/7197/pull-kubevirt-e2e-k8s-1.26-sev/1626202588405829632#1:build-log.txt%3A218

/cc @dhiller @xpivarc 