### PR TITLE
Update go version to 1.19 for testgrid config presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -655,7 +655,7 @@ presubmits:
             memory: "8Gi"
         env:
         - name: GIMME_GO_VERSION
-          value: "1.18"
+          value: "1.19"
   - name: pull-kubevirt-org-github-config-updater
     run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
     annotations:


### PR DESCRIPTION
Seems to be on Go 1.19 even though go.mod says otherwise.