### PR TITLE
Rename kubernetes.kubevirt repo to kubevirt.core

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -346,7 +346,7 @@ orgs:
         description: Holds all scripts to create packages and manifest file required for publishing the virtctl binary as a krew package for kubectl.
         default_branch: main
         has_projects: true
-      kubernetes.kubevirt:
+      kubevirt.core:
         description: Lean Ansible bindings for KubeVirt
         has_projects: true
       kubernetes-device-plugins:
@@ -975,11 +975,11 @@ orgs:
           - vladikr
         repos:
           managed-tenant-quota: admin
-      kubernetes.kubevirt-maintainers:
-        description: Maintainers of kubernetes.kubevirt
+      kubevirt.core-maintainers:
+        description: Maintainers of kubevirt.core
         privacy: closed
         maintainers:
           - 0xFelix
           - lyarwood
         repos:
-          kubernetes.kubevirt: admin
+          kubevirt.core: admin

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -133,7 +133,7 @@ tide:
     kubevirt/test-benchmarks: merge
     kubevirt/vm-console-proxy: merge
     kubevirt/sig-release: merge
-    kubevirt/kubernetes.kubevirt: merge
+    kubevirt/kubevirt.core: merge
 
   queries:
   - repos:
@@ -195,7 +195,7 @@ tide:
     - kubevirt/must-gather
     - kubevirt/csi-driver
     - kubevirt/vm-console-proxy
-    - kubevirt/kubernetes.kubevirt
+    - kubevirt/kubevirt.core
     labels:
     - lgtm
     - approved
@@ -426,7 +426,7 @@ branch-protection:
           branches:
             main:
               protect: true
-        kubernetes.kubevirt:
+        kubevirt.core:
           branches:
             main:
               protect: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -246,7 +246,7 @@ plugins:
     - lgtm
     - trigger
 
-  kubevirt/kubernetes.kubevirt:
+  kubevirt/kubevirt.core:
     plugins:
     - approve
     - lgtm
@@ -557,7 +557,7 @@ triggers:
   - kubevirt/secrets
   - kubevirt/test-benchmarks
   - kubevirt/vm-console-proxy
-  - kubevirt/kubernetes.kubevirt
+  - kubevirt/kubevirt.core
   - kubevirt/managed-tenant-quota
 - repos:
   - virtblocks/virtblocks
@@ -610,7 +610,7 @@ approve:
   - kubevirt/test-benchmarks
   - kubevirt/vm-console-proxy
   - kubevirt/sig-release
-  - kubevirt/kubernetes.kubevirt
+  - kubevirt/kubevirt.core
   - kubevirt/managed-tenant-quota
   require_self_approval: true
   lgtm_acts_as_approve: false
@@ -668,7 +668,7 @@ lgtm:
   - kubevirt/test-benchmarks
   - kubevirt/vm-console-proxy
   - kubevirt/sig-release
-  - kubevirt/kubernetes.kubevirt
+  - kubevirt/kubevirt.core
   - kubevirt/managed-tenant-quota
   review_acts_as_lgtm: true
 


### PR DESCRIPTION
Rename https://github.com/kubevirt/kubernetes.kubevirt to https://github.com/kubevirt/kubevirt.core. This repo will hold lean Ansible bindings for KubeVirt.