### PR TITLE
kubevirt e2e Arm64: using kind-1.27 cluster to run e2e test on Arm64

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -789,9 +789,9 @@ periodics:
       - automation/test.sh
       env:
       - name: TARGET
-        value: kind-1.23
+        value: kind-1.27
       - name: KUBEVIRT_PROVIDER
-        value: kind-1.23
+        value: kind-1.27
       - name: KUBEVIRT_NUM_NODES
         value: "1"
       - name: KUBEVIRT_E2E_FOCUS

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1080,7 +1080,7 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.23
+          value: kind-1.27
         - name: KUBEVIRT_NUM_NODES
           value: "1"
         - name: KUBEVIRT_E2E_FOCUS


### PR DESCRIPTION
Hold until https://github.com/kubevirt/kubevirtci/pull/1027 get merged.