### PR TITLE
Revert move of prow-deploy-test

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -435,7 +435,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
Since the move it is failing:

https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-project-infra-prow-deploy-test

I suggest to move it back and investigate what is wrong.

/cc @brianmcarey @enp0s3