### PR TITLE
Update bootstrap image to make podman in container setup more resilient

### DIFF
--- a/images/bootstrap/containers.conf
+++ b/images/bootstrap/containers.conf
@@ -1,5 +1,5 @@
 [containers]
-netns="host"
+netns="private"
 userns="host"
 ipcns="host"
 cgroupns="host"

--- a/images/bootstrap/podman.json
+++ b/images/bootstrap/podman.json
@@ -17,6 +17,9 @@
   "ipv6_enabled": true,
   "internal": false,
   "dns_enabled": true,
+  "network_dns_servers": [
+    "8.8.8.8"
+  ],
   "ipam_options": {
     "driver": "host-local"
   }

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -91,7 +91,7 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
     )
     # the service can be started but the socket not ready, wait for ready
     WAIT_N=0
-    MAX_WAIT=10
+    MAX_WAIT=20
     while true; do
         # wait for podman socket to be ready
         curl --unix-socket "${PODMAN_SOCKET}" http://d/v3.0.0/libpod/info >/dev/null 2>&1 && break


### PR DESCRIPTION
 - Increase wait for podman socket to be ready - When a large numbers of jobs start on a node at once, there is high disk
IO which causes the podman socket to take longer to reach a ready
state[1] - increase the timeout to allow for this.

- Add upstream dns server for podman in container network - This helps to reduce the dependency on the host CI clusters DNS and
reduces the number of search domains that is included in the podman in
podman containers.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9268/pull-kubevirt-e2e-k8s-1.24-sig-storage/1653301111404105728

/cc @dhiller 