### PR TITLE
Move project-infra prowjobs from old workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -175,7 +175,7 @@ periodics:
     repo: project-infra
     base_ref: main
     work_dir: true
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/autoowners:v20220817-6d185c5
@@ -524,7 +524,7 @@ periodics:
       repo: project-infra
       base_ref: main
       workdir: true
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -553,7 +553,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -584,7 +584,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -615,7 +615,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     securityContext:
       runAsUser: 0
@@ -647,7 +647,7 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-shared-images: "true"
-  cluster: prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -96,7 +96,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -316,7 +316,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -346,7 +346,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -979,7 +979,7 @@ postsubmits:
       always_run: false
       annotations:
         testgrid-create-test-group: "false"
-      cluster: prow-workloads
+      cluster: ibm-prow-jobs
       decorate: true
       decoration_config:
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -328,7 +328,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -355,7 +355,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
@@ -435,7 +435,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -477,7 +477,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -514,7 +514,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -551,7 +551,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -588,7 +588,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -625,7 +625,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -662,7 +662,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -700,7 +700,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-bazel-cache: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
This change moves the lighter jobs to the managed control plane cluster and the heavier jobs to the new workloads cluster. 

/cc @dhiller 