### PR TITLE
Temporarily move prow deploy test lane back to old cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -460,7 +460,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"
-    cluster: kubevirt-prow-control-plane
+    cluster: ibm-prow-jobs
     spec:
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
There seems to be an issue starting the kind cluster on the new control plane cluster[1]. Temporarily moving back to the old cluster while investigating the issue.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/2994/pull-project-infra-prow-deploy-test/1704811297931005952

/cc @dhiller 