### PR TITLE
CDI push builder images on release branches

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -159,6 +159,7 @@ postsubmits:
   - name: push-containerized-data-importer-builder
     branches:
     - main
+    - release-v\d+\.\d+
     cluster: ibm-prow-jobs
     always_run: true
     optional: false


### PR DESCRIPTION
Sometimes we need to create a specific builder for a release branch (maybe new version of go). Right now it is not possible to push a new builder from a branch This modifies the job to also push from release branches if there is a new builder.