### PR TITLE
Add cri-o version 1.28 to the kubevirt mirror

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -30,7 +30,7 @@ periodics:
           - name: BASE_REPOID
             value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
-            value: "1.22,1.23,1.24,1.25,1.26,1.27"
+            value: "1.22,1.23,1.24,1.25,1.26,1.27,1.28"
         command: ["/bin/sh", "-ce"]
         args:
           - |


### PR DESCRIPTION
cri-o v1.28.0 has been released[1] - this should be added to the mirror so that it can be installed to the 1.28 kubevirtci provider

[1] https://github.com/cri-o/cri-o/releases/tag/v1.28.0

