### PR TITLE
Migrate kubevirtci check-provision jobs to new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -162,88 +162,6 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio        
-  - always_run: false
-    annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-dind-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-installer-pull-token: "true"
-      rehearsal.allowed: "true"
-      sriov-pod: "true"
-    max_concurrency: 1
-    name: check-up-kind-1.25-sriov
-    spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-          - labelSelector:
-              matchExpressions:
-              - key: sriov-pod-multi
-                operator: In
-                values:
-                - "true"
-            topologyKey: kubernetes.io/hostname
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - |
-          trap "echo teardown && make cluster-down" EXIT SIGINT
-          make cluster-up
-          ./cluster-up/cluster/kind/check-cluster-up.sh
-        env:
-        - name: KUBEVIRT_PROVIDER
-          value: kind-1.25-sriov
-        - name: KUBEVIRT_NUM_NODES
-          value: "3"
-        - name: RUN_KUBEVIRT_CONFORMANCE
-          value: "true"
-        - name: SONOBUOY_EXTRA_ARGS
-          value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
-        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
-        name: ""
-        resources:
-          requests:
-            memory: 15Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-        - mountPath: /dev/vfio/
-          name: vfio
-      nodeSelector:
-        hardwareSupport: sriov-nic
-      priorityClassName: sriov
-      volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-      - hostPath:
-          path: /dev/vfio/
-          type: Directory
-        name: vfio
   - always_run: true
     cluster: prow-workloads
     decorate: true
@@ -423,33 +341,6 @@ presubmits:
           path: /dev
           type: Directory
         name: devices
-  - always_run: false
-    cluster: kubevirt-prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 2
-    name: check-provision-k8s-1.24-psa
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.24-psa && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
-        name: ""
-        resources:
-          requests:
-            memory: 14Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - always_run: true
     cluster: kubevirt-prow-workloads
     decorate: true
@@ -493,32 +384,6 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.25 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230105-1dbefc0
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 1
-    name: check-provision-k8s-1.26
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.26 && KUBEVIRT_PSA='true' ../provision.sh
         image: quay.io/kubevirtci/golang:v20230105-1dbefc0
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -424,7 +424,7 @@ presubmits:
           type: Directory
         name: devices
   - always_run: false
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -451,7 +451,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -477,7 +477,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -529,7 +529,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -555,7 +555,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s


### PR DESCRIPTION
This change also removes some of the presubmit lanes that are no longer needed. 

/cc @dhiller @xpivarc 