### PR TITLE
Remove mykaul from kubevirt org

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -135,7 +135,6 @@ orgs:
       - mrnold
       - mshitrit
       - myakove
-      - mykaul
       - n1r1
       - nellyc
       - nelsonspbr


### PR DESCRIPTION
mykaul is no longer involved with the KubeVirt community so removing from the github org

/cc @dhiller @dankenigsberg 