### PR TITLE
Update sig-monitoring presubmit to use k8s-1.26-centos9 target

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1413,7 +1413,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-sig-monitoring
+          value: k8s-1.26-centos9-sig-monitoring
         - name: KUBEVIRT_NUM_NODES
           value: "2"
         image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0


### PR DESCRIPTION
The centos8 based k8-1.26 target was removed so the sig-monitoring presubmit lane can no longer complte successfully[1].

Update to use the centos stream 9 target

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9392/pull-kubevirt-e2e-k8s-1.26-sig-monitoring/1638096889373003776#1:build-log.txt%3A54

/cc @dhiller @xpivarc 