### PR TITLE
Add restartPolicy: OnFailure for kubevirtci publish

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -33,6 +33,7 @@ postsubmits:
                   - bare-metal-9
         nodeSelector:
           type: bare-metal-external
+        restartPolicy: OnFailure
         volumes:
         - hostPath:
             path: /lib/modules


### PR DESCRIPTION
Please note that there's no maxRetry property on the PodSpec currently, see https://github.com/kubernetes/kubernetes/issues/65797 for a feature request and KEP

This means we need to monitor whether any job keeps repeating, since reportedly there have been cases of this happening.

OTOH since we are having the presubmits in place I think this should help, especially regarding latest failures due to cleanup.

/cc @brianmcarey @oshoval 