### PR TITLE
kubevirt presubmit: publish arm64 e2e test result

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1079,7 +1079,6 @@ presubmits:
     optional: true
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
The e2e tests become stable now, we can publish the result.
https://testgrid.k8s.io/kubevirt-presubmits#pull-kubevirt-e2e-arm64