### PR TITLE
hco: require fresher golang env

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
@@ -25,6 +25,9 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "export TARGET=k8s-1.26-centos9 && automation/test.sh"
+        env:
+          - name: GIMME_GO_VERSION
+            value: "1.20.8"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -56,6 +59,9 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "export TARGET=k8s-1.27 && automation/test.sh"
+        env:
+          - name: GIMME_GO_VERSION
+            value: "1.20.8"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -28,6 +28,9 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "export TARGET=k8s-1.26-centos9 && automation/test.sh"
+        env:
+          - name: GIMME_GO_VERSION
+            value: "1.21.1"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -62,6 +65,9 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "export TARGET=k8s-1.27 && automation/test.sh"
+        env:
+          - name: GIMME_GO_VERSION
+            value: "1.21.1"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Golang 1.19 got EOL with the release of Golang 1.21 (08 Aug 2023):
require Golang 1.20.8 on release-1.10 stabilization branch and 1.21.1
on main.