### PR TITLE
Include podman log in output when podman socket fails to start

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -102,6 +102,7 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
         else
             echo "Reached maximum attempts, not waiting any longer..."
 	    echo "Podman daemon failed to start successfully"
+            cat /var/log/podman.log
             exit 1
         fi
     done


### PR DESCRIPTION
There are occasions when the podman socket fails to start within the specified timeout period. This looks to happen when a number of jobs start all at once on a node and there is high load. This is very difficult to reproduce locally.

Including the podman log will help to troubleshoot issues with the podman socket starting in time.

/cc @xpivarc @dhiller 