### PR TITLE
Add crio 1.27 to the kubevirt mirror

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.22,1.23,1.24,1.25,1.26"
+            value: "1.22,1.23,1.24,1.25,1.26,1.27"
         command: ["/bin/sh", "-ce"]
         args:
           - |


### PR DESCRIPTION
cri-o 1.27 needs to be added to the kubevirt mirror in order to allow updating of the kubevirtci 1.27 provider

/cc @dhiller 