### PR TITLE
Generalize flakefinder for future gerrit usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.4
 	github.com/prometheus/client_golang v1.14.0
+	github.com/r3labs/diff/v3 v3.0.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.6.0
 	golang.org/x/mod v0.9.0
@@ -112,7 +113,6 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	github.com/r3labs/diff/v3 v3.0.1 // indirect
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 // indirect

--- a/robots/cmd/flakefinder/BUILD.bazel
+++ b/robots/cmd/flakefinder/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//robots/pkg/flakefinder:go_default_library",
+        "//robots/pkg/flakefinder/github:go_default_library",
         "@com_github_google_go_github_v28//github:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
         "@io_k8s_test_infra//prow/config/secret:go_default_library",

--- a/robots/cmd/flakefinder/main.go
+++ b/robots/cmd/flakefinder/main.go
@@ -23,11 +23,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"k8s.io/test-infra/prow/config/secret"
 	"log"
 	"net/url"
 	"path/filepath"
 	"time"
+
+	"k8s.io/test-infra/prow/config/secret"
+	ghapi "kubevirt.io/project-infra/robots/pkg/flakefinder/github"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/go-github/v28/github"
@@ -120,7 +122,7 @@ func main() {
 	reportBaseDataOptions.SetPeriodicJobDirRegex(o.periodicJobDirRegex)
 	reportBaseDataOptions.SetBatchJobDirRegex(o.batchJobDirRegex)
 
-	reportBaseData := flakefinder.GetReportBaseData(ctx, ghClient, storageClient, reportBaseDataOptions)
+	reportBaseData := flakefinder.GetReportBaseData(ctx, ghapi.NewQuery(ghClient, o.org, o.repo, o.prBaseBranch), storageClient, reportBaseDataOptions)
 
 	err = WriteReportToBucket(ctx, storageClient, o.merged, o.org, o.repo, o.isDryRun, reportBaseData)
 	if err != nil {

--- a/robots/cmd/flakefinder/report.go
+++ b/robots/cmd/flakefinder/report.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-
 	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 )
 

--- a/robots/pkg/flakefinder/BUILD.bazel
+++ b/robots/pkg/flakefinder/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     importpath = "kubevirt.io/project-infra/robots/pkg/flakefinder",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_google_go_github_v28//github:go_default_library",
+        "//robots/pkg/flakefinder/api:go_default_library",
         "@com_github_joshdk_go_junit//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
@@ -29,7 +29,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "@com_github_google_go_github_v28//github:go_default_library",
+        "//robots/pkg/flakefinder/github:go_default_library",
         "@com_github_joshdk_go_junit//:go_default_library",
         "@com_github_onsi_ginkgo_v2//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/robots/pkg/flakefinder/api/BUILD.bazel
+++ b/robots/pkg/flakefinder/api/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/flakefinder/api",
+    visibility = ["//visibility:public"],
+)

--- a/robots/pkg/flakefinder/api/types.go
+++ b/robots/pkg/flakefinder/api/types.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"context"
+	"time"
+)
+
+type StartedStatus struct {
+	Timestamp int
+	Repos     map[string]string
+}
+
+type Change interface {
+	Matches(*StartedStatus) bool
+	ID() int
+}
+
+type Query interface {
+	Query(ctx context.Context, startOfReport time.Time, endOfReport time.Time) ([]Change, error)
+}

--- a/robots/pkg/flakefinder/downloader_test.go
+++ b/robots/pkg/flakefinder/downloader_test.go
@@ -3,9 +3,8 @@ package flakefinder_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/google/go-github/v28/github"
 	"kubevirt.io/project-infra/robots/pkg/flakefinder"
