### PR TITLE
Increase size of persistent volume attached to thanos receive

### DIFF
--- a/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
+++ b/github/ci/services/prometheus-stack/manifests/stack/production-control-plane/thanos.yaml
@@ -745,7 +745,7 @@ spec:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 10Gi
+          storage: 50Gi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The previous volume ran out of space
`panic: write header: write /var/thanos/receive/default-tenant/chunks_head/000067.tmp: no space left on device`

/cc @dhiller @xpivarc 