### PR TITLE
No reason to keep nightly jobs for mtq

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
@@ -57,38 +57,6 @@ presubmits:
           resources:
             requests:
               memory: "4Gi"
-  - name: pull-mtq-functest-nightly-kubevirt-1.1
-    context: pull-mtq-functest-nightly-kubevirt
-    branches:
-      - release-v1.1
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: kubevirt-prow-workloads
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
   - name: pull-mtq-functest-latest-stable-kubevirt-1.1
     context: pull-mtq-functest-latest-stable-kubevirt
     branches:
@@ -117,7 +85,7 @@ presubmits:
             - "automation/test.sh"
           env:
             - name: KUBEVIRT_RELEASE
-              value: latest_stable
+              value: v1.0.0
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
@@ -59,39 +59,6 @@ presubmits:
           resources:
             requests:
               memory: "4Gi"
-  - name: pull-mtq-functest-nightly-kubevirt
-    skip_branches:
-      - release-v\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 5h
-      grace_period: 5m
-    max_concurrency: 6
-    cluster: kubevirt-prow-workloads
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "automation/test.sh"
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "29Gi"
   - name: pull-mtq-functest-latest-stable-kubevirt
     skip_branches:
       - release-v\d+\.\d+


### PR DESCRIPTION
Since we descovered that there should
be version alignment between kubevirt
and mtq so we should always check the
latest version for main and use v1.0.0
for mtq v1.1