### PR TITLE
Remove check provision job for k8s-1.25 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -235,32 +235,6 @@ presubmits:
           path: /dev
           type: Directory
         name: devices
-  - always_run: false
-    cluster: kubevirt-prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 1
-    name: check-provision-k8s-1.25
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.25 && ../provision.sh
-        image: quay.io/kubevirtci/golang:v20230801-94954c0
-        name: ""
-        resources:
-          requests:
-            memory: 29Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - always_run: true
     cluster: kubevirt-prow-workloads
     decorate: true


### PR DESCRIPTION
As the k8s-1.25 provider is due to be removed[1] - this job is no longer required.

[1] https://github.com/kubevirt/kubevirtci/pull/1074

/cc @xpivarc @dhiller 