### PR TITLE
Update kubevirt-csi-driver presubmit golang to 1.20

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
               - "make test"
             env:
               - name: GIMME_GO_VERSION
-                value: "1.18"
+                value: "1.20"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -65,7 +65,7 @@ presubmits:
               - "make linter"
             env:
               - name: GIMME_GO_VERSION
-                value: "1.18"
+                value: "1.20"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -101,7 +101,7 @@ presubmits:
               - "make sanity-test"
             env:
               - name: GIMME_GO_VERSION
-                value: "1.18"
+                value: "1.20"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
Its currently at 1.18, and I am updating the libraries to k8s 1.26 which requires a newer golang.