### PR TITLE
Switch docker to podman in prowjob scripts

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -208,7 +208,7 @@ periodics:
       - |
         set -e
         build_date="$(date +%Y%m%d)"
-        cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+        cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
         export DOCKER_TAG="${build_date}_$(git show -s --format=%h)"
         make
         counter=3
@@ -285,7 +285,7 @@ periodics:
       - |
         set -e
         build_date="$(date +%Y%m%d)"
-        cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+        cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
         export DOCKER_TAG="${build_date}_$(git show -s --format=%h)-arm64"
         make
         counter=3
@@ -650,7 +650,7 @@ periodics:
         extract_secret 'amdSEVClusterKey' /ssh-key && chmod 400 /ssh-key
 
         # login quay.io
-        cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+        cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
 
         # Set up tunnel
         sshuttle -v -r kubevirt@165.204.53.121 10.216.91.126/32 192.168.0.0/24 --ssh-cmd 'ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i /ssh-key -p 30026' > /var/log/sshuttle.log 2>&1 & echo "${!}" > /var/run/sshuttle.pid
@@ -809,7 +809,7 @@ periodics:
         extract_secret 'kubeconfigPerf' /kubeconfig
 
         # login quay.io
-        cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+        cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
 
         # run test
         ./automation/perfscale-test.sh
@@ -889,7 +889,7 @@ periodics:
         extract_secret 'kubeconfigPerf' /kubeconfig
 
         # login quay.io
-        cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+        cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
 
         # run test 200
         PERFSCALE_WORKLOAD=$PERFSCALE_WORKLOAD_TWO_HUNDRED ./automation/perfscale-test.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -40,10 +40,9 @@ postsubmits:
           set -e
           major_minor="$(git tag --points-at HEAD | head -1 | grep -oE '[0-9]+.[0-9]+')"
           if [ $(expr $major_minor \>\= 0.40) -eq 1 ] || [ $(expr $major_minor \=\= 0.36) -eq 1 ]; then
-            cat $QUAY_PASSWORD | docker login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
+            cat $QUAY_PASSWORD | podman login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
             ./automation/release.sh
           fi
-        # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
@@ -79,7 +78,6 @@ postsubmits:
           make manifests
           gsutil -m rm -r "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG" || true
           gsutil cp -r "_out/manifests/testing" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG/manifests/"
-        # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
@@ -117,7 +115,6 @@ postsubmits:
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
         - ./automation/postsubmit-main.sh
-        # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
@@ -151,7 +148,6 @@ postsubmits:
             - "/bin/sh"
             - "-c"
             - "cp /etc/bazel.bazelrc ./ci.bazelrc && make goveralls"
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -194,7 +190,6 @@ postsubmits:
             - "/bin/sh"
             - "-c"
             - "make fossa"
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -237,7 +232,7 @@ postsubmits:
             - "/bin/bash"
             - "-c"
             - >
-              cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin=true &&
+              cat $QUAY_PASSWORD | podman login quay.io --username $(cat $QUAY_USER) --password-stdin=true &&
               make builder-publish
           securityContext:
             privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1582,7 +1582,7 @@ presubmits:
           extract_secret 'amdSEVClusterKey' /ssh-key && chmod 400 /ssh-key
 
           # login quay.io
-          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+          cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
 
           # Set up tunnel
           sshuttle -v -r kubevirt@165.204.53.121 10.216.91.126/32 192.168.0.0/24 --ssh-cmd 'ssh -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i /ssh-key -p 30026' > /var/log/sshuttle.log 2>&1 & echo "${!}" > /var/run/sshuttle.pid

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -357,7 +357,7 @@ presubmits:
         - -ce
         - |
           (cd cluster-provision/gocli && make test && make container)
-          docker run --rm -v $(pwd):/workdir:Z quay.io/kubevirtci/gocli provision-manager --debug
+          podman run --rm -v $(pwd):/workdir:Z quay.io/kubevirtci/gocli provision-manager --debug
         image: quay.io/kubevirtci/golang:v20230801-94954c0
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 make -C external-plugins/rehearse push
             resources:
               requests:
@@ -45,7 +45,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 bazelisk run //external-plugins/release-blocker:push
             resources:
               requests:
@@ -72,10 +72,9 @@ postsubmits:
               - "/bin/bash"
               - "-ce"
               - |
