### PR TITLE
Add usb emulation for hostdev testing

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1645,6 +1645,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: "--usb 30M --usb 40M"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
         name: ""
         resources:
@@ -1888,6 +1890,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: "--usb 30M --usb 40M"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
         name: ""
         resources:


### PR DESCRIPTION
This is possible since:
  https://github.com/kubevirt/kubevirtci/pull/996

The follow CI would benefit from it:
  https://github.com/kubevirt/kubevirt/pull/10015