### PR TITLE
sig-network: Add optional and weekly jobs to run tests with MultusV4

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1690,6 +1690,60 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
+  # 5:00AM on Sundays
+  cron: 0 5 * * 0
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-bazel-unnested: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
+  reporter_config:
+    slack:
+      job_states_to_report: []
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
+      - name: TARGET
+        value: k8s-1.26-centos9-sig-network-no-istio
+      # Set cluster-up to not deploy Multus V3 from manifests, instead CNAO will deploy Multus V4,
+      # and make the test suite run the hotplug NICs tests.
+      - name: KUBEVIRT_WITH_MULTUS_V3
+        value: "false"
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+      name: ""
+      resources:
+        requests:
+          memory: 29Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
   cron: 30 1,9,17 * * *
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1135,6 +1135,51 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+      rehearsal.allowed: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.26-centos9-sig-network-no-istio
+        # Set cluster-up to not deploy Multus V3 from manifests, instead CNAO will deploy Multus V4,
+        # and make the test suite run the hotplug NICs tests.
+        - name: KUBEVIRT_WITH_MULTUS_V3
+          value: "false"
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - always_run: true
     annotations:
       fork-per-release: "true"


### PR DESCRIPTION
Following [kubevirt/kubevirtci#973](https://github.com/kubevirt/kubevirt/pull/9388) sig-network gating lanes will run with Multus V3.

This PR adds an optional presubmit and periodic job that run the sig-network 1.26 lane with MultusV4 including the hotplug NICs tests (which depend on Multus v4).

The jobs spec sets specify the following env var`KUBEVIRT_WITH_MULTUS_V3 = false`
It makes cluster-up deploy Multus V4 with CNAO instead of Multus v3 and makes the Kubevirt test suite run the hotplug NIC tests.

The periodic job is set to run weekly at 5:00 on Sundays.
The presubmit job is optional and will run on demand by commenting `/test pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4`