### PR TITLE
sriov-passtru-cni: Use file instead of env var for reserved ifaces

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/README.md
+++ b/cni-plugins/sriov-passthrough-cni/README.md
@@ -73,7 +73,11 @@ limits:
 Some nodes external network interfaces have SR-IOV capabilities, including the cluster network interface.
 The CNI may allocate such interfaces and cause network disconnection to the node.
 
-In order to prevent from the CNI to allocate such interfaces, set the `SYSTEM_RESERVED_PFS` with the interfaces that CNI should not allocate in a comma seperated form:
+In order to prevent from the CNI to allocate such interfaces, create a file at `/etc/pfscni-system-reserved-interfaces` with the interfaces names the CNI should not allocate.
+Each interface name should be in a new line as follows:
 ```bash
-SYSTEM_RESERVED_PFS="eno1,eno2,eno3"
+cat /etc/pfscni-system-reserved-interfaces
+eno1
+eno2
+eno3
 ```

--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -6,8 +6,7 @@ readonly GW_IP=169.255.0.1
 readonly CONTAINER_NETNS_LINK="/var/run/netns/$CNI_CONTAINERID"
 readonly LOGFILE=/var/log/pfcni.log
 readonly PF_COUNT=1
-# SYSTEM_RESERVED_PFS comma seperated list of interfaces that will not be allocated, e.g: "enp1f1,enp1f2,.."
-readonly SYSTEM_RESERVED_PFS=""
+readonly SYSTEM_RESERVED_PFS_LIST_FILE="/etc/pfscni-system-reserved-interfaces"
 
 function main() {
     case "$CNI_COMMAND" in
@@ -63,8 +62,8 @@ function setns_sriov_pfs() {
 
 function reserved_pf() {
     local -r pf=$1
-    if [ -n "${SYSTEM_RESERVED_PFS}" ]; then
-        grep -w -q ${pf} <<< "${SYSTEM_RESERVED_PFS}"
+    if [ -f "${SYSTEM_RESERVED_PFS_LIST_FILE}" ]; then
+        grep -w -q ${pf} ${SYSTEM_RESERVED_PFS_LIST_FILE}
     fi
 }
 


### PR DESCRIPTION
Using an env var is not effective due to how the CNI is executed in k8s cluster.

Replace the `SYSTEM_RESERVED_PFS` with a file that will have the reserved system SR-IOV PF interface names.

The file can be created on the relevant nodes using MachineConfig API.