### PR TITLE
Skip reporting on the failing fossa presubmit check

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -876,6 +876,7 @@ presubmits:
     optional: true
     skip_branches:
     - release-\d+\.\d+
+    skip_reporting: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
The fossa check has been failing constantly for the past couple of months so it is not adding any useful feedback to PRs - skip reporting the presubmit result until the issue is resolved.

/cc @dhiller @xpivarc 