### PR TITLE
project-infra postsubmit: increase the memory limit for build multiarch legacy images

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -127,7 +127,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -145,9 +145,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "1Gi"
+                memory: "29Gi"
               limits:
-                memory: "1Gi"
+                memory: "29Gi"
     - name: publish-shared-images-controller-image
       always_run: false
       run_if_changed: "images/shared-images-controller/.*"


### PR DESCRIPTION
As the job will build both x86_64 images and Arm64 images which consumes more memory, we increase the memory limit for the job.

In terms of the corresponding presubmit job, it only builds x86_64 images, so it is not necessary to increase its memory limit.