### PR TITLE
Test tooling: introduce test-label-analyzer cli - generate a page of quarantined tests for kubevirt/kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2398,3 +2398,44 @@ periodics:
         privileged: true
     nodeSelector:
       type: bare-metal-external
+- annotations:
+    testgrid-create-test-group: "false"
+  cluster: ibm-prow-jobs
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: project-infra
+    workdir: true
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  interval: 24h
+  labels:
+    preset-gcs-credentials: "true"
+  name: periodic-kubevirt-quarantined-tests-daily-report
+  spec:
+    containers:
+    - args:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -ce
+      - |
+        go install github.com/onsi/ginkgo/v2/ginkgo
+        export PATH="$PATH:/root/go/bin"
+        output_file_name="/tmp/index.html"
+        git_commit=$(cd ../kubevirt && git --no-pager log -1 --format=%H | tr -d '\n')
+        go run ./robots/cmd/test-label-analyzer/... stats \
+          --output-html=true \
+          --config-name quarantine \
+          --test-file-path $(cd ../kubevirt && pwd)/tests \
+          --remote-url "https://github.com/kubevirt/kubevirt/tree/${git_commit}/tests" \
+            > ${output_file_name}
+          gsutil cp ${output_file_name} gs://kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/
+      command: [ "/bin/sh" ]
+      env:
+      - name: GIMME_GO_VERSION
+        value: "1.19"
+      image: quay.io/kubevirtci/golang:v20230105-1dbefc0
+      name: ""
+    resources: {}

