### PR TITLE
Bump shared images controller to the latest published image

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/shared-images-controller.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/workloads-production/resources/shared-images-controller.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: shared-images-controller
-        image: quay.io/kubevirtci/shared-images-controller:v20221208-a669d6f
+        image: quay.io/kubevirtci/shared-images-controller:v20230323-979a45c
         command: [ "/usr/local/bin/runner.sh", "/shared-images-controller"]
         resources:
           requests:


### PR DESCRIPTION
Updating the shared images controller daemonset to the latest `quay.io/kubevirtci/shared-images-controller:v20230323-979a45c` to consume the recent change[1] to allow for the centos stream 9 based 1.26 kubernetes provider.

[1] https://github.com/kubevirt/project-infra/pull/2659


/cc @enp0s3 @dhiller 