### PR TITLE
Move ci-search service to the new control plane cluster

### DIFF
--- a/github/ci/services/ci-search/BUILD.bazel
+++ b/github/ci/services/ci-search/BUILD.bazel
@@ -18,6 +18,6 @@ load("@com_adobe_rules_gitops//gitops:defs.bzl", "k8s_deploy")
     )
     for NAME, CLUSTER, USER in [
         ("testing", "kind-kind", "kind-kind"),
-        ("production", "ibm-cluster", "ibm-prow-jobs-automation"),
+        ("production", "kubevirt-control-plane-cluster", "admin/cjmudnpd085ficevj8k0"),
     ]
 ]

--- a/github/ci/services/ci-search/manifests/full.yaml
+++ b/github/ci/services/ci-search/manifests/full.yaml
@@ -18,7 +18,7 @@ spec:
     targetPort: 8080
 
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: ci-search


### PR DESCRIPTION
/cc @dhiller 

/hold  

The DNS has to be updated before merge so that the certs get applied correctly