+	ghapi "kubevirt.io/project-infra/robots/pkg/flakefinder/github"
 )
 
 var _ = Describe("downloader.go", func() {
@@ -29,20 +28,20 @@ var _ = Describe("downloader.go", func() {
 		secondHeadSHA := "8c33c116def661c69b4a8eb08fac9ca07dfbf03d"
 
 		It("finds a commit", func() {
-			pullRequest := github.PullRequest{Number: &prNumber, Head: &github.PullRequestBranch{SHA: &headSHA}}
-			isLatestCommit := flakefinder.IsLatestCommit([]byte(singleRepoJsonText), &pullRequest)
+			pullRequest := &ghapi.PullRequest{Number: prNumber, SHA: headSHA}
+			isLatestCommit := flakefinder.IsLatestCommit([]byte(singleRepoJsonText), pullRequest)
 			Expect(isLatestCommit).To(BeTrue())
 		})
 
 		It("does not find a commit if pr number wrong", func() {
-			pullRequest := github.PullRequest{Number: &oneOffPrNumber, Head: &github.PullRequestBranch{SHA: &headSHA}}
-			isLatestCommit := flakefinder.IsLatestCommit([]byte(singleRepoJsonText), &pullRequest)
+			pullRequest := &ghapi.PullRequest{Number: oneOffPrNumber, SHA: headSHA}
+			isLatestCommit := flakefinder.IsLatestCommit([]byte(singleRepoJsonText), pullRequest)
 			Expect(isLatestCommit).To(BeFalse())
 		})
 
 		It("does not find a commit if sha wrong", func() {
-			pullRequest := github.PullRequest{Number: &prNumber, Head: &github.PullRequestBranch{SHA: &secondHeadSHA}}
-			isLatestCommit := flakefinder.IsLatestCommit([]byte(singleRepoJsonText), &pullRequest)
+			pullRequest := &ghapi.PullRequest{Number: prNumber, SHA: secondHeadSHA}
+			isLatestCommit := flakefinder.IsLatestCommit([]byte(singleRepoJsonText), pullRequest)
 			Expect(isLatestCommit).To(BeFalse())
 		})
 
@@ -57,8 +56,8 @@ var _ = Describe("downloader.go", func() {
 		"kubevirt/kubevirt2":"release-0.11:577e95c340e1b21ff431cbba25ad33c891554e38,2474:8c33c116def661c69b4a8eb08fac9ca07dfbf03c"
 	}
 }`
-			pullRequest := github.PullRequest{Number: &oneOffPrNumber, Head: &github.PullRequestBranch{SHA: &headSHA}}
-			isLatestCommit := flakefinder.IsLatestCommit([]byte(jsonTextWithTwoRepos), &pullRequest)
+			pullRequest := &ghapi.PullRequest{Number: oneOffPrNumber, SHA: headSHA}
+			isLatestCommit := flakefinder.IsLatestCommit([]byte(jsonTextWithTwoRepos), pullRequest)
 			Expect(isLatestCommit).To(BeTrue())
 		})
 

--- a/robots/pkg/flakefinder/github/BUILD.bazel
+++ b/robots/pkg/flakefinder/github/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["github.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/flakefinder/github",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//robots/pkg/flakefinder/api:go_default_library",
+        "@com_github_google_go_github_v28//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)

--- a/robots/pkg/flakefinder/github/github.go
+++ b/robots/pkg/flakefinder/github/github.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v28/github"
+	"github.com/sirupsen/logrus"
+	"kubevirt.io/project-infra/robots/pkg/flakefinder/api"
+)
+
+type PullRequest struct {
+	Number int
+	SHA    string
+}
+
+func (p *PullRequest) ID() int {
+	return p.Number
+}
+
+func (p *PullRequest) Matches(status *api.StartedStatus) bool {
+	for _, v := range status.Repos {
+		if strings.Contains(v, fmt.Sprintf("%d:%s", p.Number, p.SHA)) {
+			return true
+		}
+	}
+	return false
+}
+
+type Query struct {
+	c          *github.Client
+	org        string
+	repo       string
+	baseBranch string
+}
+
+func NewQuery(c *github.Client, org string, repo string, baseBranch string) *Query {
+	return &Query{c: c, org: org, repo: repo, baseBranch: baseBranch}
+}
+
+func (q *Query) Query(ctx context.Context, startOfReport time.Time, endOfReport time.Time) ([]api.Change, error) {
+	logrus.Infof("Fetching Prs from %v till %v", startOfReport, endOfReport)
+
+	logrus.Infof("Filtering PRs for base branch %s", q.baseBranch)
+	var changes []api.Change
+	for nextPage := 1; nextPage > 0; {
+		pullRequests, response, err := q.c.PullRequests.List(ctx, q.org, q.repo, &github.PullRequestListOptions{
+			Base:        q.baseBranch,
+			State:       "closed",
+			Sort:        "updated",
+			Direction:   "desc",
+			ListOptions: github.ListOptions{Page: nextPage},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch PRs for page %d: %v.", nextPage, err)
+		}
+		nextPage = response.NextPage
+		for _, pr := range pullRequests {
+			if startOfReport.After(*pr.UpdatedAt) {
+				nextPage = 0
+				break
+			}
+			if pr.MergedAt == nil {
+				continue
+			}
+			if startOfReport.After(*pr.MergedAt) {
+				continue
+			}
+			if endOfReport.Before(*pr.MergedAt) {
+				continue
+			}
+			logrus.Infof("Adding PR %v '%v' (updated at %s)", *pr.Number, *pr.Title, pr.UpdatedAt.Format(time.RFC3339))
+			changes = append(changes, &PullRequest{
+				Number: *pr.Number,
+				SHA:    *pr.Head.SHA,
+			})
+		}
+	}
+	logrus.Infof("%d pull requests found.", len(changes))
+	return changes, nil
+}


### PR DESCRIPTION
Move github structs and clients behind interfaces which allow working on gerrit and gerrit Change Requests in the future as well.

* `PullRequest` is now hidden behind an `api.Change` interface
* GitHub client is hidden behind a `api.Query` interface

Checking if a prow job was executed on the latest change was moved behind the `api.Query` interface.