### PR TITLE
Reenable FOSSA license check

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -172,8 +172,6 @@ postsubmits:
     annotations:
       testgrid-create-test-group: "false"
     always_run: true
-    optional: true
-    skip_report: true
     decorate: true
     decoration_config:
       timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -717,10 +717,8 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-fossa
-    optional: true
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
We have disabled the FOSSA license check to remove strain for contributors, since those were failing due to erroneous things (i.e. license failures that weren't even present in the dependency tree any more).

Since the licensing issues have been resolved, we can enable them again.

/cc @stu-gott @xpivarc 