### PR TITLE
Move remaining prow jobs to the new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - main
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
@@ -34,7 +34,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - ^v\d+\.\d+\.\d+$
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
@@ -33,7 +33,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
@@ -35,7 +35,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - main
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
@@ -34,7 +34,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - ^v\d+\.\d+\.\d+$
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.29.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.29.yaml
@@ -16,7 +16,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     optional: true
     decorate: true
     skip_report: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decoration_config:
       grace_period: 5m0s
       timeout: 3h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - main
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
@@ -34,7 +34,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - ^\d+\.\d+\.\d+$
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 6
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     always_run: true
     optional: false
     skip_report: false
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 10m
@@ -47,7 +47,7 @@ presubmits:
     always_run: true
     optional: false
     skip_report: false
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 10m
@@ -80,7 +80,7 @@ presubmits:
     always_run: true
     optional: false
     decorate: true
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decoration_config:
       grace_period: 5m0s
       timeout: 3h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -101,7 +101,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -132,7 +132,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -163,7 +163,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -194,7 +194,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -225,7 +225,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -256,7 +256,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
@@ -27,7 +27,7 @@ presubmits:
       - release-0.1
     always_run: false
     run_if_changed: "^common.*yaml"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       annotations:
         testgrid-create-test-group: "false"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       - main
     always_run: false
     run_if_changed: "^common.*yaml"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       timeout: 3h
       grace_period: 5m
     max_concurrency: 6
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-release-hostpath-provisioner-operator-images
     branches:
     - release-v\d+\.\d+
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     always_run: true
     optional: false
     skip_report: true
@@ -43,7 +43,7 @@ postsubmits:
   - name: push-latest-hostpath-provisioner-operator-images
     branches:
     - main
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -72,7 +72,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-github-credentials: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       always_run: true
       optional: false
       decorate: true
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2254,7 +2254,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-workloads
+  cluster: kubevirt-prow-workloads
   cron: 50 3,11,19 * * *
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -228,7 +228,7 @@ postsubmits:
     reporter_config:
       slack:
         job_states_to_report: []
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -378,7 +378,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -584,7 +584,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -784,7 +784,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1192,7 +1192,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1227,7 +1227,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1263,7 +1263,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1564,7 +1564,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1641,7 +1641,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1676,7 +1676,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1781,7 +1781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -436,7 +436,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -643,7 +643,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -845,7 +845,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1253,7 +1253,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1288,7 +1288,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1323,7 +1323,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1623,7 +1623,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1700,7 +1700,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1735,7 +1735,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1805,7 +1805,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1840,7 +1840,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1881,7 +1881,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -436,7 +436,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -643,7 +643,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -845,7 +845,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1253,7 +1253,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1288,7 +1288,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1324,7 +1324,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1624,7 +1624,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1701,7 +1701,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1736,7 +1736,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1841,7 +1841,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1882,7 +1882,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -435,7 +435,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -640,7 +640,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -840,7 +840,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1248,7 +1248,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1283,7 +1283,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1318,7 +1318,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1618,7 +1618,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1695,7 +1695,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1725,7 +1725,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1760,7 +1760,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1865,7 +1865,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1906,7 +1906,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1937,7 +1937,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -298,7 +298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -337,7 +337,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -434,7 +434,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -757,7 +757,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1165,7 +1165,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1200,7 +1200,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1235,7 +1235,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1535,7 +1535,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1612,7 +1612,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1642,7 +1642,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1677,7 +1677,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1782,7 +1782,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1823,7 +1823,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1854,7 +1854,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -298,7 +298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -337,7 +337,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -434,7 +434,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -748,7 +748,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1156,7 +1156,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1191,7 +1191,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1226,7 +1226,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1526,7 +1526,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1603,7 +1603,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1633,7 +1633,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1668,7 +1668,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1773,7 +1773,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1814,7 +1814,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1845,7 +1845,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -183,7 +183,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -260,7 +260,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -435,7 +435,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -750,7 +750,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1158,7 +1158,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1193,7 +1193,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1228,7 +1228,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1528,7 +1528,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1605,7 +1605,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1635,7 +1635,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1700,7 +1700,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1805,7 +1805,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1846,7 +1846,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1877,7 +1877,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1923,7 +1923,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1959,7 +1959,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
@@ -44,7 +44,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirtci-bump-kubevirt
     decorate: true
     decoration_config:
