### PR TITLE
Make hostpath provisioner operator unit test lane required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     skip_report: false
-    optional: true
+    optional: false
     decorate: true
     decoration_config:
       timeout: 1h


### PR DESCRIPTION
The lane was marked optional which is an oversight, it should be required.