### PR TITLE
Remove the auto deploy postsubmit for the old control plane cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -423,39 +423,6 @@ postsubmits:
                 memory: "4Gi"
               limits:
                 memory: "4Gi"
-    - name: post-project-infra-prow-control-plane-deployment
-      always_run: false
-      run_if_changed: "github/ci/prow-deploy/.*"
-      annotations:
-        testgrid-create-test-group: "false"
-      decorate: true
-      branches:
-      - ^main$
-      labels:
-        preset-docker-mirror-proxy: "true"
-        preset-gcs-credentials: "true"
-        preset-github-credentials: "true"
-        preset-pgp-bot-key: "true"
-      skip_report: false
-      cluster: kubevirt-prow-control-plane
-      spec:
-        securityContext:
-          runAsUser: 0
-        containers:
-        - image: quay.io/kubevirtci/prow-deploy:v20230908-02ce73e
-          env:
-          - name: DEPLOY_ENVIRONMENT
-            value: ibmcloud-production
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-c"
-            - "./github/ci/prow-deploy/hack/deploy.sh"
-          resources:
-            requests:
-              memory: "8Gi"
-            limits:
-              memory: "8Gi"
     - name: post-project-infra-kubevirt-prow-control-plane-deployment
       always_run: false
       run_if_changed: "github/ci/prow-deploy/.*"


### PR DESCRIPTION
We do not want deployments running while the prow services are being moved over to the new control plane cluster.

/cc @dhiller 

/hold 

Only to be merged when ready to move cluster.