### PR TITLE
Remove fromanirh from org since user doesn't exist any more

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -72,7 +72,6 @@ orgs:
       - fedepaol
       - fgimenez
       - fossedihelm
-      - fromanirh
       - gabrielecerami
       - gbenhaim
       - geetikakay


### PR DESCRIPTION
See https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-org-github-config-updater/1641324948611928064#1:build-log.txt%3A8

/cc @brianmcarey 