### PR TITLE
Skip ceph wffc lane on release branches

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -339,11 +339,7 @@ presubmits:
               memory: "29Gi"
   - name: pull-containerized-data-importer-e2e-ceph-wffc
     skip_branches:
-      - release-v1.28
-      - release-v1.34
-      - release-v1.38
-      - release-v1.43
-      - release-v1.49
+      - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits


### PR DESCRIPTION
Whoops - never meant to run this on any release branches. just main is enough