### PR TITLE
Move CNAO release lanes to the new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -138,7 +138,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -171,7 +171,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -200,7 +200,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -233,7 +233,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -266,7 +266,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
@@ -136,7 +136,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -167,7 +167,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -194,7 +194,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 4
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -225,7 +225,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 4
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -256,7 +256,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 4
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -101,7 +101,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -132,7 +132,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -163,7 +163,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -194,7 +194,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -225,7 +225,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -259,7 +259,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -290,7 +290,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -102,7 +102,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -135,7 +135,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -162,7 +162,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -193,7 +193,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -224,7 +224,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -255,7 +255,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -102,7 +102,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -135,7 +135,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -162,7 +162,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -193,7 +193,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -224,7 +224,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -255,7 +255,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -286,7 +286,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -317,7 +317,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"


### PR DESCRIPTION
The CNAO e2e lanes for the main branch have been running ok against the new workloads cluster[1] so the release lanes can now be moved over.

[1] https://github.com/kubevirt/project-infra/pull/2697