### PR TITLE
Update bazel WORKSPACE, add missing files

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -150,6 +150,167 @@ go_repository(
     version = "v1.1.1",
 )
 
+go_repository(
+    name = "com_github_ajstarks_deck",
+    importpath = "github.com/ajstarks/deck",
+    sum = "h1:7kQgkwGRoLzC9K0oyXdJo7nve/bynv/KwUsxbiTlzAM=",
+    version = "v0.0.0-20200831202436-30c9fc6549a9",
+)
+
+go_repository(
+    name = "com_github_ajstarks_deck_generate",
+    importpath = "github.com/ajstarks/deck/generate",
+    sum = "h1:iXUgAaqDcIUGbRoy2TdeofRG/j1zpGRSEmNK05T+bi8=",
+    version = "v0.0.0-20210309230005-c3f852c02e19",
+)
+
+go_repository(
+    name = "com_github_ajstarks_svgo",
+    importpath = "github.com/ajstarks/svgo",
+    sum = "h1:slYM766cy2nI3BwyRiyQj/Ud48djTMtMebDqepE95rw=",
+    version = "v0.0.0-20211024235047-1546f124cd8b",
+)
+
+go_repository(
+    name = "com_github_boombuler_barcode",
+    importpath = "github.com/boombuler/barcode",
+    sum = "h1:NDBbPmhS+EqABEs5Kg3n/5ZNjy73Pz7SIV+KCeqyXcs=",
+    version = "v1.0.1",
+)
+
+go_repository(
+    name = "com_github_fogleman_gg",
+    importpath = "github.com/fogleman/gg",
+    sum = "h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=",
+    version = "v1.3.0",
+)
+
+go_repository(
+    name = "com_github_go_fonts_dejavu",
+    importpath = "github.com/go-fonts/dejavu",
+    sum = "h1:JSajPXURYqpr+Cu8U9bt8K+XcACIHWqWrvWCKyeFmVQ=",
+    version = "v0.1.0",
+)
+
+go_repository(
+    name = "com_github_go_fonts_latin_modern",
+    importpath = "github.com/go-fonts/latin-modern",
+    sum = "h1:5/Tv1Ek/QCr20C6ZOz15vw3g7GELYL98KWr8Hgo+3vk=",
+    version = "v0.2.0",
+)
+
+go_repository(
+    name = "com_github_go_fonts_liberation",
+    importpath = "github.com/go-fonts/liberation",
+    sum = "h1:jAkAWJP4S+OsrPLZM4/eC9iW7CtHy+HBXrEwZXWo5VM=",
+    version = "v0.2.0",
+)
+
+go_repository(
+    name = "com_github_go_fonts_stix",
+    importpath = "github.com/go-fonts/stix",
+    sum = "h1:UlZlgrvvmT/58o573ot7NFw0vZasZ5I6bcIft/oMdgg=",
+    version = "v0.1.0",
+)
+
+go_repository(
+    name = "com_github_go_latex_latex",
+    importpath = "github.com/go-latex/latex",
+    sum = "h1:6zl3BbBhdnMkpSj2YY30qV3gDcVBGtFgVsV3+/i+mKQ=",
+    version = "v0.0.0-20210823091927-c0d11ff05a81",
+)
+
+go_repository(
+    name = "com_github_go_pdf_fpdf",
+    importpath = "github.com/go-pdf/fpdf",
+    sum = "h1:MlgtGIfsdMEEQJr2le6b/HNr1ZlQwxyWr77r2aj2U/8=",
+    version = "v0.6.0",
+)
+
+go_repository(
+    name = "com_github_golang_freetype",
+    importpath = "github.com/golang/freetype",
+    sum = "h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=",
+    version = "v0.0.0-20170609003504-e2365dfdc4a0",
+)
+
+go_repository(
+    name = "com_github_jung_kurt_gofpdf",
+    importpath = "github.com/jung-kurt/gofpdf",
+    sum = "h1:EroSdlP9BOoL5ssLYf3uLJXhCQMMM2fFxCJDKA3RhnA=",
+    version = "v1.0.0",
+)
+
+go_repository(
+    name = "com_github_metalblueberry_go_plotly",
+    importpath = "github.com/MetalBlueberry/go-plotly",
+    sum = "h1:ld/FLZIwLmPdv09ljANonwEqSoI1uNn7myLYAVjBQ48=",
+    version = "v0.4.0",
+)
+
+go_repository(
+    name = "com_github_phpdave11_gofpdf",
+    importpath = "github.com/phpdave11/gofpdf",
+    sum = "h1:KPKiIbfwbvC/wOncwhrpRdXVj2CZTCFlw4wnoyjtHfQ=",
+    version = "v1.4.2",
+)
+
+go_repository(
+    name = "com_github_phpdave11_gofpdi",
+    importpath = "github.com/phpdave11/gofpdi",
+    sum = "h1:o61duiW8M9sMlkVXWlvP92sZJtGKENvW3VExs6dZukQ=",
+    version = "v1.0.13",
+)
+
+go_repository(
+    name = "com_github_pkg_browser",
+    importpath = "github.com/pkg/browser",
+    sum = "h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=",
+    version = "v0.0.0-20180916011732-0a3d74bf9ce4",
+)
+
+go_repository(
+    name = "com_github_ruudk_golang_pdf417",
+    importpath = "github.com/ruudk/golang-pdf417",
+    sum = "h1:K1Xf3bKttbF+koVGaX5xngRIZ5bVjbmPnaxE/dR08uY=",
+    version = "v0.0.0-20201230142125-a7e3863a1245",
+)
+
+go_repository(
+    name = "ht_sr_git_sbinet_gg",
+    importpath = "git.sr.ht/~sbinet/gg",
+    sum = "h1:LNhjNn8DerC8f9DHLz6lS0YYul/b602DUxDgGkd/Aik=",
+    version = "v0.3.1",
+)
+
+go_repository(
+    name = "io_rsc_pdf",
+    importpath = "rsc.io/pdf",
+    sum = "h1:k1MczvYDUvJBe93bYd7wrZLLUEcLZAuF824/I4e5Xr4=",
+    version = "v0.1.1",
+)
+
+go_repository(
+    name = "org_gioui",
+    importpath = "gioui.org",
+    sum = "h1:K72hopUosKG3ntOPNG4OzzbuhxGuVf06fa2la1/H/Ho=",
+    version = "v0.0.0-20210308172011-57750fc8a0a6",
+)
+
+go_repository(
+    name = "org_golang_x_exp_shiny",
+    importpath = "golang.org/x/exp/shiny",
+    sum = "h1:pkl1Ko5DrhA4ezwKwdnmO7H1sKmMy9qLuYKRjS7SlmE=",
+    version = "v0.0.0-20220722155223-a9213eeb770e",
+)
+
+go_repository(
+    name = "org_gonum_v1_plot",
+    importpath = "gonum.org/v1/plot",
+    sum = "h1:y1ZNmfz/xHuHvtgFe8USZVyykQo5ERXPnspQNVK15Og=",
+    version = "v0.12.0",
+)
+
 gazelle_dependencies()
 
 register_toolchains("//:py_toolchain")

