### PR TITLE
Create periodic job for perf-report-creator

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -807,6 +807,7 @@ periodics:
         - "/bin/sh"
         - "-ce"
         - |
+          go build -o /usr/local/bin/perf-report-creator ./robots/cmd/perf-report-creator/...
           (
             cd ..
             git clone "https://kubevirt-bot@github.com/$TARGET_GITHUB_REPO.git"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -771,3 +771,56 @@ periodics:
       resources:
         requests:
           memory: "1Gi"
+- annotations:
+    testgrid-create-test-group: "false"
+  cluster: ibm-prow-jobs
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  interval: 168h
+  labels:
+    preset-bazel-cache: "true"
+    preset-gcs-credentials: "true"
+    preset-github-credentials: "true"
+  max_concurrency: 1
+  name: periodic-project-infra-perf-report-creator
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/golang:v20230502-bfaa042
+      env:
+        - name: GIMME_GO_VERSION
+          value: "1.19"
+        - name: GIT_AUTHOR_NAME
+          value: kubevirt-bot
+        - name: GIT_AUTHOR_EMAIL
+          value: kubevirtbot@redhat.com
+        - name: TARGET_GITHUB_REPO
+          value: kubevirt/ci-performance-benchmarks
+      command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
+        - |
+          (
+            cd ..
+            git clone "https://kubevirt-bot@github.com/$TARGET_GITHUB_REPO.git"
+            cd ci-performance-benchmarks
+            git config user.email "$GIT_AUTHOR_EMAIL"
+            git config user.name "$GIT_AUTHOR_NAME"
+          )
+          ci_perf_repo_dir=$(cd ../ci-performance-benchmarks && pwd)
+          bazel run //robots/cmd/perf-report-creator -- results --credentials-file $GOOGLE_APPLICATION_CREDENTIALS --output-dir $ci_perf_repo_dir/output/results
+          cd $ci_perf_repo_dir
+          git add -A $ci_perf_repo_dir/output/results
+          current_date=$(date --iso-8601=date)
+          git commit --signoff -m "Periodic data update from $current_date"
+          git push "https://kubevirt-bot@github.com/$TARGET_GITHUB_REPO.git" HEAD:main
+      resources:
+        requests:
+          memory: "1Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -815,7 +815,7 @@ periodics:
             git config user.name "$GIT_AUTHOR_NAME"
           )
           ci_perf_repo_dir=$(cd ../ci-performance-benchmarks && pwd)
-          bazel run //robots/cmd/perf-report-creator -- results --credentials-file $GOOGLE_APPLICATION_CREDENTIALS --output-dir $ci_perf_repo_dir/output/results
+          bazel run //robots/cmd/perf-report-creator -- results --since 168h --credentials-file $GOOGLE_APPLICATION_CREDENTIALS --output-dir $ci_perf_repo_dir/output/results
           cd $ci_perf_repo_dir
           git add -A $ci_perf_repo_dir/output/results
           current_date=$(date --iso-8601=date)

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -814,10 +814,11 @@ periodics:
             git config user.email "$GIT_AUTHOR_EMAIL"
             git config user.name "$GIT_AUTHOR_NAME"
           )
+          scrape_dir=$(mktemp -d)
           ci_perf_repo_dir=$(cd ../ci-performance-benchmarks && pwd)
-          bazel run //robots/cmd/perf-report-creator -- results --since 168h --credentials-file $GOOGLE_APPLICATION_CREDENTIALS --output-dir $ci_perf_repo_dir/output/results
+          ./robots/cmd/perf-report-creator/scrape.sh $GOOGLE_APPLICATION_CREDENTIALS $ci_perf_repo_dir $scrape_dir
           cd $ci_perf_repo_dir
-          git add -A $ci_perf_repo_dir/output/results
+          git add -A results weekly
           current_date=$(date --iso-8601=date)
           git commit --signoff -m "Periodic data update from $current_date"
           git push "https://kubevirt-bot@github.com/$TARGET_GITHUB_REPO.git" HEAD:main


### PR DESCRIPTION
Creates a job that executes the perf-report-creator robots from project-infra on a weekly basis.

This can serve as the groundwork for #2705, we could add the graph plotting etc. to the same job or create a different one.

/hold

/cc @alaypatel07 @rthallisey @xpivarc 