### PR TITLE
kubevirt-presubmits: Enable Istio tests to run with 1.26 CentOS Stream 9

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1004,7 +1004,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-centos9-sig-network-no-istio
+          value: k8s-1.26-centos9-sig-network
         - name: KUBEVIRT_WITH_MULTUS_V3
           value: "false"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1554,7 +1554,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-centos9-sig-network-no-istio
+          value: k8s-1.26-centos9-sig-network
         - name: KUBEVIRT_PSA
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY


### PR DESCRIPTION
Istio should run fine now with CentOS Stream 9.