### PR TITLE
Update sig-virtualization label to sig-compute

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -219,13 +219,15 @@ default:
       previously:
         - name: topic/storage
           color: c5def5
-    - name: sig/virtualization
+    - name: sig/compute
       color: c5def5
       target: both
       prowPlugin: label
       addedBy: anyone
       previously:
         - name: topic/virtualization
+          color: c5def5
+        - name: sig-virtualization
           color: c5def5
     - name: sig/code-quality
       color: ce23cf


### PR DESCRIPTION
As I understand it 'sig-virtualization' is an outdated term for the group that is now called 'sig-compute'.

Suggestion was to change the label to recognise this ahead of the release notes changes:
https://github.com/kubevirt/kubevirt/pull/8752#discussion_r1189961016

Happy to add rather than replace if that makes more sense. 