### PR TITLE
Add check provision job for 1.28 kubevirtci provider to allow for testing

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -313,6 +313,32 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    cluster: kubevirt-prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 1
+    name: check-provision-k8s-1.28
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.28 && KUBEVIRT_PSA='true' ../provision.sh
+        image: quay.io/kubevirtci/golang:v20230626-e1b7af2
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - always_run: true
     cluster: ibm-prow-jobs
     decorate: true


### PR DESCRIPTION
The 1.28 beta will be released soon  - add this prowjob to allow testing of the new provider. 

/cc @xpivarc @dhiller @enp0s3 