### PR TITLE
sriov-passtru-cni: Do not override SYSTEM_RESERVED_NICS env var

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -6,8 +6,6 @@ readonly GW_IP=169.255.0.1
 readonly CONTAINER_NETNS_LINK="/var/run/netns/$CNI_CONTAINERID"
 readonly LOGFILE=/var/log/pfcni.log
 readonly PF_COUNT=1
-# SYSTEM_RESERVED_PFS comma seperated list of interfaces that will not be allocated, e.g: "enp1f1,enp1f2,.."
-readonly SYSTEM_RESERVED_PFS=""
 
 function main() {
     case "$CNI_COMMAND" in


### PR DESCRIPTION
Following #2719, make the CNI to not override the `SYSTEM_RESERVED_NICS` env var.

The `SYSTEM_RESERVED_NICS` should be set in the context where the CNI runs, if it is deployed using a  DaemonSet it should be specified in the spec.