### PR TITLE
job configs: remove KUBEVIRT_PSA since it always enabled

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1440,8 +1440,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network-no-istio
       image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1489,8 +1487,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-network
       image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1537,8 +1533,6 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
@@ -1636,8 +1630,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-compute
       image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1733,8 +1725,6 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-operator
@@ -1870,8 +1860,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
       - name: TARGET
         value: k8s-1.27-sig-network
       image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1918,8 +1906,6 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.27-sig-storage
@@ -1968,8 +1954,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
-      - name: KUBEVIRT_PSA
-        value: "true"
       - name: TARGET
         value: k8s-1.27-sig-compute
       image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -2016,8 +2000,6 @@ periodics:
       - name: KUBEVIRT_E2E_RUN_ALL_SUITES
         value: "true"
       - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
         value: k8s-1.27-sig-operator

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -1288,8 +1288,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-ipv6-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1758,8 +1756,6 @@ presubmits:
         - -c
         - automation/test.sh
         env:
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: TARGET
           value: k8s-1.25-sig-network
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
@@ -1905,8 +1901,6 @@ presubmits:
         - -c
         - automation/test.sh
         env:
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: TARGET
           value: k8s-1.25-sig-compute
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
@@ -1944,8 +1938,6 @@ presubmits:
         - -c
         - automation/test.sh
         env:
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: TARGET
           value: k8s-1.25-sig-storage
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
@@ -2167,8 +2159,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network-no-istio
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -2205,8 +2195,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2243,8 +2231,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2317,8 +2303,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator-configuration
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:
@@ -2356,8 +2340,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -1438,8 +1438,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network-no-istio
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1477,8 +1475,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1516,8 +1512,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1555,8 +1549,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1663,8 +1655,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1702,8 +1692,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1741,8 +1729,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1780,8 +1766,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1555,8 +1555,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network-no-istio
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1598,8 +1596,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1641,8 +1637,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1684,8 +1678,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1798,8 +1790,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1841,8 +1831,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1884,8 +1872,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
@@ -1927,8 +1913,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -277,7 +277,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - cd cluster-provision/k8s/1.26-centos9 && KUBEVIRT_PSA='true' ../provision.sh
+        - cd cluster-provision/k8s/1.26-centos9 && ../provision.sh
         image: quay.io/kubevirtci/golang:v20230626-e1b7af2
         name: ""
         resources:
@@ -303,7 +303,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - cd cluster-provision/k8s/1.27 && KUBEVIRT_PSA='true' ../provision.sh
+        - cd cluster-provision/k8s/1.27 && ../provision.sh
         image: quay.io/kubevirtci/golang:v20230626-e1b7af2
         name: ""
         resources:


### PR DESCRIPTION
Signed-off-by: enp0s3 <ibezukh@redhat.com>

KUBEVIRT_PSA has no actual effect for our providers since its always enabled:
*  as part of `k8s-provision.sh` script for VM based providers.
* as part of built-in configuration in kind nodes.