--- a/external-plugins/rehearse/plugin/handler/BUILD.bazel
+++ b/external-plugins/rehearse/plugin/handler/BUILD.bazel
@@ -38,5 +38,6 @@ go_test(
         "@io_k8s_test_infra//prow/config:go_default_library",
         "@io_k8s_test_infra//prow/git/localgit:go_default_library",
         "@io_k8s_test_infra//prow/git/v2:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
     ],
 )

--- a/go_third_party.bzl
+++ b/go_third_party.bzl
@@ -40,8 +40,8 @@ def go_deps():
         name = "co_honnef_go_tools",
         build_file_proto_mode = "disable",
         importpath = "honnef.co/go/tools",
-        sum = "h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=",
-        version = "v0.0.1-2020.1.4",
+        sum = "h1:qTakTkI6ni6LFD5sBwwsdSO+AQqbSIxOauHTTQKZ/7o=",
+        version = "v0.1.3",
     )
     go_repository(
         name = "com_github_agnivade_levenshtein",
@@ -1483,8 +1483,8 @@ def go_deps():
         name = "com_github_golang_mock",
         build_file_proto_mode = "disable",
         importpath = "github.com/golang/mock",
-        sum = "h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=",
-        version = "v1.4.4",
+        sum = "h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=",
+        version = "v1.5.0",
     )
     go_repository(
         name = "com_github_golang_protobuf",
@@ -2185,8 +2185,8 @@ def go_deps():
         name = "com_github_huandu_xstrings",
         build_file_proto_mode = "disable",
         importpath = "github.com/huandu/xstrings",
-        sum = "h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=",
-        version = "v1.2.0",
+        sum = "h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=",
+        version = "v1.3.2",
     )
     go_repository(
         name = "com_github_ianlancetaylor_demangle",
@@ -4658,15 +4658,15 @@ def go_deps():
         name = "org_golang_x_exp",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/exp",
-        sum = "h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=",
-        version = "v0.0.0-20200224162631-6cc2880d07d6",
+        sum = "h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=",
+        version = "v0.0.0-20220827204233-334a2380cb91",
     )
     go_repository(
         name = "org_golang_x_image",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/image",
-        sum = "h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=",
-        version = "v0.0.0-20190802002840-cff245a6509b",
+        sum = "h1:Lj6HJGCSn5AjxRAH2+r35Mir4icalbqku+CLUtjnvXY=",
+        version = "v0.0.0-20220902085622-e7cb96979f69",
     )
     go_repository(
         name = "org_golang_x_lint",
@@ -4715,8 +4715,8 @@ def go_deps():
         name = "org_golang_x_sys",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/sys",
-        sum = "h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=",
-        version = "v0.0.0-20220520151302-bc2c85ada10a",
+        sum = "h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=",
+        version = "v0.0.0-20220722155257-8c9f86f7a55f",
     )
     go_repository(
         name = "org_golang_x_term",
@@ -4757,8 +4757,8 @@ def go_deps():
         name = "org_gonum_v1_gonum",
         build_file_proto_mode = "disable",
         importpath = "gonum.org/v1/gonum",
-        sum = "h1:OB/uP/Puiu5vS5QMRPrXCDWUPb+kt8f1KW8oQzFejQw=",
-        version = "v0.0.0-20190331200053-3d26580ed485",
+        sum = "h1:xKuo6hzt+gMav00meVPUlXwSdoEJP46BR+wdxQEFK2o=",
+        version = "v0.12.0",
     )
     go_repository(
         name = "org_gonum_v1_netlib",

--- a/images/shared-images-controller/BUILD.bazel
+++ b/images/shared-images-controller/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/images/shared-images-controller",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/pkg/querier:go_default_library",
+        "@com_github_containers_podman_v4//pkg/bindings:go_default_library",
+        "@com_github_containers_podman_v4//pkg/bindings/images:go_default_library",
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "shared-images-controller",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/cmd/perf-report-creator/BUILD.bazel
+++ b/robots/cmd/perf-report-creator/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "api.go",
+        "main.go",
+        "plot.go",
+        "record.go",
+    ],
+    importpath = "kubevirt.io/project-infra/robots/cmd/perf-report-creator",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/pkg/flakefinder:go_default_library",
+        "@com_github_metalblueberry_go_plotly//graph_objects:go_default_library",
+        "@com_github_metalblueberry_go_plotly//offline:go_default_library",
+        "@com_google_cloud_go_storage//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
+        "@org_gonum_v1_plot//:go_default_library",
+        "@org_gonum_v1_plot//plotter:go_default_library",
+        "@org_gonum_v1_plot//vg:go_default_library",
+        "@org_gonum_v1_plot//vg/draw:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "perf-report-creator",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/pkg/flakefinder/BUILD.bazel
+++ b/robots/pkg/flakefinder/BUILD.bazel
@@ -14,8 +14,8 @@ go_library(
         "@com_github_joshdk_go_junit//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
-        "@org_golang_google_api//iterator:go_default_library",
         "@io_k8s_test_infra//prow/apis/prowjobs/v1:go_default_library",
+        "@org_golang_google_api//iterator:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Seems like we missed some updates for bazel workspace when the latest modifications to `go.mod` got in.