### PR TITLE
Bump performance and network single stack presubmits to use 1.27

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 4
-    name: pull-kubevirt-e2e-k8s-1.25-sig-performance
+    name: pull-kubevirt-e2e-k8s-1.27-sig-performance
     run_if_changed: ^cmd/.*|^rpm/.*|^tests/performance/.*|^hack/perftests.sh|^tools/perfscale-audit/.*|^bazel/.*|^third_party/.*|^staging/src/.*|^api/.*|^pkg/virt-.*|^pkg/controlller/.*
     skip_branches:
     - release-\d+\.\d+
@@ -76,7 +76,7 @@ presubmits:
           FUNC_TEST_ARGS="--no-color --seed=42" make perftest
         env:
         - name: KUBEVIRT_PROVIDER
-          value: k8s-1.25
+          value: k8s-1.27
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
@@ -819,7 +819,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
+    name: pull-kubevirt-e2e-k8s-1.27-ipv6-sig-network
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -831,7 +831,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.25-sig-network
+          value: k8s-1.27-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY


### PR DESCRIPTION
Since 1.25 is going to be removed soon, we are bumping presubmits to use 1.27.

* performance
* network single stack

/cc @rthallisey @acardace 