### PR TITLE
flake-stats: make org and repo configurable

### DIFF
--- a/robots/cmd/flake-stats/flake-stats.gohtml
+++ b/robots/cmd/flake-stats/flake-stats.gohtml
@@ -205,7 +205,7 @@
 </head>
 <body onload="initRowsShown();updateFilteredRows();enableFilterFields();">
 
-<h1>Flake stats for last {{ $.DaysInThePast }} days
+<h1>Flake stats for {{$.Org}}/{{$.Repo}} - last {{ $.DaysInThePast }} days
     &nbsp;<a style="text-decoration: none;" href="https://github.com/kubevirt/project-infra/blob/main/robots/cmd/flake-stats/README.md">&#9432;</a></h1>
 <div id="legend" class="legend">
     Share of overall failures:


### PR DESCRIPTION
Since the data is available for other projects as well, we make `org` and `repo` configurable, while keeping defaults for `kubevirt/kubevirt`.