@@ -159,7 +159,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -199,7 +199,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -239,7 +239,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
     decorate: true
     decoration_config:
@@ -278,7 +278,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
     decorate: true
     decoration_config:
@@ -377,7 +377,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -632,7 +632,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -693,7 +693,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1113,7 +1113,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1149,7 +1149,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1185,7 +1185,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1453,7 +1453,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1531,7 +1531,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1562,7 +1562,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1629,7 +1629,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1737,7 +1737,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1779,7 +1779,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1811,7 +1811,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1858,7 +1858,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1894,7 +1894,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
@@ -43,7 +43,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirtci-bump-kubevirt
     decorate: true
     decoration_config:
@@ -79,7 +79,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -195,7 +195,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -234,7 +234,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
     decorate: true
     decoration_config:
@@ -271,7 +271,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
     decorate: true
     decoration_config:
@@ -329,7 +329,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -368,7 +368,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -707,7 +707,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1445,7 +1445,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1522,7 +1522,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1617,7 +1617,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1722,7 +1722,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1763,7 +1763,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1796,7 +1796,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1877,7 +1877,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -43,7 +43,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirtci-bump-kubevirt
     decorate: true
     decoration_config:
@@ -79,7 +79,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -195,7 +195,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -234,7 +234,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
     decorate: true
     decoration_config:
@@ -271,7 +271,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
     decorate: true
     decoration_config:
@@ -368,7 +368,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -707,7 +707,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1183,7 +1183,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1444,7 +1444,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1521,7 +1521,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1616,7 +1616,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1721,7 +1721,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1762,7 +1762,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1795,7 +1795,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1876,7 +1876,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -2017,7 +2017,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -122,7 +122,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirtci-bump-kubevirt
     decorate: true
     decoration_config:
@@ -158,7 +158,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -197,7 +197,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -236,7 +236,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -351,7 +351,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-root
     decorate: true
     decoration_config:
@@ -389,7 +389,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-performance
     decorate: true
     decoration_config:
@@ -447,7 +447,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator-root
     decorate: true
     decoration_config:
@@ -485,7 +485,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -756,7 +756,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -789,7 +789,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -816,7 +816,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -845,7 +845,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -874,7 +874,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -930,7 +930,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -957,7 +957,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1014,7 +1014,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1053,7 +1053,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1080,7 +1080,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1107,7 +1107,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1134,7 +1134,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1515,7 +1515,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1545,7 +1545,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:
@@ -1575,7 +1575,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
     decorate: true
     decoration_config:
@@ -1617,7 +1617,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
     decorate: true
     decoration_config:
@@ -1651,7 +1651,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
     decorate: true
     decoration_config:
@@ -1773,7 +1773,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -1920,7 +1920,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-storage
     decorate: true
     decoration_config:
@@ -1995,7 +1995,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage
     decorate: true
     decoration_config:
@@ -2180,7 +2180,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -548,7 +548,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1386,7 +1386,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1467,7 +1467,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -2148,7 +2148,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -44,7 +44,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     optional: true
     decorate: true
     skip_report: false
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -45,7 +45,7 @@ presubmits:
     always_run: true
     optional: false
     skip_report: false
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       timeout: 10m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: prow-workloads
+    cluster: kubevirt-prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
The major CI jobs have been running on the new workloads cluster for the past couple of weeks. This change moves the remaining prow jobs from the old cluster to the new workloads cluster.

As the old cluster is due to be decommissioned - these jobs have to be moved over.

/cc @dhiller @enp0s3 @xpivarc 