### PR TITLE
kubevirt, vgpu: Bump to 1.27

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -418,7 +418,7 @@ periodics:
     preset-podman-shared-images: "true"
     vgpu: "true"
   max_concurrency: 1
-  name: periodic-kubevirt-e2e-kind-1.25-vgpu
+  name: periodic-kubevirt-e2e-kind-1.27-vgpu
   reporter_config:
     slack:
       job_states_to_report: []
@@ -446,7 +446,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: kind-1.25-vgpu
+        value: kind-1.27-vgpu
       image: quay.io/kubevirtci/golang:v20230607-07930d7
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -241,7 +241,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       vgpu: "true"
     max_concurrency: 1
-    name: pull-kubevirt-e2e-kind-1.25-vgpu
+    name: pull-kubevirt-e2e-kind-1.27-vgpu
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -266,7 +266,7 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.25-vgpu
+          value: kind-1.27-vgpu
         image: quay.io/kubevirtci/bootstrap:v20230607-07930d7
         name: ""
         resources:


### PR DESCRIPTION
Once `kind-1.27-vgpu` lands on kubevirt https://github.com/kubevirt/kubevirt/pull/9893
and then need to delete the old one from kubevirtci itself.
