### PR TITLE
Create sig-release repo and release-team

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -465,6 +465,10 @@ orgs:
         description: A repo to store all our secrets for automation
         has_projects: true
         private: true
+      sig-release:
+        default_branch: main
+        description: A repo to hold and organize all the information required for KubeVirt releases
+        has_wiki: true
       ssp-operator:
         description: Kubevirt SSP Operator
         has_projects: true
@@ -786,6 +790,17 @@ orgs:
           - isaacdorfman
         repos:
           terraform-provider-kubevirt: admin
+      release-team:
+        description: Team maintaining the release of KubeVirt
+        maintainers:
+        - aburdenthehand
+        - acardace
+        - dhiller
+        - davidvossel
+        - fabiand
+        - xpivarc
+        repos:
+          sig-release: write
       rerun-jobs-hco:
         description: can rerun failed job in the hyperconverged-cluster-operator repository
         maintainers:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -131,6 +131,7 @@ tide:
     kubevirt/secrets: merge
     kubevirt/test-benchmarks: merge
     kubevirt/vm-console-proxy: merge
+    kubevirt/sig-release: merge
 
   queries:
   - repos:
@@ -154,6 +155,7 @@ tide:
     - kubevirt/cloud-provider-kubevirt
     - kubevirt/secrets
     - kubevirt/test-benchmarks
+    - kubevirt/sig-release
     labels:
     - lgtm
     - approved
@@ -413,6 +415,10 @@ branch-protection:
             main:
               protect: true
         kubesecondarydns:
+          branches:
+            main:
+              protect: true
+        sig-release:
           branches:
             main:
               protect: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -238,6 +238,11 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - name: sig/release
+      color: 2943CF
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: e11d21
       description: Indicates the PR's author has not DCO signed all their commits.
       name: "dco-signoff: no"

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -371,6 +371,13 @@ plugins:
     - lgtm
     - trigger
 
+  kubevirt/sig-release:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+
   kubevirt/ssp-operator:
     plugins:
     - approve
@@ -508,6 +515,7 @@ triggers:
   - kubevirt/node-labeller
   - kubevirt/kubevirt-template-validator
   - kubevirt/kubevirt-ssp-operator
+  - kubevirt/sig-release
   - kubevirt/ssp-operator
   - kubevirt/must-gather
   - kubevirt/demo
@@ -576,6 +584,7 @@ approve:
   - kubevirt/cloud-provider-kubevirt
   - kubevirt/test-benchmarks
   - kubevirt/vm-console-proxy
+  - kubevirt/sig-release
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -631,6 +640,7 @@ lgtm:
   - kubevirt/secrets
   - kubevirt/test-benchmarks
   - kubevirt/vm-console-proxy
+  - kubevirt/sig-release
   review_acts_as_lgtm: true
 
 override:


### PR DESCRIPTION
Also configure prow plugins to enable tide on sig-release PRs.

Add a new sig-release label.

Originated from [Slack thread](https://kubernetes.slack.com/archives/C0163DT0R8X/p1678956725745269)

/cc @acardace @aburdenthehand @fabiand @xpivarc @rthallisey 