### PR TITLE
Move sig-network lanes for 0.58 back to old workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -156,7 +156,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -1113,7 +1113,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1148,7 +1148,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1551,7 +1551,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1841,7 +1841,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:


### PR DESCRIPTION
The 0.58 sig network lanes are hitting DNS issues on the new cluster

Move them to the old cluster until the issue is resolved

/cc @xpivarc @dhiller 