### PR TITLE
Fix csi-driver post submit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -27,7 +27,7 @@ postsubmits:
             env:
               - name: REPO
                 value: quay.io/kubevirt
-              - name: IMAGE
+              - name: TARGET_NAME
                 value: csi-driver
               - name: TAG
                 value: latest
@@ -37,7 +37,7 @@ postsubmits:
               - "-c"
               - >
                 cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin=true &&
-                make push
+                make image-push
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Make target had changed and the environment variable indicating which repo to push to has changed as well. Converging on kubevirt-csi-driver repo.