### PR TITLE
Generate support matrix for kubevirt/kubevirt

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -246,3 +246,41 @@ postsubmits:
           resources:
             requests:
               memory: "8Gi"
+  - name: push-kubevirt-update-support-matrix
+    branches:
+    # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+    cluster: ibm-prow-jobs
+    always_run: true
+    optional: false
+    skip_report: false
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    extra_refs:
+    - org: kubevirt
+      repo: project-infra
+      base_ref: main
+    - org: kubevirt
+      repo: sig-release
+      base_ref: main
+    labels:
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/golang:v20230801-94954c0
+        env:
+        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+        args:
+        - |
+          set -e
+          project_infra_dir=$(cd ../project-infra && pwd)
+          cd ${project_infra_dir}
+          sig_release_dir=$(cd ../sig-release && pwd)
+          ./hack/git-pr.sh -c "go run ./robots/cmd/kubevirt get support-matrix --output-file=${sig_release_dir}/releases/k8s-support-matrix.md --overwrite-output-file --job-config-path=${project_infra_dir}/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt" -p ${sig_release_dir} -r sig-release -b update-support-matrix -T main
+        resources:
+          requests:
+            memory: "200Mi"

--- a/robots/pkg/kubevirt/cmd/get/BUILD.bazel
+++ b/robots/pkg/kubevirt/cmd/get/BUILD.bazel
@@ -6,12 +6,15 @@ go_library(
         "get.go",
         "periodics.go",
         "presubmits.go",
+        "release-model.go",
+        "support-matrix.go",
     ],
     embedsrcs = [
         "periodics.gohtml",
         "presubmits.gohtml",
         "periodics.gocsv",
         "presubmits.gocsv",
+        "support-matrix.gomd",
     ],
     importpath = "kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/get",
     visibility = ["//visibility:public"],
@@ -19,8 +22,11 @@ go_library(
         "//robots/pkg/kubevirt/cmd/flags:go_default_library",
         "//robots/pkg/kubevirt/log:go_default_library",
         "//robots/pkg/kubevirt/prowjobconfigs:go_default_library",
+        "//robots/pkg/querier:go_default_library",
         "@com_github_lnquy_cron//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
         "@io_k8s_test_infra//prow/config:go_default_library",
     ],
 )
@@ -28,6 +34,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["periodics_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = ["@io_k8s_test_infra//prow/config:go_default_library"],
 )

