### PR TITLE
Increase memory request for test-github-ci-services

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -96,9 +96,9 @@ presubmits:
         - "bazel build //github/ci/services/..."
         resources:
           requests:
-            memory: "2Gi"
+            memory: "4Gi"
           limits:
-            memory: "2Gi"
+            memory: "4Gi"
         securityContext:
           runAsUser: 0
   - name: build-kubevirt-infra-bootstrap-image


### PR DESCRIPTION
Presubmit seems to get killed due to OOM, let's increase the memory request.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2717/pull-project-infra-test-github-ci-services/1648694386088742912

Successful run here:

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2717/pull-project-infra-test-github-ci-services/1648704604306673664

/cc @brianmcarey 