### PR TITLE
Add flakefinder urls to flake-stats report per day headlines

### DIFF
--- a/robots/cmd/flake-stats/flake-stats.gohtml
+++ b/robots/cmd/flake-stats/flake-stats.gohtml
@@ -47,11 +47,7 @@
     <table class="failureBlock {{ .ShareCategory.CSSClassName }}">
         <tr>
             <td colspan="2" class="failureHeader">
-                {{ if .ShowURL }}
-                    <a href="{{ .URL }}">{{ .Name }}</a>
-                {{ else }}
-                    {{ .Name }}
-                {{ end }}
+                {{ if .URL }}<a href="{{ .URL }}">{{ end }}{{ .Name }}{{ if .URL }}</a>{{ end }}
             </td>
         </tr>
         <tr>

--- a/robots/cmd/flake-stats/flake-stats.gohtml
+++ b/robots/cmd/flake-stats/flake-stats.gohtml
@@ -48,7 +48,7 @@
         <tr>
             <td colspan="2" class="failureHeader">
                 {{ if .ShowURL }}
-                    <a href="https://testgrid.k8s.io/kubevirt-presubmits#{{ .Name }}&width=20">{{ .Name }}</a>
+                    <a href="{{ .URL }}">{{ .Name }}</a>
                 {{ else }}
                     {{ .Name }}
                 {{ end }}

--- a/robots/cmd/flake-stats/flake-stats.gohtml
+++ b/robots/cmd/flake-stats/flake-stats.gohtml
@@ -138,7 +138,7 @@
         }
 
         .noteHasBeenQuarantined {
-            background-color: gray;
+            background-color: grey;
         }
 
         -->

--- a/robots/cmd/flake-stats/main.go
+++ b/robots/cmd/flake-stats/main.go
@@ -96,9 +96,8 @@ func (t TopXTests) CalculateShareFromTotalFailures() *TopXTest {
 			if !failuresPerDayExists {
 				date := formatFromSourceToTargetFormat(day, time.RFC3339, rfc3339Date)
 				overall.FailuresPerDay[day] = &FailureCounter{
-					Name:    failuresPerDay.Name,
-					ShowURL: true,
-					URL:     fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html", date),
+					Name: failuresPerDay.Name,
+					URL:  fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html", date),
 				}
 			}
 			overall.FailuresPerDay[day].add(failuresPerDay.Sum)
@@ -109,9 +108,8 @@ func (t TopXTests) CalculateShareFromTotalFailures() *TopXTest {
 			_, failuresPerLaneExists := overall.FailuresPerLane[lane]
 			if !failuresPerLaneExists {
 				overall.FailuresPerLane[lane] = &FailureCounter{
-					Name:    lane,
-					ShowURL: true,
-					URL:     fmt.Sprintf("https://testgrid.k8s.io/kubevirt-presubmits#%s&width=20", lane),
+					Name: lane,
+					URL:  fmt.Sprintf("https://testgrid.k8s.io/kubevirt-presubmits#%s&width=20", lane),
 				}
 			}
 			overall.FailuresPerLane[lane].add(failuresPerLane.Sum)
@@ -151,7 +149,6 @@ type FailureCounter struct {
 	Max           int
 	SharePercent  float64
 	ShareCategory ShareCategory
-	ShowURL       bool
 	URL           string
 }
 
@@ -285,9 +282,8 @@ func main() {
 				if !failuresPerDayExists {
 					date := formatFromSourceToTargetFormat(reportData.StartOfReport, time.RFC3339, rfc3339Date)
 					currentTopXTest.FailuresPerDay[reportData.StartOfReport] = &FailureCounter{
-						Name:    formatToDay(reportData.StartOfReport),
-						ShowURL: true,
-						URL:     fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html", date),
+						Name: formatToDay(reportData.StartOfReport),
+						URL:  fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html", date),
 					}
 				}
 				currentTopXTest.FailuresPerDay[reportData.StartOfReport].add(jobFailures.Failed)
@@ -296,9 +292,8 @@ func main() {
 				_, failuresPerLaneExists := currentTopXTest.FailuresPerLane[jobName]
 				if !failuresPerLaneExists {
 					currentTopXTest.FailuresPerLane[jobName] = &FailureCounter{
-						Name:    jobName,
-						ShowURL: true,
-						URL:     fmt.Sprintf("https://testgrid.k8s.io/kubevirt-presubmits#%s&width=20", jobName),
+						Name: jobName,
+						URL:  fmt.Sprintf("https://testgrid.k8s.io/kubevirt-presubmits#%s&width=20", jobName),
 					}
 				}
 				currentTopXTest.FailuresPerLane[jobName].add(jobFailures.Failed)

--- a/robots/cmd/flake-stats/main.go
+++ b/robots/cmd/flake-stats/main.go
@@ -94,10 +94,12 @@ func (t TopXTests) CalculateShareFromTotalFailures() *TopXTest {
 		for day, failuresPerDay := range test.FailuresPerDay {
 			_, failuresPerDayExists := overall.FailuresPerDay[day]
 			if !failuresPerDayExists {
-				date := formatFromSourceToTargetFormat(day, time.RFC3339, rfc3339Date)
 				overall.FailuresPerDay[day] = &FailureCounter{
 					Name: failuresPerDay.Name,
-					URL:  fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html", date),
+					URL: fmt.Sprintf(
+						"https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html",
+						formatFromRFC3339ToRFCDate(day),
+					),
 				}
 			}
 			overall.FailuresPerDay[day].add(failuresPerDay.Sum)
@@ -280,9 +282,9 @@ func main() {
 				// aggregate failures per test per day
 				_, failuresPerDayExists := currentTopXTest.FailuresPerDay[reportData.StartOfReport]
 				if !failuresPerDayExists {
-					date := formatFromSourceToTargetFormat(reportData.StartOfReport, time.RFC3339, rfc3339Date)
+					date := formatFromRFC3339ToRFCDate(reportData.StartOfReport)
 					currentTopXTest.FailuresPerDay[reportData.StartOfReport] = &FailureCounter{
-						Name: formatToDay(reportData.StartOfReport),
+						Name: formatFromSourceToTargetFormat(reportData.StartOfReport, time.RFC3339, dayFormat),
 						URL:  fmt.Sprintf("https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flakefinder-%s-024h.html", date),
 					}
 				}
@@ -335,8 +337,8 @@ func main() {
 
 }
 
-func formatToDay(dayDate string) string {
-	return formatFromSourceToTargetFormat(dayDate, time.RFC3339, dayFormat)
+func formatFromRFC3339ToRFCDate(date string) string {
+	return formatFromSourceToTargetFormat(date, time.RFC3339, rfc3339Date)
 }
 
 func formatFromSourceToTargetFormat(dayDate, sourceFormat, targetFormat string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
* Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
-->

**What this PR does / why we need it**:

Since we currently can't see when the failures that are shown per date occurred we are adding to each per day header (that contains a date) a link to the flakefinder report of that day.

Example flake-stats report: https://storage.googleapis.com/kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/flake-stats-14days-2023-09-25-preview.html

Background: since the failures in a pull request may occur many days before that PR gets merged, but are shown in the report window of the day and thus appear as if they happened on that day in the flake-stats report, we need a way to check whether the failures are current or not.

See also [flake-stats: per day values not correct](https://github.com/kubevirt/project-infra/issues/2980)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey
