### PR TITLE
Preserve a copy of the flake-stats report with timestamp

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2093,10 +2093,12 @@ periodics:
       - -ce
       - |
         output_file=/tmp/flake-stats-14days.html
+        copy_file="flake-stats-14days-$(date +%Y-%m-%d).html"
         go run ./robots/cmd/flake-stats/main.go \
           --output-file ${output_file} \
           --overwrite-output-file=true
         gsutil cp ${output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/
+        gsutil cp ${output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/${copy_file}
       command:
       - /bin/sh
       env:


### PR DESCRIPTION
In order to have a lookback we store a timestamped copy so we can compare with earlier days.

Example: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flake-stats-14days-2023-07-19.html