### PR TITLE
Move prow-deploy presubmit to the large workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -488,12 +488,12 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"
-    cluster: ibm-prow-jobs
+    cluster: kubevirt-prow-workloads
     spec:
       securityContext:
         runAsUser: 0
       containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20231103-20ce73e
+        - image: quay.io/kubevirtci/prow-deploy:v20231109-df048fe
           env:
           - name: GITHUB_TOKEN
             value: "/etc/github/oauth"
@@ -504,13 +504,10 @@ presubmits:
             - "github/ci/prow-deploy/hack/test.sh"
           securityContext:
             privileged: true
+            runAsUser: 0
           resources:
             requests:
-              cpu: "2"
-              memory: "8Gi"
-            limits:
-              cpu: "2"
-              memory: "8Gi"
+              memory: "29Gi"
           volumeMounts:
           - name: molecule-docker
             mountPath: /tmp/prow-deploy-molecule

--- a/github/ci/prow-deploy/molecule/default/molecule.yml
+++ b/github/ci/prow-deploy/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ driver:
 
 platforms:
   - name: instance
-    image: quay.io/kubevirtci/prow-deploy:v20230908-bfaa042
+    image: quay.io/kubevirtci/prow-deploy:v20231109-df048fe
     privileged: True
     etc_hosts:
       "gcsweb.prowdeploy.ci": "127.0.0.1"

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -40,19 +40,14 @@
               apiVersion: kind.x-k8s.io/v1alpha4
               nodes:
               - role: control-plane
-              - role: worker
+                labels:
+                  ingress-ready: true
+                  ci.kubevirt.io/cachenode: true
                 extraPortMappings:
                 - containerPort: 80
                   hostPort: 80
                 - containerPort: 443
                   hostPort: 443
-                kubeadmConfigPatches:
-                - |
-                  kind: JoinConfiguration
-                  nodeRegistration:
-                    name: '{{ node_name }}'
-                    kubeletExtraArgs:
-                      node-labels: "ingress-ready=true"
         - name: Launch cluster
           shell: |
             kind delete cluster

--- a/github/ci/prow-deploy/molecule/default/smoke_tests.yml
+++ b/github/ci/prow-deploy/molecule/default/smoke_tests.yml
@@ -17,6 +17,7 @@
     url: "https://{{ gcswebUrl }}/healthz"
     validate_certs: no
     return_content: yes
+    timeout: 60
   register: gcs_response
 
 - name: verify GCS interface response is healthy
@@ -33,6 +34,7 @@
     method: GET
     validate_certs: no
     return_content: yes
+    timeout: 60
   register: deck_response
 
 - name: verify Deck response is healthy

--- a/images/bootstrap/containers.conf
+++ b/images/bootstrap/containers.conf
@@ -5,6 +5,7 @@ ipcns="host"
 cgroupns="host"
 cgroups="disabled"
 log_driver = "k8s-file"
+pids_limit="2048"
 [engine]
 cgroup_manager = "cgroupfs"
 events_logger="file"

--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubevirtci/golang:v20230502-bfaa042 as builder
+FROM quay.io/kubevirtci/golang:v20230801-94954c0 as builder
 
 RUN git clone https://github.com/kubernetes/test-infra.git && \
   cd test-infra && \
@@ -10,7 +10,7 @@ RUN git clone https://github.com/kubernetes/test-infra.git && \
   /usr/local/bin/runner.sh /bin/sh -ce 'go build -o /usr/local/bin/hmac ./prow/cmd/hmac' && \
   hmac --help
 
-FROM quay.io/kubevirtci/bootstrap:v20230502-bfaa042
+FROM quay.io/kubevirtci/bootstrap:v20230801-94954c0
 
 COPY --from=builder /usr/local/bin/config-bootstrapper /usr/local/bin/phony /usr/local/bin/hmac /usr/local/bin/
 
@@ -23,7 +23,7 @@ RUN curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_lin
   chmod a+x ./yq && \
   mv ./yq /usr/local/bin
 
-RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.20.0/kind-linux-amd64 && \
+RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.15.0/kind-linux-amd64 && \
   chmod a+x ./kind && \
   mv ./kind /usr/local/bin
 


### PR DESCRIPTION
The job requires more performance than the control plane cluster is
currently offering so it should be moved to our e2e workloads cluster