--- a/robots/cmd/test-label-analyzer/BUILD.bazel
+++ b/robots/cmd/test-label-analyzer/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/robots/cmd/test-label-analyzer",
+    visibility = ["//visibility:private"],
+    deps = ["//robots/cmd/test-label-analyzer/cmd:go_default_library"],
+)
+
+go_binary(
+    name = "test-label-analyzer",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/cmd/test-label-analyzer/Makefile
+++ b/robots/cmd/test-label-analyzer/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all clean verify format test push
+all: format test build
+
+format:
+	gofmt -w .
+
+test:
+	go test -v ./... ../../pkg/test-label-analyzer/...
+
+build:
+	go build -v ./...

--- a/robots/cmd/test-label-analyzer/README.md
+++ b/robots/cmd/test-label-analyzer/README.md
@@ -1,0 +1,18 @@
+# test-label-analyzer
+
+This tool has two main use cases
+* generate status about what tests are in a certain category
+* given certain categories generate a string that can be used directly with [Ginkgo] `--filter` or `--skip` flags
+
+Both use cases support input files that define a set of regular expressions for test names to match a certain category.
+
+## generate status about what tests are in a certain category
+
+Say we want to know about how many tests of a given set (i.e. directory or file set) are in a certain category. We provide a configuration file to define what labels (either inside the test name or as an explicit [Ginkgo label]) match a certain category.
+
+The tool then prints an overview of how many tests are in each category, additionally it prints out a list of all test names including their attributes as where to find each test inside the code base.
+
+## generate a string that can be used directly with [Ginkgo] `--filter` or `--skip` flags
+
+[Ginkgo]: https://onsi.github.io/ginkgo/
+[Ginkgo label]: https://onsi.github.io/ginkgo/#spec-labels

--- a/robots/cmd/test-label-analyzer/README.md
+++ b/robots/cmd/test-label-analyzer/README.md
@@ -50,6 +50,22 @@ $ # from the output we can generate the concatenated test names
 $ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
 ```
 
+#### Directly letting `test-labels-analyzer` filter tests with regular expression
+
+```sh
+# point test-label-analyzer to the directory containing the test source files
+$ test-label-analyzer stats --test-name-label-re '.*Console Proxy Operand Resource.*' --test-file-path /home/dhiller/Projects/github.com/kubevirt.io/ssp-operator/tests \
+        > /tmp/test-label-analyzer-output.json
+$ # print the output
+$ cat /tmp/test-label-analyzer-output.json
+{"SpecsTotal":278,"SpecsMatching":40,"MatchingSpecPathes":[[{"name":"Describe", ...
+$ # from the output we can generate the concatenated test names
+$ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
+"VM Console Proxy Operand Resource creation created cluster resource [test_id:TODO] cluster role"
+"VM Console Proxy Operand Resource creation created cluster resource [test_id:TODO] cluster role binding"
+...
+```
+
 ## generate a string that can be used directly with [Ginkgo] `--filter` or `--skip` flags
 
 _**NOT YET IMPLEMENTED**_

--- a/robots/cmd/test-label-analyzer/README.md
+++ b/robots/cmd/test-label-analyzer/README.md
@@ -1,16 +1,33 @@
 # test-label-analyzer
 
 This tool has two main use cases
-* generate status about what tests are in a certain category
+* generate stats about what tests are in a certain category
 * given certain categories generate a string that can be used directly with [Ginkgo] `--filter` or `--skip` flags
 
 Both use cases support input files that define a set of regular expressions for test names to match a certain category.
 
-## generate status about what tests are in a certain category
+## generate stats about what tests are in a certain category
 
 Say we want to know about how many tests of a given set (i.e. directory or file set) are in a certain category. We provide a configuration file to define what labels (either inside the test name or as an explicit [Ginkgo label]) match a certain category.
 
 The tool then prints an overview of how many tests are in each category, additionally it prints out a list of all test names including their attributes as where to find each test inside the code base.
+
+Example:
+
+```sh
+$ # create an output directory
+$ mkdir -p /tmp/ginkgo-outlines
+$ # generate outline data files from the ginkgo test files (those that contain an import from ginkgo)
+$ for test_file in $(cd $ginkgo_test_dir && grep -l 'github.com/onsi/ginkgo/v2' ./*.go); do; ginkgo outline --format json $test_file > /tmp/ginkgo-outlines/${test_file//[\/\.]/_}.ginkgooutline.json ; done
+$ # feed input files to test-label-analyzer to generate stats
+$ test-label-analyzer stats --config-name quarantine \
+    $(for outline_file in $(ls /tmp/ginkgo-outlines/); do; \
+        echo " --test-outline-filepath /tmp/ginkgo-outlines/$outline_file" | \
+        tr -d '\n'; done; echo "") \
+        > /tmp/test-label-analyzer-output.json
+$ # from the output we can generate the concatenated test names
+$ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
+```
 
 ## generate a string that can be used directly with [Ginkgo] `--filter` or `--skip` flags
 

--- a/robots/cmd/test-label-analyzer/README.md
+++ b/robots/cmd/test-label-analyzer/README.md
@@ -66,6 +66,15 @@ $ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer
 ...
 ```
 
+#### Generating an html page from an existing profile
+
+```shell
+$ test-label-analyzer stats --output-html=true \
+  --config-name quarantine \
+  --test-file-path $(cd ../kubevirt && pwd)/tests \
+  --remote-url 'https://github.com/kubevirt/kubevirt/tree/main/tests' > /tmp/test-output.html
+
+```
 ## generate a string that can be used directly with [Ginkgo] `--filter` or `--skip` flags
 
 _**NOT YET IMPLEMENTED**_

--- a/robots/cmd/test-label-analyzer/README.md
+++ b/robots/cmd/test-label-analyzer/README.md
@@ -32,9 +32,9 @@ $ test-label-analyzer stats --config-name quarantine \
         > /tmp/test-label-analyzer-output.json
 $ # print the output
 $ cat /tmp/test-label-analyzer-output.json
-{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPathes":[[{"name":"Describe","text":...
+{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPaths":[[{"name":"Describe","text":...
 $ # from the output we can generate the concatenated test names
-$ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
+$ jq '.MatchingSpecPaths[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
 ```
 
 #### Letting `test-labels-analyzer` call ginkgo to retrieve the outline data
@@ -45,9 +45,9 @@ $ test-label-analyzer stats --config-name quarantine --test-file-path /path/to/t
         > /tmp/test-label-analyzer-output.json
 $ # print the output
 $ cat /tmp/test-label-analyzer-output.json
-{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPathes":[[{"name":"Describe","text":...
+{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPaths":[[{"name":"Describe","text":...
 $ # from the output we can generate the concatenated test names
-$ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
+$ jq '.MatchingSpecPaths[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
 ```
 
 #### Directly letting `test-labels-analyzer` filter tests with regular expression
@@ -58,9 +58,9 @@ $ test-label-analyzer stats --test-name-label-re '.*Console Proxy Operand Resour
         > /tmp/test-label-analyzer-output.json
 $ # print the output
 $ cat /tmp/test-label-analyzer-output.json
-{"SpecsTotal":278,"SpecsMatching":40,"MatchingSpecPathes":[[{"name":"Describe", ...
+{"SpecsTotal":278,"SpecsMatching":40,"MatchingSpecPaths":[[{"name":"Describe", ...
 $ # from the output we can generate the concatenated test names
-$ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
+$ jq '.MatchingSpecPaths[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
 "VM Console Proxy Operand Resource creation created cluster resource [test_id:TODO] cluster role"
 "VM Console Proxy Operand Resource creation created cluster resource [test_id:TODO] cluster role binding"
 ...

--- a/robots/cmd/test-label-analyzer/README.md
+++ b/robots/cmd/test-label-analyzer/README.md
@@ -32,7 +32,7 @@ $ test-label-analyzer stats --config-name quarantine \
         > /tmp/test-label-analyzer-output.json
 $ # print the output
 $ cat /tmp/test-label-analyzer-output.json
-{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPathes":[[{"name":"Describe","text":"...
+{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPathes":[[{"name":"Describe","text":...
 $ # from the output we can generate the concatenated test names
 $ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
 ```
@@ -45,7 +45,7 @@ $ test-label-analyzer stats --config-name quarantine --test-file-path /path/to/t
         > /tmp/test-label-analyzer-output.json
 $ # print the output
 $ cat /tmp/test-label-analyzer-output.json
-{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPathes":[[{"name":"Describe","text":"...
+{"SpecsTotal":1483,"SpecsMatching":9,"MatchingSpecPathes":[[{"name":"Describe","text":...
 $ # from the output we can generate the concatenated test names
 $ jq '.MatchingSpecPathes[] | [ .[].text ] | join(" ")' /tmp/test-label-analyzer-output.json
 ```

--- a/robots/cmd/test-label-analyzer/cmd/BUILD.bazel
+++ b/robots/cmd/test-label-analyzer/cmd/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "filter.go",
+        "root.go",
+        "stats.go",
+    ],
+    embedsrcs = ["stats.gohtml"],
+    importpath = "kubevirt.io/project-infra/robots/cmd/test-label-analyzer/cmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robots/pkg/test-label-analyzer:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "stats_test.go",
+        "test_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//robots/pkg/test-label-analyzer:go_default_library",
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+    ],
+)

--- a/robots/cmd/test-label-analyzer/cmd/filter.go
+++ b/robots/cmd/test-label-analyzer/cmd/filter.go
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// filterCmd represents the filter command
+var filterCmd = &cobra.Command{
+	Use:   "filter",
+	Short: "A brief description of your command", // TODO
+	Long:  `TODO`,                                // TODO
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("filter called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(filterCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// filterCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// filterCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/robots/cmd/test-label-analyzer/cmd/root.go
+++ b/robots/cmd/test-label-analyzer/cmd/root.go
@@ -49,6 +49,9 @@ type configOptions struct {
 
 	// testNameLabelRE is the regular expression for an on the fly created configuration of test names to match against
 	testNameLabelRE string
+
+	// outputHTML defines whether HTML should be generated, default is JSON
+	outputHTML bool
 }
 
 // validate checks the configuration options for validity and returns an error describing the first error encountered
@@ -147,4 +150,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.testFilePath, "test-file-path", "", "path containing tests to be analyzed")
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.remoteURL, "remote-url", "", "remote path to tests to be analyzed")
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.testNameLabelRE, "test-name-label-re", "", "regular expression for test names to match against")
+	rootCmd.PersistentFlags().BoolVar(&rootConfigOpts.outputHTML, "output-html", false, "defines whether HTML output should be generated, default is JSON")
 }

--- a/robots/cmd/test-label-analyzer/cmd/root.go
+++ b/robots/cmd/test-label-analyzer/cmd/root.go
@@ -123,15 +123,16 @@ var configNamesToConfigs = map[string]*test_label_analyzer.Config{
 	"quarantine": test_label_analyzer.NewQuarantineDefaultConfig(),
 }
 
-// rootCmd represents the base command when called without any subcommands
+const shortRootDescription = "Collects a set of tools for generating statistics and filter strings over sets of Ginkgo tests"
+
 var rootCmd = &cobra.Command{
 	Use:   "test-label-analyzer",
-	Short: "blah",
-	Long:  `TODO`,
+	Short: shortRootDescription,
+	Long: shortRootDescription + `
+
+Supports predefined configuration profiles and custom configurations to define which sets of tests should be targeted.`,
 }
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/robots/cmd/test-label-analyzer/cmd/root.go
+++ b/robots/cmd/test-label-analyzer/cmd/root.go
@@ -85,10 +85,10 @@ func (s *configOptions) validate() error {
 	if s.testFilePath != "" {
 		stat, err := os.Stat(s.testFilePath)
 		if os.IsNotExist(err) {
-			return fmt.Errorf("test-file-path not set correctly, %q is not a directory, %v", s.ginkgoOutlinePaths, err)
+			return fmt.Errorf("test-file-path not set correctly, %q is not a directory, %v", s.testFilePath, err)
 		}
 		if !stat.IsDir() {
-			return fmt.Errorf("test-file-path not set correctly, %q is not a directory", s.ginkgoOutlinePaths)
+			return fmt.Errorf("test-file-path not set correctly, %q is not a directory", s.testFilePath)
 		}
 		if s.remoteURL == "" {
 			return fmt.Errorf("remote-url is required together with test-file-path")

--- a/robots/cmd/test-label-analyzer/cmd/root.go
+++ b/robots/cmd/test-label-analyzer/cmd/root.go
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// configOptions contains the set of options that the stats command provides
+//
+// one of configFile or configName is required
+type configOptions struct {
+
+	// configFile is the path to the configuration file that resembles the test_label_analyzer.Config
+	configFile string
+
+	// configName is the name of the default configuration that resembles the test_label_analyzer.Config
+	configName string
+
+	// testPath is the path to the files that contain the tests to analyze
+	testPath string
+}
+
+func (s *configOptions) verify() error {
+	if s.configFile == "" && s.configName == "" || s.configFile != "" && s.configName != "" {
+		return fmt.Errorf("one of configFile or configName is required")
+	}
+	stat, err := os.Stat(s.testPath)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("test-path not set correctly, %q is not a directory, %v", s.testPath, err)
+	}
+	if !stat.IsDir() {
+		return fmt.Errorf("test-path not set correctly, %q is not a directory", s.testPath)
+	}
+	return nil
+}
+
+var configOpts = configOptions{}
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "test-label-analyzer",
+	Short: "blah",
+	Long:  `TODO`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&configOpts.configFile, "config-file", "", "config file defining categories of tests")
+	rootCmd.PersistentFlags().StringVar(&configOpts.configName, "config-name", "", "config name defining categories of tests")
+	rootCmd.PersistentFlags().StringVar(&configOpts.testPath, "test-path", "", "path containing tests to be analyzed")
+}

--- a/robots/cmd/test-label-analyzer/cmd/root.go
+++ b/robots/cmd/test-label-analyzer/cmd/root.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
-	test_label_analyzer "kubevirt.io/project-infra/robots/pkg/test-label-analyzer"
+	testlabelanalyzer "kubevirt.io/project-infra/robots/pkg/test-label-analyzer"
 	"os"
 )
 
@@ -37,8 +37,8 @@ type configOptions struct {
 	// configName is the name of the default configuration that resembles the test_label_analyzer.Config
 	configName string
 
-	// ginkgoOutlinePathes is the pathes to the files that contain the test outlines to analyze
-	ginkgoOutlinePathes []string
+	// ginkgoOutlinePaths holds the paths to the files that contain the test outlines to analyze
+	ginkgoOutlinePaths []string
 
 	// testFilePath is the path to the files that contain the test code
 	testFilePath string
@@ -67,28 +67,28 @@ func (s *configOptions) validate() error {
 	if s.configFile != "" {
 		stat, err := os.Stat(s.configFile)
 		if os.IsNotExist(err) {
-			return fmt.Errorf("test-outline-filepath not set correctly, %q is not a file, %v", s.ginkgoOutlinePathes, err)
+			return fmt.Errorf("config-file not set correctly, %q is not a file, %v", s.configFile, err)
 		}
 		if stat.IsDir() {
-			return fmt.Errorf("test-outline-filepath not set correctly, %q is not a file", s.ginkgoOutlinePathes)
+			return fmt.Errorf("config-file not set correctly, %q is not a file", s.configFile)
 		}
 	}
-	for _, ginkgoOutlinePath := range s.ginkgoOutlinePathes {
+	for _, ginkgoOutlinePath := range s.ginkgoOutlinePaths {
 		stat, err := os.Stat(ginkgoOutlinePath)
 		if os.IsNotExist(err) {
-			return fmt.Errorf("test-outline-filepath not set correctly, %q is not a file, %v", s.ginkgoOutlinePathes, err)
+			return fmt.Errorf("test-outline-filepath not set correctly, %q is not a file, %v", s.ginkgoOutlinePaths, err)
 		}
 		if stat.IsDir() {
-			return fmt.Errorf("test-outline-filepath not set correctly, %q is not a file", s.ginkgoOutlinePathes)
+			return fmt.Errorf("test-outline-filepath not set correctly, %q is not a file", s.ginkgoOutlinePaths)
 		}
 	}
 	if s.testFilePath != "" {
 		stat, err := os.Stat(s.testFilePath)
 		if os.IsNotExist(err) {
-			return fmt.Errorf("test-file-path not set correctly, %q is not a directory, %v", s.ginkgoOutlinePathes, err)
+			return fmt.Errorf("test-file-path not set correctly, %q is not a directory, %v", s.ginkgoOutlinePaths, err)
 		}
 		if !stat.IsDir() {
-			return fmt.Errorf("test-file-path not set correctly, %q is not a directory", s.ginkgoOutlinePathes)
+			return fmt.Errorf("test-file-path not set correctly, %q is not a directory", s.ginkgoOutlinePaths)
 		}
 		if s.remoteURL == "" {
 			return fmt.Errorf("remote-url is required together with test-file-path")
@@ -98,9 +98,9 @@ func (s *configOptions) validate() error {
 }
 
 // getConfig returns a configuration with which the matching tests are being retrieved or an error in case the configuration is wrong
-func (s *configOptions) getConfig() (*test_label_analyzer.Config, error) {
+func (s *configOptions) getConfig() (*testlabelanalyzer.Config, error) {
 	if s.testNameLabelRE != "" {
-		return test_label_analyzer.NewTestNameDefaultConfig(s.testNameLabelRE), nil
+		return testlabelanalyzer.NewTestNameDefaultConfig(s.testNameLabelRE), nil
 	}
 	if s.configName != "" {
 		return configNamesToConfigs[s.configName], nil
@@ -110,7 +110,7 @@ func (s *configOptions) getConfig() (*test_label_analyzer.Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		var config *test_label_analyzer.Config
+		var config *testlabelanalyzer.Config
 		err = json.Unmarshal(file, &config)
 		return config, err
 	}
@@ -119,8 +119,8 @@ func (s *configOptions) getConfig() (*test_label_analyzer.Config, error) {
 
 var rootConfigOpts = configOptions{}
 
-var configNamesToConfigs = map[string]*test_label_analyzer.Config{
-	"quarantine": test_label_analyzer.NewQuarantineDefaultConfig(),
+var configNamesToConfigs = map[string]*testlabelanalyzer.Config{
+	"quarantine": testlabelanalyzer.NewQuarantineDefaultConfig(),
 }
 
 const shortRootDescription = "Collects a set of tools for generating statistics and filter strings over sets of Ginkgo tests"
@@ -147,7 +147,7 @@ func init() {
 		configNames = append(configNames, configName)
 	}
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.configName, "config-name", "", fmt.Sprintf("config name defining categories of tests (possible values: %v)", configNames))
-	rootCmd.PersistentFlags().StringArrayVar(&rootConfigOpts.ginkgoOutlinePathes, "test-outline-filepath", nil, "path to test outline file to be analyzed")
+	rootCmd.PersistentFlags().StringArrayVar(&rootConfigOpts.ginkgoOutlinePaths, "test-outline-filepath", nil, "path to test outline file to be analyzed")
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.testFilePath, "test-file-path", "", "path containing tests to be analyzed")
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.remoteURL, "remote-url", "", "remote path to tests to be analyzed")
 	rootCmd.PersistentFlags().StringVar(&rootConfigOpts.testNameLabelRE, "test-name-label-re", "", "regular expression for test names to match against")

--- a/robots/cmd/test-label-analyzer/cmd/stats.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats.go
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// statsCmd represents the stats command
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Generates stats over test categories",
+	Long:  `TODO`,
+	RunE:  runStatsCommand,
+}
+
+func init() {
+	rootCmd.AddCommand(statsCmd)
+}
+
+func runStatsCommand(cmd *cobra.Command, args []string) error {
+	err := configOpts.verify()
+	if err != nil {
+		return err
+	}
+
+	ginkgo.internal.
+
+	return fmt.Errorf("stats called")
+}

--- a/robots/cmd/test-label-analyzer/cmd/stats.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats.go
@@ -35,11 +35,16 @@ import (
 	"time"
 )
 
+const shortStatsDescription = "Generates stats over test categories"
+
 // statsCmd represents the stats command
 var statsCmd = &cobra.Command{
 	Use:   "stats",
-	Short: "Generates stats over test categories",
-	Long:  `TODO`,
+	Short: shortStatsDescription,
+	Long: shortStatsDescription + `
+
+Can either emit json or html format data about the targeted tests.
+`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		return runStatsCommand(rootConfigOpts)
 	},

--- a/robots/cmd/test-label-analyzer/cmd/stats.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats.go
@@ -186,7 +186,7 @@ func runStatsCommand(configurationOptions configOptions) error {
 		return err
 	}
 
-	if len(configurationOptions.ginkgoOutlinePathes) > 0 {
+	if len(configurationOptions.ginkgoOutlinePaths) > 0 {
 		jsonOutput, err := collectStatsFromGinkgoOutlines(configurationOptions)
 		if err != nil {
 			return err
@@ -351,7 +351,7 @@ func collectStatsFromGinkgoOutlines(configurationOptions configOptions) (string,
 
 	// collect the test outline data from the files and merge it into one slice
 	var testOutlines []*test_label_analyzer.GinkgoNode
-	for _, path := range configurationOptions.ginkgoOutlinePathes {
+	for _, path := range configurationOptions.ginkgoOutlinePaths {
 		fileData, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("failed to read file %q: %v", path, err)

--- a/robots/cmd/test-label-analyzer/cmd/stats.gohtml
+++ b/robots/cmd/test-label-analyzer/cmd/stats.gohtml
@@ -27,16 +27,15 @@
         .date {
             white-space: nowrap;
         }
-        a.permalink {
+
+        a.nounderline {
             text-decoration: none;
         }
-        .matchingDate {
-            color: crimson;
-            font-weight: bold;
-        }
+
         .matchingLine {
             font-weight: bold;
         }
+
         .code {
             font-family: monospace;
             display: block;
@@ -45,21 +44,34 @@
     </style>
 </head>
 <body>
-    <h1>Overview of {{ (index $.Config.Categories 0).Name }} tests</h1>
-    <div>Total: {{ $.TestHTMLData | len }} tests</div>
-    <table>
-{{- range $testHTMLDataElem := $.TestHTMLData }}
-    {{- if $testHTMLDataElem.GitBlameLines }}
-        {{- range $index, $gitBlame := $testHTMLDataElem.GitBlameLines }}<tr>
-            {{ if (index $testHTMLDataElem.ElementsMatchingConfig $index) -}}
-                <td class="date matchingDate">{{ $gitBlame.Date.Format "2006-01-02" }}{{ if (index $testHTMLDataElem.Permalinks $index) }}<a class="permalink" title="{{ $gitBlame.CommitID }} by {{ $gitBlame.Author }}" href="{{ index $testHTMLDataElem.Permalinks $index }}">🔗</a>{{ end }}
-                </td>{{ else }}<td></td>{{ end }}
-            <td class="{{ if (index $testHTMLDataElem.ElementsMatchingConfig $index) }}matchingLine{{ end }}"><a href="{{ $testHTMLDataElem.RemoteURL }}#L{{ $gitBlame.LineNo }}"><span class="code">{{ $gitBlame.Line }}</span></a></td>
-        </tr>{{ end -}}
-        <tr><td colspan="2"><hr/></td></tr>
+<h1>Overview of {{ (index $.Config.Categories 0).Name }} tests</h1>
+<div>Total: {{ $.TestHTMLData | len }} tests</div>
+<table>
+    {{- range $testHTMLDataElem := $.TestHTMLData }}
+        {{- if $testHTMLDataElem.GitBlameLines }}
+            {{- range $index, $gitBlame := $testHTMLDataElem.GitBlameLines }}
+                <tr>
+                    {{ if (index $testHTMLDataElem.ElementsMatchingConfig $index) -}}
+                        <td class="date">{{ index $testHTMLDataElem.Age $index }}
+                            {{- if (index $testHTMLDataElem.Permalinks $index) -}}
+                                <a class="nounderline" title="{{ $gitBlame.CommitID }} by {{ $gitBlame.Author }}"
+                                   href="{{ index $testHTMLDataElem.Permalinks $index }}">🔗</a>
+                            {{- end }}</td>
+                    {{- else }}
+                        <td></td>{{ end }}
+                    <td
+                            {{- if (index $testHTMLDataElem.ElementsMatchingConfig $index) }} class="matchingLine"{{ end -}}
+                    ><a class="nounderline" href="{{ $testHTMLDataElem.RemoteURL }}#L{{ $gitBlame.LineNo }}"><span
+                                    class="code">{{ $gitBlame.Line }}</span></a></td>
+                </tr>{{ end -}}
+            <tr>
+                <td colspan="2">
+                    <hr/>
+                </td>
+            </tr>
+        {{ end -}}
     {{ end -}}
-{{ end -}}
-    </table>
-    <div style="text-align: right"><i>Last updated: {{ $.Date}}</i></div>
+</table>
+<div style="text-align: right"><i>Last updated: {{ $.Date}}</i></div>
 </body>
 </html>

--- a/robots/cmd/test-label-analyzer/cmd/stats.gohtml
+++ b/robots/cmd/test-label-analyzer/cmd/stats.gohtml
@@ -1,0 +1,65 @@
+{{- /*
+
+    This file is part of the KubeVirt project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Copyright 2023 Red Hat, Inc.
+
+*/ -}}
+
+{{- /* gotype: kubevirt.io/project-infra/robots/cmd/test-label-analyzer/cmd.StatsHTMLData */ -}}
+
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <style>
+        .date {
+            white-space: nowrap;
+        }
+        a.permalink {
+            text-decoration: none;
+        }
+        .matchingDate {
+            color: crimson;
+            font-weight: bold;
+        }
+        .matchingLine {
+            font-weight: bold;
+        }
+        .code {
+            font-family: monospace;
+            display: block;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+<body>
+    <h1>Overview of {{ (index $.Config.Categories 0).Name }} tests</h1>
+    <div>Total: {{ $.TestHTMLData | len }} tests</div>
+    <table>
+{{- range $testHTMLDataElem := $.TestHTMLData }}
+    {{- if $testHTMLDataElem.GitBlameLines }}
+        {{- range $index, $gitBlame := $testHTMLDataElem.GitBlameLines }}<tr>
+            {{ if (index $testHTMLDataElem.ElementsMatchingConfig $index) -}}
+                <td class="date matchingDate">{{ $gitBlame.Date.Format "2006-01-02" }}{{ if (index $testHTMLDataElem.Permalinks $index) }}<a class="permalink" title="{{ $gitBlame.CommitID }} by {{ $gitBlame.Author }}" href="{{ index $testHTMLDataElem.Permalinks $index }}">🔗</a>{{ end }}
+                </td>{{ else }}<td></td>{{ end }}
+            <td class="{{ if (index $testHTMLDataElem.ElementsMatchingConfig $index) }}matchingLine{{ end }}"><a href="{{ $testHTMLDataElem.RemoteURL }}#L{{ $gitBlame.LineNo }}"><span class="code">{{ $gitBlame.Line }}</span></a></td>
+        </tr>{{ end -}}
+        <tr><td colspan="2"><hr/></td></tr>
+    {{ end -}}
+{{ end -}}
+    </table>
+    <div style="text-align: right"><i>Last updated: {{ $.Date}}</i></div>
+</body>
+</html>

--- a/robots/cmd/test-label-analyzer/cmd/stats.gohtml
+++ b/robots/cmd/test-label-analyzer/cmd/stats.gohtml
@@ -48,14 +48,15 @@
 <div>Total: {{ $.TestHTMLData | len }} tests</div>
 <table>
     {{- range $testHTMLDataElem := $.TestHTMLData }}
+        <tr><td colspan="2"><a href="{{ $testHTMLDataElem.RemoteURL }}">{{ $testHTMLDataElem.RemoteURL }}</a></td></tr>
         {{- if $testHTMLDataElem.GitBlameLines }}
             {{- range $index, $gitBlame := $testHTMLDataElem.GitBlameLines }}
                 <tr>
                     {{ if (index $testHTMLDataElem.ElementsMatchingConfig $index) -}}
-                        <td class="date">{{ index $testHTMLDataElem.Age $index }}
+                        <td class="date">
                             {{- if (index $testHTMLDataElem.Permalinks $index) -}}
                                 <a class="nounderline" title="{{ $gitBlame.CommitID }} by {{ $gitBlame.Author }}"
-                                   href="{{ index $testHTMLDataElem.Permalinks $index }}">🔗</a>
+                                   href="{{ index $testHTMLDataElem.Permalinks $index }}">{{ index $testHTMLDataElem.Age $index }}</a>
                             {{- end }}</td>
                     {{- else }}
                         <td></td>{{ end }}

--- a/robots/cmd/test-label-analyzer/cmd/stats_test.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats_test.go
@@ -49,7 +49,7 @@ var _ = Describe("cmd/stats", func() {
 					Config: simpleQuarantineConfig,
 					TestStats: &test_label_analyzer.TestStats{
 						SpecsTotal: 2,
-						MatchingSpecPathes: []*test_label_analyzer.PathStats{
+						MatchingSpecPaths: []*test_label_analyzer.PathStats{
 							{
 								Lines: nil,
 								GitBlameLines: []*test_label_analyzer.GitBlameInfo{
@@ -76,7 +76,7 @@ var _ = Describe("cmd/stats", func() {
 					Config: simpleQuarantineConfig,
 					TestStats: &test_label_analyzer.TestStats{
 						SpecsTotal: 2,
-						MatchingSpecPathes: []*test_label_analyzer.PathStats{
+						MatchingSpecPaths: []*test_label_analyzer.PathStats{
 							{
 								Lines: nil,
 								GitBlameLines: []*test_label_analyzer.GitBlameInfo{

--- a/robots/cmd/test-label-analyzer/cmd/stats_test.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats_test.go
@@ -17,12 +17,19 @@
  *
  */
 
-package testdata
+package cmd
 
-import "github.com/onsi/ginkgo/v2"
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
-var _ = ginkgo.Describe("whatever", func() {
-	ginkgo.Context("i don't care", func() {
-		ginkgo.It("is so meh", func() {})
+var _ = Describe("", func() {
+	Context("", func() {
+		It("", func() {
+			outline, err := getGinkgoOutlineFromFile("testdata/simple_test.go")
+			Expect(err).To(BeNil())
+			Expect(outline).ToNot(BeNil())
+		})
 	})
 })

--- a/robots/cmd/test-label-analyzer/cmd/test_suite_test.go
+++ b/robots/cmd/test-label-analyzer/cmd/test_suite_test.go
@@ -17,12 +17,16 @@
  *
  */
 
-package testdata
+package cmd
 
-import "github.com/onsi/ginkgo/v2"
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
-var _ = ginkgo.Describe("whatever", func() {
-	ginkgo.Context("i don't care", func() {
-		ginkgo.It("is so meh", func() {})
-	})
-})
+	"testing"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cmd Main Suite")
+}

--- a/robots/cmd/test-label-analyzer/cmd/testdata/BUILD.bazel
+++ b/robots/cmd/test-label-analyzer/cmd/testdata/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["simple_test.go"],
+    deps = ["@com_github_onsi_ginkgo_v2//:go_default_library"],
+)

--- a/robots/cmd/test-label-analyzer/cmd/testdata/migration_test.go.ginkgooutline.json
+++ b/robots/cmd/test-label-analyzer/cmd/testdata/migration_test.go.ginkgooutline.json
@@ -1,0 +1,6721 @@
+[
+  {
+    "name": "Describe",
+    "text": "[rfe_id:393][crit:high][vendor:cnv-qe@redhat.com][level:system][sig-compute] VM Live Migration",
+    "start": 3327,
+    "end": 189895,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": [],
+    "nodes": [
+      {
+        "name": "BeforeEach",
+        "text": "",
+        "start": 7812,
+        "end": 7922,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "undefined",
+        "start": 9026,
+        "end": 9067,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "taining the node with `NoExecute`, the framework will reset the node's taints and un-schedulable properties on test teardown",
+        "start": 9965,
+        "end": 10095,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Retrieving the VMI post migration",
+        "start": 10301,
+        "end": 10340,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Verifying the VMI's migration mode",
+        "start": 10500,
+        "end": 10540,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "BeforeEach",
+        "text": "",
+        "start": 11167,
+        "end": 11230,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Retrieving the VMI post migration",
+        "start": 11328,
+        "end": 11367,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Verifying the VMI's migration state",
+        "start": 11527,
+        "end": 11568,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Verifying the VMI's is in the running state",
+        "start": 12196,
+        "end": 12245,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Waiting until the migration is completed",
+        "start": 12435,
+        "end": 12481,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Retrieving the VMI post migration",
+        "start": 13061,
+        "end": 13100,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Verifying the VMI's migration state",
+        "start": 13273,
+        "end": 13314,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Verifying the VMI's is in the running state",
+        "start": 14064,
+        "end": 14113,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Cancelling a Migration",
+        "start": 14317,
+        "end": 14345,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Cancelling a Migration with virtctl",
+        "start": 14541,
+        "end": 14582,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Starting a Migration",
+        "start": 14973,
+        "end": 14999,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Waiting until the Migration is Running",
+        "start": 15227,
+        "end": 15271,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Starting a Migration",
+        "start": 16161,
+        "end": 16187,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Waiting until the Migration is Running",
+        "start": 16415,
+        "end": 16459,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Starting a Migration",
+        "start": 16940,
+        "end": 16966,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Waiting until the Migration Completes",
+        "start": 17193,
+        "end": 17236,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Finding the prometheus endpoint",
+        "start": 17909,
+        "end": 17946,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Waiting until the Migration Completes",
+        "start": 18255,
+        "end": 18298,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Scraping the Prometheus endpoint",
+        "start": 18394,
+        "end": 18432,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Checking the collected metrics",
+        "start": 18504,
+        "end": 18540,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Run a stress test to dirty some pages and slow down the migration",
+        "start": 19426,
+        "end": 19497,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "By",
+        "text": "Expecting alert to be removed",
+        "start": 22164,
+        "end": 22199,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": null,
+        "nodes": []
+      },
+      {
+        "name": "Context",
+        "text": "with Headless service",
+        "start": 22476,
+        "end": 24788,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "AfterEach",
+            "text": "",
+            "start": 22549,
+            "end": 22777,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "It",
+            "text": "should remain to able resolve the VM IP",
+            "start": 22781,
+            "end": 24784,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting hello world in the VM",
+                "start": 23465,
+                "end": 23501,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Exposing headless service matching subdomain",
+                "start": 23564,
+                "end": 23614,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "undefined",
+                "start": 23907,
+                "end": 23914,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Executing a migration",
+                "start": 24433,
+                "end": 24460,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Describe",
+        "text": "Starting a VirtualMachineInstance ",
+        "start": 24790,
+        "end": 132827,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 24912,
+            "end": 25034,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Creating the VMI",
+            "start": 25102,
+            "end": 25124,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Checking that the VirtualMachineInstance console has expected output",
+            "start": 26161,
+            "end": 26235,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Running stress test to allow transition to post-copy",
+            "start": 26374,
+            "end": 26432,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Starting the Migration for iteration",
+            "start": 26558,
+            "end": 26600,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Checking VMI, confirm migration state",
+            "start": 26771,
+            "end": 26814,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Is agent connected after migration",
+            "start": 26915,
+            "end": 26955,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Checking that the migrated VirtualMachineInstance console has expected output",
+            "start": 27102,
+            "end": 27185,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Checking that the service account is mounted",
+            "start": 27294,
+            "end": 27344,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Deleting the VMI",
+            "start": 27581,
+            "end": 27603,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Waiting for VMI to disappear",
+            "start": 27746,
+            "end": 27780,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "Context",
+            "text": "with a bridge network interface",
+            "start": 27853,
+            "end": 29392,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:3226]should reject a migration of a vmi with a bridge interface",
+                "start": 27908,
+                "end": 29387,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 28493,
+                    "end": 28567,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 28826,
+                    "end": 28852,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 29114,
+                    "end": 29136,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 29281,
+                    "end": 29315,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] with bandwidth limitations",
+            "start": 29395,
+            "end": 31351,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Checking that the VirtualMachineInstance console has expected output",
+                "start": 29866,
+                "end": 29940,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "starting the migration",
+                "start": 30001,
+                "end": 30029,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6968]should apply them and result in different migration durations",
+                "start": 30787,
+                "end": 31346,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 30975,
+                    "end": 31016,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "with a Alpine disk",
+            "start": 31354,
+            "end": 50348,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:6969]should be successfully migrate with a tablet device",
+                "start": 31396,
+                "end": 32536,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 31709,
+                    "end": 31750,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 31804,
+                    "end": 31878,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 31937,
+                    "end": 31965,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 32263,
+                    "end": 32285,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 32430,
+                    "end": 32464,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "should be successfully migrate with a WriteBack disk cache",
+                "start": 32540,
+                "end": 33936,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 32775,
+                    "end": 32816,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 32870,
+                    "end": 32944,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 33003,
+                    "end": 33031,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking if requested cache 'writeback' has been set",
+                    "start": 33454,
+                    "end": 33512,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 33663,
+                    "end": 33685,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 33830,
+                    "end": 33864,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6970]should migrate vmi with cdroms on various bus types",
+                "start": 33941,
+                "end": 34919,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 34330,
+                    "end": 34371,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 34425,
+                    "end": 34499,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 34611,
+                    "end": 34639,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "should migrate vmi and use Live Migration method with read-only disks",
+                "start": 34924,
+                "end": 36433,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Defining a VMI with PVC disk and read-only CDRoms",
+                    "start": 35013,
+                    "end": 35068,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 35523,
+                    "end": 35564,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 35671,
+                    "end": 35699,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Ensuring migration is using Live Migration method",
+                    "start": 35979,
+                    "end": 36034,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6971]should migrate with a downwardMetrics disk",
+                "start": 36438,
+                "end": 37972,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 36825,
+                    "end": 36853,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking if the metrics are still updated after the migration",
+                    "start": 37091,
+                    "end": 37158,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking that the new nodename is reflected in the downward metrics",
+                    "start": 37658,
+                    "end": 37731,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6842]should migrate with TSC frequency set",
+                "start": 37977,
+                "end": 39572,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Checking the TSC frequency on the Domain XML",
+                    "start": 38584,
+                    "end": 38634,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 38938,
+                    "end": 38966,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking the TSC frequency on the Domain XML on the new node",
+                    "start": 39204,
+                    "end": 39270,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:4113]should be successfully migrate with cloud-init disk with devices on the root bus",
+                "start": 39577,
+                "end": 41233,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 39878,
+                    "end": 39919,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 39973,
+                    "end": 40047,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 40159,
+                    "end": 40187,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking that we really migrated a VMI with only the root bus",
+                    "start": 40467,
+                    "end": 40534,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 40960,
+                    "end": 40982,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 41127,
+                    "end": 41161,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "should migrate vmi with a usb disk",
+                "start": 41238,
+                "end": 42144,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 41555,
+                    "end": 41596,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 41650,
+                    "end": 41724,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 41836,
+                    "end": 41864,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:1783]should be successfully migrated multiple times with cloud-init disk",
+                "start": 42149,
+                "end": 43924,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 42344,
+                    "end": 42385,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 42439,
+                    "end": 42513,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "undefined",
+                    "start": 42672,
+                    "end": 42733,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Check if Migrated VMI has updated IP and IPs fields",
+                    "start": 43086,
+                    "end": 43143,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 43650,
+                    "end": 43672,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 43817,
+                    "end": 43851,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:4746]should migrate even if virtqemud has restarted at some point.",
+                "start": 44361,
+                "end": 46612,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 44550,
+                    "end": 44591,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 44645,
+                    "end": 44719,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "undefined",
+                    "start": 45195,
+                    "end": 45248,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "undefined",
+                    "start": 45999,
+                    "end": 46040,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 46338,
+                    "end": 46360,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 46505,
+                    "end": 46539,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6972]should migrate to a persistent (non-transient) libvirt domain.",
+                "start": 46617,
+                "end": 48056,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 46807,
+                    "end": 46848,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 46902,
+                    "end": 46976,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "undefined",
+                    "start": 47088,
+                    "end": 47129,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 47782,
+                    "end": 47804,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 47949,
+                    "end": 47983,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6973]should be able to successfully migrate with a paused vmi",
+                "start": 48060,
+                "end": 50343,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 48244,
+                    "end": 48285,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 48339,
+                    "end": 48413,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Pausing the VirtualMachineInstance",
+                    "start": 48472,
+                    "end": 48512,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "verifying that the vmi is still paused before migration",
+                    "start": 48764,
+                    "end": 48825,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting the migration",
+                    "start": 49072,
+                    "end": 49100,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "verifying that the vmi is still paused after migration",
+                    "start": 49380,
+                    "end": 49440,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "verify that VMI can be unpaused after migration",
+                    "start": 49684,
+                    "end": 49737,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "verifying that the vmi is running",
+                    "start": 50075,
+                    "end": 50114,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "with an pending target pod",
+            "start": 50352,
+            "end": 56135,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 50431,
+                "end": 50669,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "should automatically cancel unschedulable migration after a timeout period",
+                "start": 50674,
+                "end": 53416,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 51059,
+                    "end": 51100,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 51206,
+                    "end": 51234,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Should receive warning event that target pod is currently unschedulable",
+                    "start": 51688,
+                    "end": 51765,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Migration should observe a timeout period before canceling unschedulable target pod",
+                    "start": 52025,
+                    "end": 52114,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Migration should fail eventually due to pending target pod timeout",
+                    "start": 52567,
+                    "end": 52639,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 53143,
+                    "end": 53165,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 53310,
+                    "end": 53344,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "should automatically cancel pending target pod after a catch all timeout period",
+                "start": 53421,
+                "end": 56130,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 53669,
+                    "end": 53710,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 53816,
+                    "end": 53844,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 54440,
+                    "end": 54466,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Migration should observe a timeout period before canceling pending target pod",
+                    "start": 54745,
+                    "end": 54828,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Migration should fail eventually due to pending target pod timeout",
+                    "start": 55281,
+                    "end": 55353,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 55857,
+                    "end": 55879,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 56024,
+                    "end": 56058,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] with auto converge enabled",
+            "start": 56138,
+            "end": 57838,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 56205,
+                "end": 56445,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:3237]should complete a migration",
+                "start": 56450,
+                "end": 57833,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 56660,
+                    "end": 56701,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 56981,
+                    "end": 57055,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 57234,
+                    "end": 57262,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 57560,
+                    "end": 57582,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 57727,
+                    "end": 57761,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "with setting guest time",
+            "start": 57841,
+            "end": 60123,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:4114]should set an updated time after a migration",
+                "start": 57888,
+                "end": 60118,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 58159,
+                    "end": 58200,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 58254,
+                    "end": 58328,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Set wrong time on the guest",
+                    "start": 58613,
+                    "end": 58646,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 58910,
+                    "end": 58938,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the migrated VirtualMachineInstance has an updated time",
+                    "start": 59361,
+                    "end": 59436,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for the agent to set the right time",
+                    "start": 59548,
+                    "end": 59597,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the guest has an updated time",
+                    "start": 59858,
+                    "end": 59907,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "with an Alpine DataVolume",
+            "start": 60127,
+            "end": 65803,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 60176,
+                "end": 60296,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:3239]should reject a migration of a vmi with a non-shared data volume",
+                "start": 60301,
+                "end": 62297,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 61350,
+                    "end": 61424,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 61695,
+                    "end": 61721,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 61979,
+                    "end": 62001,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 62146,
+                    "end": 62180,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:1479][storage-req] should migrate a vmi with a shared block disk",
+                "start": 62301,
+                "end": 63426,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 62601,
+                    "end": 62642,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 62696,
+                    "end": 62770,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 62829,
+                    "end": 62855,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 63153,
+                    "end": 63175,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 63320,
+                    "end": 63354,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6974]should reject additional migrations on the same VMI if the first one is not finished",
+                "start": 63430,
+                "end": 65798,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 63697,
+                    "end": 63738,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 64017,
+                    "end": 64091,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Stressing the VMI",
+                    "start": 64245,
+                    "end": 64268,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a first migration",
+                    "start": 64322,
+                    "end": 64354,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting 10 more migrations expecting all to fail to create",
+                    "start": 64726,
+                    "end": 64791,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 65525,
+                    "end": 65547,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 65692,
+                    "end": 65726,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[storage-req]with an Alpine shared block volume PVC",
+            "start": 65806,
+            "end": 68324,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:1854]should migrate a VMI with shared and non-shared disks",
+                "start": 65905,
+                "end": 67192,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 66367,
+                    "end": 66408,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 66462,
+                    "end": 66536,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 66595,
+                    "end": 66621,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 66919,
+                    "end": 66941,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 67086,
+                    "end": 67120,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[release-blocker][test_id:1377]should be successfully migrated multiple times",
+                "start": 67196,
+                "end": 68319,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 67587,
+                    "end": 67661,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 68046,
+                    "end": 68068,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 68213,
+                    "end": 68247,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[storage-req]with an Alpine shared block volume PVC",
+            "start": 68327,
+            "end": 69871,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:3240]should be successfully with a cloud init",
+                "start": 68426,
+                "end": 69866,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 68933,
+                    "end": 69007,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that MigrationMethod is set to BlockMigration",
+                    "start": 69066,
+                    "end": 69126,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration for iteration",
+                    "start": 69253,
+                    "end": 69295,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 69593,
+                    "end": 69615,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 69760,
+                    "end": 69794,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "with a Fedora shared NFS PVC (using nfs ipv4 address), cloud init and service account",
+            "start": 69874,
+            "end": 72300,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 70700,
+                "end": 70902,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "AfterEach",
+                "text": "",
+                "start": 70907,
+                "end": 70968,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:2653] should be migrated successfully, using guest agent on VM with default migration configuration",
+                "start": 70973,
+                "end": 71225,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Creating the DV",
+                    "start": 71101,
+                    "end": 71122,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6975] should have guest agent functional after migration",
+                "start": 71230,
+                "end": 72295,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Creating the DV",
+                    "start": 71315,
+                    "end": 71336,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Creating the VMI",
+                    "start": 71387,
+                    "end": 71409,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking guest agent",
+                    "start": 71733,
+                    "end": 71759,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration for iteration",
+                    "start": 71908,
+                    "end": 71950,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Agent stays connected",
+                    "start": 72117,
+                    "end": 72144,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "By",
+            "text": "waiting for the dv import to pvc to finish",
+            "start": 73435,
+            "end": 73483,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] migration to nonroot",
+            "start": 73626,
+            "end": 76876,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 73761,
+                "end": 73917,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "AfterEach",
+                "text": "",
+                "start": 73921,
+                "end": 74118,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "DescribeTable",
+                "text": "should migrate root implementation to nonroot",
+                "start": 74123,
+                "end": 76871,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Create a VMI that will run root(default)",
+                    "start": 74292,
+                    "end": 74338,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 74367,
+                    "end": 74408,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 74540,
+                    "end": 74614,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the launcher is running as root",
+                    "start": 74661,
+                    "end": 74712,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting new migration and waiting for it to succeed",
+                    "start": 74819,
+                    "end": 74877,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying Second Migration Succeeeds",
+                    "start": 75032,
+                    "end": 75074,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the launcher is running as qemu",
+                    "start": 75142,
+                    "end": 75193,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 75254,
+                    "end": 75328,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 75520,
+                    "end": 75542,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 75687,
+                    "end": 75721,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[test_id:8609] with simple VMI",
+                    "start": 75799,
+                    "end": 76059,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[test_id:8610] with DataVolume",
+                    "start": 76066,
+                    "end": 76345,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[test_id:8611] with CD + CloudInit + SA + ConfigMap + Secret + DownwardAPI + Kernel Boot",
+                    "start": 76352,
+                    "end": 76589,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[test_id:8612] with PVC",
+                    "start": 76596,
+                    "end": 76865,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] migration to root",
+            "start": 76879,
+            "end": 80239,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 77011,
+                "end": 77167,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "AfterEach",
+                "text": "",
+                "start": 77171,
+                "end": 77407,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "DescribeTable",
+                "text": "should migrate nonroot implementation to root",
+                "start": 77412,
+                "end": 80234,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Create a VMI that will run root(default)",
+                    "start": 77581,
+                    "end": 77627,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 77788,
+                    "end": 77829,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 77961,
+                    "end": 78035,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the launcher is running as root",
+                    "start": 78082,
+                    "end": 78133,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting new migration and waiting for it to succeed",
+                    "start": 78241,
+                    "end": 78299,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying Second Migration Succeeeds",
+                    "start": 78454,
+                    "end": 78496,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the launcher is running as qemu",
+                    "start": 78564,
+                    "end": 78615,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 78674,
+                    "end": 78748,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 78943,
+                    "end": 78965,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 79110,
+                    "end": 79144,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "with simple VMI",
+                    "start": 79222,
+                    "end": 79467,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "with DataVolume",
+                    "start": 79474,
+                    "end": 79738,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "with CD + CloudInit + SA + ConfigMap + Secret + DownwardAPI + Kernel Boot",
+                    "start": 79745,
+                    "end": 79967,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "with PVC",
+                    "start": 79974,
+                    "end": 80228,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "migration security",
+            "start": 80242,
+            "end": 88257,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "Context",
+                "text": "[Serial] with TLS disabled",
+                "start": 80284,
+                "end": 84621,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "It",
+                    "text": "[test_id:6976] should be successfully migrated",
+                    "start": 80343,
+                    "end": 81492,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 80651,
+                        "end": 80692,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Checking that the VirtualMachineInstance console has expected output",
+                        "start": 80748,
+                        "end": 80822,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "starting the migration",
+                        "start": 80883,
+                        "end": 80911,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Deleting the VMI",
+                        "start": 81215,
+                        "end": 81237,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Waiting for VMI to disappear",
+                        "start": 81384,
+                        "end": 81418,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:6977]should not secure migrations with TLS",
+                    "start": 81498,
+                    "end": 84615,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 81968,
+                        "end": 82009,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the Migration",
+                        "start": 82481,
+                        "end": 82509,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Waiting for the proxy connection details to appear",
+                        "start": 82713,
+                        "end": 82769,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "checking if we fail to connect with our own cert",
+                        "start": 83338,
+                        "end": 83392,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "checking that we were never able to connect",
+                        "start": 84394,
+                        "end": 84443,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "text": "with TLS enabled",
+                "start": 84625,
+                "end": 88252,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "BeforeEach",
+                    "text": "",
+                    "start": 84666,
+                    "end": 84923,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:2303][posneg:negative] should secure migrations with TLS",
+                    "start": 84929,
+                    "end": 88246,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Limiting the bandwidth of migrations in the test namespace",
+                        "start": 85166,
+                        "end": 85230,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 85362,
+                        "end": 85403,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the Migration",
+                        "start": 85807,
+                        "end": 85835,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Waiting for the proxy connection details to appear",
+                        "start": 86078,
+                        "end": 86134,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "checking if we fail to connect with our own cert",
+                        "start": 86703,
+                        "end": 86757,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "checking that we were never able to connect",
+                        "start": 87854,
+                        "end": 87903,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] migration postcopy",
+            "start": 88261,
+            "end": 91292,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 88349,
+                "end": 89532,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Allowing post-copy and limit migration bandwidth",
+                    "start": 88521,
+                    "end": 88575,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "AfterEach",
+                "text": "",
+                "start": 89537,
+                "end": 89598,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:5004] should be migrated successfully, using guest agent on VM with postcopy",
+                "start": 89603,
+                "end": 89763,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:4747] should migrate using cluster level config for postcopy",
+                "start": 89768,
+                "end": 91287,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 90085,
+                    "end": 90126,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 90180,
+                    "end": 90254,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 90656,
+                    "end": 90684,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 91014,
+                    "end": 91036,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 91181,
+                    "end": 91215,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] migration monitor",
+            "start": 91296,
+            "end": 109192,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "AfterEach",
+                "text": "",
+                "start": 91382,
+                "end": 91793,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 91797,
+                "end": 92177,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "PIt",
+                "text": "[test_id:2227] should abort a vmi migration without progress",
+                "start": 92181,
+                "end": 93528,
+                "spec": true,
+                "focused": false,
+                "pending": true,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 92404,
+                    "end": 92445,
+                    "spec": false,
+                    "focused": false,
+                    "pending": true,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 92499,
+                    "end": 92573,
+                    "spec": false,
+                    "focused": false,
+                    "pending": true,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 92975,
+                    "end": 93003,
+                    "spec": false,
+                    "focused": false,
+                    "pending": true,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 93255,
+                    "end": 93277,
+                    "spec": false,
+                    "focused": false,
+                    "pending": true,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 93422,
+                    "end": 93456,
+                    "spec": false,
+                    "focused": false,
+                    "pending": true,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6978] Should detect a failed migration",
+                "start": 93533,
+                "end": 97619,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 93742,
+                    "end": 93783,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 93837,
+                    "end": 93911,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting our migration killer pods",
+                    "start": 94311,
+                    "end": 94351,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 95385,
+                    "end": 95413,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Removing our migration killer pods",
+                    "start": 95647,
+                    "end": 95687,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for virt-handler to come back online",
+                    "start": 96454,
+                    "end": 96504,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting new migration and waiting for it to succeed",
+                    "start": 97006,
+                    "end": 97064,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying Second Migration Succeeeds",
+                    "start": 97218,
+                    "end": 97260,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 97346,
+                    "end": 97368,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 97513,
+                    "end": 97547,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "old finalized migrations should get garbage collected",
+                "start": 97624,
+                "end": 99722,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 98012,
+                    "end": 98053,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 98192,
+                    "end": 98220,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 99449,
+                    "end": 99471,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 99616,
+                    "end": 99650,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6979]Target pod should exit after failed migration",
+                "start": 99727,
+                "end": 101526,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 100121,
+                    "end": 100162,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 100269,
+                    "end": 100297,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 101253,
+                    "end": 101275,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 101420,
+                    "end": 101454,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:6980]Migration should fail if target pod fails during target preparation",
+                "start": 101531,
+                "end": 104650,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 101953,
+                    "end": 101994,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 102075,
+                    "end": 102103,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for Migration to reach Preparing Target Phase",
+                    "start": 102342,
+                    "end": 102401,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Killing the target pod and expecting failure",
+                    "start": 102819,
+                    "end": 102869,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Expecting VMI migration failure",
+                    "start": 103332,
+                    "end": 103369,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 104377,
+                    "end": 104399,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 104544,
+                    "end": 104578,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "Migration should generate empty isos of the right size on the target",
+                "start": 104654,
+                "end": 109187,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Creating a VMI with cloud-init and config maps",
+                    "start": 104742,
+                    "end": 104794,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 106006,
+                    "end": 106047,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 106128,
+                    "end": 106156,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for Migration to reach Preparing Target Phase",
+                    "start": 106395,
+                    "end": 106454,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Sanity checking the volume status size and the actual virt-launcher file",
+                    "start": 107151,
+                    "end": 107229,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 108914,
+                    "end": 108936,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 109081,
+                    "end": 109115,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[storage-req]with an Alpine non-shared block volume PVC",
+            "start": 109195,
+            "end": 110639,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:1862][posneg:negative]should reject migrations for a non-migratable vmi",
+                "start": 109298,
+                "end": 110634,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 109748,
+                    "end": 109822,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 110085,
+                    "end": 110111,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 110361,
+                    "end": 110383,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 110528,
+                    "end": 110562,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "live migration cancelation",
+            "start": 110643,
+            "end": 121828,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "DescribeTable",
+                "text": "should be able to cancel a migration",
+                "start": 112005,
+                "end": 113726,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Limiting the bandwidth of migrations in the test namespace",
+                    "start": 112254,
+                    "end": 112318,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 112448,
+                    "end": 112489,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 112543,
+                    "end": 112571,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for the migration object to disappear",
+                    "start": 112829,
+                    "end": 112880,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 112971,
+                    "end": 112993,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-storage][test_id:2226] with ContainerDisk",
+                    "start": 113143,
+                    "end": 113255,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-storage][storage-req][test_id:2731] with RWX block disk from block volume PVC",
+                    "start": 113261,
+                    "end": 113431,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-storage][test_id:2228] with ContainerDisk and virtctl",
+                    "start": 113437,
+                    "end": 113560,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-storage][storage-req][test_id:2732] with RWX block disk and virtctl",
+                    "start": 113566,
+                    "end": 113725,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "DescribeTable",
+                "text": "Immediate migration cancellation after migration starts running",
+                "start": 113731,
+                "end": 115220,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Limiting the bandwidth of migrations in the test namespace",
+                    "start": 113991,
+                    "end": 114055,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 114185,
+                    "end": 114226,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 114333,
+                    "end": 114361,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for the migration object to disappear",
+                    "start": 114630,
+                    "end": 114681,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 114772,
+                    "end": 114794,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 114939,
+                    "end": 114973,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-compute][test_id:3241]cancel a migration by deleting vmim object",
+                    "start": 115050,
+                    "end": 115135,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-compute][test_id:8583]cancel a migration with virtctl",
+                    "start": 115141,
+                    "end": 115214,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "DescribeTable",
+                "text": "Immediate migration cancellation before migration starts running",
+                "start": 115225,
+                "end": 117762,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Limiting the bandwidth of migrations in the test namespace",
+                    "start": 115486,
+                    "end": 115550,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 115680,
+                    "end": 115721,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 115871,
+                    "end": 115899,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting a Migration",
+                    "start": 115972,
+                    "end": 115998,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting until the Migration has UID",
+                    "start": 116260,
+                    "end": 116301,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Cancelling migration",
+                    "start": 116583,
+                    "end": 116609,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for the migration object to disappear",
+                    "start": 116670,
+                    "end": 116721,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Retrieving the VMI post migration",
+                    "start": 116794,
+                    "end": 116833,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying the VMI's migration state",
+                    "start": 116999,
+                    "end": 117040,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying the VMI's is in the running state and on original node",
+                    "start": 117096,
+                    "end": 117166,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Deleting the VMI",
+                    "start": 117314,
+                    "end": 117336,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting for VMI to disappear",
+                    "start": 117481,
+                    "end": 117515,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-compute][test_id:8584]cancel a migration by deleting vmim object",
+                    "start": 117592,
+                    "end": 117677,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "[sig-compute][test_id:8585]cancel a migration with virtctl",
+                    "start": 117683,
+                    "end": 117756,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "text": "[Serial]when target pod cannot be scheduled and is suck in Pending phase",
+                "start": 117767,
+                "end": 121822,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "BeforeEach",
+                    "text": "",
+                    "start": 117913,
+                    "end": 118412,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Keeping only one schedulable node",
+                        "start": 117938,
+                        "end": 117977,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "AfterEach",
+                    "text": "",
+                    "start": 118418,
+                    "end": 118626,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Restoring nodes to be schedulable",
+                        "start": 118442,
+                        "end": 118481,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "should be able to properly abort migration",
+                    "start": 118632,
+                    "end": 121815,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Starting a VirtualMachineInstance",
+                        "start": 118695,
+                        "end": 118734,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Trying to migrate VM and expect for the migration to get stuck",
+                        "start": 118823,
+                        "end": 118891,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Finding VMI's pod and expecting one to be running and the other to be pending",
+                        "start": 119566,
+                        "end": 119649,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Aborting the migration",
+                        "start": 120517,
+                        "end": 120545,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Expecting migration to be deleted",
+                        "start": 120718,
+                        "end": 120757,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Making sure source pod is still running",
+                        "start": 121056,
+                        "end": 121101,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Making sure the VMI's migration state remains nil",
+                        "start": 121346,
+                        "end": 121401,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "with a host-model cpu",
+            "start": 121832,
+            "end": 130647,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[test_id:6981]should migrate only to nodes supporting right cpu model",
+                "start": 123390,
+                "end": 125774,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Creating a VMI with default CPU mode to land in source node",
+                    "start": 123846,
+                    "end": 123911,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Making sure the vmi start running on the source node and will be able to run only in source/target nodes",
+                    "start": 123978,
+                    "end": 124088,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 124312,
+                    "end": 124353,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Fetching original host CPU model & supported CPU features",
+                    "start": 124476,
+                    "end": 124539,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the migration and expecting it to end successfully",
+                    "start": 124819,
+                    "end": 124884,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Ensuring that target pod has correct nodeSelector label",
+                    "start": 125051,
+                    "end": 125112,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Ensuring that target node has correct CPU mode & features",
+                    "start": 125364,
+                    "end": 125427,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "text": "[Serial]Should trigger event if vmi with host-model start on source node with uniq host-model",
+                "start": 125779,
+                "end": 128144,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "BeforeEach",
+                    "text": "",
+                    "start": 126039,
+                    "end": 126566,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Creating a VMI with default CPU mode",
+                        "start": 126064,
+                        "end": 126106,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 126219,
+                        "end": 126260,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Saving the original node's state",
+                        "start": 126316,
+                        "end": 126354,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "AfterEach",
+                    "text": "",
+                    "start": 126572,
+                    "end": 126897,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Resuming node labeller",
+                        "start": 126596,
+                        "end": 126624,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:7505]when no node is suited for host model",
+                    "start": 126903,
+                    "end": 128137,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Changing node labels to support fake host model",
+                        "start": 126975,
+                        "end": 127028,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the migration",
+                        "start": 127691,
+                        "end": 127719,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Expecting for an alert to be triggered",
+                        "start": 127845,
+                        "end": 127889,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "text": "[Serial]Should trigger event if the nodes doesn't contain MigrationSelectorLabel for the vmi host-model type",
+                "start": 128149,
+                "end": 130641,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "BeforeEach",
+                    "text": "",
+                    "start": 128358,
+                    "end": 129030,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Creating a VMI with default CPU mode",
+                        "start": 128598,
+                        "end": 128640,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 128753,
+                        "end": 128794,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "AfterEach",
+                    "text": "",
+                    "start": 129036,
+                    "end": 129637,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Restore node to its original state",
+                        "start": 129060,
+                        "end": 129100,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "no node contain suited SupportedHostModelMigrationCPU label",
+                    "start": 129643,
+                    "end": 130634,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Changing node labels to support fake host model",
+                        "start": 129723,
+                        "end": 129776,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the migration",
+                        "start": 130202,
+                        "end": 130230,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Expecting for an alert to be triggered",
+                        "start": 130356,
+                        "end": 130400,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial] with migration policies",
+            "start": 130651,
+            "end": 132823,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Verifying the VMI's configuration source",
+                "start": 130811,
+                "end": 130857,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "DescribeTable",
+                "text": "migration policy",
+                "start": 131145,
+                "end": 132817,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Updating config to allow auto converge",
+                    "start": 131218,
+                    "end": 131262,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Creating a migration policy that overrides cluster policy",
+                    "start": 131584,
+                    "end": 131647,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 131950,
+                    "end": 131991,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 132045,
+                    "end": 132073,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Retrieving the VMI post migration",
+                    "start": 132333,
+                    "end": 132372,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "should override cluster-wide policy if defined",
+                    "start": 132676,
+                    "end": 132737,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  },
+                  {
+                    "name": "Entry",
+                    "text": "should not affect cluster-wide policy if not defined",
+                    "start": 132743,
+                    "end": 132811,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "with sata disks",
+        "start": 132830,
+        "end": 133907,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "It",
+            "text": "[test_id:1853]VM with containerDisk + CloudInit + ServiceAccount + ConfigMap + Secret + DownwardAPI + External Kernel Boot + USB Disk",
+            "start": 132869,
+            "end": 133903,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting the Migration",
+                "start": 133314,
+                "end": 133342,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Deleting the VMI",
+                "start": 133634,
+                "end": 133656,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Waiting for VMI to disappear",
+                "start": 133799,
+                "end": 133833,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "with a live-migrate eviction strategy set",
+        "start": 133910,
+        "end": 155353,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "Context",
+            "text": "[ref_id:2293] with a VMI running with an eviction strategy set",
+            "start": 133974,
+            "end": 152061,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "BeforeEach",
+                "text": "",
+                "start": 134100,
+                "end": 134167,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "[test_id:3242]should block the eviction api and migrate",
+                "start": 134172,
+                "end": 135645,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Ensuring the VMI has migrated and lives on another node",
+                    "start": 134623,
+                    "end": 134684,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[sig-compute][test_id:3243]should recreate the PDB if VMIs with similar names are recreated",
+                "start": 135650,
+                "end": 137176,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "creating the VMI",
+                    "start": 135791,
+                    "end": 135813,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking that the PDB appeared",
+                    "start": 135957,
+                    "end": 135993,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "waiting for VMI",
+                    "start": 136309,
+                    "end": 136330,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "deleting the VMI",
+                    "start": 136396,
+                    "end": 136418,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking that the PDB disappeared",
+                    "start": 136564,
+                    "end": 136603,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller",
+                "start": 137181,
+                "end": 138599,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "creating the VMI",
+                    "start": 137280,
+                    "end": 137302,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "waiting for VMI",
+                    "start": 137451,
+                    "end": 137472,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Adding a fake old virt-controller PDB",
+                    "start": 137543,
+                    "end": 137586,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking that the PDB disappeared",
+                    "start": 138298,
+                    "end": 138337,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "It",
+                "text": "[test_id:3244]should block the eviction api while a slow migration is in progress",
+                "start": 138604,
+                "end": 141666,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting the VirtualMachineInstance",
+                    "start": 138748,
+                    "end": 138789,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that the VirtualMachineInstance console has expected output",
+                    "start": 138843,
+                    "end": 138917,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Starting the Migration",
+                    "start": 139240,
+                    "end": 139268,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Waiting until we have two available pods",
+                    "start": 139502,
+                    "end": 139548,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying at least once that both pods are protected",
+                    "start": 140056,
+                    "end": 140114,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Verifying that both pods are protected by the PodDisruptionBudget for the whole migration",
+                    "start": 140425,
+                    "end": 140520,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "text": "[Serial] with node tainted during node drain",
+                "start": 141671,
+                "end": 152056,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "BeforeEach",
+                    "text": "",
+                    "start": 141748,
+                    "end": 142235,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "AfterEach",
+                    "text": "",
+                    "start": 142241,
+                    "end": 142307,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:6982]should migrate a VMI only one time",
+                    "start": 142313,
+                    "end": 144241,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 142521,
+                        "end": 142562,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:2221] should migrate a VMI under load to another node",
+                    "start": 144247,
+                    "end": 145884,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 144469,
+                        "end": 144510,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Checking that the VirtualMachineInstance console has expected output",
+                        "start": 144566,
+                        "end": 144640,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:2222] should migrate a VMI when custom taint key is configured",
+                    "start": 145890,
+                    "end": 147249,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Configuring a custom nodeDrainTaintKey in kubevirt configuration",
+                        "start": 146121,
+                        "end": 146191,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance",
+                        "start": 146377,
+                        "end": 146418,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  },
+                  {
+                    "name": "It",
+                    "text": "[test_id:2224] should handle mixture of VMs with different eviction strategies.",
+                    "start": 147255,
+                    "end": 152050,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Starting the VirtualMachineInstance with eviction set to live migration",
+                        "start": 148681,
+                        "end": 148758,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Verifying all VMIs are collcated on the same node",
+                        "start": 150031,
+                        "end": 150086,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      },
+                      {
+                        "name": "By",
+                        "text": "Verify expected vmis migrated after node drain completes",
+                        "start": 150427,
+                        "end": 150489,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "[Serial]with multiple VMIs with eviction policies set",
+            "start": 152064,
+            "end": 155348,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node",
+                "start": 152150,
+                "end": 155343,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "selecting a node as the source",
+                    "start": 152522,
+                    "end": 152558,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "starting four VMIs on that node",
+                    "start": 152738,
+                    "end": 152775,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "waiting until the VMIs are ready",
+                    "start": 152955,
+                    "end": 152993,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "selecting a node as the target",
+                    "start": 153096,
+                    "end": 153132,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "tainting the source node as non-schedulabele",
+                    "start": 153312,
+                    "end": 153362,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "waiting until migration kicks in",
+                    "start": 153459,
+                    "end": 153497,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "checking that all VMIs were migrated, and we never see more than two running migrations in parallel",
+                    "start": 153874,
+                    "end": 153979,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Checking that all migrated VMIs have the new pod IP address on VMI status",
+                    "start": 154727,
+                    "end": 154806,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "[test_id:8482] Migration Metrics",
+        "start": 155356,
+        "end": 156471,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "It",
+            "text": "exposed to prometheus during VM migration",
+            "start": 155411,
+            "end": 156467,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Limiting the bandwidth of migrations in the test namespace",
+                "start": 155618,
+                "end": 155682,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the VirtualMachineInstance",
+                "start": 155810,
+                "end": 155851,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Checking that the VirtualMachineInstance console has expected output",
+                "start": 155903,
+                "end": 155977,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the Migration",
+                "start": 156310,
+                "end": 156338,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Describe",
+        "text": "[Serial] with a cluster-wide live-migrate eviction strategy set",
+        "start": 156474,
+        "end": 159336,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 156600,
+            "end": 156875,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "AfterEach",
+            "text": "",
+            "start": 156879,
+            "end": 156975,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "Context",
+            "text": "with a VMI running",
+            "start": 156979,
+            "end": 159332,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "Context",
+                "text": "with no eviction strategy set",
+                "start": 157021,
+                "end": 158691,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "It",
+                    "text": "should block the eviction api and migrate",
+                    "start": 157075,
+                    "end": 158685,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": [
+                      {
+                        "name": "By",
+                        "text": "Ensuring the VMI has migrated and lives on another node",
+                        "start": 157643,
+                        "end": 157704,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": null,
+                        "nodes": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "Context",
+                "text": "with eviction strategy set to 'None'",
+                "start": 158696,
+                "end": 159327,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "It",
+                    "text": "The VMI should get evicted",
+                    "start": 158757,
+                    "end": 159321,
+                    "spec": true,
+                    "focused": false,
+                    "pending": false,
+                    "labels": [],
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "[Serial] With Huge Pages",
+        "start": 159339,
+        "end": 161892,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 159441,
+            "end": 159564,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "DescribeTable",
+            "text": "should consume hugepages ",
+            "start": 159568,
+            "end": 161888,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting hugepages VMI",
+                "start": 160896,
+                "end": 160924,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "starting the migration",
+                "start": 161130,
+                "end": 161158,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Deleting the VMI",
+                "start": 161477,
+                "end": 161499,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Waiting for VMI to disappear",
+                "start": 161660,
+                "end": 161694,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "Entry",
+                "text": "[test_id:6983]hugepages-2Mi",
+                "start": 161777,
+                "end": 161828,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": []
+              },
+              {
+                "name": "Entry",
+                "text": "[test_id:6984]hugepages-1Gi",
+                "start": 161833,
+                "end": 161883,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "[Serial] with CPU pinning and huge pages",
+        "start": 161895,
+        "end": 164100,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "It",
+            "text": "should not make migrations fail",
+            "start": 161966,
+            "end": 162915,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting a VirtualMachineInstance",
+                "start": 162489,
+                "end": 162528,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Performing a migration",
+                "start": 162721,
+                "end": 162749,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "Context",
+            "text": "and NUMA passthrough",
+            "start": 162918,
+            "end": 164096,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "should not make migrations fail",
+                "start": 162962,
+                "end": 164091,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                  {
+                    "name": "By",
+                    "text": "Starting a VirtualMachineInstance",
+                    "start": 163658,
+                    "end": 163697,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  },
+                  {
+                    "name": "By",
+                    "text": "Performing a migration",
+                    "start": 163894,
+                    "end": 163922,
+                    "spec": false,
+                    "focused": false,
+                    "pending": false,
+                    "labels": null,
+                    "nodes": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "It",
+        "text": "should replace containerdisk and kernel boot images with their reproducible digest during migration",
+        "start": 164103,
+        "end": 166569,
+        "spec": true,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "By",
+            "text": "Starting a VirtualMachineInstance",
+            "start": 164387,
+            "end": 164426,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Verifying that all relevant images are without the digest on the source",
+            "start": 164676,
+            "end": 164753,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Collecting digest information from the container statuses",
+            "start": 165171,
+            "end": 165234,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Performing a migration",
+            "start": 165591,
+            "end": 165619,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Verifying that all imageIDs are in a reproducible form on the target",
+            "start": 165776,
+            "end": 165850,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "[Serial]Testing host-model cpuModel edge cases in the cluster if the cluster is host-model migratable",
+        "start": 166571,
+        "end": 172565,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 166907,
+            "end": 167137,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "AfterEach",
+            "text": "",
+            "start": 167141,
+            "end": 167589,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Resuming node labeller",
+                "start": 167163,
+                "end": 167191,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Validating that fake labels are being removed",
+                "start": 167260,
+                "end": 167311,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "It",
+            "text": "Should be able to migrate back to the initial node from target node with host-model even if target is newer than source",
+            "start": 167593,
+            "end": 170503,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Creating a VMI with default CPU mode to land in source node",
+                "start": 167967,
+                "end": 168032,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Making sure the vmi start running on the source node and will be able to run only in source/target nodes",
+                "start": 168106,
+                "end": 168216,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the VirtualMachineInstance",
+                "start": 168442,
+                "end": 168483,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the Migration to target node(with the amazing feature",
+                "start": 168733,
+                "end": 168801,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Fetching virt-launcher pod",
+                "start": 169344,
+                "end": 169376,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the Migration to return to the source node",
+                "start": 169651,
+                "end": 169708,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Fetching virt-launcher pod",
+                "start": 170124,
+                "end": 170156,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "It",
+            "text": "vmi with host-model should be able to migrate to node that support the initial node's host-model even if this model isn't the target's host-model",
+            "start": 170507,
+            "end": 172561,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Creating a VMI with default CPU mode to land in source node",
+                "start": 171225,
+                "end": 171290,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Making sure the vmi start running on the source node and will be able to run only in source/target nodes",
+                "start": 171364,
+                "end": 171474,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the VirtualMachineInstance",
+                "start": 171700,
+                "end": 171741,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Starting the Migration to target node(with the amazing feature",
+                "start": 171991,
+                "end": 172059,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "with dedicated CPUs",
+        "start": 172568,
+        "end": 180579,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 175170,
+            "end": 177521,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": [
+              {
+                "name": "By",
+                "text": "getting the list of worker nodes that have cpumanager enabled",
+                "start": 175600,
+                "end": 175667,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "creating a migratable VMI with 2 dedicated CPU cores",
+                "start": 176066,
+                "end": 176124,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "creating a template for a pause pod with 2 dedicated CPU cores",
+                "start": 176449,
+                "end": 176517,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "AfterEach",
+            "text": "",
+            "start": 177525,
+            "end": 177722,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "It",
+            "text": "should successfully update a VMI's CPU set on migration",
+            "start": 177726,
+            "end": 180575,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "ensuring at least 2 worker nodes have cpumanager",
+                "start": 177800,
+                "end": 177854,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "starting a VMI on the first node of the list",
+                "start": 177980,
+                "end": 178030,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "waiting until the VirtualMachineInstance starts",
+                "start": 178170,
+                "end": 178223,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "determining cgroups version",
+                "start": 178444,
+                "end": 178477,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "ensuring the VMI started on the correct node",
+                "start": 178539,
+                "end": 178589,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "reserving the cores used by the VMI on the second node with a paused pod",
+                "start": 178650,
+                "end": 178728,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "creating another paused pod since last didn't have common cores with the VMI",
+                "start": 178995,
+                "end": 179077,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "deleting the paused pods that don't have cores in common with the VMI",
+                "start": 179087,
+                "end": 179162,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "migrating the VMI from first node to second node",
+                "start": 179353,
+                "end": 179407,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "ensuring the target cpuset is different from the source",
+                "start": 179747,
+                "end": 179808,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "ensuring the libvirt domain cpuset is equal to the virt-launcher pod cpuset",
+                "start": 180180,
+                "end": 180261,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "deleting the last paused pod",
+                "start": 180375,
+                "end": 180409,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "[Serial][QUARANTINE] with a dedicated migration network",
+        "start": 180582,
+        "end": 182800,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 180668,
+            "end": 181218,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Creating the Network Attachment Definition",
+                "start": 180726,
+                "end": 180774,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Setting it as the migration network in the KubeVirt CR",
+                "start": 181105,
+                "end": 181165,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "AfterEach",
+            "text": "",
+            "start": 181221,
+            "end": 181726,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Clearing the migration network in the KubeVirt CR",
+                "start": 181243,
+                "end": 181298,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Deleting the Network Attachment Definition",
+                "start": 181345,
+                "end": 181393,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "It",
+            "text": "Should migrate over that network",
+            "start": 181729,
+            "end": 182796,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting the migration",
+                "start": 181983,
+                "end": 182011,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Checking if the migration happened, and over the right network",
+                "start": 182183,
+                "end": 182251,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Deleting the VMI",
+                "start": 182499,
+                "end": 182521,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Waiting for VMI to disappear",
+                "start": 182692,
+                "end": 182726,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "It",
+        "text": "should update MigrationState's MigrationConfiguration of VMI status",
+        "start": 182803,
+        "end": 183881,
+        "spec": true,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "By",
+            "text": "Starting a VMI",
+            "start": 182888,
+            "end": 182908,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Starting a Migration",
+            "start": 183048,
+            "end": 183074,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Ensuring MigrationConfiguration is updated",
+            "start": 183283,
+            "end": 183331,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Deleting the VMI",
+            "start": 183616,
+            "end": 183638,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "By",
+            "text": "Waiting for VMI to disappear",
+            "start": 183779,
+            "end": 183813,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "with a live-migration in flight",
+        "start": 183884,
+        "end": 185399,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "It",
+            "text": "there should always be a single active migration per VMI",
+            "start": 183938,
+            "end": 185395,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting a VMI",
+                "start": 184013,
+                "end": 184033,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Checking that there always is at most one migration running",
+                "start": 184239,
+                "end": 184304,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "topology hints",
+        "start": 185402,
+        "end": 186690,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "Context",
+            "text": "needs to be set when",
+            "start": 185495,
+            "end": 186685,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "It",
+                "text": "invtsc feature exists",
+                "start": 186028,
+                "end": 186291,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": []
+              },
+              {
+                "name": "It",
+                "text": "HyperV reenlightenment is enabled",
+                "start": 186296,
+                "end": 186679,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Context",
+        "text": "when evacuating fails",
+        "start": 186693,
+        "end": 189892,
+        "spec": false,
+        "focused": false,
+        "pending": false,
+        "labels": [],
+        "nodes": [
+          {
+            "name": "BeforeEach",
+            "text": "",
+            "start": 186998,
+            "end": 187258,
+            "spec": false,
+            "focused": false,
+            "pending": false,
+            "labels": null,
+            "nodes": []
+          },
+          {
+            "name": "It",
+            "text": "[Serial] retrying immediately should be blocked by the migration backoff",
+            "start": 187262,
+            "end": 188142,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting the VirtualMachineInstance",
+                "start": 187361,
+                "end": 187402,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Waiting for the migration to fail",
+                "start": 187454,
+                "end": 187493,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Try again",
+                "start": 187674,
+                "end": 187689,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Expecting for a MigrationBackoff event to be sent",
+                "start": 187869,
+                "end": 187924,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          },
+          {
+            "name": "It",
+            "text": "[Serial] after a successful migration backoff should be cleared",
+            "start": 188146,
+            "end": 189888,
+            "spec": true,
+            "focused": false,
+            "pending": false,
+            "labels": [],
+            "nodes": [
+              {
+                "name": "By",
+                "text": "Starting the VirtualMachineInstance",
+                "start": 188236,
+                "end": 188277,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Waiting for the migration to fail",
+                "start": 188329,
+                "end": 188368,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Patch VMI",
+                "start": 188549,
+                "end": 188564,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Try again with backoff",
+                "start": 188935,
+                "end": 188963,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "There should be no backoff now",
+                "start": 189348,
+                "end": 189384,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              },
+              {
+                "name": "By",
+                "text": "Checking that no backoff event occurred",
+                "start": 189585,
+                "end": 189630,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": null,
+                "nodes": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "By",
+    "text": "undefined",
+    "start": 191355,
+    "end": 191451,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": null,
+    "nodes": []
+  },
+  {
+    "name": "By",
+    "text": "undefined",
+    "start": 191558,
+    "end": 191655,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": null,
+    "nodes": []
+  },
+  {
+    "name": "By",
+    "text": "undefined",
+    "start": 192497,
+    "end": 192602,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": null,
+    "nodes": []
+  },
+  {
+    "name": "By",
+    "text": "undefined",
+    "start": 192955,
+    "end": 193085,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": null,
+    "nodes": []
+  },
+  {
+    "name": "By",
+    "text": "undefined",
+    "start": 193267,
+    "end": 193373,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": null,
+    "nodes": []
+  },
+  {
+    "name": "By",
+    "text": "Updating Kubevirt CR to wake node-labeller up",
+    "start": 194295,
+    "end": 194346,
+    "spec": false,
+    "focused": false,
+    "pending": false,
+    "labels": null,
+    "nodes": []
+  }
+]

--- a/robots/cmd/test-label-analyzer/cmd/testdata/simple_test.go
+++ b/robots/cmd/test-label-analyzer/cmd/testdata/simple_test.go
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package testdata
+
+import "github.com/onsi/ginkgo"
+
+var _ = ginkgo.Describe("whatever", func() {
+	ginkgo.Context("i don't care", func() {
+		ginkgo.It("is so meh", func() {})
+	})
+})

--- a/robots/cmd/test-label-analyzer/main.go
+++ b/robots/cmd/test-label-analyzer/main.go
@@ -1,0 +1,25 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package main
+
+import "kubevirt.io/project-infra/robots/cmd/test-label-analyzer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/robots/pkg/test-label-analyzer/BUILD.bazel
+++ b/robots/pkg/test-label-analyzer/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "ginkgo.go",
+        "stats.go",
+        "time.go",
+    ],
+    importpath = "kubevirt.io/project-infra/robots/pkg/test-label-analyzer",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "stats_test.go",
+        "test_suite_test.go",
+        "time_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+    ],
+)

--- a/robots/pkg/test-label-analyzer/config.go
+++ b/robots/pkg/test-label-analyzer/config.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package test_label_analyzer
+
+import "regexp"
+
+// A LabelCategory defines a category of tests that share a common label either in their test name or as a Ginkgo label
+type LabelCategory struct {
+	Name            string         `yaml:"name"`
+	TestNameLabelRE *regexp.Regexp `yaml:"testNameLabelRE"`
+	GinkgoLabelRE   *regexp.Regexp `yaml:"ginkgoLabelRE"`
+}
+
+// Config defines the configuration file structure that is required to map tests to categories.
+type Config struct {
+	Categories []LabelCategory `yaml:"categories"`
+}
+
+func NewQuarantineDefaultConfig() Config {
+	return Config{
+		Categories: []LabelCategory{
+			{
+				Name:            "Quarantine",
+				TestNameLabelRE: regexp.MustCompile("\\[QUARANTINE\\]"),
+				GinkgoLabelRE:   regexp.MustCompile("Quarantine"),
+			},
+		},
+	}
+}

--- a/robots/pkg/test-label-analyzer/config.go
+++ b/robots/pkg/test-label-analyzer/config.go
@@ -18,7 +18,10 @@
 
 package test_label_analyzer
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // A LabelCategory defines a category of tests that share a common label either in their test name or as a Ginkgo label
 type LabelCategory struct {
@@ -27,9 +30,21 @@ type LabelCategory struct {
 	GinkgoLabelRE   *Regexp `json:"ginkgo_label_re"`
 }
 
+func (c *LabelCategory) String() string {
+	return c.Name
+}
+
 // Config defines the configuration file structure that is required to map tests to categories.
 type Config struct {
 	Categories []LabelCategory `json:"categories"`
+}
+
+func (c *Config) String() string {
+	var s []string
+	for _, cat := range c.Categories {
+		s = append(s, cat.String())
+	}
+	return strings.Join(s, ", ")
 }
 
 // Regexp adds unmarshalling from json for regexp.Regexp

--- a/robots/pkg/test-label-analyzer/config.go
+++ b/robots/pkg/test-label-analyzer/config.go
@@ -32,8 +32,8 @@ type Config struct {
 	Categories []LabelCategory `yaml:"categories"`
 }
 
-func NewQuarantineDefaultConfig() Config {
-	return Config{
+func NewQuarantineDefaultConfig() *Config {
+	return &Config{
 		Categories: []LabelCategory{
 			{
 				Name:            "Quarantine",

--- a/robots/pkg/test-label-analyzer/ginkgo.go
+++ b/robots/pkg/test-label-analyzer/ginkgo.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package test_label_analyzer
+
+type GinkgoNode struct {
+	Name    string        `json:"name"`
+	Text    string        `json:"text"`
+	Start   int           `json:"start"`
+	End     int           `json:"end"`
+	Spec    bool          `json:"spec"`
+	Focused bool          `json:"focused"`
+	Pending bool          `json:"pending"`
+	Labels  []string      `json:"labels"`
+	Nodes   []*GinkgoNode `json:"nodes"`
+}
+
+func (n GinkgoNode) CloneWithoutNodes() *GinkgoNode {
+	return &GinkgoNode{
+		Name:    n.Name,
+		Text:    n.Text,
+		Start:   n.Start,
+		End:     n.End,
+		Spec:    n.Spec,
+		Focused: n.Focused,
+		Pending: n.Pending,
+		Labels:  n.Labels,
+	}
+}

--- a/robots/pkg/test-label-analyzer/ginkgo.go
+++ b/robots/pkg/test-label-analyzer/ginkgo.go
@@ -19,18 +19,40 @@
 
 package test_label_analyzer
 
+// GinkgoNode is the basic structure that is compatible with the output of the command `ginkgo outline --format json`
 type GinkgoNode struct {
-	Name    string        `json:"name"`
-	Text    string        `json:"text"`
-	Start   int           `json:"start"`
-	End     int           `json:"end"`
-	Spec    bool          `json:"spec"`
-	Focused bool          `json:"focused"`
-	Pending bool          `json:"pending"`
-	Labels  []string      `json:"labels"`
-	Nodes   []*GinkgoNode `json:"nodes"`
+
+	// Name of the node, usually `Describe`, `Context` ....
+	Name string `json:"name"`
+
+	// Text holds the description of the node
+	Text string `json:"text"`
+
+	// Start is the beginning of the textual representation of this Ginkgo node, i.e. the byte offset in the file from
+	// which the outline originated from
+	Start int `json:"start"`
+
+	// End is the end of the textual representation of this Ginkgo node, i.e. the byte offset in the file from
+	// which the outline originated from
+	End int `json:"end"`
+
+	// Spec denotes whether this is an actual Spec aka test or not
+	Spec bool `json:"spec"`
+
+	// Focused states whether the spec is focused
+	Focused bool `json:"focused"`
+
+	// Pending states whether the spec is pending
+	Pending bool `json:"pending"`
+
+	// Labels gives an array of the labels attached to the node
+	Labels []string `json:"labels"`
+
+	// Nodes holds the child nodes of this node
+	Nodes []*GinkgoNode `json:"nodes"`
 }
 
+// CloneWithoutNodes creates a copy of this node excluding its children
 func (n GinkgoNode) CloneWithoutNodes() *GinkgoNode {
 	return &GinkgoNode{
 		Name:    n.Name,

--- a/robots/pkg/test-label-analyzer/stats.go
+++ b/robots/pkg/test-label-analyzer/stats.go
@@ -19,16 +19,53 @@
 
 package test_label_analyzer
 
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// TestStats contains the results of traversing a set of Ginkgo outlines and collecting the pathes in the form of
+// GinkgoNode slices matching a Config describing the criteria to match against.
 type TestStats struct {
-	SpecsTotal         int
-	SpecsMatching      int
-	MatchingSpecPathes [][]*GinkgoNode
+
+	// SpecsTotal is the total number of specs encountered during traversal of the outline
+	SpecsTotal int `json:"specs_total"`
+
+	// MatchingSpecPathes is the slice of PathStats to matching specs for the collection of outlines traversed.
+	// Each PathStats inside this slice is the path to each of the matching specs defined by the Config
+	// being used. Please note that the GinkgoNode.Nodes are being removed during traversal.
+	MatchingSpecPathes []*PathStats `json:"matching_spec_pathes"`
+}
+
+// PathStats contains all relevant data to a path matching a Config.
+type PathStats struct {
+
+	// Lines has the line numbers for the matching nodes
+	Lines []int `json:"lines"`
+
+	// GitBlameLines is the output of the blame command for each of the Lines
+	GitBlameLines []*GitBlameInfo `json:"git_blame_lines"`
+
+	// Path denotes the path to the spec that has been found to match
+	Path []*GinkgoNode `json:"path"`
+}
+
+// FileStats contains the information of the file whose outline was traversed and the results of the
+// traversal.
+type FileStats struct {
+	*Config    `json:"config"`
+	*TestStats `json:"test_stats"`
+
+	// RemoteURL is the absolute path to the file, most certainly an absolute URL inside a version control repository
+	// containing a commit ID in order to exactly define the state of the file that was traversed
+	RemoteURL string `json:"path"`
 }
 
 func GetStatsFromGinkgoOutline(config *Config, gingkoOutline []*GinkgoNode) *TestStats {
 	stats := &TestStats{
-		SpecsTotal:    0,
-		SpecsMatching: 0,
+		SpecsTotal: 0,
 	}
 	traverseNodesRecursively(stats, config, gingkoOutline, nil)
 	return stats
@@ -42,23 +79,60 @@ func traverseNodesRecursively(stats *TestStats, config *Config, gingkoOutline []
 		if node.Spec {
 			stats.SpecsTotal++
 			for _, category := range config.Categories {
-				testNameMatchesLabelRE := false
+				var testName string
 				for _, nodeFromPath := range parentsWithNode {
-					testNameMatchesLabelRE = category.TestNameLabelRE.MatchString(nodeFromPath.Text)
-					if testNameMatchesLabelRE {
-						break
-					}
+					testName = strings.Join([]string{testName, nodeFromPath.Text}, " ")
 				}
-				if testNameMatchesLabelRE {
-					stats.SpecsMatching++
+				if category.TestNameLabelRE.MatchString(testName) {
 					var path []*GinkgoNode
 					for _, pathNode := range parentsWithNode {
 						path = append(path, pathNode.CloneWithoutNodes())
 					}
-					stats.MatchingSpecPathes = append(stats.MatchingSpecPathes, path)
+					stats.MatchingSpecPathes = append(stats.MatchingSpecPathes, &PathStats{
+						Path: path,
+					})
 				}
 			}
 		}
 		traverseNodesRecursively(stats, config, node.Nodes, parentsWithNode)
 	}
+}
+
+const gitDateLayout = "2006-01-02 15:04:05 -0700"
+
+// "749cf0488 (Ben Oukhanov 2023-02-15 18:24:49 +0200  26) var _ = Describe(\"VM Console Proxy Operand\", func() {",
+var gitBlameRegex = regexp.MustCompile("^([0-9a-f]+) \\(([\\w ]+)\\s([0-9]{4}-[0-9]{2}-[0-9]{2}\\s[0-9]{2}:[0-9]{2}:[0-9]{2}\\s[-+][0-9]{4})\\s+([0-9]+)\\)\\s(.*)$")
+
+type GitBlameInfo struct {
+	CommitID string    `json:"commit_id"`
+	Author   string    `json:"author"`
+	Date     time.Time `json:"date"`
+	LineNo   int       `json:"line_no"`
+	Line     string    `json:"line"`
+}
+
+func ExtractGitBlameInfo(lines []string) []*GitBlameInfo {
+	var info []*GitBlameInfo
+	for _, line := range lines {
+		if !gitBlameRegex.MatchString(line) {
+			continue
+		}
+		submatches := gitBlameRegex.FindAllStringSubmatch(line, -1)
+		date, err := time.Parse(gitDateLayout, submatches[0][3])
+		if err != nil {
+			panic(err)
+		}
+		lineNo, err := strconv.Atoi(submatches[0][4])
+		if err != nil {
+			panic(err)
+		}
+		info = append(info, &GitBlameInfo{
+			CommitID: submatches[0][1],
+			Author:   submatches[0][2],
+			Date:     date,
+			LineNo:   lineNo,
+			Line:     submatches[0][5],
+		})
+	}
+	return info
 }

--- a/robots/pkg/test-label-analyzer/stats.go
+++ b/robots/pkg/test-label-analyzer/stats.go
@@ -26,6 +26,17 @@ import (
 	"time"
 )
 
+// FileStats contains the information of the file whose outline was traversed and the results of the
+// traversal.
+type FileStats struct {
+	*Config    `json:"config"`
+	*TestStats `json:"test_stats"`
+
+	// RemoteURL is the absolute path to the file, most certainly an absolute URL inside a version control repository
+	// containing a commit ID in order to exactly define the state of the file that was traversed
+	RemoteURL string `json:"path"`
+}
+
 // TestStats contains the results of traversing a set of Ginkgo outlines and collecting the pathes in the form of
 // GinkgoNode slices matching a Config describing the criteria to match against.
 type TestStats struct {
@@ -50,17 +61,6 @@ type PathStats struct {
 
 	// Path denotes the path to the spec that has been found to match
 	Path []*GinkgoNode `json:"path"`
-}
-
-// FileStats contains the information of the file whose outline was traversed and the results of the
-// traversal.
-type FileStats struct {
-	*Config    `json:"config"`
-	*TestStats `json:"test_stats"`
-
-	// RemoteURL is the absolute path to the file, most certainly an absolute URL inside a version control repository
-	// containing a commit ID in order to exactly define the state of the file that was traversed
-	RemoteURL string `json:"path"`
 }
 
 func GetStatsFromGinkgoOutline(config *Config, gingkoOutline []*GinkgoNode) *TestStats {

--- a/robots/pkg/test-label-analyzer/stats.go
+++ b/robots/pkg/test-label-analyzer/stats.go
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package test_label_analyzer
+
+type TestStats struct {
+	SpecsTotal         int
+	SpecsMatching      int
+	MatchingSpecPathes [][]*GinkgoNode
+}
+
+func GetStatsFromGinkgoOutline(config *Config, gingkoOutline []*GinkgoNode) *TestStats {
+	stats := &TestStats{
+		SpecsTotal:    0,
+		SpecsMatching: 0,
+	}
+	traverseNodesRecursively(stats, config, gingkoOutline, nil)
+	return stats
+}
+
+func traverseNodesRecursively(stats *TestStats, config *Config, gingkoOutline []*GinkgoNode, parents []*GinkgoNode) {
+	for _, node := range gingkoOutline {
+		var parentsWithNode []*GinkgoNode
+		parentsWithNode = append(parentsWithNode, parents...)
+		parentsWithNode = append(parentsWithNode, node)
+		if node.Spec {
+			stats.SpecsTotal++
+			for _, category := range config.Categories {
+				testNameMatchesLabelRE := false
+				for _, nodeFromPath := range parentsWithNode {
+					testNameMatchesLabelRE = category.TestNameLabelRE.MatchString(nodeFromPath.Text)
+					if testNameMatchesLabelRE {
+						break
+					}
+				}
+				if testNameMatchesLabelRE {
+					stats.SpecsMatching++
+					var path []*GinkgoNode
+					for _, pathNode := range parentsWithNode {
+						path = append(path, pathNode.CloneWithoutNodes())
+					}
+					stats.MatchingSpecPathes = append(stats.MatchingSpecPathes, path)
+				}
+			}
+		}
+		traverseNodesRecursively(stats, config, node.Nodes, parentsWithNode)
+	}
+}

--- a/robots/pkg/test-label-analyzer/stats.go
+++ b/robots/pkg/test-label-analyzer/stats.go
@@ -44,10 +44,10 @@ type TestStats struct {
 	// SpecsTotal is the total number of specs encountered during traversal of the outline
 	SpecsTotal int `json:"specs_total"`
 
-	// MatchingSpecPathes is the slice of PathStats to matching specs for the collection of outlines traversed.
+	// MatchingSpecPaths is the slice of PathStats to matching specs for the collection of outlines traversed.
 	// Each PathStats inside this slice is the path to each of the matching specs defined by the Config
 	// being used. Please note that the GinkgoNode.Nodes are being removed during traversal.
-	MatchingSpecPathes []*PathStats `json:"matching_spec_pathes"`
+	MatchingSpecPaths []*PathStats `json:"matching_spec_paths"`
 }
 
 // PathStats contains all relevant data to a path matching a Config.
@@ -88,7 +88,7 @@ func traverseNodesRecursively(stats *TestStats, config *Config, gingkoOutline []
 					for _, pathNode := range parentsWithNode {
 						path = append(path, pathNode.CloneWithoutNodes())
 					}
-					stats.MatchingSpecPathes = append(stats.MatchingSpecPathes, &PathStats{
+					stats.MatchingSpecPaths = append(stats.MatchingSpecPaths, &PathStats{
 						Path: path,
 					})
 				}

--- a/robots/pkg/test-label-analyzer/stats_test.go
+++ b/robots/pkg/test-label-analyzer/stats_test.go
@@ -65,7 +65,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 1,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{
@@ -114,7 +114,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 1,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{},
@@ -150,7 +150,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 1,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{
@@ -191,7 +191,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 1,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{
@@ -232,7 +232,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 1,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{
@@ -277,7 +277,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 2,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{
@@ -336,7 +336,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 				})).To(BeEquivalentTo(
 				&TestStats{
 					SpecsTotal: 2,
-					MatchingSpecPathes: []*PathStats{
+					MatchingSpecPaths: []*PathStats{
 						{
 							Path: []*GinkgoNode{
 								{

--- a/robots/pkg/test-label-analyzer/stats_test.go
+++ b/robots/pkg/test-label-analyzer/stats_test.go
@@ -22,6 +22,7 @@ package test_label_analyzer
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"time"
 )
 
 var _ = Describe("GetStatsFromGinkgoOutline", func() {
@@ -36,8 +37,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    0,
-					SpecsMatching: 0,
+					SpecsTotal: 0,
 				}))
 		})
 
@@ -50,8 +50,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 0,
+					SpecsTotal: 1,
 				}))
 		})
 
@@ -65,13 +64,14 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 1,
-					MatchingSpecPathes: [][]*GinkgoNode{
+					SpecsTotal: 1,
+					MatchingSpecPathes: []*PathStats{
 						{
-							{
-								Text: "[QUARANTINE]",
-								Spec: true,
+							Path: []*GinkgoNode{
+								{
+									Text: "[QUARANTINE]",
+									Spec: true,
+								},
 							},
 						},
 					},
@@ -95,8 +95,7 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 0,
+					SpecsTotal: 1,
 				}))
 		})
 
@@ -114,14 +113,15 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 1,
-					MatchingSpecPathes: [][]*GinkgoNode{
+					SpecsTotal: 1,
+					MatchingSpecPathes: []*PathStats{
 						{
-							{},
-							{
-								Text: "[QUARANTINE]",
-								Spec: true,
+							Path: []*GinkgoNode{
+								{},
+								{
+									Text: "[QUARANTINE]",
+									Spec: true,
+								},
 							},
 						},
 					},
@@ -149,24 +149,24 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 1,
-					MatchingSpecPathes: [][]*GinkgoNode{
+					SpecsTotal: 1,
+					MatchingSpecPathes: []*PathStats{
 						{
-							{
-								Text: "parent",
-							},
-							{
-								Text: "child",
-								Spec: false,
-							},
-							{
-								Text: "[QUARANTINE]",
-								Spec: true,
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text: "child",
+									Spec: false,
+								},
+								{
+									Text: "[QUARANTINE]",
+									Spec: true,
+								},
 							},
 						},
-					},
-				}))
+					}}))
 		})
 
 		It("collects the test names if parent contains the matching label", func() {
@@ -190,24 +190,24 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 1,
-					MatchingSpecPathes: [][]*GinkgoNode{
+					SpecsTotal: 1,
+					MatchingSpecPathes: []*PathStats{
 						{
-							{
-								Text: "parent",
-							},
-							{
-								Text: "[QUARANTINE]",
-								Spec: false,
-							},
-							{
-								Text: "child",
-								Spec: true,
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text: "[QUARANTINE]",
+									Spec: false,
+								},
+								{
+									Text: "child",
+									Spec: true,
+								},
 							},
 						},
-					},
-				}))
+					}}))
 		})
 
 		It("doesnt collect the test names twice if parent and child contain the matching label", func() {
@@ -231,24 +231,24 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    1,
-					SpecsMatching: 1,
-					MatchingSpecPathes: [][]*GinkgoNode{
+					SpecsTotal: 1,
+					MatchingSpecPathes: []*PathStats{
 						{
-							{
-								Text: "parent",
-							},
-							{
-								Text: "[QUARANTINE]",
-								Spec: false,
-							},
-							{
-								Text: "[QUARANTINE]",
-								Spec: true,
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text: "[QUARANTINE]",
+									Spec: false,
+								},
+								{
+									Text: "[QUARANTINE]",
+									Spec: true,
+								},
 							},
 						},
-					},
-				}))
+					}}))
 		})
 
 		It("does collect the test nodes twice if parent contains the matching label", func() {
@@ -276,39 +276,132 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					},
 				})).To(BeEquivalentTo(
 				&TestStats{
-					SpecsTotal:    2,
-					SpecsMatching: 2,
-					MatchingSpecPathes: [][]*GinkgoNode{
+					SpecsTotal: 2,
+					MatchingSpecPathes: []*PathStats{
 						{
-							{
-								Text: "parent",
-							},
-							{
-								Text: "[QUARANTINE]",
-								Spec: false,
-							},
-							{
-								Text: "first",
-								Spec: true,
-							},
-						},
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text: "[QUARANTINE]",
+									Spec: false,
+								},
+								{
+									Text: "first",
+									Spec: true,
+								},
+							}},
 						{
-							{
-								Text: "parent",
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text: "[QUARANTINE]",
+									Spec: false,
+								},
+								{
+									Text: "second",
+									Spec: true,
+								},
 							},
+						}},
+				}))
+		})
+
+		It("does collect the test node if the expression would match more than a single node", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewTestNameDefaultConfig("parent first child"),
+				[]*GinkgoNode{
+					{
+						Text: "parent",
+						Nodes: []*GinkgoNode{
 							{
-								Text: "[QUARANTINE]",
+								Text: "first child",
 								Spec: false,
-							},
-							{
-								Text: "second",
-								Spec: true,
+								Nodes: []*GinkgoNode{
+									{
+										Text: "child of first child",
+										Spec: true,
+									},
+									{
+										Text: "second child of first child",
+										Spec: true,
+									},
+								},
 							},
 						},
 					},
-				}))
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal: 2,
+					MatchingSpecPathes: []*PathStats{
+						{
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text: "first child",
+									Spec: false,
+								},
+								{
+									Text: "child of first child",
+									Spec: true,
+								},
+							}},
+						{Path: []*GinkgoNode{
+							{
+								Text: "parent",
+							},
+							{
+								Text: "first child",
+								Spec: false,
+							},
+							{
+								Text: "second child of first child",
+								Spec: true,
+							},
+						},
+						},
+					}}))
 		})
 
 	})
 
