### PR TITLE
Move workloads from old control plane cluster to the new cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
   - name: periodic-publish-kubemacpool-flakefinder-weekly-report
     cron: "50 0 * * *"
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
     spec:
@@ -36,7 +36,7 @@ periodics:
             secretName: gcs
   - name: periodic-publish-kubemacpool-flakefinder-daily-report
     cron: "30 0 * * *"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
@@ -74,7 +74,7 @@ periodics:
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
@@ -12,7 +12,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
@@ -11,7 +11,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 6
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 6
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
@@ -28,7 +28,7 @@ periodics:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
@@ -49,7 +49,7 @@ periodics:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
         preset-github-credentials: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
@@ -11,7 +11,7 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-docker-mirror: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/common-instancetypes-builder:v20221104-3adec0b

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
@@ -11,7 +11,7 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-docker-mirror: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/common-instancetypes-builder:v20221104-3adec0b

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
     max_concurrency: 5
     labels:
       preset-docker-mirror: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/common-instancetypes-builder:v20221104-3adec0b

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
     - name: postsubmit-community-update-kubevirt-devstats-repo-sql
       branches:
         - main
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       always_run: false
       run_if_changed: "sigs.yaml"
       extra_refs:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/community:
   - name: pull-community-generate-kubevirt-devstats-repo-sql
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: false
     run_if_changed: "sigs.yaml"
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     optional: false
     annotations:
       testgrid-create-test-group: "false"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -30,7 +30,7 @@ presubmits:
     optional: false
     annotations:
       testgrid-create-test-group: "false"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
@@ -29,7 +29,7 @@ periodics:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
@@ -51,7 +51,7 @@ periodics:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-release-containerized-data-importer-images
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -41,7 +41,7 @@ postsubmits:
   - name: push-latest-containerized-data-importer-images
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -77,7 +77,7 @@ postsubmits:
   - name: push-release-containerized-data-importer-tag
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -118,7 +118,7 @@ postsubmits:
   - name: push-containerized-data-importer-main
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -160,7 +160,7 @@ postsubmits:
     branches:
     - main
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
@@ -94,7 +94,7 @@ presubmits:
     context: pull-cdi-generate-verify
     branches:
       - release-v1.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true
@@ -123,7 +123,7 @@ presubmits:
     context: pull-cdi-apidocs
     branches:
       - release-v1.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true
@@ -152,7 +152,7 @@ presubmits:
     context: pull-cdi-linter
     branches:
       - release-v1.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
@@ -32,7 +32,7 @@ presubmits:
     context: pull-cdi-generate-verify
     branches:
       - release-v1.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true
@@ -61,7 +61,7 @@ presubmits:
     context: pull-cdi-apidocs
     branches:
       - release-v1.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true
@@ -90,7 +90,7 @@ presubmits:
     context: pull-cdi-linter
     branches:
       - release-v1.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
@@ -32,7 +32,7 @@ presubmits:
     context: pull-cdi-generate-verify
     branches:
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true
@@ -61,7 +61,7 @@ presubmits:
     context: pull-cdi-apidocs
     branches:
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true
@@ -90,7 +90,7 @@ presubmits:
     context: pull-cdi-linter
     branches:
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
       - release-v1.38
       - release-v1.43
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -68,7 +68,7 @@ presubmits:
       - release-v1.38
       - release-v1.43
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -100,7 +100,7 @@ presubmits:
       - release-v1.38
       - release-v1.43
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -132,7 +132,7 @@ presubmits:
       - release-v1.38
       - release-v1.43
       - release-v1.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -446,7 +446,7 @@ presubmits:
     optional: false
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/csi-driver:
     - name: pull-csi-driver-unit-test
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       skip_branches:
         - release-\d+\.\d+
       annotations:
@@ -37,7 +37,7 @@ presubmits:
               requests:
                 memory: "4Gi"
     - name: pull-csi-driver-linter
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       skip_branches:
         - release-\d+\.\d+
       annotations:
