### PR TITLE
Merge split operator lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2294,91 +2294,6 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-sig-operator-upgrade
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.26-centos9-sig-operator-upgrade
-        - name: KUBEVIRT_PSA
-          value: "true"
-        # FIXME: remove after 0.59 release
-        - name: PREVIOUS_RELEASE_TAG
-          value: v0.59.0-rc.0
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-sig-operator-configuration
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.26-centos9-sig-operator-configuration
-        - name: KUBEVIRT_PSA
-          value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-operator
     skip_branches:
     - release-\d+\.\d+
@@ -2391,8 +2306,13 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          value: k8s-1.26-centos9-sig-operator
+        - name: KUBEVIRT_PSA
+          value: "true"
+        # FIXME: remove after 0.59 release
+        - name: PREVIOUS_RELEASE_TAG
+          value: v0.59.0-rc.0
+        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
           requests:


### PR DESCRIPTION
Since we don't need to run the upgrade tests without PSA (as 0.59 is
PSA ready) we merge the two lanes operator-upgrade and
operator-configuration together into one.

Also we remove the 1.26 CentOS 8 lane for sig-operator.

/cc @xpivarc @brianmcarey @fossedihelm