### PR TITLE
Make the 1.27 check-provision presubmit required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -554,8 +554,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
-    optional: true
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
The k8s-1.27 provider has been merged[1] and the check-provision presubmit is passing. We should make this job required so that we can keep this provider in a ready state for when it is needed.

[1] https://github.com/kubevirt/kubevirtci/pull/988

/cc @dhiller 
