### PR TITLE
Add the help plugin to a number of projects

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -143,6 +143,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    - help
 
   kubevirt/common-templates:
     plugins:
@@ -151,6 +152,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    - help
 
   kubevirt/community:
     plugins:
@@ -166,6 +168,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    - help
 
   kubevirt/containerized-data-importer:
     plugins:
@@ -385,6 +388,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    - help
 
   kubevirt/terraform-provider-kubevirt:
     plugins:
@@ -414,6 +418,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    - help
 
   kubevirt/vm-import-operator:
     plugins:


### PR DESCRIPTION
/cc @0xFelix 
/cc @ksimon1 
/cc @akrejcir 
/cc @jcanocan 
/cc @opokornyy 
/cc @codingben 

The Red Hat CNV Infra team would like to adopt the use of the help prow plugin and commands across a number of projects where we are the main contributors. More details on the plugin available here:

https://www.kubernetes.dev/docs/guide/help-wanted/