### PR TITLE
vm-image-builder: update vm-image-builder

### DIFF
--- a/images/vm-image-builder/Dockerfile
+++ b/images/vm-image-builder/Dockerfile
@@ -10,3 +10,6 @@ RUN dnf install -y \
     virt-install && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+COPY qemu.conf /etc/libvirt/qemu.conf
+COPY start_libvirtd.sh /usr/local/bin/start_libvirtd.sh

--- a/images/vm-image-builder/Dockerfile
+++ b/images/vm-image-builder/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf install -y \
     libguestfs-tools-c \
     libvirt \
     qemu-img \
+    qemu-system-aarch64 \
     genisoimage \
     virt-install && \
     dnf clean all && \

--- a/images/vm-image-builder/Dockerfile
+++ b/images/vm-image-builder/Dockerfile
@@ -6,6 +6,7 @@ RUN dnf install -y \
     libguestfs-tools-c \
     libvirt \
     qemu-img \
+    genisoimage \
     virt-install && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*

--- a/images/vm-image-builder/README.md
+++ b/images/vm-image-builder/README.md
@@ -1,0 +1,21 @@
+vm-image-builder image
+===============
+
+KubeVirt CI general purpose image for building Customized ephemeral container-disk images for KubeVirt VM's.
+
+To be more specific, for building VM images in kubevirtci/cluster-provision/images/vm-image-builder.
+
+How to setup the image
+-----------------
+The container is required to run in privileged mode, as /dev/kvm is needed. The shell script `start_libvirt.sh` would start the libvirtd related daemon, then libvirt related cli can works.
+
+```yaml
+spec:
+    containers:
+    - command:
+      -  /usr/local/bin/start_libvirtd.sh && /usr/local/bin/runner.sh
+      ...
+      securityContext:
+        privileged: true
+
+```

--- a/images/vm-image-builder/qemu.conf
+++ b/images/vm-image-builder/qemu.conf
@@ -1,0 +1,2 @@
+user = "qemu"
+group = "qemu"

--- a/images/vm-image-builder/start_libvirtd.sh
+++ b/images/vm-image-builder/start_libvirtd.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright 2023 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+chown qemu:qemu /dev/kvm
+/usr/sbin/libvirtd > /var/log/libvirtd.log 2>&1 &
+/usr/sbin/virtlogd > /var/log/virtlogd.log 2>&1 &


### PR DESCRIPTION
In order to use vm-image-builder to build multi-arch VM image and make it works in prow CICD pipeline. Some update are needed.