### PR TITLE
Increase timeout for publish bootstrap legacy job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -123,6 +123,9 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 5h0m0s
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"


### PR DESCRIPTION
Current timeout default of 2h is not sufficient:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-bootstrap-legacy-images/1696460103638585344#1:build-log.txt%3A5526

/cc @brianmcarey @zhlhahaha 