### PR TITLE
Turn off flapping alerts

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/node-exporter-alerting.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/node-exporter-alerting.yaml
@@ -132,15 +132,15 @@ spec:
 
   - name: node-exporter_network.rules
     rules:
-    - alert: HostUnusualNetworkThroughputIn
-      annotations:
-        summary: Host unusual network throughput in (instance {{ $labels.instance }})
-        description: "Host network interfaces are probably receiving too much data (> 3000 MB/s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-      expr: sum by (instance) (rate(node_network_receive_bytes_total[2m])) / 1024 / 1024 > 3000
-      for: 5m
-      labels:
-        severity: warning
-        namespace: monitoring
+#    - alert: HostUnusualNetworkThroughputIn
+#      annotations:
+#        summary: Host unusual network throughput in (instance {{ $labels.instance }})
+#        description: "Host network interfaces are probably receiving too much data (> 3000 MB/s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+#      expr: sum by (instance) (rate(node_network_receive_bytes_total[2m])) / 1024 / 1024 > 3000
+#      for: 5m
+#      labels:
+#        severity: warning
+#        namespace: monitoring
     - alert: HostUnusualNetworkThroughputOut
       annotations:
         summary: Host unusual network throughput out (instance {{ $labels.instance }})
@@ -178,8 +178,8 @@ spec:
         severity: warning
         namespace: monitoring
 
-  - name: node-exporter_cpu.rules
-    rules:
+#  - name: node-exporter_cpu.rules
+#    rules:
 #    - alert: HostHighCpuLoad
 #      annotations:
 #        summary: Host high CPU load (instance {{ $labels.instance }})
@@ -189,16 +189,17 @@ spec:
 #      labels:
 #        severity: warning
 #        namespace: monitoring
-    - alert: HostContextSwitching
-      annotations:
-        summary: Host context switching (instance {{ $labels.instance }})
-        description: "Context switching is growing on node (> 8000 / s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-      expr: (rate(node_context_switches_total[5m])) / (count without(cpu, mode) (node_cpu_seconds_total{mode="idle"})) > 8000
-      for: 6m
-      labels:
-        severity: warning
-        namespace: monitoring
-
+# FIXME: turned off since they were flapping
+#    - alert: HostContextSwitching
+#      annotations:
+#        summary: Host context switching (instance {{ $labels.instance }})
+#        description: "Context switching is growing on node (> 8000 / s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+#      expr: (rate(node_context_switches_total[5m])) / (count without(cpu, mode) (node_cpu_seconds_total{mode="idle"})) > 8000
+#      for: 6m
+#      labels:
+#        severity: warning
+#        namespace: monitoring
+#
   - name: node-exporter_misc.rules
     rules:
     - alert: HostClockSkew


### PR DESCRIPTION
The alerts need to get reconfigured so that they are not flapping any more, we are going to do this in a later task.

For now we are disabling them since they are creating noise which makes us not see the failing job notifications.