### PR TITLE
Update e2e presubmits to run etcd in memory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -33,6 +33,8 @@ presubmits:
           value: k8s-1.25-sig-compute
         - name: KUBEVIRT_CGROUPV2
           value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -110,6 +112,8 @@ presubmits:
         - name: TARGET
           value: k8s-1.25-sig-storage
         - name: KUBEVIRT_CGROUPV2
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
@@ -915,6 +919,8 @@ presubmits:
           value: k8s-1.25-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1000,6 +1006,8 @@ presubmits:
           value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_WITH_MULTUS_V3
           value: "false"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1043,6 +1051,8 @@ presubmits:
           value: "3"
         - name: KUBEVIRT_STORAGE
           value: rook-ceph-default
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1252,6 +1262,8 @@ presubmits:
           value: k8s-1.26-centos9-sig-monitoring
         - name: KUBEVIRT_NUM_NODES
           value: "2"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1339,6 +1351,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-network
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1417,6 +1431,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-compute
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1498,6 +1514,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.25-sig-operator
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1538,6 +1556,8 @@ presubmits:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network-no-istio
         - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
@@ -1580,6 +1600,8 @@ presubmits:
           value: k8s-1.26-centos9-sig-storage
         - name: KUBEVIRT_PSA
           value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1621,6 +1643,8 @@ presubmits:
           value: k8s-1.26-centos9-sig-compute
         - name: KUBEVIRT_PSA
           value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1661,6 +1685,8 @@ presubmits:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator
         - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
@@ -1774,6 +1800,8 @@ presubmits:
           value: k8s-1.27-sig-network
         - name: KUBEVIRT_PSA
           value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1814,6 +1842,8 @@ presubmits:
         - name: TARGET
           value: k8s-1.27-sig-storage
         - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
@@ -1856,6 +1886,8 @@ presubmits:
           value: k8s-1.27-sig-compute
         - name: KUBEVIRT_PSA
           value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1896,6 +1928,8 @@ presubmits:
         - name: TARGET
           value: k8s-1.27-sig-operator
         - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""


### PR DESCRIPTION
When there is high disk IO on a node, we can sometimes see jobs fail due to etcd timeouts[1][2]. Update these jobs to run etcd in memory to reduce reliance on node disks.

`Error from server: error when creating "/home/prow/go/src/github.com/kubevirt/kubevirt/_out/manifests/release/kubevirt-cr.yaml": etcdserver: request timed out`

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9848/pull-kubevirt-e2e-k8s-1.27-sig-operator/1666679307365257216#1:build-log.txt%3A2065
[2] https://search.ci.kubevirt.io/?search=etcdserver%3A+request+timed+out&maxAge=336h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

/cc @dhiller @EdDev @xpivarc 