### PR TITLE
Add SYS_CHROOT capability to podman in bootstrap image

### DIFF
--- a/images/bootstrap/containers.conf
+++ b/images/bootstrap/containers.conf
@@ -4,6 +4,7 @@ userns="host"
 ipcns="host"
 cgroupns="host"
 cgroups="disabled"
+default_capabilities = ["CHOWN",  "DAC_OVERRIDE", "FOWNER",  "FSETID",  "KILL",  "NET_BIND_SERVICE",  "SETFCAP",  "SETGID",  "SETPCAP",  "SETUID", "SYS_CHROOT"]
 log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"


### PR DESCRIPTION
A number of CI jobs require this capability to complete successfully[1]

It was recently removed from the default set of podman capabilities[2]

[1] https://github.com/kubevirt/kubevirt/issues/9279
[2] https://blog.podman.io/2022/12/dropping-capabilities-making-containers-more-secure/