### PR TITLE
Add ppc64le support in kubevirt hostpath provisioner

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -31,6 +31,7 @@ postsubmits:
           make clean &&
           GOARCH=arm64 make manifest &&
           GOARCH=amd64 make manifest &&
+          GOARCH=ppc64le make manifest &&
           # Only push images on tags
           [ -z "$(git tag --points-at HEAD | head -1)" ] ||
           TAG="$(git tag --points-at HEAD | head -1)" make manifest-push
@@ -71,6 +72,7 @@ postsubmits:
           make clean &&
           GOARCH=arm64 make manifest &&
           GOARCH=amd64 make manifest &&
+          GOARCH=ppc64le make manifest &&
           make manifest-push
         # docker-in-docker needs privileged mode
         securityContext:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -32,6 +32,7 @@ postsubmits:
           make clean &&
           GOARCH=arm64 make manifest &&
           GOARCH=amd64 make manifest &&
+          GOARCH=ppc64le make manifest &&
           # Only push images on tags
           [ -z "$(git tag --points-at HEAD | head -1)" ] ||
           TAG="$(git tag --points-at HEAD | head -1)" make manifest-push
@@ -73,6 +74,7 @@ postsubmits:
           make clean &&
           GOARCH=arm64 make manifest &&
           GOARCH=amd64 make manifest &&
+          GOARCH=ppc64le make manifest &&
           make manifest-push
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
Had a request for a ppc64le build, they verified that setting the GOARCH was enough to make it work. So it seems relatively straight forward to add it to the post submit jobs to help them out.