### PR TITLE
Remove running etcd in memory from sig-storage lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1600,8 +1600,6 @@ presubmits:
           value: k8s-1.26-centos9-sig-storage
         - name: KUBEVIRT_PSA
           value: "true"
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
         name: ""
         resources:
@@ -1844,8 +1842,6 @@ presubmits:
         - name: TARGET
           value: k8s-1.27-sig-storage
         - name: KUBEVIRT_PSA
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
         name: ""


### PR DESCRIPTION
Very high memory usage has been seen in the sig-storage presubmit lanes
that does not appear in the periodic lanes.

The periodic lanes do not include running etcd from memory.

Presubmit lanes use about 32.5 GB RAM at max usage while the periodic lanes use just 26.5 GB RAM.