### PR TITLE
Disable pull-kubevirt-apidocs for 0.59 & 1.0 branches 

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -1050,7 +1050,7 @@ presubmits:
       - name: kubevirtci-coveralls
         secret:
           secretName: kubevirtci-coveralls-token
-  - always_run: true
+  - always_run: false
     branches:
     - release-0.59
     cluster: kubevirt-prow-workloads
@@ -1070,6 +1070,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
+        - # FIXME: reenable this lane after missing dependency issue has been resolved
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -673,7 +673,7 @@ presubmits:
       - name: kubevirtci-coveralls
         secret:
           secretName: kubevirtci-coveralls-token
-  - always_run: true
+  - always_run: false
     branches:
     - release-1.0
     cluster: ibm-prow-jobs
@@ -694,6 +694,7 @@ presubmits:
         - /bin/sh
         - -c
         - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
+        - # FIXME: reenable this lane after missing dependency issue has been resolved
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:


### PR DESCRIPTION
This lane was disabled in main[1] - disabling in 0.59 and 1.0 branches to unblock backports

[1] https://github.com/kubevirt/project-infra/pull/2846

/cc @dhiller @rmohr @enp0s3 @xpivarc 