### PR TITLE
project-infra presubmit, postsubmit: Build multiarch bootstrap-legacy and golang-legacy

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -138,8 +138,8 @@ postsubmits:
               - |
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
-                ./publish_image.sh bootstrap-legacy quay.io kubevirtci
-                ./publish_image.sh golang-legacy quay.io kubevirtci
+                ./publish_multiarch_image.sh bootstrap-legacy quay.io kubevirtci
+                ./publish_multiarch_image.sh -l golang-legacy quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -207,8 +207,8 @@ presubmits:
             - "-ce"
             - |
               cd images
-              ./publish_image.sh -b bootstrap-legacy quay.io kubevirtci
-              ./publish_image.sh -b golang-legacy quay.io kubevirtci
+              ./publish_multiarch_image.sh -a -b bootstrap-legacy quay.io kubevirtci
+              ./publish_multiarch_image.sh -a -b -l golang-legacy quay.io kubevirtci
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
update postsubmit and presubmit of project-infra to enable build multiarch bootstrap-legacy and golang-legacy images