### PR TITLE
Fix rehearsal plugin checkout

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,9 +9,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "59d5b42ac315e7eadffa944e86e90c2990110a1c8075f1cd145f487e999d22b3",
-    strip_prefix = "rules_docker-0.17.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.17.0/rules_docker-v0.17.0.tar.gz"],
+    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
+    #strip_prefix = "rules_docker-0.25.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
 )
 
 http_archive(
@@ -79,7 +79,7 @@ container_pull(
     name = "infra-base",
     registry = "gcr.io",
     repository = "k8s-testimages/bootstrap",
-    tag = "v20190516-c6832d9",
+    tag = "v20210913-fc7c4e8",
 )
 
 container_pull(

--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -227,7 +227,7 @@ func (h *GitHubEventsHandler) handleRehearsalForPR(log *logrus.Entry, pr *github
 	log.Infoln("Rebasing the PR on the target branch")
 	git.Config("user.email", "kubevirtbot@redhat.com")
 	git.Config("user.name", "Kubevirt Bot")
-	err = git.MergeAndCheckout(pr.Base.Ref, string(github.MergeSquash), pr.Head.SHA)
+	err = git.MergeAndCheckout(pr.Base.SHA, string(github.MergeSquash), pr.Head.SHA)
 	if err != nil {
 		log.WithError(err).Error("Could not rebase the PR on the target branch.")
 		return

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20230502-3f3ec5a3
+          image: quay.io/kubevirtci/rehearse:v20230505-0cdece69
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
Instead of checking out the pr.Base.Ref we checkout pr.Base.SHA to fetch the exact base of the branching point. This way we avoid getting updates that happened after the branching.

/cc @brianmcarey @xpivarc 