### PR TITLE
Disable required status checks in kubevirt.core

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -434,6 +434,10 @@ branch-protection:
           branches:
             main:
               protect: true
+              required_status_checks:
+                # Disable status checks so the Ansible Middleware
+                # release automation is able to run
+                contexts: []
     k8snetworkplumbingwg:
       repos:
         kubemacpool:


### PR DESCRIPTION
This is required so the Ansible Middleware release automation is able to create and push the necessary commits.