--- a/robots/pkg/kubevirt/cmd/get/get.go
+++ b/robots/pkg/kubevirt/cmd/get/get.go
@@ -36,6 +36,7 @@ var getCommand = &cobra.Command{
 func init() {
 	getCommand.AddCommand(GetPeriodicsCommand())
 	getCommand.AddCommand(GetPresubmitsCommand())
+	getCommand.AddCommand(getSupportMatrixCommand)
 }
 
 func GetCommand() *cobra.Command {

--- a/robots/pkg/kubevirt/cmd/get/release-model.go
+++ b/robots/pkg/kubevirt/cmd/get/release-model.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Original file: https://raw.githubusercontent.com/kubernetes/release/master/cmd/schedule-builder/cmd/model.go
+ */
+
+package get
+
+// PatchSchedule main struct to hold the schedules
+type PatchSchedule struct {
+	Schedules []Schedule `yaml:"schedules"`
+}
+
+// PreviousPatches struct to define the old patch schedules
+type PreviousPatches struct {
+	Release            string `yaml:"release"`
+	CherryPickDeadline string `yaml:"cherryPickDeadline"`
+	TargetDate         string `yaml:"targetDate"`
+	Note               string `yaml:"note"`
+}
+
+type NextRelease struct {
+	Release            string `yaml:"release"`
+	CherryPickDeadline string `yaml:"cherryPickDeadline"`
+	TargetDate         string `yaml:"targetDate"`
+}
+
+// Schedule struct to define the release schedule for a specific version
+type Schedule struct {
+	Release            string            `yaml:"release"`
+	Next               NextRelease       `yaml:"next"`
+	CherryPickDeadline string            `yaml:"cherryPickDeadline"`
+	TargetDate         string            `yaml:"targetDate"`
+	EndOfLifeDate      string            `yaml:"endOfLifeDate"`
+	PreviousPatches    []PreviousPatches `yaml:"previousPatches"`
+}
+
+type ReleaseSchedule struct {
+	Releases []Release `yaml:"releases"`
+}
+
+type Release struct {
+	Version  string     `yaml:"version"`
+	Timeline []Timeline `yaml:"timeline"`
+}
+
+type Timeline struct {
+	What     string `yaml:"what"`
+	Who      string `yaml:"who"`
+	When     string `yaml:"when"`
+	Week     string `yaml:"week"`
+	CISignal string `yaml:"ciSignal"`
+	Tldr     bool   `yaml:"tldr"`
+}
+
+type EOLDoc struct {
+	Branches []*Branch
+}
+
+type Branch struct {
+	Release           string `yaml:"release"`
+	FinalPatchRelease string `yaml:"finalPatchRelease"`
+	EndOfLifeDate     string `yaml:"endOfLifeDate"`
+	Note              string `yaml:"note"`
+}

--- a/robots/pkg/kubevirt/cmd/get/support-matrix.go
+++ b/robots/pkg/kubevirt/cmd/get/support-matrix.go
@@ -1,0 +1,385 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package get
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+	"html/template"
+	"io"
+	"io/fs"
+	"k8s.io/test-infra/prow/config"
+	"kubevirt.io/project-infra/robots/pkg/querier"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"time"
+)
+
+const k8sScheduleYAML = "https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml"
+const k8sEOLYAML = "https://raw.githubusercontent.com/kubernetes/website/main/data/releases/eol.yaml"
+
+type schedulesDoc struct {
+	Schedules []*Schedule `yaml:"schedules"`
+}
+
+var getSupportMatrixCommand = &cobra.Command{
+	Use:   "support-matrix",
+	Short: "kubevirt get support-matrix generates a support matrix document from k8s release schedule and project-infra job data for kubevirt/kubevirt",
+	Long: getPeriodicsShortDescription + `
+
+It reads the job configurations for kubevirt/kubevirt e2e presubmit jobs, extracts information and creates a table in 
+html format, matching supported k8s versions towards k6t versions.
+`,
+	RunE: GetSupportMatrix,
+}
+
+var jobNameRegex = regexp.MustCompile(`^pull-kubevirt-e2e-k8s-([0-9]+\.[0-9]+)-sig-compute$`)
+var k6tVersionRegex = regexp.MustCompile(`^.*kubevirt-presubmits(-([0-9]+\.[0-9]+))?\.yaml$`)
+
+//go:embed support-matrix.gomd
+var getSupportMatrixTemplate string
+
+type getSupportMatrixOptions struct {
+	OutputFile string
+}
+
+func (o *getSupportMatrixOptions) validateOptions() error {
+	if o.OutputFile != "" {
+		_, err := os.Stat(o.OutputFile)
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("output file %s might exist already: %v", o.OutputFile, err)
+		}
+	}
+	return nil
+}
+
+var getSupportMatrixOpts = getSupportMatrixOptions{}
+
+func init() {
+	getSupportMatrixCommand.PersistentFlags().StringVar(&getSupportMatrixOpts.OutputFile, "output-file", "", "output file to write to,m otherwise standard out will be used")
+}
+
+func majorMinorString(i *querier.SemVer) string {
+	return fmt.Sprintf("%s.%s", i.Major, i.Minor)
+}
+
+type checkSemVerFunc func(k8sVersion string) bool
+
+type SupportMatrixTemplateData struct {
+	K6tVersions          []string
+	K8sVersions          []string
+	SupportedK8sVersions map[string]bool
+	MapK6tToK8sVersions  map[string]map[string]bool
+}
+
+func GetSupportMatrix(_ *cobra.Command, _ []string) error {
+	fileNames, err := getJobConfigFileNames()
+	if err != nil {
+		return err
+	}
+
+	// each k8t version supports the latest three k8s versions at time of release
+	// but to make sure that we actually print the ones that versions are tested against we read the kubevirt presubmit job files and check against
+	// sig-compute required ones, aka always_run: true, optional: false
+	k8sVersionsSet := make(map[string]struct{})
+	k6tVersionsSet := make(map[string]struct{})
+	mapK6tToK8sVersions := make(map[string]map[string]bool)
+	for _, file := range fileNames {
+		k6tVersion := ""
+		if !k6tVersionRegex.MatchString(file) {
+			return fmt.Errorf("no k6t version available: %s", file)
+		}
+		submatch := k6tVersionRegex.FindStringSubmatch(file)
+		if submatch != nil {
+			k6tVersion = submatch[2]
+		}
+		if k6tVersion == "" {
+			continue
+		} else {
+			k6tVersionsSet[k6tVersion] = struct{}{}
+		}
+		jobConfig, readConfigErr := config.ReadJobConfig(file)
+		if readConfigErr != nil {
+			return fmt.Errorf("failed to read job config: %v", readConfigErr)
+		}
+		for _, presubmit := range jobConfig.PresubmitsStatic["kubevirt/kubevirt"] {
+			if presubmit.AlwaysRun == false || presubmit.Optional == true {
+				continue
+			}
+			k8sVersion := ""
+			if !jobNameRegex.MatchString(presubmit.Name) && !jobNameRegex.MatchString(presubmit.Context) {
+				continue
+			}
+			if jobNameRegex.MatchString(presubmit.Context) {
+				k8sVersion = jobNameRegex.FindStringSubmatch(presubmit.Context)[1]
+			}
+			if jobNameRegex.MatchString(presubmit.Name) {
+				k8sVersion = jobNameRegex.FindStringSubmatch(presubmit.Name)[1]
+			}
+			if k8sVersion == "" {
+				continue
+			}
+			k8sVersionsSet[k8sVersion] = struct{}{}
+			if _, exists := mapK6tToK8sVersions[k6tVersion]; !exists {
+				mapK6tToK8sVersions[k6tVersion] = make(map[string]bool)
+			}
+			mapK6tToK8sVersions[k6tVersion][k8sVersion] = true
+		}
+	}
+
+	k6tVersions := make([]string, 0)
+	for k6tVersion := range k6tVersionsSet {
+		k6tVersions = append(k6tVersions, k6tVersion)
+	}
+	k8sVersions := make([]string, 0)
+	for k8sVersion := range k8sVersionsSet {
+		k8sVersions = append(k8sVersions, k8sVersion)
+	}
+
+	latestK8sEOLRelease, err := fetchLatestK8sEOLRelease()
+	if err != nil {
+		return err
+	}
+	isK8sVersionEOL := func(k8sVersion string) bool {
+		semVer := mustParseMajorMinor(k8sVersion)
+		return latestK8sEOLRelease.Compare(&semVer) >= 0
+	}
+	supportedK8sVersions := make(map[string]bool, 0)
+	for _, k8sVersion := range k8sVersions {
+		if isK8sVersionEOL(k8sVersion) {
+			continue
+		}
+		supportedK8sVersions[k8sVersion] = true
+	}
+
+	generateStringSemVerComparison := func(versions []string) func(i, j int) bool {
+		return func(i, j int) bool {
+			jSemVer, iSemVer := mustParseMajorMinor(versions[j]), mustParseMajorMinor(versions[i])
+			return jSemVer.Compare(&iSemVer) < 0
+		}
+	}
+
+	sort.SliceStable(k8sVersions, generateStringSemVerComparison(k8sVersions))
+
+	// no more than three EOL K8S versions
+	noMoreThanXEOLK8sVersions := 3
+	numberOfEOLK8sVersionsSoFar := 0
+	k8sVersionsWithLessEOLVersions := make([]string, 0)
+	for _, k8sVersion := range k8sVersions {
+		if isK8sVersionEOL(k8sVersion) {
+			if numberOfEOLK8sVersionsSoFar >= noMoreThanXEOLK8sVersions {
+				break
+			}
+			numberOfEOLK8sVersionsSoFar++
+		}
+		k8sVersionsWithLessEOLVersions = append(k8sVersionsWithLessEOLVersions, k8sVersion)
+	}
+	k8sVersions = k8sVersionsWithLessEOLVersions
+
+	k8sVersionsSet = make(map[string]struct{})
+	for _, k8sVersion := range k8sVersions {
+		k8sVersionsSet[k8sVersion] = struct{}{}
+	}
+
+	k6tVersionsWithK8sInformation := make([]string, 0)
+	for k6tVersion, supportedK8sVersionsForK6tVersion := range mapK6tToK8sVersions {
+		// if no support for any version then continue
+		if len(supportedK8sVersionsForK6tVersion) == 0 {
+			continue
+		}
+
+		// search for any supported version inside the stripped down versions
+		contains := false
+	containsLoop:
+		for supportedK8sVersion := range supportedK8sVersionsForK6tVersion {
+			if _, k8sVersionExists := k8sVersionsSet[supportedK8sVersion]; k8sVersionExists {
+				contains = true
+				break containsLoop
+			}
+		}
+		if !contains {
+			continue
+		}
+		k6tVersionsWithK8sInformation = append(k6tVersionsWithK8sInformation, k6tVersion)
+	}
+	k6tVersions = k6tVersionsWithK8sInformation
+	sort.SliceStable(k6tVersions, generateStringSemVerComparison(k6tVersions))
+
+	var writer io.Writer
+	if getSupportMatrixOpts.OutputFile != "" {
+		writer, err = os.OpenFile(getSupportMatrixOpts.OutputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	} else {
+		writer = os.Stdout
+	}
+
+	supportMatrixTemplate, err := template.New("support-matrix").Parse(getSupportMatrixTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse go template: %v", err)
+	}
+
+	err = supportMatrixTemplate.Execute(writer, SupportMatrixTemplateData{
+		K6tVersions:          k6tVersions,
+		K8sVersions:          k8sVersions,
+		SupportedK8sVersions: supportedK8sVersions,
+		MapK6tToK8sVersions:  mapK6tToK8sVersions,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to execute go template: %v", err)
+	}
+
+	return nil
+}
+
+func mustParseMajorMinor(k8sVersion string) querier.SemVer {
+	semVer, parseErr := parseMajorMinor(k8sVersion)
+	if parseErr != nil {
+		log.Fatalf("failed to parse %q: %v", k8sVersion, parseErr)
+	}
+	return semVer
+}
+
+func fetchLatestK8sEOLRelease() (querier.SemVer, error) {
+	schedules, err := fetchK8sSchedules()
+	if err != nil {
+		return querier.SemVer{}, fmt.Errorf("failed to fetch k8s eols: %v", err)
+	}
+	eols, err := fetchK8sEOLs()
+	if err != nil {
+		return querier.SemVer{}, fmt.Errorf("failed to fetch k8s eols: %v", err)
+	}
+	k8sReleasesToEOLDates, err := getK8sReleasesToEOLDates(schedules.Schedules, eols.Branches)
+	if err != nil {
+		return querier.SemVer{}, fmt.Errorf("failed to get k8s releases to eol dates: %v", err)
+	}
+	var latestEOLRelease querier.SemVer
+	var latestEOLDate time.Time
+	for k8sRelease, eolDate := range k8sReleasesToEOLDates {
+		if !eolDate.Before(time.Now()) {
+			continue
+		}
+		if !eolDate.After(latestEOLDate) {
+			continue
+		}
+		eolRelease, parseMajorMinorErr := parseMajorMinor(k8sRelease)
+		if parseMajorMinorErr != nil {
+			return querier.SemVer{}, fmt.Errorf("failed to parse k8s version %q: %v", k8sRelease, parseMajorMinorErr)
+		}
+		latestEOLRelease, latestEOLDate = eolRelease, eolDate
+	}
+	return latestEOLRelease, nil
+}
+
+var semVerWithOptionalReleaseRegex = regexp.MustCompile(`^([0-9]+)\.([0-9]+)(\.([0-9]+))?$`)
+
+func parseMajorMinor(version string) (querier.SemVer, error) {
+	if !semVerWithOptionalReleaseRegex.MatchString(version) {
+		return querier.SemVer{}, fmt.Errorf("invalid major minor version string: %s", version)
+	}
+	subMatches := semVerWithOptionalReleaseRegex.FindAllStringSubmatch(version, -1)
+	return querier.SemVer{
+		Major: subMatches[0][1],
+		Minor: subMatches[0][2],
+	}, nil
+}
+
+func getJobConfigFileNames() ([]string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get workdir: %v", err)
+	}
+	workDir := filepath.Join(dir, "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/")
+	var fileNames []string
+	err = filepath.WalkDir(workDir, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() || !k6tVersionRegex.MatchString(d.Name()) {
+			return nil
+		}
+		fileNames = append(fileNames, filepath.Join(workDir, d.Name()))
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk dir %q: %v", workDir, err)
+	}
+	return fileNames, nil
+}
+
+func fetchK8sSchedules() (*schedulesDoc, error) {
+	resp, err := http.Get(k8sScheduleYAML)
+	if err != nil {
+		return nil, fmt.Errorf("error when fetching k8s schedule yaml: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	var k8sSchedules *schedulesDoc
+	err = yaml.Unmarshal(body, &k8sSchedules)
+	if err != nil {
+		return nil, fmt.Errorf("error on deserializing k8s schedule yaml: %v", err)
+	}
+	return k8sSchedules, nil
+}
+
+func fetchK8sEOLs() (*EOLDoc, error) {
+	resp, err := http.Get(k8sEOLYAML)
+	if err != nil {
+		return nil, fmt.Errorf("error when fetching %q: %v", k8sEOLYAML, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	var eolDoc *EOLDoc
+	err = yaml.Unmarshal(body, &eolDoc)
+	if err != nil {
+		return nil, fmt.Errorf("error on deserializing %q: %v", k8sEOLYAML, err)
+	}
+	return eolDoc, nil
+}
+
+func getK8sReleasesToEOLDates(k8sSchedules []*Schedule, branches []*Branch) (map[string]time.Time, error) {
+	supportedK8sReleases := make(map[string]time.Time)
+	for _, k8sSchedule := range k8sSchedules {
+		date := k8sSchedule.EndOfLifeDate
+		eolDate, err := parseDate(date)
+		if err != nil {
+			return nil, err
+		}
+		supportedK8sReleases[k8sSchedule.Release] = eolDate
+	}
+	for _, branch := range branches {
+		date := branch.EndOfLifeDate
+		eolDate, err := parseDate(date)
+		if err != nil {
+			return nil, err
+		}
+		supportedK8sReleases[branch.Release] = eolDate
+	}
+	return supportedK8sReleases, nil
+}
+
+func parseDate(date string) (time.Time, error) {
+	eolDate, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error on parsing eol date: %v", err)
+	}
+	return eolDate, nil
+}

--- a/robots/pkg/kubevirt/cmd/get/support-matrix.gomd
+++ b/robots/pkg/kubevirt/cmd/get/support-matrix.gomd
@@ -1,0 +1,32 @@
+{{- /*
+  This file is part of the KubeVirt project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  Copyright 2023 Red Hat, Inc.
+*/ -}}
+{{- /* gotype: kubevirt.io/project-infra/robots/pkg/kubevirt/cmd/get.SupportMatrixTemplateData */ -}}
+# KubeVirt to Kubernetes version support matrix
+
+| KubeVirt version |
+{{- range $k8sVersion := .K8sVersions}} {{ $k8sVersion }}{{ if not (index $.SupportedK8sVersions $k8sVersion) }}<sup>EOL</sup>{{ else }}              {{ end }} |{{ end }}
+|------------------|{{ range $k8sVersion := .K8sVersions }}--------------------|{{ end }}
+{{ range $k6tVersion := .K6tVersions }}|              {{ $k6tVersion }} |
+    {{- range $k8sVersion := $.K8sVersions -}}
+        {{ if (index $.MapK6tToK8sVersions $k6tVersion $k8sVersion ) }}
+        {{- if (index $.SupportedK8sVersions $k8sVersion) }} ✓                  {{ else }} EOL                {{ end -}}
+        {{ else }} -                  {{ end -}}
+        |{{- end }}
+{{ end }}
+
+Note: _EOL_ means that the Kubernetes version was supported by KubeVirt but has reached end of life. See [Kubernetes releases](https://kubernetes.io/releases/) for more details


### PR DESCRIPTION
Generates from the testing job configurations a markdown document a matrix of all kubevirt versions vs. the k8s versions, including information about which versions are already EOL.

Information is reduced to a reasonable amout:

* only the last three k8s EOL versions are shown, regardless of how many are there, resulting in 6 k8s versions shown at any time
* all the K6t versions that don't support any of the former K8s versions are removed from the data set

# All versions

Result:

---

# KubeVirt to Kubernetes version support matrix

| KubeVirt version | 1.27               | 1.26               | 1.25               | 1.24<sup>EOL</sup> | 1.23<sup>EOL</sup> | 1.22<sup>EOL</sup> |
|------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
|              1.0 | ✓                  | ✓                  | ✓                  | -                  | -                  | -                  |
|              0.59 | -                  | ✓                  | ✓                  | EOL                | -                  | -                  |
|              0.58 | -                  | -                  | -                  | EOL                | EOL                | EOL                |
|              0.57 | -                  | -                  | -                  | EOL                | EOL                | EOL                |
|              0.56 | -                  | -                  | -                  | EOL                | EOL                | EOL                |
|              0.55 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.54 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.53 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.52 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.51 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.50 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.49 | -                  | -                  | -                  | -                  | EOL                | EOL                |
|              0.48 | -                  | -                  | -                  | -                  | -                  | EOL                |


Note: _EOL_ means that the Kubernetes version was supported by KubeVirt but has reached end of life. See [Kubernetes releases](https://kubernetes.io/releases/) for more details

---

# Single version

Using `--kubevirt-version 0.59` only generates the table for the given version, omitting the flag generates the complete table.

```
$ go run ./robots/cmd/kubevirt/... get support-matrix \
	--job-config-path ./project-infra/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt \
	--kubevirt-version 0.59 
```

Result:

---

# KubeVirt to Kubernetes version support matrix

| KubeVirt version | 1.26               | 1.25               | 1.24<sup>EOL</sup> |
|------------------|--------------------|--------------------|--------------------|
|              0.59 | ✓                  | ✓                  | EOL                |


Note: _EOL_ means that the Kubernetes version was supported by KubeVirt but has reached end of life. See [Kubernetes releases](https://kubernetes.io/releases/) for more details

---

Closes #2946, #2976 