@@ -73,7 +73,7 @@ presubmits:
               requests:
                 memory: "4Gi"
     - name: pull-csi-driver-sanity-test
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       skip_branches:
         - release-\d+\.\d+
       annotations:
@@ -214,7 +214,7 @@ presubmits:
               requests:
                 memory: "29Gi"
     - name: pull-csi-driver-goveralls
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       skip_branches:
         - release-\d+\.\d+
       annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -83,7 +83,7 @@ postsubmits:
   - name: push-release-hostpath-provisioner-operator-tag
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/hostpath-provisioner-operator:
   - name: pull-hostpath-provisioner-operator-unit-test
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -85,7 +85,7 @@ postsubmits:
   - name: push-release-hostpath-provisioner-tag
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -81,7 +81,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/golang:v20230801-94954c0
@@ -130,7 +130,7 @@ presubmits:
             requests:
               memory: "29Gi"
   - name: pull-hpp-unit-test
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     skip_branches:
       - release-\d+\.\d+
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -11,7 +11,7 @@ postsubmits:
         preset-podman-in-container-enabled: "true"
         preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
@@ -21,7 +21,7 @@ periodics:
     preset-docker-mirror: "true"
     preset-github-credentials: "true"
     preset-shared-images: "true"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1
@@ -48,7 +48,7 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
         repo: kubevirt-tutorial
         base_ref: main
         path_alias: kubevirt-tutorial
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tutorial/kubevirt-tutorial-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-release-kvp-images
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -41,7 +41,7 @@ postsubmits:
   - name: push-latest-kvp-images
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -77,7 +77,7 @@ postsubmits:
   - name: push-release-kvp-tag
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/kubevirt-velero-plugin:
   - name: pull-kvp-unit-test
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     skip_branches:
       - release-\d+\.\d+
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
         repo: kubevirt.github.io
         base_ref: main
         path_alias: kubevirt.github.io
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
     - org: kubevirt
       repo: project-infra
       base_ref: main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       securityContext:
         runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     decorate: true
     always_run: true
     skip_report: false
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f
@@ -20,7 +20,7 @@ presubmits:
       preset-github-credentials: "true"
     decorate: true
     always_run: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       securityContext:
         runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 5 * * * *
   decorate: true
   labels:
@@ -25,7 +25,7 @@ periodics:
       resources: {}
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 45 0 * * *
   decorate: true
   labels:
@@ -49,7 +49,7 @@ periodics:
       resources: {}
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 25 0 * * *
   decorate: true
   labels:
@@ -73,7 +73,7 @@ periodics:
       resources: {}
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 25 1 * * *
   decorate: true
   extra_refs:
@@ -98,7 +98,7 @@ periodics:
       resources: {}
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -332,7 +332,7 @@ periodics:
       type: bare-metal-external
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 2 15 */7 * *
   decorate: true
   decoration_config:
@@ -568,7 +568,7 @@ periodics:
       name: vfio
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 15 22 * * 0
   decorate: true
   decoration_config:
@@ -606,7 +606,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 35 6 * * *
   decorate: true
   decoration_config:
@@ -764,7 +764,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 40 4 * * *
   decorate: true
   decoration_config:
@@ -844,7 +844,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 40 15 * * *
   decorate: true
   decoration_config:
@@ -1512,7 +1512,7 @@ periodics:
       type: bare-metal-external
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 5 7 * * 6
   decorate: true
   decoration_config:
@@ -1942,7 +1942,7 @@ periodics:
       type: bare-metal-external
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   decorate: true
   extra_refs:
   - base_ref: main
@@ -1984,7 +1984,7 @@ periodics:
       resources: {}
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: 45 1 * * *
   decorate: true
   extra_refs:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -455,9 +455,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
       - mountPath: /sys/fs/cgroup
         name: cgroup
       - mountPath: /dev/vfio/
@@ -468,10 +465,6 @@ periodics:
       hardwareSupport: gpu
     priorityClassName: vgpu
     volumes:
-    - hostPath:
-        path: /lib/modules
-        type: Directory
-      name: modules
     - hostPath:
         path: /sys/fs/cgroup
         type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
     branches:
     # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: false
