### PR TITLE
Increase max concurrency of vpgu e2e lane to 2

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -322,7 +322,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       vgpu: "true"
-    max_concurrency: 1
+    max_concurrency: 2
     name: pull-kubevirt-e2e-kind-1.25-vgpu
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
There are two nodes that have GPUs for vgpu testing. The anti-affinity should stop the jobs from being scheduled on the same node so the max concurrency should be increased from 1 to make use of our GPU nodes.

/cc @jean-edouard @fossedihelm @dhiller 