### PR TITLE
Increase ingress wait timeout

### DIFF
--- a/github/ci/prow-deploy/molecule/default/smoke_tests.yml
+++ b/github/ci/prow-deploy/molecule/default/smoke_tests.yml
@@ -7,7 +7,7 @@
     kubectl wait --namespace ingress-nginx \
           --for=condition=ready pod \
           --selector=app.kubernetes.io/component=controller \
-          --timeout=180s
+          --timeout=300s
   changed_when: false
   environment:
     KUBECONFIG: '{{ kubeconfig_path }}'


### PR DESCRIPTION
Sometimes the wait timeout exceeds the limit, let's increase it a bit.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2600/pull-project-infra-prow-deploy-test/1665966696432668672

/cc @brianmcarey @oshoval 