@@ -51,7 +51,7 @@ postsubmits:
   - name: push-update-testing-manifests-on-kubevirt-tag
     branches:
     - ^v0\.3[46]\.[0-9]+$
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     annotations:
       testgrid-create-test-group: "false"
@@ -86,7 +86,7 @@ postsubmits:
   - name: push-kubevirt-main
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: false
@@ -121,7 +121,7 @@ postsubmits:
           requests:
             memory: "8Gi"
   - name: push-kubevirt-goveralls
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - main
     annotations:
@@ -162,7 +162,7 @@ postsubmits:
           secret:
             secretName: kubevirtci-coveralls-token
   - name: push-kubevirt-fossa
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - main
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -494,7 +494,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -521,7 +521,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -534,7 +534,7 @@ presubmits:
     context: pull-kubevirt-build-release-0.34
     optional: false
     skip_report: false
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - command:
@@ -552,7 +552,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -579,7 +579,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -618,7 +618,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -645,7 +645,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -672,7 +672,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -700,7 +700,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.34
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -300,7 +300,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -329,7 +329,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -358,7 +358,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -385,7 +385,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -412,7 +412,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -453,7 +453,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -480,7 +480,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -507,7 +507,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -535,7 +535,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.36
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -331,7 +331,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -358,7 +358,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -389,7 +389,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -418,7 +418,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -445,7 +445,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -472,7 +472,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -512,7 +512,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -539,7 +539,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -566,7 +566,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -593,7 +593,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.37
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
@@ -331,7 +331,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -358,7 +358,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -389,7 +389,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -418,7 +418,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -445,7 +445,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -472,7 +472,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -512,7 +512,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -539,7 +539,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -566,7 +566,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -593,7 +593,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.38
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -338,7 +338,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -365,7 +365,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -396,7 +396,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -425,7 +425,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -452,7 +452,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -479,7 +479,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -519,7 +519,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -546,7 +546,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -573,7 +573,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -600,7 +600,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.39
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
@@ -541,7 +541,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -568,7 +568,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -599,7 +599,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -628,7 +628,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -655,7 +655,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -682,7 +682,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -722,7 +722,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -749,7 +749,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -776,7 +776,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -803,7 +803,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.40
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
@@ -832,7 +832,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -859,7 +859,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -890,7 +890,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -919,7 +919,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -946,7 +946,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -976,7 +976,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1003,7 +1003,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1043,7 +1043,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1070,7 +1070,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1097,7 +1097,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1124,7 +1124,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.41
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
@@ -665,7 +665,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-e2e-kind-1.17-sriov-nonroot
     decorate: true
     decoration_config:
@@ -827,7 +827,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-e2e-kind-1.19-sriov
     decorate: true
     decoration_config:
@@ -1015,7 +1015,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -1042,7 +1042,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -1073,7 +1073,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -1102,7 +1102,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1129,7 +1129,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1159,7 +1159,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1186,7 +1186,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1226,7 +1226,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1253,7 +1253,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1280,7 +1280,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1308,7 +1308,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.42
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.43.yaml
@@ -897,7 +897,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -924,7 +924,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -955,7 +955,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -984,7 +984,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1011,7 +1011,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1041,7 +1041,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1068,7 +1068,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1107,7 +1107,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1134,7 +1134,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1161,7 +1161,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1188,7 +1188,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1215,7 +1215,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.43
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.44.yaml
@@ -857,7 +857,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -884,7 +884,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -913,7 +913,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -944,7 +944,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -973,7 +973,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1000,7 +1000,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1030,7 +1030,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1057,7 +1057,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1096,7 +1096,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1123,7 +1123,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1150,7 +1150,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1177,7 +1177,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1204,7 +1204,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.44
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.45.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.45.yaml
@@ -913,7 +913,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -940,7 +940,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -969,7 +969,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -1000,7 +1000,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -1029,7 +1029,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1056,7 +1056,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1086,7 +1086,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1113,7 +1113,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1152,7 +1152,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1179,7 +1179,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1206,7 +1206,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1233,7 +1233,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1260,7 +1260,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.45
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.46.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.46.yaml
@@ -960,7 +960,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -987,7 +987,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -1016,7 +1016,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -1047,7 +1047,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -1076,7 +1076,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1103,7 +1103,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1133,7 +1133,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1160,7 +1160,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1200,7 +1200,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1227,7 +1227,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1254,7 +1254,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1282,7 +1282,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1309,7 +1309,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.46
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.47.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.47.yaml
@@ -1185,7 +1185,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -1212,7 +1212,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -1241,7 +1241,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -1272,7 +1272,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -1301,7 +1301,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1328,7 +1328,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1358,7 +1358,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1385,7 +1385,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1425,7 +1425,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1452,7 +1452,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1479,7 +1479,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1507,7 +1507,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1534,7 +1534,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.47
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.48.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.48.yaml
@@ -1044,7 +1044,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -1071,7 +1071,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -1100,7 +1100,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -1131,7 +1131,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -1160,7 +1160,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1187,7 +1187,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1217,7 +1217,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1244,7 +1244,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1284,7 +1284,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1311,7 +1311,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1338,7 +1338,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1366,7 +1366,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1393,7 +1393,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.48
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -816,7 +816,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -843,7 +843,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -872,7 +872,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -903,7 +903,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -932,7 +932,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -959,7 +959,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -989,7 +989,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1016,7 +1016,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1056,7 +1056,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1083,7 +1083,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1110,7 +1110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1138,7 +1138,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1165,7 +1165,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -877,7 +877,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -904,7 +904,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -933,7 +933,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -964,7 +964,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -993,7 +993,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1020,7 +1020,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1050,7 +1050,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1077,7 +1077,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1117,7 +1117,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1144,7 +1144,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1171,7 +1171,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1199,7 +1199,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1226,7 +1226,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -877,7 +877,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -904,7 +904,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -933,7 +933,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -964,7 +964,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -993,7 +993,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1020,7 +1020,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1050,7 +1050,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1077,7 +1077,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1117,7 +1117,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1144,7 +1144,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1171,7 +1171,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1199,7 +1199,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1226,7 +1226,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -872,7 +872,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -899,7 +899,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -928,7 +928,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -959,7 +959,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -988,7 +988,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -1015,7 +1015,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -1045,7 +1045,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1072,7 +1072,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1112,7 +1112,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1139,7 +1139,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1166,7 +1166,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1194,7 +1194,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1221,7 +1221,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
@@ -789,7 +789,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -816,7 +816,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -845,7 +845,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -876,7 +876,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -905,7 +905,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -932,7 +932,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -962,7 +962,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -989,7 +989,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1029,7 +1029,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1056,7 +1056,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1083,7 +1083,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1111,7 +1111,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1138,7 +1138,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
@@ -780,7 +780,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -807,7 +807,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -836,7 +836,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -867,7 +867,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -896,7 +896,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -923,7 +923,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -953,7 +953,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -980,7 +980,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1020,7 +1020,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1047,7 +1047,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1074,7 +1074,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1102,7 +1102,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1129,7 +1129,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
@@ -782,7 +782,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -809,7 +809,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -838,7 +838,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -869,7 +869,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -898,7 +898,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -925,7 +925,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -955,7 +955,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -982,7 +982,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1022,7 +1022,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1049,7 +1049,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1076,7 +1076,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1104,7 +1104,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1131,7 +1131,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:
@@ -1670,7 +1670,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
@@ -725,7 +725,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -753,7 +753,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -783,7 +783,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -814,7 +814,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -844,7 +844,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -872,7 +872,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -903,7 +903,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -931,7 +931,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -972,7 +972,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1000,7 +1000,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1028,7 +1028,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1057,7 +1057,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1085,7 +1085,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:
@@ -1598,7 +1598,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
@@ -739,7 +739,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -766,7 +766,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -795,7 +795,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -825,7 +825,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -854,7 +854,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -881,7 +881,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -911,7 +911,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -938,7 +938,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -978,7 +978,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1005,7 +1005,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1032,7 +1032,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1060,7 +1060,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1087,7 +1087,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:
@@ -1587,7 +1587,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -739,7 +739,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -766,7 +766,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -795,7 +795,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -824,7 +824,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -853,7 +853,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -880,7 +880,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -910,7 +910,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -937,7 +937,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -977,7 +977,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1004,7 +1004,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1031,7 +1031,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1059,7 +1059,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1086,7 +1086,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:
@@ -1586,7 +1586,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -567,9 +567,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /dev/vfio/
@@ -580,10 +577,6 @@ presubmits:
         hardwareSupport: gpu
       priorityClassName: vgpu
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -724,9 +717,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /dev/vfio/
@@ -737,10 +727,6 @@ presubmits:
         hardwareSupport: gpu
       priorityClassName: vgpu
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -1493,18 +1479,11 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /var/log/audit
           name: audit
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -987,7 +987,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -1162,7 +1162,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -261,9 +261,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /dev/vfio/
@@ -274,10 +271,6 @@ presubmits:
         hardwareSupport: gpu
       priorityClassName: vgpu
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -1014,18 +1007,11 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /var/log/audit
           name: audit
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -45,7 +45,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirtci-bump-kubevirt
     decorate: true
     decoration_config:
