### PR TITLE
Give pull-containerized-data-importer-e2e-ceph 6h to complete

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -281,8 +281,8 @@ presubmits:
     optional: false
     decorate: true
     decoration_config:
-      timeout: 5h
-      grace_period: 5m
+      timeout: 6h
+      grace_period: 10m
     max_concurrency: 6
     cluster: kubevirt-prow-workloads
     labels:


### PR DESCRIPTION
Currently getting very close to 5h limit.  Going over with some new functionality.