### PR TITLE
Set repo flag to project-infra for pull request

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -767,7 +767,7 @@ periodics:
       args:
       - "-ce"
       - |
-        ./hack/git-pr.sh -c "bazel run //robots/cmd/dependabot:dependabot -- --github-token-path /etc/github/oauth --repo project-infra --org kubevirt --repo-dir $(pwd) && make gazelle gazelle-update-repos test" -b dependabot-update -T main
+        ./hack/git-pr.sh -c "bazel run //robots/cmd/dependabot:dependabot -- --github-token-path /etc/github/oauth --repo project-infra --org kubevirt --repo-dir $(pwd) && make gazelle gazelle-update-repos test" -b dependabot-update -r project-infra -T main
       resources:
         requests:
           memory: "1Gi"


### PR DESCRIPTION
This failure https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-dependabot-update/1650474493983854592#1:build-log.txt%3A1686 shows that the PR is created against the wrong repo (kubevirt/kubevirt). This PR corrects the repo for the PR. 