### PR TITLE
Update 1.26 kubevirtci image name to match provider name

### DIFF
--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -79,7 +79,13 @@ func pullRequiredImages(ctx context.Context, tag string) error {
 
 	for _, version := range versions {
 		log.Infoln("Kubevirt Provider version: ", version)
+
 		name := fmt.Sprintf("%sk8s-%s:%s", kubevirtci_repo, version, tag)
+		// k8s-1.26 kubevirtci provider was renamed to k8s-1.26-centos9
+		// to track the change to CentOS Stream 9
+		if version == "1.26" {
+			name = fmt.Sprintf("%sk8s-%s-centos9:%s", kubevirtci_repo, version, tag)
+		}
 		if _, exists := imageNames[name]; exists {
 			log.Infoln("Image already present:", name)
 			continue
@@ -87,7 +93,7 @@ func pullRequiredImages(ctx context.Context, tag string) error {
 		log.Infoln("Pulling image: ", name)
 		_, err := images.Pull(ctx, name, nil)
 		if err != nil {
-			return err
+			log.WithError(err).Errorf("Failed to pull image '%s'", name)
 		}
 	}
 	return nil


### PR DESCRIPTION
Currently the `shared-images-controller` is failing to pull the k8s-1.26 provider image as the provider[1] was removed and is no longer published. 

Updated to temporarily handle the new provider name for 1.26 - `k8s-1.26-centos9`

Also removed the return - as if it fails to pull the first image, we still want it to continue to try to download the rest. 

[1] https://github.com/kubevirt/kubevirtci/pull/969

/cc @dhiller @xpivarc 