### PR TITLE
Use correct container for fcos image, rename dir

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -393,9 +393,9 @@ postsubmits:
                 memory: "29Gi"
               limits:
                 memory: "29Gi"
-    - name: publish-fcos-image
+    - name: publish-fedora-coreos-kubevirt-image
       always_run: false
-      run_if_changed: "images/fcos/.*"
+      run_if_changed: "images/fedora-coreos-kubevirt/.*"
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
@@ -414,7 +414,7 @@ postsubmits:
               - |
                 cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
-                ./publish_image.sh fcos quay.io kubevirtci
+                ./publish_image.sh fedora-coreos-kubevirt quay.io kubevirtci
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -426,9 +426,9 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
-  - name: build-fcos-image
+  - name: build-fedora-coreos-kubevirt-image
     always_run: false
-    run_if_changed: "images/fcos/.*"
+    run_if_changed: "images/fedora-coreos-kubevirt/.*"
     decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
@@ -442,7 +442,7 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/bash"
             - "-ce"
-            - "cd images && ./publish_image.sh -b fcos quay.io kubevirtci"
+            - "cd images && ./publish_image.sh -b fedora-coreos-kubevirt quay.io kubevirtci"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/images/fcos/Dockerfile
+++ b/images/fcos/Dockerfile
@@ -1,1 +1,0 @@
-FROM quay.io/fedora/fedora-coreos@sha256:1100ec4cc0ec47e9846750137b43dedf4f20d9b56bafb99f5866ceff152f88d1

--- a/images/fedora-coreos-kubevirt/Dockerfile
+++ b/images/fedora-coreos-kubevirt/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/fedora/fedora-coreos-kubevirt@sha256:5bc92e9bc89601851b8d2b06628de07c967fbdc328264cf059d26ea403863aeb


### PR DESCRIPTION
The fedora coreos kubevirt image was using the wrong container, this PR rename the directory and point to the proper one.