### PR TITLE
sriov-passthru-cni: Enable allocation restriction of system reserved PFs

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -68,3 +68,12 @@ requests:
 limits:
   prow/sriov: "2"
 ```
+
+# Reserved system SR-IOV PFs
+Some nodes external network interfaces have SR-IOV capabilities, including the cluster network interface.
+The CNI may allocate such interfaces and cause network disconnection to the node.
+
+In order to prevent from the CNI to allocate such interfaces, set the `SYSTEM_RESERVED_PFS` with the interfaces that CNI should not allocate in a comma seperated form:
+```bash
+SYSTEM_RESERVED_PFS="eno1,eno2,eno3"
+```

--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -6,6 +6,8 @@ readonly GW_IP=169.255.0.1
 readonly CONTAINER_NETNS_LINK="/var/run/netns/$CNI_CONTAINERID"
 readonly LOGFILE=/var/log/pfcni.log
 readonly PF_COUNT=1
+# SYSTEM_RESERVED_PFS comma seperated list of interfaces that will not be allocated, e.g: "enp1f1,enp1f2,.."
+readonly SYSTEM_RESERVED_PFS=""
 
 function main() {
     case "$CNI_COMMAND" in
@@ -38,6 +40,11 @@ function setns_sriov_pfs() {
   for pf in "${sriov_pfs[@]}"; do
     local pf_name="${pf%%/device/*}"
     pf_name="${pf_name##*/}"
+
+    if reserved_pf "${pf_name}"; then
+      continue
+    fi
+
     if ip link set "$pf_name" netns "$CNI_CONTAINERID"; then
       if timeout 5s bash -c "until ip netns exec $CNI_CONTAINERID ip link show $pf_name > /dev/null; do sleep 1; done"; then
         log "Added $pf_name to netns $CNI_CONTAINERID"
@@ -52,6 +59,13 @@ function setns_sriov_pfs() {
 
   log "FATAL: Could not allocate enough PFs"
   exit 1
+}
+
+function reserved_pf() {
+    local -r pf=$1
+    if [ -n "${SYSTEM_RESERVED_PFS}" ]; then
+        grep -w -q ${pf} <<< "${SYSTEM_RESERVED_PFS}"
+    fi
 }
 
 function gen_result_config() {


### PR DESCRIPTION
Some nodes external network interfaces have SR-IOV capabilities, including the cluster network interface.
Nothing prevent the CNI from allocating such interfaces, which if they do get allocated, the node will have network disconnection.

To prevent such cases, the 'SYSTEM_RESERVED_PFS' env var is introduced to enable users specify the interfaces the CNI should not allocate.

The CNI will not allocate interfaces that specified in the 'SYSTEM_RESERVED_PFS' env var.

The 'SYSTEM_RESERVED_PFS' env var value is expected to be in the form of comma separated list: "eno1,eno2,eno3".