+})
+
+var _ = Describe("Extract git info", func() {
+	Context("blame", func() {
+
+		var lines = []string{
+			"749cf0488 (Ben Oukhanov 2023-02-15 18:24:49 +0200  26) var _ = Describe(\"VM Console Proxy Operand\", func() {",
+			"749cf0488 (Ben Oukhanov 2023-02-15 18:24:49 +0200 179) \tContext(\"Resource change\", func() {",
+			"749cf0488 (Ben Oukhanov 2023-02-15 18:24:49 +0200 208) \t\tDescribeTable(\"should restore modified app labels\", expectAppLabelsRestoreAfterUpdate,",
+			"749cf0488 (Ben Oukhanov 2023-02-15 18:24:49 +0200 213) \t\t\tEntry(\"[test_id:TODO] deployment\", \u0026deploymentResource),",
+		}
+		var expectedCommitID = "749cf0488"
+		var expectedAuthor = "Ben Oukhanov"
+		var expectedDate time.Time
+		var expectedLineNo = 26
+		var expectedLine = "var _ = Describe(\"VM Console Proxy Operand\", func() {"
+
+		BeforeEach(func() {
+			expectedDate, _ = time.Parse(gitDateLayout, "2023-02-15 18:24:49 +0200")
+		})
+
+		It("extracts info", func() {
+			Expect(ExtractGitBlameInfo(lines)).ToNot(BeNil())
+		})
+
+		It("fills fields", func() {
+			gitBlameInfo := ExtractGitBlameInfo(lines)[0]
+			Expect(gitBlameInfo.CommitID).To(BeEquivalentTo(expectedCommitID))
+			Expect(gitBlameInfo.Author).To(BeEquivalentTo(expectedAuthor))
+			Expect(gitBlameInfo.Date).To(BeEquivalentTo(expectedDate))
+			Expect(gitBlameInfo.LineNo).To(BeEquivalentTo(expectedLineNo))
+			Expect(gitBlameInfo.Line).To(BeEquivalentTo(expectedLine))
+		})
+	})
 })

