### PR TITLE
Bump kubevirtci on controller-lifecycle-operator-sdk-e2e

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
   kubevirt/controller-lifecycle-operator-sdk:
-  - name: pull-controller-lifecycle-operator-sdk-e2e-k8s-1.18
+  - name: pull-controller-lifecycle-operator-sdk-e2e-k8s-1.24
     always_run: true
     optional: true
     decorate: true
@@ -22,7 +22,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "cd examples/sample-operator &&  export TARGET=k8s-1.18 && automation/test.sh"
+            - "cd examples/sample-operator && export TARGET=k8s-1.24 && automation/test.sh"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Current kubevirtci is ancient (pulls from dockerhub!) 
Verified locally