### PR TITLE
Revert "Run hack/bump-prow-job-images.sh (#2650)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -37,7 +37,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             command:
@@ -52,7 +52,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -37,7 +37,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         - /bin/sh
         - -c
         - make functest
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -37,7 +37,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
@@ -23,7 +23,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -61,7 +61,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -97,7 +97,7 @@ presubmits:
         - /bin/sh
         - -c
         - make functest
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -17,7 +17,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -54,7 +54,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -86,7 +86,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -119,7 +119,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -150,7 +150,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -183,7 +183,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -216,7 +216,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -249,7 +249,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -282,7 +282,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -315,7 +315,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -348,7 +348,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             env:
               - name: COMMON_INSTANCETYPES_CRI
                 value: podman

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
       env:
       - name: GIMME_GO_VERSION
         value: "1.19"
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
         env:
         - name: GIMME_GO_VERSION
           value: "1.19"
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -55,7 +55,7 @@ presubmits:
         env:
         - name: GIMME_GO_VERSION
           value: "1.19"
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -94,7 +94,7 @@ postsubmits:
       preset-github-credentials: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -135,7 +135,7 @@ postsubmits:
       preset-github-credentials: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -51,7 +51,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -83,7 +83,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -149,7 +149,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -183,7 +183,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -217,7 +217,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -255,7 +255,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -293,7 +293,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -327,7 +327,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -361,7 +361,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -399,7 +399,7 @@ presubmits:
         env:
         - name: FOSSA_TOKEN_FILE
           value: /root/.docker/secrets/fossa/token
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -23,7 +23,7 @@ postsubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             env:
               - name: REPO
                 value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -57,7 +57,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -93,7 +93,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -131,7 +131,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -166,7 +166,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -201,7 +201,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -232,7 +232,7 @@ presubmits:
         preset-bazel-cache: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             env:
               - name: COVERALLS_TOKEN_FILE
                 value: /root/.docker/secrets/coveralls/token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -18,7 +18,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt
@@ -58,7 +58,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt
@@ -98,7 +98,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt
@@ -60,7 +60,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt
@@ -100,7 +100,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_REPO
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -54,7 +54,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -84,7 +84,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -117,7 +117,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -147,7 +147,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -25,7 +25,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+    - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -56,7 +56,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -77,7 +77,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
     nodeSelector:
       type: bare-metal-external
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+    - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -57,7 +57,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -94,7 +94,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "false"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -51,7 +51,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -93,7 +93,7 @@ periodics:
       env:
       - name: GIMME_GO_VERSION
         value: "1.19"
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources: {}
 - annotations:
@@ -158,7 +158,7 @@ periodics:
         value: windows_sysprep
       - name: KUBEVIRT_WINDOWS_PRODUCT_KEY_PATH
         value: /etc/win-sysprep/productKey
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -247,7 +247,7 @@ periodics:
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -321,7 +321,7 @@ periodics:
         value: quay.io/kubevirt
       - name: BUILD_ARCH
         value: crossbuild-aarch64
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -359,7 +359,7 @@ periodics:
             gsutil -m rm -r ${nightly_build_dir};
           fi;
         done
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -391,7 +391,7 @@ periodics:
       - /bin/sh
       - -c
       - automation/conformance.sh
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -447,7 +447,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: kind-1.25-vgpu
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -670,7 +670,7 @@ periodics:
         value: /kubeconfig
       - name: IMAGE_PULL_POLICY
         value: Always
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -714,7 +714,7 @@ periodics:
         value: "1"
       - name: KUBEVIRT_E2E_FOCUS
         value: arm64
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -754,7 +754,7 @@ periodics:
       - /bin/sh
       - -c
       - make test
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -834,7 +834,7 @@ periodics:
         value: Always
       - name: PERFSCALE_WORKLOAD
         value: tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-burst-100.yaml
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -925,7 +925,7 @@ periodics:
         value: tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-burst-400.yaml
       - name: PERFSCALE_WORKLOAD_SIX_HUNDRED
         value: tools/perfscale-load-generator/examples/workload/kubevirt-density/kubevirt-burst-600.yaml
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -986,7 +986,7 @@ periodics:
         value: "true"
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --prometheus-port 30007
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1036,7 +1036,7 @@ periodics:
         value: k8s-1.24-sig-storage
       - name: KUBEVIRT_CGROUPV2
         value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1085,7 +1085,7 @@ periodics:
         value: k8s-1.25-sig-storage
       - name: KUBEVIRT_CGROUPV2
         value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1134,7 +1134,7 @@ periodics:
         value: k8s-1.24-sig-compute
       - name: KUBEVIRT_CGROUPV2
         value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1183,7 +1183,7 @@ periodics:
         value: k8s-1.25-sig-compute
       - name: KUBEVIRT_CGROUPV2
         value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1249,7 +1249,7 @@ periodics:
         value: "512"
       - name: KUBEVIRT_REALTIME_SCHEDULER
         value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1301,7 +1301,7 @@ periodics:
         value: "3"
       - name: KUBEVIRT_STORAGE
         value: rook-ceph-default
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1348,7 +1348,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.24-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1395,7 +1395,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.24-sig-storage
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1442,7 +1442,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.24-sig-compute
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1489,7 +1489,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.24-sig-operator
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1536,7 +1536,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.25-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1583,7 +1583,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.25-sig-storage
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1630,7 +1630,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.25-sig-compute
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1677,7 +1677,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.25-sig-operator
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1726,7 +1726,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1775,7 +1775,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1824,7 +1824,7 @@ periodics:
         value: k8s-1.26-centos9-sig-storage
       - name: FEATURE_GATES
         value: Root
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1873,7 +1873,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-compute
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1922,7 +1922,7 @@ periodics:
         value: k8s-1.26-centos9-sig-compute
       - name: FEATURE_GATES
         value: Root
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -1971,7 +1971,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:
@@ -2020,7 +2020,7 @@ periodics:
         value: k8s-1.26-centos9-sig-operator
       - name: FEATURE_GATES
         value: Root
