### PR TITLE
Use make target for rehearse push

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
               - "-c"
               - |
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
-                bazelisk run //external-plugins/rehearse/plugin:push
+                make -C external-plugins/rehearse push
             resources:
               requests:
                 memory: "8Gi"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20230403-169195b5
+          image: quay.io/kubevirtci/rehearse:v20230502-3f3ec5a3
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
Instead of using the pure bazel target we override the stamping inside the Makefile to use a short version for the tag.

We also update the image for rehearse plugin to include fix from #2737