@@ -404,7 +404,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -432,7 +432,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -462,7 +462,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -492,7 +492,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -549,7 +549,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -577,7 +577,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -608,7 +608,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
     decorate: true
     decoration_config:
@@ -636,7 +636,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -676,7 +676,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -705,7 +705,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -733,7 +733,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -761,7 +761,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -789,7 +789,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
     decorate: true
     decoration_config:
@@ -1068,7 +1068,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:
@@ -1569,7 +1569,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-e2e-k8s-1.26-sev
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -187,9 +187,6 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /dev/vfio/
@@ -200,10 +197,6 @@ presubmits:
         hardwareSupport: gpu
       priorityClassName: vgpu
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -1017,18 +1010,11 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /var/log/audit
           name: audit
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -338,7 +338,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -367,7 +367,7 @@ presubmits:
   - always_run: false
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -398,7 +398,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -428,7 +428,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       rehearsal.allowed: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -488,7 +488,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-planee
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -517,7 +517,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -550,7 +550,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -579,7 +579,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -619,7 +619,7 @@ presubmits:
         secret:
           secretName: kubevirtci-coveralls-token
   - always_run: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -659,7 +659,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -688,7 +688,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -717,7 +717,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -747,7 +747,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -776,7 +776,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1073,7 +1073,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1454,7 +1454,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1911,7 +1911,7 @@ presubmits:
   - always_run: false
     annotations:
       fork-per-release: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -59,7 +59,7 @@ periodics:
     preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -314,7 +314,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       timeout: 0h5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -219,18 +219,11 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
         - mountPath: /dev
           name: devices
       nodeSelector:
         type: bare-metal-external
       volumes:
-      - hostPath:
-          path: /lib/modules
-          type: Directory
-        name: modules
       - hostPath:
           path: /dev
           type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -22,7 +22,7 @@ periodics:
      repo: libguestfs-appliance
      base_ref: main
      work_dir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -38,7 +38,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-release-mtq-images
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -41,7 +41,7 @@ postsubmits:
   - name: push-latest-mtq-images
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -77,7 +77,7 @@ postsubmits:
   - name: push-mtq-tag
     branches:
     - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -118,7 +118,7 @@ postsubmits:
   - name: push-mtq-main
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -159,7 +159,7 @@ postsubmits:
   - name: push-mtq-builder
     branches:
     - main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
