### PR TITLE
Update kubevirtci to use podman based golang image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-dind-enabled: "true"
+        preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -43,7 +43,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        - image: quay.io/kubevirtci/golang:v20230801-94954c0
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"


### PR DESCRIPTION
The go version in the legacy image is getting quite old and can cause the publish job to fail[1].

Lets update this job to use the podman based golang image which has a more up to date version of go.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1697339447776907264#1:build-log.txt%3A8

/cc @dhiller @xpivarc 