### PR TITLE
common-instancetypes: Increase node memory in functest

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -48,6 +48,9 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+        env:
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: "8192"
         image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
         name: ""
         resources:


### PR DESCRIPTION
This doubles the node memory from the default of 4096 to 8192 so we can start VirtualMachines using the u1.medium instance type that itself requires 4Gi.