@@ -4,7 +4,7 @@ presubmits:
     context: pull-mtq-unit-test
     branches:
       - release-v1.1
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     decorate: true
@@ -32,7 +32,7 @@ presubmits:
     context: pull-mtq-generate-verify
     branches:
       - release-v1.1
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-mtq-unit-test
     skip_branches:
       - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -32,7 +32,7 @@ presubmits:
   - name: pull-mtq-generate-verify
     skip_branches:
       - release-v\d+\.\d+
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     annotations:
       fork-per-release: "true"
     always_run: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-latest-node-maintenance-operator
     branches:
     - master
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true
@@ -37,7 +37,7 @@ postsubmits:
     branches:
     # branches also handle tags
     - ^v\d+\.\d+\.\d+$
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/node-maintenance-operator:
   - name: pull-node-maintenance-operator-check
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     skip_branches:
       - release-\d+\.\d+
       - release-v\d+\.\d+\.\d+
@@ -32,7 +32,7 @@ presubmits:
             requests:
               memory: "4Gi"
   - name: pull-node-maintenance-operator-build
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     skip_branches:
       - release-\d+\.\d+
       - release-v\d+\.\d+\.\d+

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.10.yaml
@@ -34,7 +34,7 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-node-maintenance-operator-check
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.10
     annotations:
@@ -63,7 +63,7 @@ presubmits:
             requests:
               memory: "4Gi"
   - name: pull-node-maintenance-operator-build
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.10
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.11.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.11.yaml
@@ -1,7 +1,7 @@
 presubmits:
   kubevirt/node-maintenance-operator:
   - name: pull-node-maintenance-operator-check
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.11
     annotations:
@@ -30,7 +30,7 @@ presubmits:
             requests:
               memory: "4Gi"
   - name: pull-node-maintenance-operator-build
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.11
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -34,7 +34,7 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-node-maintenance-operator-check
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.8
     annotations:
@@ -63,7 +63,7 @@ presubmits:
             requests:
               memory: "4Gi"
   - name: pull-node-maintenance-operator-build
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.8
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
@@ -34,7 +34,7 @@ presubmits:
           requests:
             memory: "29Gi"
   - name: pull-node-maintenance-operator-check
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.9
     annotations:
@@ -63,7 +63,7 @@ presubmits:
             requests:
               memory: "4Gi"
   - name: pull-node-maintenance-operator-build
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     branches:
       - release-0.9
     annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230908-12387e8f71
@@ -49,7 +49,7 @@ periodics:
   labels:
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230908-12387e8f71
@@ -78,7 +78,7 @@ periodics:
   labels:
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230908-12387e8f71
@@ -106,7 +106,7 @@ periodics:
   labels:
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230908-12387e8f71
@@ -138,7 +138,7 @@ periodics:
   labels:
     preset-github-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: gcr.io/k8s-prow/commenter:v20230908-12387e8f71
@@ -175,7 +175,7 @@ periodics:
     repo: project-infra
     base_ref: main
     work_dir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/autoowners:v20220817-6d185c5
@@ -203,7 +203,7 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
       - image: quay.io/kubevirtci/indexpagecreator:v20230102-5ed6f7d7
@@ -234,7 +234,7 @@ periodics:
   - org: kubevirt
     repo: containerized-data-importer
     base_ref: main
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -272,7 +272,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: main
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -308,7 +308,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: main
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -340,7 +340,7 @@ periodics:
   - org: kubevirt
     repo: kubevirtci
     base_ref: main
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -382,7 +382,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -412,7 +412,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -454,7 +454,7 @@ periodics:
     workdir: true
   interval: 2h
   max_concurrency: 1
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - name: peribolos
@@ -496,7 +496,7 @@ periodics:
   - org: kubernetes
     repo: test-infra
     base_ref: master
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -525,7 +525,7 @@ periodics:
       repo: project-infra
       base_ref: main
       workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -554,7 +554,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -585,7 +585,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -616,7 +616,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -648,7 +648,7 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-shared-images: "true"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -680,7 +680,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
       runAsUser: 0
@@ -700,7 +700,7 @@ periodics:
           memory: "200Mi"
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   decorate: true
   decoration_config:
     timeout: 1h
@@ -744,7 +744,7 @@ periodics:
           memory: "1Gi"
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   decorate: true
   decoration_config:
     timeout: 1h
