### PR TITLE
Give aburdenthehand and xpivarc 'write' permissions to help out with kubevirt/kubevirt releases

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -709,6 +709,8 @@ orgs:
           - phoracek
           - SchSeba
           - awels
+          - aburdenthehand
+          - xpivarc
         privacy: closed
         repos:
           cloud-provider-kubevirt: write


### PR DESCRIPTION
Andrew and Lubo are helping out with releases. They need write permissions to make and edit releases.