### PR TITLE
Remove missing GitHub user `sudo-NithishKarthik` from org

### DIFF
--- a/github/ci/prow-deploy/files/orgs.yaml
+++ b/github/ci/prow-deploy/files/orgs.yaml
@@ -143,7 +143,6 @@ orgs:
       - nelsonspbr
       - nertpinx
       - nirarg
-      - sudo-NithishKarthik
       - nunnatsa
       - ohadlevy
       - omeryahud
@@ -608,7 +607,6 @@ orgs:
         description: "team for k8s-seccomp-generator repo"
         maintainers:
           - alicefr
-          - sudo-NithishKarthik
           - xpivarc
         privacy: secret
         repos:


### PR DESCRIPTION
GitHub user [`sudo-NithishKarthik`](https://github.com/sudo-NithishKarthik) has vanished from GitHub. We therefore remove him, since our GitHub org config automation fails.

```
...
{"component":"peribolos","file":"k8s.io/test-infra/prow/cmd/peribolos/main.go:194","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure kubevirt teams: failed to update k8s-seccomp-generator members: UpdateTeamMembership(k8s-seccomp-generator(k8s-seccomp-generator), sudo-nithishkarthik, true) failed: status code 404 not one of [200], body: {\"message\":\"Not Found\",\"documentation_url\":\"https://docs.github.com/rest/teams/members#add-or-update-team-membership-for-a-user\"}","severity":"fatal","time":"2023-08-23T15:36:20Z"}
```
([source](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-org-github-config-updater/1694351330971226112#1:build-log.txt%3A310))

User needs to reapply with his new account.

/cc @xpivarc @alicefr 