### PR TITLE
Bump sig-performance periodics to use 1.27

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -952,7 +952,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.25-sig-performance
+  name: periodic-kubevirt-e2e-k8s-1.27-sig-performance
   reporter_config:
     slack:
       job_states_to_report: []
@@ -975,7 +975,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.25
+        value: k8s-1.27
       - name: KUBEVIRT_STORAGE
         value: hpp
       - name: KUBEVIRT_MEMORY_SIZE
@@ -1016,7 +1016,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.25-sig-performance-realtime
+  name: periodic-kubevirt-e2e-k8s-1.27-sig-performance-realtime
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1036,7 +1036,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make realtime-perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.25
+        value: k8s-1.27
       - name: KUBEVIRT_STORAGE
         value: rook-ceph-default
       - name: KUBEVIRT_MEMORY_SIZE


### PR DESCRIPTION
Since 1.25 is going to be removed soon, we are bumping the sig-performance jobs to 1.27.

/cc @rthallisey @brianmcarey 