### PR TITLE
ssp-operator: Archive kubevirt-ssp-operator & kubevirt-template-validator

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -685,6 +685,7 @@ presubmits:
         - --fix-team-members=false
         - --fix-team-repos=false
         - --fix-repos=true
+        - --allow-repo-archival
         - --confirm=false
         resources:
           requests:

--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -392,6 +392,7 @@ orgs:
         has_projects: true
       kubevirt-ssp-operator:
         has_projects: true
+        archived: true
       kubevirt-tekton-tasks:
         allow_rebase_merge: false
         allow_squash_merge: false
@@ -401,6 +402,7 @@ orgs:
       kubevirt-template-validator:
         description: validating webhook to check templates sent to the cluster.
         has_projects: true
+        archived: true
       kubevirt-tutorial:
         description: Demo that guides users through an end to end KubeVirt experience.
         has_projects: true


### PR DESCRIPTION
These have been unused for some time now and even marked as deprecated within the repo README so lets archive.