### PR TITLE
Add ARG ARCH in Dockerfile of bootstrap-legacy and golang-legacy

### DIFF
--- a/images/bootstrap-legacy/Dockerfile
+++ b/images/bootstrap-legacy/Dockerfile
@@ -94,9 +94,10 @@ RUN mkdir /docker-graph
 #
 
 # Cache the most commonly used bazel versions in the container
-RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64 && \
-     chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
-     cd /usr/local/bin && ln -s bazelisk bazel
+ARG ARCH=amd64
+RUN curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH} && \
+    chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
+    cd /usr/local/bin && ln -s bazelisk bazel
 
 # Cache the most commonly used bazel versions inside the image
 # and remove resulting cache directories to save a few hundred MB

--- a/images/golang-legacy/Dockerfile
+++ b/images/golang-legacy/Dockerfile
@@ -1,4 +1,5 @@
-FROM bootstrap-legacy
+ARG ARCH=amd64
+FROM bootstrap-legacy-${ARCH}
 
 ENV GIMME_GO_VERSION=1.17.8
 


### PR DESCRIPTION
Amend Dockerfile of bootstrap-legacy and golang-legacy to enable multiarch image build