### PR TITLE
rehearse-plugin: checkout branch(es) from job spec

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler_test.go
+++ b/external-plugins/rehearse/plugin/handler/handler_test.go
@@ -250,7 +250,7 @@ var _ = Describe("PR filtering", func() {
 			pr = &github.PullRequest{
 				Base: github.PullRequestBranch{
 					Repo: github.Repo{
-						FullName: "kubevirt/kubevirt",
+						FullName: "kubevirt/project-infra",
 					},
 				},
 			}
@@ -271,6 +271,14 @@ var _ = Describe("PR filtering", func() {
 			headConfig.PresubmitsStatic["kubevirt/kubevirt"][0].Cluster = "new-cluster"
 			presubmits := handler.generatePresubmits(headConfig, baseConfig, pr, "42")
 			Expect(presubmits).ToNot(BeEmpty())
+		})
+
+		It("generates a prowjob for branch if context changes", func() {
+			headConfig.PresubmitsStatic["kubevirt/kubevirt"][0].Cluster = "new-cluster"
+			headConfig.PresubmitsStatic["kubevirt/kubevirt"][0].Branches = []string{"release-42"}
+			presubmits := handler.generatePresubmits(headConfig, baseConfig, pr, "42")
+			Expect(presubmits).ToNot(BeEmpty())
+			Expect(presubmits[0].Spec.ExtraRefs[0].BaseRef).To(BeEquivalentTo("release-42"))
 		})
 	})
 


### PR DESCRIPTION
Currently all rehearsal jobs that are created by the plugin are targeting the HEAD branch (usually main).

Since there are jobs that are targeting other branches, i.e. release branch jobs, we run rehearsals against the correct branch(es) when doing the rehearsal.

Closes #2783 

/cc @brianmcarey @qinqon 