### PR TITLE
sriov cni: Return sriov pfs to root ns

### DIFF
--- a/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
+++ b/cni-plugins/sriov-passthrough-cni/plugin/sriov-passthrough-cni
@@ -16,8 +16,9 @@ function main() {
             setns_sriov_pfs
             gen_result_config
             ;;
-        DELETE)
-            log "Received DELETE command."
+        DEL)
+            log "Received DEL command."
+            set_root_ns
             ip netns del "$CNI_CONTAINERID" ||:
             ;;
     esac
@@ -58,6 +59,13 @@ function setns_sriov_pfs() {
 
   log "FATAL: Could not allocate enough PFs"
   exit 1
+}
+
+function set_root_ns() {
+    sriov_pfs=($( ip netns exec $CNI_CONTAINERID ip -details address | grep "vf 0" -B 2 | grep -E 'UP|DOWN' | awk -F": " '{print $2}' ))
+    for pf in "${sriov_pfs[@]}"; do
+        ip netns exec $CNI_CONTAINERID ip link set $pf netns 1
+    done
 }
 
 function reserved_pf() {


### PR DESCRIPTION
Upon DEL command (the previous command was wrong), gracefully detach the SR-IOV nics.
The reason is if it isn't done as such, it might
take time until it be available again by the kernel.

Depends on https://github.com/kubevirt/kubevirtci/pull/1040 (merged)
