### PR TITLE
Introduce check for bazel configurations

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -101,6 +101,34 @@ presubmits:
             memory: "4Gi"
         securityContext:
           runAsUser: 0
+  - name: pull-project-infra-test-bazel-config
+    run_if_changed: "github/ci/services/.*|external-plugins/.*|releng/.*|robots/.*|go.mod"
+    decorate: true
+    cluster: ibm-prow-jobs
+    labels:
+      preset-bazel-cache: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
+        - |
+          make gazelle gazelle-update-repos
+          if [ $(git status --short | wc -l) -gt 0 ]; then
+            echo "Bazel configs need an update"
+            echo "Uncommitted changes:"
+            git diff
+            exit 1
+          fi
+        resources:
+          requests:
+            memory: "4Gi"
+          limits:
+            memory: "4Gi"
+        securityContext:
+          runAsUser: 0
   - name: build-kubevirt-infra-bootstrap-image
     always_run: false
     run_if_changed: "images/kubevirt-infra-bootstrap/.*"


### PR DESCRIPTION
In the past it was forgotten to update the bazel configurations after changes were merged. Thus we introduce a presubmit that checks whether the config files need an update.

Example run against https://github.com/kubevirt/project-infra/pull/2703 here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2703/pull-project-infra-test-bazel-config/1649399907032764416

/cc @brianmcarey @enp0s3 @xpivarc 