### PR TITLE
Move release sig-compute and sig-operator lanes to new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -662,7 +662,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -721,7 +721,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1298,7 +1298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: ikubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1333,7 +1333,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1372,7 +1372,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1411,7 +1411,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1450,7 +1450,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1494,7 +1494,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1529,7 +1529,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1711,7 +1711,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1746,7 +1746,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -397,7 +397,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -721,7 +721,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -781,7 +781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1358,7 +1358,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1393,7 +1393,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1432,7 +1432,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1471,7 +1471,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1510,7 +1510,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1553,7 +1553,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1588,7 +1588,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1770,7 +1770,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -397,7 +397,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -721,7 +721,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -781,7 +781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1359,7 +1359,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1394,7 +1394,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1433,7 +1433,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1472,7 +1472,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1511,7 +1511,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1554,7 +1554,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1589,7 +1589,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1771,7 +1771,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1806,7 +1806,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -396,7 +396,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -718,7 +718,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -777,7 +777,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1353,7 +1353,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1388,7 +1388,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1427,7 +1427,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1466,7 +1466,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1505,7 +1505,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1548,7 +1548,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1583,7 +1583,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1795,7 +1795,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1830,7 +1830,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -395,7 +395,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -634,7 +634,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -694,7 +694,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1270,7 +1270,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1305,7 +1305,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1344,7 +1344,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1383,7 +1383,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1422,7 +1422,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1465,7 +1465,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1500,7 +1500,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1712,7 +1712,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1747,7 +1747,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -395,7 +395,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -629,7 +629,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -687,7 +687,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1261,7 +1261,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1296,7 +1296,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1335,7 +1335,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1374,7 +1374,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1413,7 +1413,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1456,7 +1456,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1491,7 +1491,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1703,7 +1703,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1738,7 +1738,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
@@ -75,7 +75,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -221,7 +221,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -396,7 +396,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -631,7 +631,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -689,7 +689,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1263,7 +1263,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1298,7 +1298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1337,7 +1337,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1376,7 +1376,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1415,7 +1415,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1458,7 +1458,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1493,7 +1493,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1735,7 +1735,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1770,7 +1770,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1995,7 +1995,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -2031,7 +2031,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -80,7 +80,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -119,7 +119,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -337,7 +337,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -574,7 +574,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -1221,7 +1221,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1257,7 +1257,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1297,7 +1297,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1337,7 +1337,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1381,7 +1381,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1417,7 +1417,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1665,7 +1665,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1701,7 +1701,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1930,7 +1930,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1966,7 +1966,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -117,7 +117,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -564,7 +564,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -634,7 +634,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1219,7 +1219,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1254,7 +1254,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1293,7 +1293,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1332,7 +1332,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1375,7 +1375,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1410,7 +1410,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1652,7 +1652,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1687,7 +1687,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1912,7 +1912,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1947,7 +1947,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -117,7 +117,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -329,7 +329,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -564,7 +564,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -634,7 +634,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -1218,7 +1218,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1253,7 +1253,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1292,7 +1292,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1331,7 +1331,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1374,7 +1374,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1409,7 +1409,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1651,7 +1651,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1686,7 +1686,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1911,7 +1911,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1946,7 +1946,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:
@@ -1981,7 +1981,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -44,7 +44,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -83,7 +83,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -275,7 +275,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-root
     decorate: true
     decoration_config:
@@ -677,7 +677,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-root
     decorate: true
     decoration_config:
@@ -1301,7 +1301,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations-root
     decorate: true
     decoration_config:
@@ -1343,7 +1343,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1383,7 +1383,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1419,7 +1419,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime-root
     decorate: true
     decoration_config:
@@ -1809,7 +1809,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1845,7 +1845,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:
@@ -1881,7 +1881,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-compute
     decorate: true
     decoration_config:
@@ -2031,7 +2031,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute
     decorate: true
     decoration_config:
@@ -2067,7 +2067,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
     decorate: true
     decoration_config:
@@ -2106,7 +2106,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-operator
     decorate: true
     decoration_config:
@@ -2218,7 +2218,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
     decorate: true
     decoration_config:
@@ -2256,7 +2256,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator-upgrade
     decorate: true
     decoration_config:
@@ -2292,7 +2292,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator-configuration
     decorate: true
     decoration_config:
@@ -2330,7 +2330,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-psa-sig-operator
     decorate: true
     decoration_config:


### PR DESCRIPTION
These workloads from the main branch have been stable on the new
cluster[1] - move over the release e2e lanes to the new cluster.

[1] https://github.com/kubevirt/project-infra/pull/2681

/cc @dhiller @enp0s3 