### PR TITLE
Update base image for prow-deploy

### DIFF
--- a/hack/update-containerfiles-with-latest-baseimage.sh
+++ b/hack/update-containerfiles-with-latest-baseimage.sh
@@ -37,6 +37,13 @@ EOF
 }
 
 IMAGE_NAME="quay.io/kubevirtci/bootstrap"
+if [ $# -gt 0 ]; then
+    if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
+        usage
+        exit 0
+    fi
+    IMAGE_NAME="$1"
+fi
 if [ $# -gt 1 ]; then
     if [ ! -d "$2" ]; then
         usage
@@ -45,13 +52,6 @@ if [ $# -gt 1 ]; then
     fi
     image_dir="$2"
 else
-    if [ $# -gt 0 ]; then
-        if [[ $1 == "-h" ]] || [[ $1 == "--help" ]]; then
-            usage
-            exit 0
-        fi
-        IMAGE_NAME="$1"
-    fi
     image_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname "$0")" && pwd)"'/../images' && pwd)")"
 fi
 

--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubevirtci/golang:v20221222-8f66e7e as builder
+FROM quay.io/kubevirtci/golang:v20230502-bfaa042 as builder
 
 RUN git clone https://github.com/kubernetes/test-infra.git && \
   cd test-infra && \


### PR DESCRIPTION
In order to update the [`Offending RSA key in /github_known_hosts`](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-secrets-check-public-ssh-key-expiry/1665566644920913920#1:build-log.txt%3A40) we need
to update the base image for prow-deploy.

Aside that we fix a mishandling of arguments that only uses the first argument in case more than one arg was given.