-                  cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io
+                  cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io
                   cd images
                   ./publish_image.sh kubevirt-infra-bootstrap quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -105,11 +104,10 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_multiarch_image.sh  bootstrap quay.io kubevirtci
                 ./publish_multiarch_image.sh -l golang quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -139,11 +137,10 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_multiarch_image.sh bootstrap-legacy quay.io kubevirtci
                 ./publish_multiarch_image.sh -l golang-legacy quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -170,10 +167,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh shared-images-controller quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -201,10 +197,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh kubekins-e2e quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -236,11 +231,10 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 cp -r ../../kubevirt.github.io/_config kubevirt-kubevirt.github.io
                 ./publish_image.sh kubevirt-kubevirt.github.io quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -268,10 +262,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh kubevirt-user-guide quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -298,10 +291,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh prow-deploy quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -328,10 +320,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh autoowners quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -358,10 +349,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_image.sh pr-creator quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -393,10 +383,9 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
                 ./publish_multiarch_image.sh vm-image-builder quay.io kubevirtci
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -679,7 +668,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 bazelisk run //robots/cmd/ci-usage-exporter:push
             resources:
               requests:
@@ -706,9 +695,8 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
-                cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 make -C ./robots/cmd/test-report push
-            # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
             resources:
@@ -735,7 +723,7 @@ postsubmits:
           - |
             set -e
 
-            cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+            cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
             hack/mirror-images.sh
           resources:
             requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -154,7 +154,6 @@ presubmits:
             - "/bin/bash"
             - "-ce"
             - "cd images && ./publish_image.sh -b kubevirt-infra-bootstrap quay.io kubevirtci"
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -182,7 +181,6 @@ presubmits:
               cd images
               ./publish_multiarch_image.sh -a -b bootstrap quay.io kubevirtci
               ./publish_multiarch_image.sh -a -b -l golang quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -209,7 +207,6 @@ presubmits:
               cd images
               ./publish_multiarch_image.sh -a -b bootstrap-legacy quay.io kubevirtci
               ./publish_multiarch_image.sh -a -b -l golang-legacy quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -235,7 +232,6 @@ presubmits:
             - |
               cd images
               ./publish_image.sh -b shared-images-controller quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -262,7 +258,6 @@ presubmits:
             - |
               cd images
               ./publish_image.sh -b kubekins-e2e quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -294,7 +289,6 @@ presubmits:
               cd images
               cp -r ../../kubevirt.github.io/_config kubevirt-kubevirt.github.io
               ./publish_image.sh -b kubevirt-kubevirt.github.io quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -321,7 +315,6 @@ presubmits:
             - |
               cd images
               ./publish_image.sh -b kubevirt-user-guide quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -348,7 +341,6 @@ presubmits:
             - |
               cd images
               ./publish_image.sh -b prow-deploy quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -375,7 +367,6 @@ presubmits:
             - |
               cd images
               ./publish_image.sh -b autoowners quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -402,7 +393,6 @@ presubmits:
             - |
               cd images
               ./publish_image.sh -b pr-creator quay.io kubevirtci
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -429,7 +419,6 @@ presubmits:
             - "/bin/bash"
             - "-ce"
             - "cd images && ./publish_multiarch_image.sh -a -b vm-image-builder quay.io kubevirtci"
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -460,7 +449,6 @@ presubmits:
             - "/bin/bash"
             - "-ce"
             - "github/ci/prow-deploy/hack/test.sh"
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
           resources:
@@ -509,7 +497,6 @@ presubmits:
               ./github/ci/services/cert-manager/hack/deploy.sh testing
 
               bazelisk test //github/ci/services/cert-manager/e2e:go_default_test --test_output=all --test_arg=-test.v
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
             runAsUser: 0
@@ -546,7 +533,6 @@ presubmits:
               ./github/ci/services/ci-search/hack/deploy.sh testing
 
               bazelisk test //github/ci/services/ci-search/e2e:go_default_test --test_output=all --test_arg=-test.v
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
             runAsUser: 0
@@ -583,7 +569,6 @@ presubmits:
               ./github/ci/services/loki/hack/deploy.sh testing
 
               bazelisk test //github/ci/services/loki/e2e:go_default_test --test_output=all --test_arg=-test.v
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
             runAsUser: 0
@@ -620,7 +605,6 @@ presubmits:
               ./github/ci/services/prometheus-stack/hack/deploy.sh testing
 
               bazelisk test //github/ci/services/prometheus-stack/e2e:go_default_test --test_output=all --test_arg=-test.v
-          # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
             runAsUser: 0


### PR DESCRIPTION
The jobs are really using podman rather than docker so it is more clear for everyone to swap to using podman in the scripts.

`docker` is just symlinked to podman in the bootstrap image[1].

[1] https://github.com/kubevirt/project-infra/blob/33c4878341d4274b58052616bbebd61b5513716e/images/bootstrap/Dockerfile#L84

/cc @enp0s3 @dhiller 