### PR TITLE
Switch publish kubevirtci prowjob back to docker

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-podman-in-container-enabled: "true"
+        preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -43,7 +43,7 @@ postsubmits:
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang:v20230801-94954c0
+        - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"
@@ -54,6 +54,9 @@ postsubmits:
             echo "$(git tag --points-at HEAD | head -1)" > latest &&
             gsutil cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest
           # docker-in-docker needs privileged mode
+          env:
+          - name: GIMME_GO_VERSION
+            value: "1.19.9"
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
Providers that have been published since the switch to publishing with podman[1] are failing to start up correctly when run with docker so we need to change back to publishing with docker for now.

[1] https://github.com/kubevirt/project-infra/pull/2972

/cc @dhiller @xpivarc 