### PR TITLE
Make 1.27 sig lanes gating

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2120,7 +2120,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-network
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2162,7 +2161,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2204,7 +2202,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-compute
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2246,7 +2243,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-operator
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
According to testgrid the presubmit lanes should be good to go for gating. This PR enables gating for sig-operator, sig-compute, sig-network and sig-storage presubmit lanes.

See https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-k8s-1.27-sig-compute&width=20

/cc @rthallisey @acardace @phoracek @awels 