### PR TITLE
kubevirt, periodics, SR-IOV: Reduce rate

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -489,7 +489,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 22, 11 * * *
+  cron: 0 23 * * 6
   decorate: true
   decoration_config:
     grace_period: 30m0s
@@ -571,7 +571,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 22, 12 * * *
+  cron: 0 21 * * *
   decorate: true
   decoration_config:
     grace_period: 30m0s


### PR DESCRIPTION
Currently we are running both k3d and kind periodics, each one twice a day.
We even run them on the same time so they might [fall](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-k3d-1.25-sriov/1638206139675971584) to schedule.

Reduce the rate, as we are running k3d on every presubmit,
in order to save resources during work hours.
Increase the delta between the two periodics in order to reduce
collisions.

Kind was changed to `"At 23:00 on Saturday”`.
K3d was changed to `“At 21:00”`.

Note:
We can even consider to remove kind periodic, 
or maybe bump it from 1.23 to 1.25 but without cpu manager
tests and config, and keep the periodic of it.