### PR TITLE
Update to Fedora 38 and go 1.19.9 in the bootstrap images

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:37
+FROM fedora:38
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -101,7 +101,7 @@ ENV _CONTAINERS_USERNS_CONFIGURED=""
 
 # Cache the most commonly used bazel versions in the container
 ARG ARCH
-RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-${ARCH} && \
+RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH} && \
      chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
      cd /usr/local/bin && ln -s bazelisk bazel
 

--- a/images/golang/Dockerfile
+++ b/images/golang/Dockerfile
@@ -1,7 +1,7 @@
 ARG ARCH
 FROM bootstrap-$ARCH
 
-ENV GIMME_GO_VERSION=1.19.2
+ENV GIMME_GO_VERSION=1.19.9
 
 # Cache latest stable golang version
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme


### PR DESCRIPTION
- Update base image for bootstrap to Fedora 38 : Fedora 38 was released a few weeks ago - update bootstrap to fedora 38 base.

- Upgrade go to version 1.19.9 in golang bootstrap : The builder image is being updated to v1.19.9[1] - this golang image used for testing should use the same version.

- This change also includes an update to bazelisk to the latest release[2]

[1] https://github.com/kubevirt/kubevirt/pull/9848
[2] https://github.com/bazelbuild/bazelisk/releases/tag/v1.17.0

/cc @dhiller @enp0s3 