### PR TITLE
Disable flapping alerts UnusualDiskReadWrite and job

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
@@ -143,17 +143,18 @@ spec:
       labels:
         severity: warning
         namespace: monitoring
-    - alert: KubeJobCompletion
-      annotations:
-        message: 'Job {{ $labels.namespaces }}/{{ $labels.job }} is taking more than
-          one hour to complete.'
-        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
-      expr: |
-        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  > 0
-      for: 1h
-      labels:
-        severity: warning
-        namespace: monitoring
+# FIXME: turned off since they were flapping
+#    - alert: KubeJobCompletion
+#      annotations:
+#        message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than
+#          one hour to complete.'
+#        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+#      expr: |
+#        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  > 0
+#      for: 1h
+#      labels:
+#        severity: warning
+#        namespace: monitoring
     - alert: KubeJobFailed
       annotations:
         message: 'Job {{ $labels.namespaces }}/{{ $labels.job }} failed to complete.'

--- a/github/ci/services/prometheus-stack/manifests/rules/common/node-exporter-alerting.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/node-exporter-alerting.yaml
@@ -27,24 +27,24 @@ spec:
       labels:
         severity: warning
         namespace: monitoring
-    - alert: HostUnusualDiskReadRate
-      annotations:
-        summary: Host unusual disk read rate (instance {{ $labels.instance }})
-        description: "Disk is probably reading too much data (> 400 MB/s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-      expr: sum by (instance) (rate(node_disk_read_bytes_total[2m])) / 1024 / 1024 > 400
-      for: 5m
-      labels:
-        severity: warning
-        namespace: monitoring
-    - alert: HostUnusualDiskWriteRate
-      annotations:
-        summary: Host unusual disk write rate (instance {{ $labels.instance }})
-        description: "Disk is probably writing too much data (> 200 MB/s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
-      expr: sum by (instance) (rate(node_disk_written_bytes_total[2m])) / 1024 / 1024 > 200
-      for: 5m
-      labels:
-        severity: warning
-        namespace: monitoring
+#    - alert: HostUnusualDiskReadRate
+#      annotations:
+#        summary: Host unusual disk read rate (instance {{ $labels.instance }})
+#        description: "Disk is probably reading too much data (> 400 MB/s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+#      expr: sum by (instance) (rate(node_disk_read_bytes_total[2m])) / 1024 / 1024 > 400
+#      for: 5m
+#      labels:
+#        severity: warning
+#        namespace: monitoring
+#    - alert: HostUnusualDiskWriteRate
+#      annotations:
+#        summary: Host unusual disk write rate (instance {{ $labels.instance }})
+#        description: "Disk is probably writing too much data (> 200 MB/s)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+#      expr: sum by (instance) (rate(node_disk_written_bytes_total[2m])) / 1024 / 1024 > 200
+#      for: 5m
+#      labels:
+#        severity: warning
+#        namespace: monitoring
     - alert: HostUnusualDiskReadLatency
       annotations:
         summary: Host unusual disk read latency (instance {{ $labels.instance }})


### PR DESCRIPTION
Disable alerts since they are flapping and creating noise:
* KubeJobCompletion
* HostUnusualDiskReadRate
* HostUnusualDiskWriteRate

/cc @brianmcarey 