### PR TITLE
Remove bugzilla search queries from ci-search statefulset

### DIFF
--- a/github/ci/services/ci-search/manifests/full.yaml
+++ b/github/ci/services/ci-search/manifests/full.yaml
@@ -56,10 +56,6 @@ spec:
       nodeSelector:
         ci.openshift.io/ci-search: "true"
       automountServiceAccountToken: false
-      volumes:
-      - name: bugzilla-token
-        secret:
-          secretName: bugzilla-credentials-openshift-bugzilla-robot
       containers:
       - name: web
         image: ci-search:latest
@@ -68,8 +64,6 @@ spec:
             cpu: 100m
             memory: 1Gi
         volumeMounts:
-        - name: bugzilla-token
-          mountPath: /etc/bugzilla/
         - mountPath: /var/lib/ci-search/
           name: search
         command:
@@ -80,9 +74,6 @@ spec:
         - --interval=10m
         - --path=/var/lib/ci-search/
         - --deck-uri=https://prow.ci.openshift.org
-        - --bugzilla-url=https://bugzilla.redhat.com/rest
-        - --bugzilla-token-file=/etc/bugzilla/api
-        - --bugzilla-search=OPEN version:4.7,4.6,4.5,4.4,4.3,4.2 product="OpenShift Container Platform" AND delta_ts>-2w
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -27,12 +27,5 @@ spec:
         - --deck-uri=https://prow.ci.kubevirt.io/
         - --job-uri-prefix=https://prow.ci.kubevirt.io/view/gs/
         - --index-bucket=kubevirt-prow
-        - --bugzilla-url=https://bugzilla.redhat.com/rest
-        - --bugzilla-search=OPEN version:1.4,2.5,2.6 product="Container Native Virtualization (CNV)" AND delta_ts>-2w
-        - --bugzilla-token-file=/etc/bugzilla/api
       securityContext:
         fsGroup: 1000
-      volumes:
-      - name: bugzilla-token
-        secret:
-          secretName: bugzilla-credentials


### PR DESCRIPTION
These requests are causing a large number of failed authentications to bugzilla - removing for now.

/cc @dhiller @enp0s3 