### PR TITLE
Actually use ci-maintainers alias

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,21 +1,17 @@
 filters:
   ".*":
     reviewers:
+      - ci-maintainers
       - aglitke
-      - brianmcarey
       - davidvossel
-      - dhiller
-      - enp0s3
       - phoracek
       - rmohr
       - tiraboschi
       - vladikr
     approvers:
+      - ci-maintainers
       - aglitke
-      - brianmcarey
       - davidvossel
-      - dhiller
-      - enp0s3
       - phoracek
       - rmohr
       - tiraboschi

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,3 +3,4 @@ aliases:
   - dhiller
   - brianmcarey
   - enp0s3
+  - xpivarc


### PR DESCRIPTION
According to the [prow documentation](https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/#overview) `OWNERS` files contain either references to GitHub users or to groups of users, which are defined in `OWNERS_ALIASES`. Since we didn't reference `ci-maintainers` the group actually was not used.

This PR adds the group `ci-maintainers` from `OWNERS_ALIASES` to `reviewers` and `approvers` in `OWNERS`.

(we could argue about whether we want to add this group to approvers in order to reduce the load of reviews for ci-maintainers group)

/cc @brianmcarey 

FYI @xpivarc 