### PR TITLE
test-report filter: convert yaml output into text and create several files

### DIFF
--- a/robots/cmd/test-report/cmd/filter/BUILD.bazel
+++ b/robots/cmd/test-report/cmd/filter/BUILD.bazel
@@ -7,8 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//robots/pkg/test-report:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
-        "@io_k8s_sigs_yaml//:go_default_library",
     ],
 )
 


### PR DESCRIPTION
`test-report filter` command filters the `json` output of the test-report that contains the data of the observed timeframe of tests being run over a set of lanes. In detail the json captures whether a test was seen to have run on any lane or whether it was seen inside a dont_run_tests.json file, which indicates it's not supported on a version.

From this data we had created a YAML file that contained all data spanning all versions and groups, but the yaml output was too complicated for the audience to look at.

We are now generating one file per group per version in order to make it easy to consume the files. Each of these files contains a plaintext set of test names.

/cc @dominikholler