### PR TITLE
Create managed-tenant-quota repo entry after transfer

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -559,6 +559,11 @@ orgs:
       ci-performance-benchmarks:
         description: Store for performance results of perf-report-creator
         default_branch: main
+      managed-tenant-quota:
+        default_branch: main
+        has_projects: true
+        has_wiki: true
+        has_issues: true
     teams:
       QE:
         description: ""
@@ -955,3 +960,10 @@ orgs:
         - xpivarc
         repos:
           ci-performance-benchmarks: admin
+      managed-tenant-quota:
+        description: members of the managed-tenant-quota group
+        members:
+          - Barakmor1
+          - vladikr
+        repos:
+          managed-tenant-quota: admin


### PR DESCRIPTION
Create entry for repository in order to keep peribolos in sync, also create github team.

/cc @Barakmor1 @vladikr @brianmcarey 