### PR TITLE
Move network kubevirt e2e lanes to the new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1395,7 +1395,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 10 7,15,23 * * *
   decorate: true
   decoration_config:
@@ -1430,7 +1430,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.24-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+      image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
       name: ""
       resources:
         requests:
@@ -1583,7 +1583,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 20 0,8,16 * * *
   decorate: true
   decoration_config:
@@ -1618,7 +1618,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.25-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+      image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
       name: ""
       resources:
         requests:
@@ -1771,7 +1771,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 0 5 * * 0
   decorate: true
   decoration_config:
@@ -1812,7 +1812,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network-no-istio
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+      image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
       name: ""
       resources:
         requests:
@@ -1824,7 +1824,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 30 1,9,17 * * *
   decorate: true
   decoration_config:
@@ -1861,7 +1861,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+      image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
       name: ""
       resources:
         requests:
@@ -2118,7 +2118,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 30 6,22 * * *
   decorate: true
   decoration_config:
@@ -2205,7 +2205,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 40 2,10,18 * * *
   decorate: true
   decoration_config:
@@ -2242,7 +2242,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.27-sig-network
-      image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+      image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
       name: ""
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
@@ -156,7 +156,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -1114,7 +1114,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1149,7 +1149,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1184,7 +1184,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1552,7 +1552,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1842,7 +1842,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -156,7 +156,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -484,10 +484,10 @@ presubmits:
         name: vfio
   - always_run: false
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -1113,7 +1113,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1148,7 +1148,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1551,7 +1551,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1841,7 +1841,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -313,7 +313,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network-root
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
           value: k8s-1.24-sig-network
         - name: FEATURE_GATES
           value: Root
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1188,7 +1188,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1212,7 +1212,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-ipv6-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1224,7 +1224,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1249,7 +1249,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-ipv6-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1261,7 +1261,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-psa-sig-network
     decorate: true
     decoration_config:
@@ -1289,7 +1289,7 @@ presubmits:
           value: k8s-1.26-ipv6-sig-network
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1698,7 +1698,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1722,7 +1722,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1734,7 +1734,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-network
     decorate: true
     decoration_config:
@@ -1761,7 +1761,7 @@ presubmits:
           value: "true"
         - name: TARGET
           value: k8s-1.25-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1959,7 +1959,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-network
     decorate: true
     decoration_config:
@@ -1983,7 +1983,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -2142,7 +2142,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
     decorate: true
     decoration_config:
@@ -2168,7 +2168,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -88,7 +88,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: ibm-prow-jobs
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1051,7 +1051,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1079,7 +1079,7 @@ presubmits:
           value: k8s-1.25-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1092,7 +1092,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1121,7 +1121,7 @@ presubmits:
           value: k8s-1.26-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1134,7 +1134,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1164,7 +1164,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_WITH_MULTUS_V3
           value: "false"
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1515,7 +1515,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1541,7 +1541,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.24-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1671,7 +1671,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1697,7 +1697,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1869,7 +1869,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1897,7 +1897,7 @@ presubmits:
           value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -2104,7 +2104,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -2133,7 +2133,7 @@ presubmits:
           value: k8s-1.27-sig-network
         - name: KUBEVIRT_PSA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:


### PR DESCRIPTION
Successful run of 1.25 network periodic:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.25-sig-network/1653466335042080768

/cc @dhiller 