@@ -774,7 +774,7 @@ periodics:
           memory: "1Gi"
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   decorate: true
   decoration_config:
     timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
         preset-bazel-cache: "true"
@@ -32,7 +32,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
         preset-bazel-cache: "true"
@@ -63,7 +63,7 @@ postsubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -158,7 +158,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -188,7 +188,7 @@ postsubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -218,7 +218,7 @@ postsubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       extra_refs:
       - org: kubevirt
         repo: kubevirt.github.io
@@ -253,7 +253,7 @@ postsubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -282,7 +282,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -403,7 +403,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -437,7 +437,7 @@ postsubmits:
         preset-github-credentials: "true"
         preset-pgp-bot-key: "true"
       skip_report: false
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         securityContext:
           runAsUser: 0
@@ -470,7 +470,7 @@ postsubmits:
         preset-github-credentials: "true"
         preset-pgp-bot-key: "true"
       skip_report: false
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         securityContext:
           runAsUser: 0
@@ -501,7 +501,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-github-credentials: "true"
         preset-pgp-bot-key: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         securityContext:
           runAsUser: 0
@@ -539,7 +539,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-github-credentials: "true"
         preset-pgp-bot-key: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         securityContext:
           runAsUser: 0
@@ -577,7 +577,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-github-credentials: "true"
         preset-pgp-bot-key: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         securityContext:
           runAsUser: 0
@@ -615,7 +615,7 @@ postsubmits:
         preset-docker-mirror-proxy: "true"
         preset-github-credentials: "true"
         preset-pgp-bot-key: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         securityContext:
           runAsUser: 0
@@ -662,7 +662,7 @@ postsubmits:
       labels:
         preset-gcs-credentials: "true"
       decorate: true
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
         - image: gcr.io/k8s-prow/configurator:v20230908-12387e8f71
@@ -685,7 +685,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
         preset-kubevirtci-quay-credential: "true"
@@ -711,7 +711,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -740,7 +740,7 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       decorate: true
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       labels:
         preset-kubevirtci-quay-credential: "true"
         preset-docker-mirror-proxy: "true"
@@ -766,7 +766,7 @@ postsubmits:
       always_run: false
       annotations:
         testgrid-create-test-group: "false"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       decorate: true
       decoration_config:
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: check-prow-config
     always_run: true
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: gcr.io/k8s-prow/checkconfig:v20230908-12387e8f71
@@ -23,7 +23,7 @@ presubmits:
     run_if_changed: "robots/.*|WORKSPACE|go_third_party.bzl|go.mod"
     optional: false
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     labels:
       preset-bazel-cache: "true"
     spec:
@@ -44,7 +44,7 @@ presubmits:
     run_if_changed: "releng/.*|WORKSPACE|go_third_party.bzl|go.mod"
     optional: false
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     labels:
       preset-bazel-cache: "true"
     spec:
@@ -63,7 +63,7 @@ presubmits:
             memory: "4Gi"
   - name: pull-project-infra-test-external-plugins
     run_if_changed: "external-plugins/.*|WORKSPACE|go_third_party.bzl|go.mod"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     optional: false
     decorate: true
     labels:
@@ -89,7 +89,7 @@ presubmits:
     run_if_changed: "github/ci/services/.*|WORKSPACE|go_third_party.bzl|go.mod"
     optional: false
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     labels:
       preset-bazel-cache: "true"
     spec:
@@ -112,7 +112,7 @@ presubmits:
   - name: pull-project-infra-test-bazel-config
     run_if_changed: "github/ci/services/.*|external-plugins/.*|releng/.*|robots/.*|go.mod"
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     labels:
       preset-bazel-cache: "true"
     spec:
@@ -145,7 +145,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -169,7 +169,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -195,7 +195,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -221,7 +221,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -247,7 +247,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -273,7 +273,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     extra_refs:
     - org: kubevirt
       repo: kubevirt.github.io
@@ -304,7 +304,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -330,7 +330,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -410,7 +410,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -434,7 +434,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -460,7 +460,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       securityContext:
         runAsUser: 0
