### PR TITLE
Use --all flag when cleaning up podman containers in bootstrap pod

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -45,7 +45,7 @@ setup_ca(){
 cleanup_pinc() {
     if [[ "${PODMAN_IN_CONTAINER_ENABLED:-false}" == "true" ]]; then
         echo "Cleaning up after podman"
-        podman ps -aq | xargs -r podman rm -f || true
+        podman rm --all --force || true
         kill "$(</var/run/podman.pid)" || true
         wait "$(</var/run/podman.pid)" || true
     fi


### PR DESCRIPTION
We should rely on podman to cleanup all of the created containers as part of the e2e tests.

`podman rm --all --force`

The above should remove all containers and we should not hit the dependent containers issue[1] that we can hit with the current cleanup.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/9974/pull-kubevirt-e2e-k8s-1.25-sig-storage-1.0/1673289162947563520#1:build-log.txt%3A3103
[2] https://docs.podman.io/en/latest/markdown/podman-rm.1.html#all-a


/cc @enp0s3 @xpivarc 