### PR TITLE
Add support for /rehearse <job-name>

### DIFF
--- a/external-plugins/rehearse/Makefile
+++ b/external-plugins/rehearse/Makefile
@@ -10,7 +10,7 @@ format:
 	gofmt -w .
 
 test:
-	$(bazelbin) test //external-plugins/rehearse/plugin:*
+	$(bazelbin) test //external-plugins/rehearse/...
 
 push:
 	$(bazelbin) run //external-plugins/rehearse/plugin:push

--- a/external-plugins/rehearse/Makefile
+++ b/external-plugins/rehearse/Makefile
@@ -13,5 +13,5 @@ test:
 	$(bazelbin) test //external-plugins/rehearse/...
 
 push:
-	$(bazelbin) run //external-plugins/rehearse/plugin:push
-	bash -x ../../hack/update-jobs-with-latest-image.sh kubevirtci/rehearse
+	$(bazelbin) run --stamp --workspace_status_command="./hack/print-workspace-status-no-git-tag.sh" //external-plugins/rehearse/plugin:push
+	bash -x ../../hack/update-jobs-with-latest-image.sh quay.io/kubevirtci/rehearse

--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -27,6 +27,12 @@ import (
 )
 
 var log *logrus.Logger
+
+// rehearseCommentRe matches either the sole command, i.e.
+// /rehearse
+// or the command followed by a job name which we then extract by the
+// capturing group, i.e.
+// /rehearse job-name
 var rehearseCommentRe = regexp.MustCompile(`(?m)^/rehearse\s*?($|\s.*)`)
 
 func init() {

--- a/external-plugins/rehearse/plugin/handler/handler_test.go
+++ b/external-plugins/rehearse/plugin/handler/handler_test.go
@@ -317,6 +317,26 @@ Gna meh whatever
 `
 			Expect(handler.extractJobNamesFromComment(commentBody)).To(BeNil())
 		})
+
+		It("extracts no job names from comment body if no element is found since only whitespace after command", func() {
+			commentBody := `Gna meh whatever 
+
+/rehearse    
+
+
+`
+			Expect(handler.extractJobNamesFromComment(commentBody)).To(BeNil())
+		})
+
+		It("extracts no job names from comment body", func() {
+			commentBody := `Gna meh whatever 
+
+/rehearse
+
+
+`
+			Expect(handler.extractJobNamesFromComment(commentBody)).To(BeNil())
+		})
 	})
 
 	Context("filtering jobs by name", func() {

--- a/hack/print-workspace-status-no-git-tag.sh
+++ b/hack/print-workspace-status-no-git-tag.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2023 Red Hat, Inc.
+#
+#
+
+# we use the untagged version since we don't want the git tags to appear in the image tag
+git_commit=$(git describe --always --dirty)
+build_date=$(date -u '+%Y%m%d')
+docker_tag="v${build_date}-${git_commit}"
+
+cat <<EOF
+DOCKER_TAG ${docker_tag}
+EOF


### PR DESCRIPTION
Add support to select jobs for rehearsal from the set of changed jobs by commenting with

    /rehearse job-name-1
    ...
    /rehearse job-name-n

Also refine command matching to allow spaces after blank /rehearse commands.

/cc @brianmcarey @xpivarc @enp0s3 @ormergi 