@@ -645,7 +645,7 @@ presubmits:
       preset-bazel-cache: "true"
     annotations:
       testgrid-create-test-group: "false"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     extra_refs:
     - org: kubernetes
       repo: test-infra
@@ -676,7 +676,7 @@ presubmits:
       timeout: 2h
       grace_period: 5m
     max_concurrency: 1
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - name: peribolos
@@ -711,7 +711,7 @@ presubmits:
       timeout: 1h
       grace_period: 5m
     max_concurrency: 1
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - name: label-sync
@@ -733,7 +733,7 @@ presubmits:
     decoration_config:
       timeout: 1h
       grace_period: 5m
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     max_concurrency: 1
     spec:
       containers:
@@ -748,7 +748,7 @@ presubmits:
       restartPolicy: Never
   - annotations:
       testgrid-create-test-group: "false"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-qe-tools-make-test
     always_run: true
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
@@ -1,7 +1,7 @@
 periodics:
 - annotations:
     testgrid-create-test-group: "false"
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   cron: "50 3 * * *"
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubevirt/secrets:
   - always_run: false
     skip_if_only_changed: .*\.md
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       ssh_key_secrets:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
@@ -12,7 +12,7 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-docker-mirror: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/golang:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
@@ -12,7 +12,7 @@ postsubmits:
     - org: kubevirt
       repo: project-infra
       base_ref: main
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       securityContext:
         runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-presubmits.yaml
@@ -4,7 +4,7 @@ presubmits:
     always_run: false
     skip_report: true
     decorate: true
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-control-plane
     spec:
       containers:
       - image: quay.io/kubevirtci/kubevirt-kubevirt.github.io:v20220825-9d7149f

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -4,7 +4,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
@@ -39,7 +39,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598
@@ -74,7 +74,7 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   decorate: true
-  cluster: ibm-prow-jobs
+  cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v20230112-ec14f598

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - main
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/golang:v20230801-94954c0
@@ -63,7 +63,7 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       branches:
         - ^v\d+\.\d+\.\d+$
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/golang:v20230801-94954c0

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
@@ -15,7 +15,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
@@ -15,7 +15,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -15,7 +15,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -15,7 +15,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: gcr.io/k8s-testimages/bootstrap:v20190516-c6832d9
@@ -90,7 +90,7 @@ presubmits:
               - "export NMSTATE_PARALLEL_ROLLOUT=true && automation/check-patch.e2e-k8s.sh"
 
     - name: pull-kubernetes-nmstate-docs-0.37
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       branches:
         - release-0.37
       always_run: true

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
@@ -15,7 +15,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20210906-994b913

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
@@ -15,7 +15,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror: "false"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/golang:v20211129-3b6e9a6

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "false"
         preset-shared-images: "true"
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       spec:
         containers:
           - image: quay.io/kubevirtci/golang:v20230801-94954c0
@@ -106,7 +106,7 @@ presubmits:
               - "automation/check-patch.e2e-k8s.sh"
 
     - name: pull-kubernetes-nmstate-docs
-      cluster: ibm-prow-jobs
+      cluster: kubevirt-prow-control-plane
       skip_branches:
         - release-\d+\.\d+
       annotations:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -475,11 +475,18 @@ presets:
   - name: PODMAN_IN_CONTAINER_ENABLED
     value: "true"
   volumes:
+  - name: modules
+    hostPath:
+      path: /lib/modules
+      type: Directory
   - name: podman-data
     emptyDir: {}
   volumeMounts:
   - name: podman-data
     mountPath: /var/lib/containers
+  - name: modules
+    mountPath: /lib/modules
+    readOnly: true
 - labels:
     preset-podman-shared-images: "true"
   volumes:


### PR DESCRIPTION
This change moves all jobs that were running on cluster `ibm-prow-jobs`
to run on the new cluster `kubevirt-prow-control-plane`

This also add /lib/modules as a read-only hostPath to jobs running with
podman in container enabled. Without this jobs would fail on the new
cluster as netavark was unable to find ipv6 modules