### PR TITLE
Increase sig-monitoring e2e test timeout

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1434,7 +1434,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 1h30m0s
+      timeout: 2h0m0s
     labels:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"


### PR DESCRIPTION
This increases the timeout of the sig-monitoring e2e tests to 2h0m0s so the whole testsuite has enough time to finish.

Fixes CI failures in https://github.com/kubevirt/kubevirt/pull/9724

/cc @brianmcarey 