-      image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       name: ""
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -66,7 +66,7 @@ postsubmits:
       preset-gcs-credentials: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
         - |
@@ -106,7 +106,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -142,7 +142,7 @@ postsubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           env:
             - name: COVERALLS_TOKEN_FILE
               value: /root/.docker/secrets/coveralls/token
@@ -187,7 +187,7 @@ postsubmits:
         job_states_to_report: []
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           env:
             - name: FOSSA_TOKEN_FILE
               value: /root/.docker/secrets/fossa/token

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -33,7 +33,7 @@ presubmits:
           value: k8s-1.26-sig-compute
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -75,7 +75,7 @@ presubmits:
           value: k8s-1.24-sig-compute
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -117,7 +117,7 @@ presubmits:
           value: k8s-1.25-sig-compute
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -197,7 +197,7 @@ presubmits:
           value: k8s-1.26-sig-storage
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -239,7 +239,7 @@ presubmits:
           value: k8s-1.24-sig-storage
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -281,7 +281,7 @@ presubmits:
           value: k8s-1.25-sig-storage
         - name: KUBEVIRT_CGROUPV2
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -341,7 +341,7 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --prometheus-port 30007
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -382,7 +382,7 @@ presubmits:
         env:
         - name: TARGET
           value: windows2016
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -433,7 +433,7 @@ presubmits:
         env:
         - name: TARGET
           value: kind-1.25-vgpu
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -575,7 +575,7 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -606,7 +606,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -637,7 +637,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -666,7 +666,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make deps-sync && hack/verify-generate.sh
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -698,7 +698,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -727,7 +727,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -756,7 +756,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -788,7 +788,7 @@ presubmits:
         env:
         - name: BUILD_ARCH
           value: crossbuild-aarch64
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -818,7 +818,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -852,7 +852,7 @@ presubmits:
         env:
         - name: COVERALLS_TOKEN_FILE
           value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -891,7 +891,7 @@ presubmits:
         env:
         - name: FOSSA_TOKEN_FILE
           value: /root/.docker/secrets/fossa/token
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -928,7 +928,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -957,7 +957,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -987,7 +987,7 @@ presubmits:
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt"
           && make olm-verify
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1016,7 +1016,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1045,7 +1045,7 @@ presubmits:
         - /bin/sh
         - -c
         - hack/check-unassigned-tests.sh
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1084,7 +1084,7 @@ presubmits:
           value: k8s-1.25-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1126,7 +1126,7 @@ presubmits:
           value: k8s-1.26-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1169,7 +1169,7 @@ presubmits:
           value: "3"
         - name: KUBEVIRT_STORAGE
           value: rook-ceph-default
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1208,7 +1208,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-compute-realtime
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1249,7 +1249,7 @@ presubmits:
           value: "1"
         - name: KUBEVIRT_E2E_FOCUS
           value: arm64
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1303,7 +1303,7 @@ presubmits:
         - -ce
         - |
           make builder-build
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1335,7 +1335,7 @@ presubmits:
         - -c
         - |
           make lint
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1378,7 +1378,7 @@ presubmits:
           value: SwapTest
         - name: KUBEVIRT_SWAP_ON
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1416,7 +1416,7 @@ presubmits:
           value: k8s-1.26-sig-monitoring
         - name: KUBEVIRT_NUM_NODES
           value: "2"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1464,7 +1464,7 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_STORAGE
           value: rook-ceph-default
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1503,7 +1503,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1542,7 +1542,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1581,7 +1581,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1620,7 +1620,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1659,7 +1659,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1698,7 +1698,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-storage
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1737,7 +1737,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-compute
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1779,7 +1779,7 @@ presubmits:
           value: k8s-1.25-sig-compute
         - name: KUBEVIRT_FIPS
           value: "1"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1818,7 +1818,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-operator
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1859,7 +1859,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1900,7 +1900,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-storage
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1941,7 +1941,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-compute
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -1982,7 +1982,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-operator
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -2055,7 +2055,7 @@ presubmits:
           value: /kubeconfig
         - name: IMAGE_PULL_POLICY
           value: Always
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
   cluster: prow-workloads
   spec:
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
           - name: OS
             value: CentOS_8_Stream

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -337,7 +337,7 @@ presubmits:
         - /bin/bash
         - -c
         - cd cluster-provision/gocli/ && make all container
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -363,7 +363,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.25 && KUBEVIRT_PSA='true' ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -399,7 +399,7 @@ presubmits:
         - -c
         - dnf install -y genisoimage libvirt && cd cluster-provision/images/vm-image-builder
           && ./create-containerdisk.sh alpine-cloud-init
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -441,7 +441,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.24-psa && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -467,7 +467,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.24 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -493,7 +493,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.25 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -519,7 +519,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.26 && KUBEVIRT_PSA='true' ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -545,7 +545,7 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.26-centos9 && KUBEVIRT_PSA='true' ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -25,7 +25,7 @@ periodics:
   cluster: ibm-prow-jobs
   spec:
     containers:
-    - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+    - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             env:
             - name: OCI_BIN
               value: podman
@@ -41,7 +41,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             env:
             - name: OCI_BIN
               value: podman

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             command:
@@ -49,7 +49,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
@@ -53,7 +53,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -19,7 +19,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
@@ -50,7 +50,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -650,7 +650,7 @@ periodics:
   cluster: prow-workloads
   spec:
     containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         env:
           - name: BUCKET_DIR
             value: kubevirtci-istioctl-mirror
@@ -719,7 +719,7 @@ periodics:
   name: periodic-project-infra-check-prow-jobconfigs
   spec:
     containers:
-    - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+    - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       env:
       - name: GIMME_GO_VERSION
         value: "1.19"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -39,7 +39,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -66,7 +66,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -99,7 +99,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -130,7 +130,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -161,7 +161,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -192,7 +192,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -227,7 +227,7 @@ postsubmits:
         base_ref: main
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -259,7 +259,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -289,7 +289,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -319,7 +319,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -349,7 +349,7 @@ postsubmits:
       cluster: prow-workloads
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -381,7 +381,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -411,7 +411,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -631,7 +631,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -669,7 +669,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -707,7 +707,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -745,7 +745,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -782,7 +782,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -833,7 +833,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -872,7 +872,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -934,7 +934,7 @@ postsubmits:
         preset-bazel-cache: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -959,7 +959,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
       spec:
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command: ["/bin/sh"]
           args:
           - -c
@@ -992,7 +992,7 @@ postsubmits:
         securityContext:
           runAsUser: 0
         containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           env:
           command:
           - /usr/local/bin/runner.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
           - "/bin/bash"
           - "-c"
@@ -47,7 +47,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
           - "/bin/bash"
           - "-c"
@@ -66,7 +66,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -88,7 +88,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -112,7 +112,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -137,7 +137,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -164,7 +164,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -191,7 +191,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -218,7 +218,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -249,7 +249,7 @@ presubmits:
       base_ref: main
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -277,7 +277,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -304,7 +304,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -331,7 +331,7 @@ presubmits:
     cluster: prow-workloads
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -358,7 +358,7 @@ presubmits:
     cluster: prow-workloads
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -387,7 +387,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -412,7 +412,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -482,7 +482,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -519,7 +519,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -556,7 +556,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -593,7 +593,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -630,7 +630,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -667,7 +667,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -705,7 +705,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
@@ -744,7 +744,7 @@ presubmits:
       base_ref: master
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         command:
         - github/ci/testgrid/hack/check.sh
         securityContext:
@@ -847,7 +847,7 @@ presubmits:
     run_if_changed: 'robots/cmd/job-config-validator/.*|go.mod|go.sum'
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         env:
         - name: GIMME_GO_VERSION
           value: "1.19"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         args:
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
     - env:
       - name: GIMME_GO_VERSION
         value: "1.18"
-      image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
       command: [ "/usr/local/bin/runner.sh", "/bin/bash", "-ce" ]
       args:
       - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
         - /bin/sh
         - -c
         - automation/test.sh
-        image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:
           requests:
@@ -59,7 +59,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+        - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
     cluster: ibm-prow-jobs
     spec:
       containers:
-      - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+      - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/bash"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -22,7 +22,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             env:
             - name: GIT_ASKPASS
               value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
@@ -66,7 +66,7 @@ postsubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             env:
             - name: GIT_ASKPASS
               value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       cluster: ibm-prow-jobs
       spec:
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             securityContext:
               privileged: true
             env:
@@ -52,7 +52,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -88,7 +88,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -121,7 +121,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             command:
@@ -154,7 +154,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:
@@ -189,7 +189,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/golang:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/golang:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230306-5b8ee3f
+          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
This reverts commit b617142d2e07a56729e049b7937cb86352ba9474.

There is an issue with the latest bootstrap image which is causing the majority of e2e lanes to fail

/cc @dhiller @xpivarc 