### PR TITLE
EMERGENCY: Disable pull-kubevirt-api presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -741,7 +741,7 @@ presubmits:
       - name: kubevirtci-fossa
         secret:
           secretName: kubevirtci-fossa-token
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
@@ -763,6 +763,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
+        - # FIXME: reenable this lane after missing dependency issue has been resolved
         image: quay.io/kubevirtci/bootstrap:v20230607-07930d7
         name: ""
         resources:


### PR DESCRIPTION
There is an issue with a deleted dependency in the `apidocs` make target. This leads to the lane failing every time.

> Could not resolve all artifacts for configuration ':classpath'.                                                                                                           > Could not find ch.netzwerg:paleo-core:0.11.0.
     Searched in the following locations:
       - file:/root/.m2/repository/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom
       - https://repo.maven.apache.org/maven2/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom - https://dl.google.com/dl/android/maven2/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom - https://jcenter.bintray.com/ch/netzwerg/paleo-core/0.11.0/paleo-core-0.11.0.pom


/cc @brianmcarey @xpivarc @enp0s3 @rmohr 