### PR TITLE
Add process document and PR template for adding repos 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/add_repo.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_repo.md
@@ -6,22 +6,73 @@
 
 This PR adds the repository `repo_name` to the KubeVirt organization.
 
-_Checklist:_
+**Why this repository is needed**:
 
-- [ ] repo is a good fit for the org
-- [ ] maintainers are ok with adding the repo
-- [ ] if CI support is planned, CI capacity will not get exhausted
-- [ ] licensing model fits the org license model
+<!--
+    Explain in detail what the repository will host, how it is related to KubeVirt and how it is beneficial for KubeVirt.
+-->
 
-CI support is planned for:
-- [/] tide [^1]
-- [ ] prow jobs [^2]
+**Which licensing model the repository is using or planning to use**:
 
-[^1]: See [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md)
-[^2]: See [How to onboard a repository to Prow](https://github.com/kubevirt/project-infra/blob/main/docs/how-to-onboard-a-repository.md)
+<!--
+    Explain which license model you are using or intending to use. Note that, since KubeVirt is a CNCF project, if the license model is in conflict with CNCF policies, this PR is not likely to get approved.
+    Note: [CNCF is recommending Apache-2.0](https://www.cncf.io/blog/2017/02/01/cncf-recommends-aslv2/)
+-->
 
-**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+**Maintainers who sponsor this repository**:
+
+<!--
+    A maintainer from https://github.com/kubevirt/community/blob/main/MAINTAINERS.md is required to sponsor the repository PR
+-->
+
+- @
+
+**New gitHub team[^1] within KubeVirt org for new repository**:
+
+<!--
+    Add a `team` section in `orgs.yaml` to give the people access to the repo that need it.
+-->
+
+GitHub team:
+
+Repo maintainers:
+
+- @
+
+Repo users:
+
+- @
+
+[^1]: See [GitHub teams docs](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams)
+
+**CI support is planned for**:
+
+- [/] tide [^2]
+- [ ] prow jobs [^3]
+
+**Note: Using [GitHub actions](https://docs.github.com/en/actions) might be an option if prow support is not available. However¸ KubeVirt CI maintainers will only support GitHub actions to the extent possible.**
+
+[^2]:
+See [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md)
+[^3]:
+See [How to onboard a repository to Prow](https://github.com/kubevirt/project-infra/blob/main/docs/how-to-onboard-a-repository.md)
+
+CI maintainer sponsoring:
+
+<!--
+    A CI maintainer from [CI maintainers](../../OWNERS_ALIASES) is required to sponsor the repository PR if CI support is required.
+-->
+
+- @
+
+**KubeVirt mailing list announcement**:
+
+<!--
+    Place a link to an email with announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) here
+-->
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close
+the issue(s) when PR gets merged)*:
 Fixes #
-
 
 ### Special notes for your reviewer

--- a/.github/PULL_REQUEST_TEMPLATE/add_repo.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_repo.md
@@ -27,7 +27,7 @@ This PR adds the repository `repo_name` to the KubeVirt organization.
 
 - @
 
-**New gitHub team[^1] within KubeVirt org for new repository**:
+**New GitHub team[^1] within KubeVirt org for new repository**:
 
 <!--
     Add a `team` section in `orgs.yaml` to give the people access to the repo that need it.

--- a/.github/PULL_REQUEST_TEMPLATE/add_repo.md
+++ b/.github/PULL_REQUEST_TEMPLATE/add_repo.md
@@ -1,0 +1,27 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+* Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
+-->
+
+**What this PR does / why we need it**:
+
+This PR adds the repository `repo_name` to the KubeVirt organization.
+
+_Checklist:_
+
+- [ ] repo is a good fit for the org
+- [ ] maintainers are ok with adding the repo
+- [ ] if CI support is planned, CI capacity will not get exhausted
+- [ ] licensing model fits the org license model
+
+CI support is planned for:
+- [/] tide [^1]
+- [ ] prow jobs [^2]
+
+[^1]: See [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md)
+[^2]: See [How to onboard a repository to Prow](https://github.com/kubevirt/project-infra/blob/main/docs/how-to-onboard-a-repository.md)
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #
+
+
+### Special notes for your reviewer

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,10 @@
+<!--  Thanks for sending a pull request!  Here are some tips for you:
+* Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+Fixes #
+
+**Special notes for your reviewer**:

--- a/docs/how-to-add-a-new-repository.md
+++ b/docs/how-to-add-a-new-repository.md
@@ -18,6 +18,8 @@ Basically you need to create a PR against `orgs.yaml`, where you add a new entry
 
 Here's the PR adding the `monitoring` repository as an example: https://github.com/kubevirt/project-infra/pull/990/files
 
+Consider looking into enabling [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md) for the new repository.
+
 ## Pull request template
 
 Before you create the pull request, you should be notified with a pull request creation url similar to this one:

--- a/docs/how-to-add-a-new-repository.md
+++ b/docs/how-to-add-a-new-repository.md
@@ -1,0 +1,41 @@
+# Adding or moving a repository to the KubeVirt organization
+
+In certain occasions it makes sense to create or move a repository to the KubeVirt GitHub organization. 
+
+However, since we don't want this to go unnoticed for several reasons, i.e. the possible advertisement that we have a new and helpful project for the KubeVirt community, we are advocating a process that every repository needs to go through before it is added to the KubeVirt GitHub org.
+
+## Questions to ask
+
+* why is the repo a good fit for the org?
+* does the licensing fit the overall licensing in KubeVirt?
+* are all maintainers ok with transitioning?
+* is CI support required and if so do we have the CI capacity left? Ask the [CI maintainers](../OWNERS_ALIASES) to make sure of this
+* are minimal parameters for repo and maintainer team defined (description, maintainers)?
+
+## Repository and team configuration
+
+Basically you need to create a PR against `orgs.yaml`, where you add a new entry to the `repos` and another to the `teams` sections. These then define the repository properties and the team that maintains and has access to the repository.
+
+Here's the PR adding the `monitoring` repository as an example: https://github.com/kubevirt/project-infra/pull/990/files
+
+## Pull request template
+
+Before you create the pull request, you should be notified with a pull request creation url similar to this one:
+
+```
+https://github.com/{your-github-handle}/project-infra/pull/new/{your-github-branch}
+```
+
+Use the template [here](../.github/PULL_REQUEST_TEMPLATE/add_repo.md) by adding the template parameter to your pull request creation url:
+
+```
+https://github.com/{your-github-handle}/project-infra/pull/new/{your-github-branch}?template=add_repo.md
+```
+
+After that PR has been merged, the automation will kick in within around two hours.
+
+## Automation
+
+Regarding how the automation works, you can find further details in [Automating GitHub org management].
+
+[Automating GitHub org management]: https://github.com/kubevirt/community/blob/main/docs/automating-github-org-management.md 


### PR DESCRIPTION
This PR adds a document that describes the process of adding a new repository to the KubeVirt org.

It also adds two pull request templates:

* a default template
* a PR template that can be used for add-repo PR

The latter template contains a checklist of things to consider when adding a repository.

See docs for adding templates here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository