### PR TITLE
Include filtered tests into report but filter them by default

### DIFF
--- a/hack/test-report.sh
+++ b/hack/test-report.sh
@@ -3,7 +3,7 @@
 function run_test_report() {
     podman run -v "$tmp_dir:/tmp:Z" \
             --network host \
-            quay.io/kubevirtci/test-report:v20230303-9f7c25ce \
+            quay.io/kubevirtci/test-report:v20230310-afd0f6b5 \
             "$@"
 }
 

--- a/robots/cmd/test-report/cmd/execution/execution_test.go
+++ b/robots/cmd/test-report/cmd/execution/execution_test.go
@@ -31,7 +31,7 @@ func Test_writeHTMLReportToOutput(t *testing.T) {
 	type args struct {
 		htmlReportOutputWriter       io.Writer
 		testNames                    []string
-		filteredTestNames            []string
+		filteredTestNames            map[string]interface{}
 		skippedTests                 map[string]interface{}
 		lookedAtJobs                 []string
 		testNamesToJobNamesToSkipped map[string]map[string]int
@@ -47,7 +47,7 @@ func Test_writeHTMLReportToOutput(t *testing.T) {
 			args: args{
 				htmlReportOutputWriter: os.Stdout,
 				testNames:              []string{"a", "b", "c", "d"},
-				filteredTestNames:      []string{"la", "le", "lu"},
+				filteredTestNames:      map[string]interface{}{"la": struct{}{}, "le": struct{}{}, "lu": struct{}{}},
 				skippedTests: map[string]interface{}{
 					"a": struct{}{}},
 				lookedAtJobs: []string{"job1", "job2", "job3"},

--- a/robots/cmd/test-report/cmd/execution/test-report.gohtml
+++ b/robots/cmd/test-report/cmd/execution/test-report.gohtml
@@ -7,7 +7,15 @@
             border: 1px solid black;
         }
         table.noborder, th.noborder, td.noborder {
-            border: 0px;
+            border: 0;
+        }
+        th.vertical {
+            writing-mode: vertical-rl;
+            text-orientation: mixed;
+        }
+        td.stateCell {
+            min-width: 2em;
+            text-align: center;
         }
         .yellow {
             background-color: #ffff80;
@@ -21,30 +29,13 @@
         .gray {
             background-color: #898989;
         }
-        .unimportant {
-        }
         .right {
             text-align: right;
             width: 100%;
         }
-
-        .popup .popuptextFilteredTestNames {
-            display: none;
-            width: 1024px;
-            background-color: #FFFFFF;
-            text-align: center;
-            border-radius: 6px;
-            padding: 8px 8px;
-            position: absolute;
-            z-index: 1;
-            left: 100%;
-            margin-left: -1024px;
-        }
-
-        .popup:hover .popuptextFilteredTestNames {
-            display: block;
-            -webkit-animation: fadeIn 1s;
-            animation: fadeIn 1s;
+        .filtered {
+            text-decoration-line: underline;
+            text-decoration-style: dotted;
         }
 
         .popup .popuptextReportConfig {
@@ -72,12 +63,14 @@
             document.getElementById("filterByName").disabled = false;
             document.getElementById("excludeByName").disabled = false;
             document.getElementById("filterByNotRunCheckBox").disabled = false;
+            document.getElementById("showDontRunCheckBox").disabled = false;
         }
         function updateFilteredRows() {
-            let filter, table, tr, td, i, txtValue, checked, shouldShow, rowsShown;
+            let filter, table, tr, td, i, txtValue, filterByNotRunChecked, shouldShow, rowsShown;
             filterTerms = document.getElementById("filterByName").value.toUpperCase().split("|");
             excludeTerms = document.getElementById("excludeByName").value.toUpperCase().split("|");
-            checked = document.getElementById("filterByNotRunCheckBox").checked;
+            filterByNotRunChecked = document.getElementById("filterByNotRunCheckBox").checked;
+            showDontRunChecked = document.getElementById("showDontRunCheckBox").checked;
             table = document.getElementById("report");
             tr = table.getElementsByTagName("tr");
 
@@ -87,7 +80,10 @@
                 if (td) {
                     shouldShow = true
                     txtValue = td.textContent || td.innerText;
-                    if (checked && td.className !== "red") {
+                    if (filterByNotRunChecked && td.className.indexOf("red") == -1) {
+                        shouldShow = false
+                    }
+                    if (!showDontRunChecked && td.className.indexOf("filtered") !== -1) {
                         shouldShow = false
                     }
                     if (excludeTerms.length > 0 && excludeTerms[0] !== "") {
@@ -129,7 +125,7 @@
         }
     </script>
 </head>
-<body onload="initRowsShown();enableFilterFields();">
+<body onload="initRowsShown();updateFilteredRows();enableFilterFields();">
 {{- /* gotype: kubevirt.io/project-infra/robots/pkg/test-report.Data */ -}}
 <h1>test execution report</h1>
 <div>
@@ -142,31 +138,33 @@
     <pre class="popuptextReportConfig right" id="targetReportConfig">{{ $.ReportConfig }}</pre>
 </div>
 
-<div id="filteredTests" class="popup right" >
-    <u>list of filtered tests</u>
-    <div class="popuptextFilteredTestNames right" id="targetfilteredTests">
-        <table width="100%">
-            <tr class="unimportant">
-                <td>
-                    Filtered test names:
-                </td>
-            </tr>{{ range $filteredTestName := $.FilteredTestNames }}
-        <tr class="unimportant">
-            <td>
-                {{ $filteredTestName | html }}
-            </td>
-        </tr>{{ end }}
-        </table>
-    </div>
-</div>
-
 <table class="noborder">
     <tr>
         <td class="noborder">
-        <b>Filters:</b>
         </td>
         <td class="noborder">
-            <label for="filterByName">Include tests that contain</label>
+            <label for="filterByNotRunCheckBox">Only <span class="red">not run tests</span></label>
+        </td>
+        <td class="noborder">
+            <input type="checkbox" id="filterByNotRunCheckBox" onClick="updateFilteredRows()" title="Show only rows that have not been run on any lane" disabled checked>
+        </td>
+    </tr>
+    <tr>
+        <td class="noborder">
+        </td>
+        <td class="noborder">
+            <label for="showDontRunCheckBox">Include <span class="red filtered">tests that have been filtered</span> on all lanes</label>
+        </td>
+        <td class="noborder">
+            <input type="checkbox" id="showDontRunCheckBox" onClick="updateFilteredRows()" title="Include tests that have been filtered with dont_run_tests.json on all lanes" disabled checked>
+        </td>
+    </tr>
+    <tr>
+        <td class="noborder">
+            <b>Filters:</b>
+        </td>
+        <td class="noborder">
+            <label for="filterByName">Exclude tests that don't contain</label>
         </td>
         <td class="noborder">
             <input type="text" id="filterByName" onkeyup="updateFilteredRows()" placeholder="term1|term2|..." disabled>
@@ -182,16 +180,6 @@
             <input type="text" id="excludeByName" onkeyup="updateFilteredRows()" placeholder="term1|term2|..." disabled>
         </td>
     </tr>
-    <tr>
-        <td class="noborder">
-        </td>
-        <td class="noborder">
-    <label for="filterByNotRunCheckBox">Only not run tests</label>
-        </td>
-        <td class="noborder">
-            <input type="checkbox" id="filterByNotRunCheckBox" onClick="updateFilteredRows()" title="Show only rows that have not been run" disabled>
-        </td>
-    </tr>
 </table>
 
 <div id="totalRowsShown"><i>Loading rows...</i></div>
@@ -200,15 +188,15 @@
         <th></th>
         <th></th>
         {{ range $job := $.LookedAtJobs }}
-            <th><a href="{{ $.JenkinsBaseURL }}/job/{{ $job }}/">{{ $job }}</a></th>
+            <th class="vertical"><a href="{{ $.JenkinsBaseURL }}/job/{{ $job }}/">{{ $job }}</a></th>
         {{ end }}
     </tr>
     {{ range $row, $test := $.TestNames }}
         <tr>
             <td><div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a></div></td>
-            <td class="{{ if (index $.SkippedTests $test) }}red{{ end }}">{{ $test }}</td>
+            <td class="{{ if (index $.SkippedTests $test) }}red{{ end }}{{ if (index $.FilteredTestNames $test) }} filtered{{ end }}">{{ $test }}</td>
             {{ range $col, $job := $.LookedAtJobs }}
-                <td class="center">{{ with $skipped := (index $.TestNamesToJobNamesToSkipped $test $job) }}
+                <td class="center stateCell">{{ with $skipped := (index $.TestNamesToJobNamesToSkipped $test $job) }}
                         <div id="r{{$row}}c{{$col}}" title="test
                                 {{- if eq $skipped (index $.TestExecutionMapping "TestExecution_Skipped") }} skipped
                                 {{- else if eq $skipped (index $.TestExecutionMapping "TestExecution_Run") }} run

--- a/robots/cmd/test-report/cmd/execution/test-report.gohtml
+++ b/robots/cmd/test-report/cmd/execution/test-report.gohtml
@@ -130,7 +130,7 @@
     </script>
 </head>
 <body onload="initRowsShown();enableFilterFields();">
-{{- /* gotype: kubevirt.io/project-infra/robots/main.Data */ -}}
+{{- /* gotype: kubevirt.io/project-infra/robots/pkg/test-report.Data */ -}}
 <h1>test execution report</h1>
 <div>
     {{ $.ReportConfigName }} report configuration<br/>

--- a/robots/pkg/test-report/test_report_test.go
+++ b/robots/pkg/test-report/test_report_test.go
@@ -47,8 +47,8 @@ func Test_CreateReportData(t *testing.T) {
 				},
 			},
 			want: NewData(
-				[]string{"testName"}, // testNames
-				[]string{},           // filteredTestNames
+				[]string{"testName"},                           // testNames
+				map[string]interface{}{},                       // filteredTestNames
 				map[string]interface{}{"testName": struct{}{}}, // skippedTests
 				[]string{"jobName"},                            // lookedAtJobs
 				map[string]map[string]int{
@@ -70,7 +70,7 @@ func Test_CreateReportData(t *testing.T) {
 			},
 			want: NewData(
 				[]string{"testName"},     // testNames
-				[]string{},               // filteredTestNames
+				map[string]interface{}{}, // filteredTestNames
 				map[string]interface{}{}, // skippedTests
 				[]string{"jobName"},      // lookedAtJobs
 				map[string]map[string]int{
@@ -91,8 +91,8 @@ func Test_CreateReportData(t *testing.T) {
 				},
 			},
 			want: NewData(
-				[]string{"testName"}, // testNames
-				[]string{},           // filteredTestNames
+				[]string{"testName"},                           // testNames
+				map[string]interface{}{},                       // filteredTestNames
 				map[string]interface{}{"testName": struct{}{}}, // skippedTests
 				[]string{"jobName"},                            // lookedAtJobs
 				map[string]map[string]int{
@@ -125,8 +125,8 @@ func Test_CreateReportData(t *testing.T) {
 				* rewrite of map to include the dont_run aka TestExecution_Unsupported
 			*/
 			want: NewData(
-				[]string{"testName"}, // testNames
-				[]string{},           // filteredTestNames
+				[]string{"testName"},                                       // testNames
+				map[string]interface{}{},                                   // filteredTestNames
 				map[string]interface{}{"testName": struct{}{}},             // skippedTests
 				[]string{"test-version-1.2-lane", "test-version-2.3-lane"}, // lookedAtJobs
 				map[string]map[string]int{
@@ -161,7 +161,7 @@ func Test_CreateReportData(t *testing.T) {
 			*/
 			want: NewData(
 				[]string{"testName"},     // testNames
-				[]string{},               // filteredTestNames
+				map[string]interface{}{}, // filteredTestNames
 				map[string]interface{}{}, // skippedTests
 				[]string{"test-version-1.2-lane", "test-version-2.3-lane"}, // lookedAtJobs
 				map[string]map[string]int{
@@ -189,14 +189,14 @@ func Test_CreateReportData(t *testing.T) {
 			},
 			/*
 				Outcome should be:
-				* it doesn't appear in the testcases
+				* it does appear in the testcases
 				* it does appear in the filtered testcases
 				* it doesn't appear in the skipped testcases
 				* rewrite of map to include the dont_run aka TestExecution_Unsupported for all
 			*/
 			want: NewData(
-				[]string{},           // testNames
-				[]string{"testName"}, // filteredTestNames
+				[]string{"testName"},                                       // testNames
+				map[string]interface{}{"testName": struct{}{}},             // filteredTestNames
 				map[string]interface{}{"testName": struct{}{}},             // skippedTests
 				[]string{"test-version-1.2-lane", "test-version-2.3-lane"}, // lookedAtJobs
 				map[string]map[string]int{
@@ -233,7 +233,7 @@ func Test_CreateReportData(t *testing.T) {
 			*/
 			want: NewData(
 				[]string{"testName"},     // testNames
-				[]string{},               // filteredTestNames
+				map[string]interface{}{}, // filteredTestNames
 				map[string]interface{}{}, // skippedTests
 				[]string{"test-version-1.2-lane", "test-version-2.3-lane", "test-version-3.4-lane"}, // lookedAtJobs
 				map[string]map[string]int{


### PR DESCRIPTION
Updates the test-report by including rows that are filtered by `dont_run_tests.json`. Switches default to showing only tests that are not run.

Readability improvements:
* Make job names in column headers displayed vertical in order to decrease column  width
* Add additional decoration to test names that are filtered by dont_run_tests.json
* Reorder filters and rephrase labels for clarity 

![image](https://user-images.githubusercontent.com/809335/224275324-fd1dcd48-7e69-4e4d-8a6d-8e7487a2bc6b.png)

/cc @dominikholler @lukas-bednar 