### PR TITLE
Add files to deploy prow services to new control plane cluster 

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/deck-ingress.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/deck-ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   name: deck
   namespace: default
 spec:
-  ingressClassName: public-iks-k8s-nginx
   tls:
   - hosts:
     - prow.ci.kubevirt.io

--- a/github/ci/prow-deploy/kustom/base/manifests/local/gcsweb-ingress.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/gcsweb-ingress.yaml
@@ -7,7 +7,6 @@ metadata:
   name: gcsweb
   namespace: default
 spec:
-  ingressClassName: public-iks-k8s-nginx
   tls:
   - hosts:
     - gcsweb.ci.kubevirt.io

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/.gitignore
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/.gitignore
@@ -1,0 +1,2 @@
+secrets/*
+configs/*

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -3,10 +3,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../base
   - ../../components/docker-mirror-proxy/base
   - ../../components/greenhouse/base
   - resources/docker-mirror-proxy_pvc.yaml
+  - resources/hook-rbac.yaml
+  - resources/horologium-rbac.yaml
+  - resources/sinker-rbac.yaml
+  - resources/prow-exporter-deployment.yaml
+  - resources/prow-exporter-rbac.yaml
+  - resources/prow-exporter-service.yaml
   # templated resources
+  - resources/admin-rbac.yaml
 
 components:
   - ../../components/docker-mirror-proxy/pv
@@ -14,22 +22,261 @@ components:
 
 patches:
   - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: rehearse
+    path: patches/JsonRFC6902/prow-rehearse-deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: gcsweb
+    path: patches/JsonRFC6902/gcsweb-deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: deck
+    path: patches/JsonRFC6902/deck_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: hook
+    path: patches/JsonRFC6902/hook_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: tide
+    path: patches/JsonRFC6902/tide_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: crier
+    path: patches/JsonRFC6902/crier_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: prow-controller-manager
+    path: patches/JsonRFC6902/prow_controller_manager_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: sinker
+    path: patches/JsonRFC6902/sinker_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: ghproxy
+    path: patches/JsonRFC6902/ghproxy_deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
+      name: pushgateway
+    path: patches/JsonRFC6902/pushgateway_deployment.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: test-pods
+      name: deck
+    path: patches/StrategicMerge/deck_role.yaml
+  - target:
       group: apps
       version: v1
       kind: Deployment
       name: docker-mirror
     path: patches/StrategicMerge/docker-mirror_deployment.yaml
-
   - target:
       version: v1
       kind: PersistentVolumeClaim
       namespace: default
       name: .*
     path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: PersistentVolumeClaim
+      name: ghproxy
+    path: patches/StrategicMerge/ghproxy.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: test-pods
+      name: crier
+    path: patches/StrategicMerge/crier_role.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: test-pods
+      name: prow-controller-manager
+    path: patches/StrategicMerge/prow_controller_manager_role.yaml
 
+  # namespaces
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: PersistentVolumeClaim
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: Service
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: ConfigMap
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: ServiceAccount
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRoleBinding
+      name: prow-rehearse
+    path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
+  - target:
+      group: rbnac.authorization.k8s.io
+      version: v1
+      kind: Role
+      namespace: test-pods
+      name: .*
+    path: patches/JsonRFC6902/prow-jobs-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      kind: Role
+      namespace: test-pods
+      name: deck
+    path: patches/JsonRFC6902/prow-jobs-rolebinding-rules.yaml
+  - target:
+      group: networking.k8s.io
+      version: v1
+      kind: Ingress
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: Secret
+      namespace: default
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      version: v1
+      kind: ConfigMap
+      namespace: ""
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
+  - target:
+      group: batch
+      version: v1
+      kind: CronJob
+      namespace: ""
+      name: .*
+    path: patches/JsonRFC6902/prow-namespace.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: config
+    files:
+      - configs/config/config.yaml
+  - name: label-config
+    files:
+      - configs/labels/labels.yaml
+  - name: plugins
+    files:
+      - configs/plugins/plugins.yaml
+  - name: cat-api-key
+    files:
+      - configs/cat-api/api-key
 
 secretGenerator:
   - name: oauth-token

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
@@ -1,0 +1,44 @@
+---
+# resets KUBECONFIG env to simple value
+- op: replace
+  path: /spec/template/spec/containers/0/env/0
+  value:
+    name: KUBECONFIG
+    value: "/etc/kubeconfig/config"
+
+# removes AWS env vars
+- op: remove
+  path: /spec/template/spec/containers/0/env/3
+- op: remove
+  path: /spec/template/spec/containers/0/env/2
+- op: remove
+  path: /spec/template/spec/containers/0/env/1
+
+# removes volume and moint for aws-iam-token
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/9
+- op: remove
+  path: /spec/template/spec/volumes/9
+
+# removes kubeconfig-eks-prow-build-cluster mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/4
+- op: remove
+  path: /spec/template/spec/volumes/8
+
+# adds gcs service account arg, volume and mount
+- op: add
+  path: /spec/template/spec/containers/0/args/0
+  value: --gcs-credentials-file=/etc/gcs/service-account.json
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/0
+  value:
+    name: gcs
+    mountPath: /etc/gcs
+    readOnly: true
+- op: add
+  path: /spec/template/spec/volumes/0
+  value:
+    name: gcs
+    secret:
+      secretName: gcs

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/deck-rolebinding-subject-prow-name.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/deck-rolebinding-subject-prow-name.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /subjects/0/namespace
+  value: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/deck_deployment.yaml
@@ -1,0 +1,44 @@
+# Removes deprecated  --redirect-http-to=
+- op: remove
+  path: /spec/template/spec/containers/0/args/2
+- op: remove
+  path: /spec/template/spec/containers/0/livenessProbe
+- op: remove
+  path: /spec/template/spec/containers/0/readinessProbe
+# sets resources
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 300m
+      memory: 2Gi
+    requests:
+      cpu: 300m
+      memory: 2Gi
+
+# resets KUBECONFIG entry to simple value
+- op: replace
+  path: /spec/template/spec/containers/0/env/0
+  value:
+    name: KUBECONFIG
+    value: "/etc/kubeconfig/config"
+
+# removes AWS env vars
+- op: remove
+  path: /spec/template/spec/containers/0/env/3
+- op: remove
+  path: /spec/template/spec/containers/0/env/2
+- op: remove
+  path: /spec/template/spec/containers/0/env/1
+
+# removes aws-iam-token mount
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/11
+- op: remove
+  path: /spec/template/spec/volumes/11
+
+# removes mount and volume for kubeconfig-eks-prow-build-cluster
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/6
+- op: remove
+  path: /spec/template/spec/volumes/7

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/gcsweb-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/gcsweb-deployment.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/1
+  value: -b=kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/ghproxy_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/ghproxy_deployment.yaml
@@ -1,0 +1,11 @@
+---
+# allow ghproxy to be scheduled on any node
+- op: remove
+  path: /spec/template/spec/tolerations
+- op: remove
+  path: /spec/template/spec/nodeSelector
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxUnavailable: 1

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/hook_deployment.yaml
@@ -1,0 +1,31 @@
+- op: remove
+  path: /spec/template/spec/containers/0/livenessProbe
+- op: remove
+  path: /spec/template/spec/containers/0/readinessProbe
+
+# replaces KUBECONFIG env to simple value
+- op: replace
+  path: /spec/template/spec/containers/0/env/0
+  value:
+    name: KUBECONFIG
+    value: "/etc/kubeconfig/config"
+
+# removes AWS env vars
+- op: remove
+  path: /spec/template/spec/containers/0/env/3
+- op: remove
+  path: /spec/template/spec/containers/0/env/2
+- op: remove
+  path: /spec/template/spec/containers/0/env/1
+
+# removes aws-iam-token mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/13
+- op: remove
+  path: /spec/template/spec/volumes/13
+
+# removes kubeconfig-eks-prow-build-cluster mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/12
+- op: remove
+  path: /spec/template/spec/volumes/12

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-jobs-namespace.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-jobs-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: kubevirt-prow-jobs

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-jobs-rolebinding-rules.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-jobs-rolebinding-rules.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /rules/1
+  value:
+    apiGroups:
+    - prow.k8s.io
+    resources:
+    - prowjobs
+    verbs:
+    - create
+    - get
+    - list
+    - watch

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-rehearse-deployment.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/1
+  value: --jobs-namespace=kubevirt-prow-jobs

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow_controller_manager_deployment.yaml
@@ -1,0 +1,37 @@
+# sets resources
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 500m
+      memory: 600Mi
+    requests:
+      cpu: 500m
+      memory: 600Mi
+
+# replaces KUBECONFIG env var to simple value
+- op: replace
+  path: /spec/template/spec/containers/0/env/0
+  value:
+    name: KUBECONFIG
+    value: "/etc/kubeconfig/config"
+
+# removes AWS env vars
+- op: remove
+  path: /spec/template/spec/containers/0/env/3
+- op: remove
+  path: /spec/template/spec/containers/0/env/2
+- op: remove
+  path: /spec/template/spec/containers/0/env/1
+
+# removes aws-iam-token mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/7
+- op: remove
+  path: /spec/template/spec/volumes/7
+
+# removes kubeconfig-eks-prow-build-cluster mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/4
+- op: remove
+  path: /spec/template/spec/volumes/4

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/pushgateway_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/pushgateway_deployment.yaml
@@ -1,0 +1,10 @@
+# sets resources
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 1000m
+      memory: 1Gi

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/rolebinding-subject-prow-name-deck.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/rolebinding-subject-prow-name-deck.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /subjects/0/name
+  value: staging-deck

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/rolebinding-subject-prow-name-tide.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/rolebinding-subject-prow-name-tide.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /subjects/0/name
+  value: tide

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /subjects/0/namespace
+  value: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/sinker_deployment.yaml
@@ -1,0 +1,37 @@
+# sets resources
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    limits:
+      cpu: 400m
+      memory: 600Mi
+    requests:
+      cpu: 400m
+      memory: 600Mi
+
+# replaces KUBECONFIG env var to simple value
+- op: replace
+  path: /spec/template/spec/containers/0/env/0
+  value:
+    name: KUBECONFIG
+    value: "/etc/kubeconfig/config"
+
+# removes AWS env vars
+- op: remove
+  path: /spec/template/spec/containers/0/env/3
+- op: remove
+  path: /spec/template/spec/containers/0/env/2
+- op: remove
+  path: /spec/template/spec/containers/0/env/1
+
+# removes aws-iam-token mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/7
+- op: remove
+  path: /spec/template/spec/volumes/7
+
+# removes kubeconfig-eks-prow-build-cluster mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/4
+- op: remove
+  path: /spec/template/spec/volumes/4

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/tide_deployment.yaml
@@ -1,0 +1,6 @@
+# REmoves hisotry-uri and status-path which point to a
+# remote google storage location
+- op: remove
+  path: /spec/template/spec/containers/0/args/7
+- op: remove
+  path: /spec/template/spec/containers/0/args/6

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/crier_role.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/crier_role.yaml
@@ -1,0 +1,29 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: crier
+rules:
+- apiGroups:
+    - "prow.k8s.io"
+  resources:
+    - "prowjobs"
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+    - "patch"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+    - "events"
+  verbs:
+    - "get"
+    - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/deck_role.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/deck_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+metadata:
+  name: deck
+  namespace: test-pods
+kind: Role
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - get
+      - list
+      - watch
+      # Required when deck runs with `--rerun-creates-job=true`
+      - create

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/ghproxy.yaml
@@ -1,0 +1,9 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: ghproxy
+spec:
+  resources:
+    requests:
+      storage: 30Gi
+  storageClassName: ibmc-vpc-block-general-purpose

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/prow_controller_manager_role.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/StrategicMerge/prow_controller_manager_role.yaml
@@ -1,0 +1,59 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: "prow-controller-manager"
+rules:
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - prow-controller-manager-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - prow-controller-manager-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - prow.k8s.io
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+   - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+  - get
+  - patch

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/hook-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/hook-rbac.yaml
@@ -1,0 +1,38 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: "hook"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: "hook"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "hook"
+subjects:
+- kind: ServiceAccount
+  name: "hook"
+  namespace: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/horologium-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/horologium-rbac.yaml
@@ -1,0 +1,29 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: "horologium"
+rules:
+  - apiGroups:
+      - "prow.k8s.io"
+    resources:
+      - prowjobs
+    verbs:
+      - create
+      - list
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: "horologium"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "horologium"
+subjects:
+- kind: ServiceAccount
+  name: "horologium"
+  namespace: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-deployment.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: prow-exporter
+  labels:
+    app: prow-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prow-exporter
+  template:
+    metadata:
+      labels:
+        app: prow-exporter
+    spec:
+      serviceAccountName: prow-exporter
+      terminationGracePeriodSeconds: 30
+      containers:
+      - name: prow-exporter
+        image: gcr.io/k8s-prow/exporter:v20230908-12387e8f71
+        imagePullPolicy: Always
+        ports:
+        - name: metrics
+          containerPort: 9090
+        - name: healthz
+          containerPort: 8081
+        args:
+        - --config-path=/etc/config/config.yaml
+        - --job-config-path=/etc/job-config
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/config"
+        volumeMounts:
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
+          readOnly: true
+        - name: config
+          mountPath: /etc/config
+          readOnly: true
+        - name: job-config
+          mountPath: /etc/job-config
+          readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: 8081
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 15
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: 100m
+            memory: 500Mi
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
+      - name: config
+        configMap:
+          name: config
+      - name: job-config
+        configMap:
+          name: job-config

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-rbac.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: kubevirt-prow
+  name: prow-exporter
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: prow-exporter
+rules:
+- apiGroups:
+  - "prow.k8s.io"
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: prow-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prow-exporter
+subjects:
+- kind: ServiceAccount
+  name: prow-exporter
+  namespace: kubevirt-prow

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-service.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: prow-exporter
+    monitoring: "true"
+  name: prow-exporter
+spec:
+  selector:
+    app: prow-exporter
+  ports:
+  - name: metrics
+    port: 9090

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/sinker-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/sinker-rbac.yaml
@@ -1,0 +1,56 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kubevirt-prow-jobs
+  name: "sinker"
+rules:
+  - apiGroups:
+    - "prow.k8s.io"
+    resources:
+    - prowjobs
+    verbs:
+    - delete
+    - list
+    - watch
+    - get
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - get
+      - patch

--- a/github/ci/prow-deploy/vars/kubevirt-prow-control-plane/main.yml
+++ b/github/ci/prow-deploy/vars/kubevirt-prow-control-plane/main.yml
@@ -1,8 +1,8 @@
 testinfra_dir: /tmp/test-infra
 kubectl_exec: kubectl
-bootstrap_full_config: false
-reconcile_github_webhooks: false
-rescale_pushgateway_deployment: false
+bootstrap_full_config: true
+reconcile_github_webhooks: true
+rescale_pushgateway_deployment: true
 project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/secrets/'
 components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'


### PR DESCRIPTION
This PR enables deployment of the prow services to the new control plane cluster. 

It includes a commit from https://github.com/kubevirt/project-infra/pull/2990 and depends on that PR being merged first. 

This PR should only be merged when the migration from the old cluster is completed successfully. 

/cc @dhiller @xpivarc 

/hold