### PR TITLE
Correct typo in older image URL for CDI release branches

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
@@ -107,7 +107,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a633
+        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
@@ -45,7 +45,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a633
+        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
@@ -45,7 +45,7 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a633
+        - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
Results in broken lanes such as https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-cdi-generate-verify-1.49