### PR TITLE
Add older versions of cri-o to mirror for backports

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.24,1.25,1.26"
+            value: "1.22,1.23,1.24,1.25,1.26"
         command: ["/bin/sh", "-ce"]
         args:
           - |


### PR DESCRIPTION
Some release prowjobs run dnf transactions which can fail due to a missing old cri-o mirror repo[1] - lets add the old mirrors back to cover these backport cases.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_cluster-network-addons-operator/1557/pull-e2e-cnao-monitoring-k8s-release-0.79/1661383673036935168#1:build-log.txt%3A446

/cc @dhiller @phoracek 