### PR TITLE
Fix publishing of rehearse image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -13,7 +13,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap-legacy:v20221205-e30b34a
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"


### PR DESCRIPTION
Doesn't work with new bootstrap, switched to bootstrap-legacy.

Successful run here:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-rehearse-image/1649342296828678144

/cc @brianmcarey 