--- a/robots/pkg/test-label-analyzer/stats_test.go
+++ b/robots/pkg/test-label-analyzer/stats_test.go
@@ -1,0 +1,314 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package test_label_analyzer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetStatsFromGinkgoOutline", func() {
+
+	Context("w/o recursion", func() {
+
+		It("does not match any test since no spec", func() {
+			Expect(GetStatsFromGinkgoOutline(NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Spec: false,
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    0,
+					SpecsMatching: 0,
+				}))
+		})
+
+		It("does not match any test since spec doesn't match", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Spec: true,
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 0,
+				}))
+		})
+
+		It("does match test text", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "[QUARANTINE]",
+						Spec: true,
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 1,
+					MatchingSpecPathes: [][]*GinkgoNode{
+						{
+							{
+								Text: "[QUARANTINE]",
+								Spec: true,
+							},
+						},
+					},
+				}))
+		})
+
+	})
+
+	Context("w recursion", func() {
+
+		It("has sub node which is a spec", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Nodes: []*GinkgoNode{
+							{
+								Spec: true,
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 0,
+				}))
+		})
+
+		It("has sub node which is a spec", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Nodes: []*GinkgoNode{
+							{
+								Text: "[QUARANTINE]",
+								Spec: true,
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 1,
+					MatchingSpecPathes: [][]*GinkgoNode{
+						{
+							{},
+							{
+								Text: "[QUARANTINE]",
+								Spec: true,
+							},
+						},
+					},
+				}))
+		})
+
+		It("collects the test names", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "parent",
+						Nodes: []*GinkgoNode{
+							{
+								Text: "child",
+								Spec: false,
+								Nodes: []*GinkgoNode{
+									{
+										Text: "[QUARANTINE]",
+										Spec: true,
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 1,
+					MatchingSpecPathes: [][]*GinkgoNode{
+						{
+							{
+								Text: "parent",
+							},
+							{
+								Text: "child",
+								Spec: false,
+							},
+							{
+								Text: "[QUARANTINE]",
+								Spec: true,
+							},
+						},
+					},
+				}))
+		})
+
+		It("collects the test names if parent contains the matching label", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "parent",
+						Nodes: []*GinkgoNode{
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+								Nodes: []*GinkgoNode{
+									{
+										Text: "child",
+										Spec: true,
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 1,
+					MatchingSpecPathes: [][]*GinkgoNode{
+						{
+							{
+								Text: "parent",
+							},
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+							},
+							{
+								Text: "child",
+								Spec: true,
+							},
+						},
+					},
+				}))
+		})
+
+		It("doesnt collect the test names twice if parent and child contain the matching label", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "parent",
+						Nodes: []*GinkgoNode{
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+								Nodes: []*GinkgoNode{
+									{
+										Text: "[QUARANTINE]",
+										Spec: true,
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    1,
+					SpecsMatching: 1,
+					MatchingSpecPathes: [][]*GinkgoNode{
+						{
+							{
+								Text: "parent",
+							},
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+							},
+							{
+								Text: "[QUARANTINE]",
+								Spec: true,
+							},
+						},
+					},
+				}))
+		})
+
+		It("does collect the test nodes twice if parent contains the matching label", func() {
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "parent",
+						Nodes: []*GinkgoNode{
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+								Nodes: []*GinkgoNode{
+									{
+										Text: "first",
+										Spec: true,
+									},
+									{
+										Text: "second",
+										Spec: true,
+									},
+								},
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal:    2,
+					SpecsMatching: 2,
+					MatchingSpecPathes: [][]*GinkgoNode{
+						{
+							{
+								Text: "parent",
+							},
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+							},
+							{
+								Text: "first",
+								Spec: true,
+							},
+						},
+						{
+							{
+								Text: "parent",
+							},
+							{
+								Text: "[QUARANTINE]",
+								Spec: false,
+							},
+							{
+								Text: "second",
+								Spec: true,
+							},
+						},
+					},
+				}))
+		})
+
+	})
+
+})

