### PR TITLE
Increase timeout for sig-perf presubmit lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -124,7 +124,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 1h0m0s
+      timeout: 2h0m0s
     labels:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -132,7 +132,7 @@ presubmits:
     decorate: true
     decoration_config:
       grace_period: 5m0s
-      timeout: 1h0m0s
+      timeout: 2h0m0s
     labels:
       preset-bazel-cache: "true"
       preset-bazel-unnested: "true"


### PR DESCRIPTION
The sig-performance lane has failed due to timeouts on a couple of occasions [1] [2]

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9931/pull-kubevirt-e2e-k8s-1.25-sig-performance-1.0/1671494579821481984#1:build-log.txt%3A2775
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9931/pull-kubevirt-e2e-k8s-1.25-sig-performance-1.0/1671476987824181248#1:build-log.txt%3A2819

/cc @dhiller @rthallisey @xpivarc 