### PR TITLE
Reduce retries, add exponential backoff

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -490,8 +490,10 @@ presubmits:
             privileged: true
           resources:
             requests:
+              cpu: "2"
               memory: "8Gi"
             limits:
+              cpu: "2"
               memory: "8Gi"
           volumeMounts:
           - name: molecule-docker

--- a/github/ci/prow-deploy/hack/test.sh
+++ b/github/ci/prow-deploy/hack/test.sh
@@ -10,10 +10,19 @@ main(){
 
     cd ${base_dir}
 
+    # preserve exit status for later to capture the artifacts in any case
+    set +e
     molecule test
+    retval=$?
+    set -e
+
     tmp=$(mktemp -d)
     docker cp instance:$ARTIFACTS $tmp
     cp -ar $tmp/artifacts/* $ARTIFACTS
+
+    if [ $retval -ne 0 ]; then
+        exit $retval
+    fi
 }
 
 main "${@}"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
         - name: rehearse
           image: quay.io/kubevirtci/rehearse:v20230505-0cdece69
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           args:
             - --dry-run=false
             - --github-token-path=/etc/github/oauth

--- a/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - name: release-blocker
         image: quay.io/kubevirtci/release-blocker:v20220815-ab4bb7e6
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/components/greenhouse/base/resources/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/greenhouse/base/resources/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: greenhouse
         image: gcr.io/k8s-testimages/greenhouse@sha256:ab1a3421cc3c072a813d8543735f218ca6caa811011391a0e5b00104700e6e7b
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - name: cache
           containerPort: 8080

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/ci-usage-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: ci-usage-exporter
         image: quay.io/kubevirtci/ci-usage-exporter:v20210713-a46682bf
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - name: metrics
           containerPort: 9836

--- a/github/ci/prow-deploy/molecule/default/converge.yml
+++ b/github/ci/prow-deploy/molecule/default/converge.yml
@@ -26,8 +26,8 @@
         - name: wait for deployment to settle
           include_tasks: retry-pod-status.yml
           vars:
-            retries: 20
-            delay: 15
+            retries: 12
+            delay: 30
       always:
         - name: collect deployment information
           include_tasks: collect.yml

--- a/github/ci/prow-deploy/molecule/default/retry-pod-status.yml
+++ b/github/ci/prow-deploy/molecule/default/retry-pod-status.yml
@@ -3,7 +3,8 @@
 - block:
     - name: Increment the retry count
       set_fact:
-        retry_count: "{{  1 if retry_count is undefined else retry_count | int + 1 }}"
+        retry_count: "{{ 1 if retry_count is undefined else retry_count | int + 1 }}"
+        delay_inc: "{{ delay if delay_inc is undefined else ((delay_inc|float)*1.5) | int }}"
 
     - name: Get a list of all pods from prow namespace
       k8s_info:
@@ -23,14 +24,12 @@
       assert:
         quiet: true
         that:
-          - item.status.containerStatuses[0].ready
-          - item.status.containerStatuses[0].started
-          - item.status.containerStatuses[0].restartCount == 0
-        fail_msg: "Pod {{ item.spec.containers.0.name }} is in status {{ item.status.phase }}"
-        success_msg: "Pod {{ item.spec.containers.0.name }} is correctly Running"
+          - "item.status.phase == 'Running'"
+        fail_msg: "Pod {{ item.metadata.name }} is in status {{ item.status.phase }}"
+        success_msg: "Pod {{ item.metadata.name }} is running"
       loop: "{{ pod_list.resources }}"
       loop_control:
-        label: "{{ item.spec.containers.0.name }}"
+        label: "{{ item.metadata.name }}"
   rescue:
     - name: fail if we hit max retry count
       fail:
@@ -38,10 +37,10 @@
       when: "retry_count | int == {{ retries }}"
     - name: Message for the retry.
       debug:
-        msg: FAILED ATTEMPT {{ retry_count }}/{{ retries }}. Retrying in {{ delay }} seconds
+        msg: FAILED ATTEMPT {{ retry_count }}/{{ retries }}. Retrying in {{ delay_inc }} seconds
     - name: Pause
       pause:
-        seconds: "{{ delay }}"
+        seconds: "{{ delay_inc }}"
     - include_tasks: retry-pod-status.yml
 
 # DO NOT put anything at the end of this file.

--- a/github/ci/prow-deploy/molecule/default/smoke_tests.yml
+++ b/github/ci/prow-deploy/molecule/default/smoke_tests.yml
@@ -1,10 +1,13 @@
 - name: deploy ingress controller
   shell: |
     kubectl apply -f '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}/resources/ingress-nginx-controller.yaml'
+    while [[ $(kubectl get pods --namespace ingress-nginx --selector=app.kubernetes.io/component=controller 2>&1) =~ ^No.resources.found.*$ ]]; do
+      echo "waiting for pods"; sleep 1;
+    done
     kubectl wait --namespace ingress-nginx \
-      --for=condition=ready pod \
-      --selector=app.kubernetes.io/component=controller \
-      --timeout=180s
+          --for=condition=ready pod \
+          --selector=app.kubernetes.io/component=controller \
+          --timeout=180s
   changed_when: false
   environment:
     KUBECONFIG: '{{ kubeconfig_path }}'


### PR DESCRIPTION
Whenever the cluster is loaded the job [project-infra-prow-deploy-test](https://prow.ci.kubevirt.io/?type=presubmit&job=pull-project-infra-prow-deploy-test) is very flaky and fails more than half of the time. First on the prow deployment check and then, if the former passes, on the ingress deployment. Also when the job fails it doesn't even capture the artifacts that are required to debug the failures.

This PR fixes these three main issues in the prow-deploy presubmit. Besides that it increases the cpu resources.

# Prow deployment check

We are seeing that if the cluster is loaded the step deploying the prow components does not get ready in time. Therefore we should use exponential backoff in order to cope with deployments taking longer.

Instead of polling pods on a constant delay we
* increase the initial delay,
* retry with exponential backoff and
* reduce the total number of retries.

# Artifact capturing

The artifacts are only captured if molecule test run does not fail, which is useless, since we want to see the artifacts in case of failure in order to be able to check. This is fixed by preserving the molecule exit code and exiting after the artifact capture has finished.

# Ingress deployment failing on error: no resources found

Also we fix the ingress-nginx deployment failing on `kubectl wait` if the resource has not yet been created: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2800/pull-project-infra-prow-deploy-test/1664515078436687872#1:build-log.txt%3A1034

See https://github.com/kubernetes/kubernetes/issues/83242