### PR TITLE
Run check-tests-for-flakes in parallel, set memory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -409,6 +409,11 @@ presubmits:
         - /bin/sh
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
+        env:
+        - name: KUBEVIRT_E2E_PARALLEL
+          value: "true"
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 9216M
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
         name: ""
         resources:
@@ -2184,7 +2189,7 @@ presubmits:
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
         name: ""
         resources:
-            requests:
-              memory: 4Gi
+          requests:
+            memory: 4Gi
         securityContext:
           privileged: true


### PR DESCRIPTION
Currently the tests are not run in parallel, therefore they are timing out sometimes. See i.e. https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-check-tests-for-flakes/1691415578037719040#1:build-log.txt%3A3438

Let's run them in parallel.

Also fix resource request on linter job.

/cc @brianmcarey @xpivarc 