--- a/robots/pkg/test-label-analyzer/test_suite_test.go
+++ b/robots/pkg/test-label-analyzer/test_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package test_label_analyzer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestTestLabelAnalyzer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TestLabelAnalyzer Main Suite")
+}

--- a/robots/pkg/test-label-analyzer/time.go
+++ b/robots/pkg/test-label-analyzer/time.go
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package test_label_analyzer
+
+import (
+	"fmt"
+	"time"
+)
+
+// Since returns a simple textual description of an approximate time that has passed since the input time and now
+func Since(date time.Time) string {
+	var age string
+	since := time.Since(date)
+	hours := int(since.Hours())
+	switch {
+	case hours < 48:
+		age = fmt.Sprintf("%d hours", hours)
+	case hours < 24*14:
+		age = fmt.Sprintf("%d days", int(hours/24))
+	case hours < 24*60:
+		age = fmt.Sprintf("%d weeks", int(hours/24/7))
+	case hours < 24*365*2:
+		age = fmt.Sprintf("%d months", int(hours/24/30))
+	default:
+		age = fmt.Sprintf("%d years", int(hours/24/365))
+	}
+	return age
+}

--- a/robots/pkg/test-label-analyzer/time_test.go
+++ b/robots/pkg/test-label-analyzer/time_test.go
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package test_label_analyzer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("time.go", func() {
+	Context("Since", func() {
+		DescribeTable("Since",
+			func(since time.Time, expected string) {
+				Expect(Since(since)).To(BeEquivalentTo(expected))
+			},
+			Entry("now", time.Now(), "0 hours"),
+			Entry("two hours", time.Now().Add(-2*time.Hour), "2 hours"),
+			Entry("less than two days", time.Now().Add(-47*time.Hour), "47 hours"),
+			Entry("two days", time.Now().Add(-48*time.Hour), "2 days"),
+			Entry("7 days", time.Now().Add(7*-24*time.Hour), "7 days"),
+			Entry("10 days", time.Now().Add(10*-24*time.Hour), "10 days"),
+			Entry("14 days are two weeks", time.Now().Add(14*-24*time.Hour), "2 weeks"),
+			Entry("fiftynine days are eight weeks", time.Now().Add(59*-24*time.Hour), "8 weeks"),
+			Entry("sixty days are two months", time.Now().Add(60*-24*time.Hour), "2 months"),
+			Entry("365 days are 12 months", time.Now().Add(365*-24*time.Hour), "12 months"),
+			Entry("730 days are 2 years", time.Now().Add(730*-24*time.Hour), "2 years"),
+		)
+	})
+})


### PR DESCRIPTION
See kubevirt/project-infra#2679

# test-label-analyzer cli

This PR introduces a new cli for analysis of label data from tests inside a given code base.

Initial target is of course `kubevirt/kubevirt`, but might be useful for other [Ginkgo] V2 based projects as well.

# quarantined tests page

The PR also creates a periodic job that leverages the cli to generate an html page of tests in quarantine for kubevirt/kubevirt, example output here: https://storage.googleapis.com/kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/index.html

# general usage

The cli is able to work in a more generalized style of using a test config in yaml form

```yaml
File: /tmp/analyzer-config.json                  
────────────────────────────────────────────────────────────────────
{                                                                   
    "categories": [                                                 
        {                                                           
            "name": "SSP test case evaluation",                                      
            "testNameLabelRE": ".*Console Proxy Operand Resource.*",
            "ginkgoLabelRE": ""                                     
        }                                                           
    ]                                                               
}                                                                   
```

which can be simplified to adding the flag

```
--test-name-label-re '.*Console Proxy Operand Resource.*'
```

# What does not (yet) work

Currently we can only filter by test name content, Ginkgo label filtering does not work, since Ginkgo `outline` doesn't resolve `Label` s as we use them inside `kubevirt/kubevirt`

[Ginkgo]: https://onsi.github.io/ginkgo/
[Ginkgo label]: https://onsi.github.io/ginkgo/#spec-labels