### PR TITLE
Update preset bazel version to match kubevirt builder image

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -541,7 +541,7 @@ presets:
     preset-bazel-cache: "true"
   env:
     - name: BAZEL_VERSION
-      value: "1.2.1"
+      value: "5.3.1"
     - name: CACHE_HOST
       value: bazel-cache.kubevirt-prow
     - name: CACHE_PORT


### PR DESCRIPTION
As the e2e jobs run the builds unnested - the bazel version set in the preset should match that of the kubevirt builder image[1]

[1] https://github.com/kubevirt/kubevirt/blob/d89207bd558440af2c273870540093951a82e97c/hack/builder/Dockerfile#L6

/cc @xpivarc @enp0s3 