### PR TITLE
Add usb emulation for 1.25

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1433,6 +1433,8 @@ presubmits:
           value: k8s-1.25-sig-compute
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: "--usb 30M --usb 40M"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
         name: ""
         resources:


### PR DESCRIPTION
Hi,

I don't remember why we have not added this in #2872 so I'm starting this thread with a PR :)
Functional tests with 1.26 and 1.27 [worked great!](https://github.com/kubevirt/kubevirt/pull/10015#issuecomment-1669212331) 

Cheers,