### PR TITLE
Remove PREVIOUS_RELEASE_TAG value

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1973,9 +1973,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_PSA
         value: "true"
-      # FIXME: remove after 0.59 release
-      - name: PREVIOUS_RELEASE_TAG
-        value: v0.59.0-rc.0
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
       image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -2025,9 +2022,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_PSA
         value: "true"
-      # FIXME: remove after 0.59 release
-      - name: PREVIOUS_RELEASE_TAG
-        value: v0.59.0-rc.0
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
       - name: FEATURE_GATES

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2309,9 +2309,6 @@ presubmits:
           value: k8s-1.26-centos9-sig-operator
         - name: KUBEVIRT_PSA
           value: "true"
-        # FIXME: remove after 0.59 release
-        - name: PREVIOUS_RELEASE_TAG
-          value: v0.59.0-rc.0
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:


### PR DESCRIPTION
Since release-0.59 has been released (https://github.com/kubevirt/kubevirt/releases/tag/v0.59.0) we can remove the workaround for PREVIOUS_RELEASE_TAG

/cc @dhiller @brianmcarey 
FYI @xpivarc 