### PR TITLE
[kubevirtci] Set check-provision-k8s-1.26-centos9 to required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -458,7 +458,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.26-centos9
-    optional: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
k8s-1.26-centos9 is our main kubernetes 1.26 test target - the presubmit to check the provisioning of this provider should be set to required.

/cc @dhiller @enp0s3 