### PR TITLE
add ability to plot data after a given date

### DIFF
--- a/robots/cmd/perf-report-creator/main.go
+++ b/robots/cmd/perf-report-creator/main.go
@@ -40,6 +40,7 @@ type weeklyGraphOpts struct {
 	resource         string
 	weeklyReportsDir string
 	plotlyHTML       bool
+	since            string
 }
 
 func resultsFlagOpts(subcommands []string) resultOpts {
@@ -80,6 +81,7 @@ func weeklyGraphFlagOpts(subcommands []string) weeklyGraphOpts {
 	fs.StringVar(&w.resource, "resource", "vmi", "resource for which the graph will be plotted")
 	fs.StringVar(&w.weeklyReportsDir, "weekly-reports-dir", "output/weekly", "the output directory from which weekly json data will be read")
 	fs.BoolVar(&w.plotlyHTML, "plotly-html", true, "boolean for selecting what kind of graph will be plotted")
+	fs.StringVar(&w.since, "since", "", "Specify the date (format: yyyy-mm-dd)")
 	err := fs.Parse(subcommands)
 	if err != nil {
 		fmt.Printf("error parsing flags: %+v\n", err)


### PR DESCRIPTION
This PR adds a flag `--since` to `weekly-graph` subcommand of perf-report-creator. 

With this subcommand even if all the data historic data exists in weekly directory 
(see [here](https://github.com/kubevirt/ci-performance-benchmarks/tree/main/weekly)) 

fixes #2816 

cc @rthallisey 