### PR TITLE
Add responses on rehearse

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler_test.go
+++ b/external-plugins/rehearse/plugin/handler/handler_test.go
@@ -337,6 +337,16 @@ Gna meh whatever
 `
 			Expect(handler.extractJobNamesFromComment(commentBody)).To(BeNil())
 		})
+
+		It("extracts question mark from comment body", func() {
+			commentBody := `Gna meh whatever 
+
+/rehearse ?
+
+
+`
+			Expect(handler.extractJobNamesFromComment(commentBody)).To(BeEquivalentTo([]string{"?"}))
+		})
 	})
 
 	Context("filtering jobs by name", func() {

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20230324-25fe21fd
+          image: quay.io/kubevirtci/rehearse:v20230403-169195b5
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
Makes the rehearse plugin reply with comments on a PR in response when a user uses `/rehearse`, so that user knows what actually happened after they added their comment.

In case of `/rehearse ?` a list of all jobs for which a rehearsal can be triggered is added as comment.

In all other cases a list of jobs for which a rehearsal was triggered is added as comment.