### PR TITLE
Fix label names in rule

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
+++ b/github/ci/services/prometheus-stack/manifests/rules/common/kubernetes-apps.yaml
@@ -157,10 +157,10 @@ spec:
 #        namespace: monitoring
     - alert: KubeJobFailed
       annotations:
-        message: 'Job {{ $labels.namespaces }}/{{ $labels.job }} failed to complete.'
+        message: 'Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.'
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
       expr: |
-        kube_job_status_failed{job="kube-state-metrics"}  > 0
+        kube_job_status_failed{job="kube-state-metrics"} > 0
       for: 1h
       labels:
         severity: warning


### PR DESCRIPTION
Alerts `KubeJobFailed` display neither the actual job name nor the namespace that has failed, i.e. https://cloud-native.slack.com/archives/C02GACK29RV/p1688376657114679

See https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/runbook.md#alert-name-kubejobfailed

/cc @brianmcarey 