### PR TITLE
add graphing to periodic job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -819,6 +819,7 @@ periodics:
           scrape_dir=$(mktemp -d)
           ci_perf_repo_dir=$(cd ../ci-performance-benchmarks && pwd)
           ./robots/cmd/perf-report-creator/scrape.sh $GOOGLE_APPLICATION_CREDENTIALS $ci_perf_repo_dir $scrape_dir
+          ./robots/cmd/perf-report-creator/graph.sh $ci_perf_repo_dir
           cd $ci_perf_repo_dir
           git add -A results weekly
           current_date=$(date --iso-8601=date)

--- a/robots/cmd/perf-report-creator/graph.sh
+++ b/robots/cmd/perf-report-creator/graph.sh
@@ -6,6 +6,7 @@ perf-report-creator weekly-graph \
   --resource=vmi \
   --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.25-sig-performance \
   --plotly-html=true \
+  --since=2022-11-29 \
   --metrics-list=vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count
 
 ## plot 100-density-test results
@@ -13,6 +14,7 @@ perf-report-creator weekly-graph \
   --resource=vm \
   --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.25-sig-performance \
   --plotly-html=true \
+  --since=2022-11-29 \
   --metrics-list=vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count
 #
 ## plot sig-performance 1.25 weekly vm
@@ -20,6 +22,7 @@ perf-report-creator weekly-graph \
   --resource=vmi \
   --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-performance-cluster-100-density-test \
   --plotly-html=true \
+  --since=2022-11-29 \
   --metrics-list=vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count
 
 


### PR DESCRIPTION
The periodic jobs already clones https://github.com/kubevirt/ci-performance-benchmarks repository. This means the graphing utility will have all the data from the history. Running the graph.sh immediately after scraping will update the index.html

fixes https://github.com/kubevirt/project-infra/issues/2926