### PR TITLE
Remove bare-metal selector as running on control-plane cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -78,8 +78,6 @@ presubmits:
             memory: 8Gi
         securityContext:
           privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - always_run: false
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -59,7 +59,7 @@ periodics:
     preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  cluster: kubevirt-prow-workloads
+  cluster: ibm-prow-jobs
   spec:
     containers:
     - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101


### PR DESCRIPTION
The bump kubevirtci presubmit job fails to get scheduled due to this selector.

This change also moves the periodic to the control plane cluster.

/cc @dhiller 