### PR TITLE
Always run the check provision job for 1.28

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -313,7 +313,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
The 1.28 provider was merged[1] so lets enable this lane to always run so that we prevent issues being introduced.

[1] https://github.com/kubevirt/kubevirtci/pull/1059

/cc @dhiller 