### PR TITLE
Move containerdisks e2e jobs to new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-containerdisks-periodics
     testgrid-alert-email: fmatouschek@redhat.com, lyarwood@redhat.com
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 0 2 * * *
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -56,7 +56,7 @@ presubmits:
     optional: false
     annotations:
       testgrid-create-test-group: "false"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -91,7 +91,7 @@ presubmits:
     run_if_changed: "artifacts/centos/.*"
     annotations:
       testgrid-create-test-group: "false"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -126,7 +126,7 @@ presubmits:
     run_if_changed: "artifacts/centosstream/.*"
     annotations:
       testgrid-create-test-group: "false"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -161,7 +161,7 @@ presubmits:
     run_if_changed: "artifacts/fedora/.*"
     annotations:
       testgrid-create-test-group: "false"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -196,7 +196,7 @@ presubmits:
     run_if_changed: "artifacts/rhcos/.*|artifacts/rhcosprerelease/.*"
     annotations:
       testgrid-create-test-group: "false"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -231,7 +231,7 @@ presubmits:
     run_if_changed: "artifacts/ubuntu/.*"
     annotations:
       testgrid-create-test-group: "false"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s


### PR DESCRIPTION
Theses jobs should be moved to the new workloads cluster as the old cluster has been reduced in size to prepare for decommissioning.

/cc @0xFelix