### PR TITLE
Fix org-github-updater settings

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -462,16 +462,17 @@ periodics:
       command:
       - /ko-app/peribolos
       args:
+      - --config-path=github/ci/prow-deploy/files/orgs.yaml
       - --github-endpoint=http://ghproxy
       - --github-endpoint=https://api.github.com
-      - --config-path=github/ci/prow-deploy/files/orgs.yaml
       - --github-token-path=/etc/github/oauth
       - --fix-org=true
       - --fix-org-members=true
-      - --fix-teams=true
+      - --fix-repos=true
       - --fix-team-members=true
       - --fix-team-repos=true
-      - --fix-repos=true
+      - --fix-teams=true
+      - --allow-repo-archival
       - --confirm=true
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -674,17 +674,18 @@ presubmits:
         image: gcr.io/k8s-prow/peribolos:v20230817-a7555751ac
         command:
         - /ko-app/peribolos
+        # when changing the peribolos settings below, please align the peribolos settings from the periodic job!
         args:
+        - --config-path=github/ci/prow-deploy/files/orgs.yaml
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --config-path=github/ci/prow-deploy/files/orgs.yaml
         - --github-token-path=/etc/github/oauth
         - --fix-org=true
         - --fix-org-members=true
-        - --fix-teams=false
-        - --fix-team-members=false
-        - --fix-team-repos=false
         - --fix-repos=true
+        - --fix-team-members=true
+        - --fix-team-repos=true
+        - --fix-teams=true
         - --allow-repo-archival
         - --confirm=false
         resources:


### PR DESCRIPTION
The periodic job that updates the org settings has to have the same settings as the presubmit job, otherwise changes might differ from what is expected. This PR aligns the settings of the two jobs.

First, we align the settings for the periodic job that actually updates the org with the presubmit that only checks the settings for validity. We add `--allow-repo-archival` and set `--fix-team...` flags to true.

Then we sort the options so that we can find them easier if required.

/cc @lyarwood @xpivarc @enp0s3 