### PR TITLE
Revert "Increase max concurrency of vpgu e2e lane to 2 (#2747)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -322,7 +322,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       vgpu: "true"
-    max_concurrency: 2
+    max_concurrency: 1
     name: pull-kubevirt-e2e-kind-1.25-vgpu
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
This reverts commit 32ccf98bb85741fb56d9dd53f2d4a3c41b7ce5e5.

There has been a significant degradation in the vgpu lane performance since this change which suggests collisions in the jobs.

https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-kind-1.25-vgpu

/cc @xpivarc @dhiller 