### PR TITLE
Add CDI non-CSI lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -414,3 +414,37 @@ presubmits:
       - name: kubevirtci-fossa
         secret:
           secretName: kubevirtci-fossa-token
+  - name: pull-containerized-data-importer-non-csi-hpp
+    skip_branches:
+       - release-v\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    cluster: kubevirt-prow-workloads
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image:  quay.io/kubevirtci/bootstrap:v20230502-bfaa042
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/non-csi-hpp.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "29Gi"


### PR DESCRIPTION
This Pull Request adds a new testing lane for CDI with `local` Storage Class as default.

This non-CSI lane will allow us to keep testing the non-populator flow once https://github.com/kubevirt/containerized-data-importer/pull/2722 is merged.