### PR TITLE
Deploy greenhouse and docker-mirror-proxy to new control plane cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -456,6 +456,39 @@ postsubmits:
               memory: "8Gi"
             limits:
               memory: "8Gi"
+    - name: post-project-infra-kubevirt-prow-control-plane-deployment
+      always_run: false
+      run_if_changed: "github/ci/prow-deploy/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      branches:
+      - ^main$
+      labels:
+        preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
+        preset-github-credentials: "true"
+        preset-pgp-bot-key: "true"
+      skip_report: false
+      cluster: ibm-prow-jobs
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
+        - image: quay.io/kubevirtci/prow-deploy:v20230908-02ce73e
+          env:
+          - name: DEPLOY_ENVIRONMENT
+            value: kubevirt-prow-control-plane
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - "./github/ci/prow-deploy/hack/deploy.sh"
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
     - name: post-project-infra-kubevirt-prow-workloads-deployment
       always_run: false
       run_if_changed: "github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/.*|github/ci/prow-deploy/kustom/components/.*"

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/pv/patches/JsonRFC6902/deployment.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/pv/patches/JsonRFC6902/deployment.yaml
@@ -11,3 +11,8 @@
     name: storage
     persistentVolumeClaim:
       claimName: docker-mirror-proxy
+- op: add
+  path: /spec/template/spec/securityContext
+  value:
+      runAsUser: 0
+      runAsGroup: 0

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -1,0 +1,125 @@
+# Requires kustomize v3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../components/docker-mirror-proxy/base
+  - ../../components/greenhouse/base
+  - resources/docker-mirror-proxy_pvc.yaml
+  # templated resources
+
+components:
+  - ../../components/docker-mirror-proxy/pv
+  - ../../components/greenhouse/pv
+
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: docker-mirror
+    path: patches/StrategicMerge/docker-mirror_deployment.yaml
+
+  - target:
+      version: v1
+      kind: PersistentVolumeClaim
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: oauth-token
+    files:
+      - oauth=secrets/oauth-token
+    type: Opaque
+  - name: oauth-token
+    namespace: kubevirt-prow-jobs
+    files:
+      - oauth=secrets/oauth-token
+    type: Opaque
+  - name: gcs
+    files:
+      - secrets/service-account.json
+    type: Opaque
+  - name: gcs
+    namespace: kubevirt-prow-jobs
+    files:
+      - secrets/service-account.json
+    type: Opaque
+  - name: slack-token
+    files:
+      - token=secrets/slack-token
+    type: Opaque
+  - name: cookie
+    files:
+      - secret=secrets/cookie
+    type: Opaque
+  - name: github-oauth-config
+    files:
+      - secret=secrets/github-oauth-config
+    type: Opaque
+  - name: kubeconfig
+    files:
+      - config=secrets/kubeconfig
+    type: Opaque
+  - name: kubeconfig-build-test-infra-trusted
+    files:
+      - kubeconfig=secrets/kubeconfig-build-test-infra-trusted
+  - name: kubeconfig-build-k8s-prow-builds
+    files:
+      - kubeconfig=secrets/kubeconfig-build-k8s-prow-builds
+  - name: kubeconfig-build-rules-k8s
+    files:
+      - kubeconfig=secrets/kubeconfig-build-rules-k8s
+  - name: unsplash-api-key
+    literals:
+      - honk.txt=
+  - name: kubevirtci-docker-credential
+    namespace: kubevirt-prow-jobs
+    # username=dockerUser
+    # password=dockerPass
+    envs:
+    - secrets/kubevirtci-docker-credential
+    type: Opaque
+
+  - name: kubevirtci-quay-credential
+    namespace: kubevirt-prow-jobs
+    # username=quayUser
+    # password=quayPass
+    envs:
+    - secrets/kubevirtci-quay-credential
+    type: Opaque
+  - name: kubevirtci-installer-pull-token
+    namespace: kubevirt-prow-jobs
+    files:
+      # installerPullToken
+      - token=secrets/kubevirtci-installer-pull-token
+    type: Opaque
+  - name: commenter-oauth-token
+    namespace: kubevirt-prow-jobs
+    # githubCommenterToken
+    files:
+      - oauth=secrets/commenter-oauth-token
+    type: Opaque
+  - name: kubevirtci-coveralls-token
+    namespace: kubevirt-prow-jobs
+    files:
+      # coverallsToken
+      - token=secrets/kubevirtci-coveralls-token
+    type: Opaque
+  - name: kubevirtci-fossa-token
+    namespace: kubevirt-prow-jobs
+    files:
+      # fossaToken
+      - token=secrets/kubevirtci-fossa-token
+    type: Opaque
+  - name: prow-kubevirtbot-github-ssh-secret
+    namespace: kubevirt-prow-jobs
+    files:
+      # prowKubevirtbotSSHPrivateKey
+      - token=secrets/prow-kubevirtbot-github-ssh-secret
+    type: Opaque

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-namespace.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/docker-mirror_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/docker-mirror_deployment.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-mirror
+spec:
+  template:
+    spec:
+      volumes:
+        - name: storage
+          hostPath:
+            path: /var/lib/docker-mirror/kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/admin-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/admin-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: rmohr@redhat.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: dhiller@redhat.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: ellorent@redhat.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: bcarey@redhat.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: ibezukh@redhat.com
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: dedicated-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: 'system:serviceaccounts:dedicated-admin'

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/bootstrap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-prow
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-prow-jobs

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/docker-mirror-proxy_pvc.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/docker-mirror-proxy_pvc.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: docker-mirror-proxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 450Gi

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/yq_scripts/README
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/yq_scripts/README
@@ -1,0 +1,2 @@
+If you change something in this directory, you need to relaunch
+the yq script to rerender your configs

--- a/github/ci/prow-deploy/vars/kubevirt-prow-control-plane/main.yml
+++ b/github/ci/prow-deploy/vars/kubevirt-prow-control-plane/main.yml
@@ -1,0 +1,16 @@
+testinfra_dir: /tmp/test-infra
+kubectl_exec: kubectl
+bootstrap_full_config: false
+reconcile_github_webhooks: false
+rescale_pushgateway_deployment: false
+project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
+secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/secrets/'
+components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
+kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
+
+shell_environment:
+  KUBECONFIG: "{{ kubeconfig_path }}"
+
+remote_cluster_prow_jobs_context: kubevirt-prow-control-plane
+ansible_python_interpreter: /usr/bin/python3
+delete_priority_classes: false


### PR DESCRIPTION
Greenhouse(Bazel cache) and the docker-mirror-proxy are required on the new cluster in order to enable the migration of workloads from the existing control plane cluster.

/cc @xpivarc @dhiller @enp0s3 