### PR TITLE
Remove unnecessary kubeconfig from prow deployments to fix auto bump

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230927-4613add0a1
+    - image: gcr.io/k8s-prow/commenter:v20231005-383927a788
       command:
       - /ko-app/commenter
       args:
@@ -52,7 +52,7 @@ periodics:
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230927-4613add0a1
+    - image: gcr.io/k8s-prow/commenter:v20231005-383927a788
       command:
       - /ko-app/commenter
       args:
@@ -81,7 +81,7 @@ periodics:
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230927-4613add0a1
+    - image: gcr.io/k8s-prow/commenter:v20231005-383927a788
       command:
       - /ko-app/commenter
       args:
@@ -109,7 +109,7 @@ periodics:
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230927-4613add0a1
+    - image: gcr.io/k8s-prow/commenter:v20231005-383927a788
       command:
       - /ko-app/commenter
       args:
@@ -141,7 +141,7 @@ periodics:
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20230927-4613add0a1
+    - image: gcr.io/k8s-prow/commenter:v20231005-383927a788
       command:
       - /ko-app/commenter
       args:
@@ -458,7 +458,7 @@ periodics:
   spec:
     containers:
     - name: peribolos
-      image: gcr.io/k8s-prow/peribolos:v20230927-4613add0a1
+      image: gcr.io/k8s-prow/peribolos:v20231005-383927a788
       command:
       - /ko-app/peribolos
       args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -665,7 +665,7 @@ postsubmits:
       cluster: kubevirt-prow-control-plane
       spec:
         containers:
-        - image: gcr.io/k8s-prow/configurator:v20230927-4613add0a1
+        - image: gcr.io/k8s-prow/configurator:v20231005-383927a788
           command:
           - /ko-app/configurator
           args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20230927-4613add0a1
+      - image: gcr.io/k8s-prow/checkconfig:v20231005-383927a788
         args:
         - "/ko-app/checkconfig"
         - "--config-path"
@@ -708,7 +708,7 @@ presubmits:
     spec:
       containers:
       - name: peribolos
-        image: gcr.io/k8s-prow/peribolos:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/peribolos:v20231005-383927a788
         command:
         - /ko-app/peribolos
         # when changing the peribolos settings below, please align the peribolos settings from the periodic job!
@@ -743,7 +743,7 @@ presubmits:
     spec:
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/label_sync:v20231005-383927a788
         command: [ "/ko-app/label_sync" ]
         args:
         - --config=github/ci/prow-deploy/files/labels.yaml
@@ -766,7 +766,7 @@ presubmits:
     spec:
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/label_sync:v20231005-383927a788
         command: [ "/ko-app/label_sync" ]
         args:
         - --config=github/ci/prow-deploy/files/labels.yaml

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -9,10 +9,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20230927-4613add0a1"
-        initupload: "gcr.io/k8s-prow/initupload:v20230927-4613add0a1"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20230927-4613add0a1"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20230927-4613add0a1"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20231005-383927a788"
+        initupload: "gcr.io/k8s-prow/initupload:v20231005-383927a788"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20231005-383927a788"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20231005-383927a788"
       gcs_configuration:
         bucket: "kubevirt-prow"
         path_strategy: "explicit"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -14,7 +14,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20230927-4613add0a1
+              image: gcr.io/k8s-prow/branchprotector:v20231005-383927a788
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/cherrypicker_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/cherrypicker:v20231005-383927a788
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20230927-4613add0a1
+              image: gcr.io/k8s-prow/label_sync:v20231005-383927a788
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20230927-4613add0a1
+              image: gcr.io/k8s-prow/label_sync:v20231005-383927a788
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/crier:v20231005-383927a788
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig:/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -74,6 +74,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -124,6 +127,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       # AWS IAM token needed to assume role to access the prow-build-cluster EKS cluster.
       - name: aws-iam-token
         projected:

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/deck:v20231005-383927a788
         imagePullPolicy: Always
         ports:
         - name: http
@@ -63,7 +63,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -92,6 +92,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -152,6 +155,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/ghproxy:v20231005-383927a788
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/hook:v20231005-383927a788
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -51,7 +51,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -102,6 +102,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         # AWS IAM token needed to assume role to access the prow-build-cluster EKS cluster.
         - mountPath: /var/run/secrets/aws-iam-token/serviceaccount
@@ -165,6 +168,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       # AWS IAM token needed to assume role to access the prow-build-cluster EKS cluster.
       - name: aws-iam-token
         projected:

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/horologium:v20231005-383927a788
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/needs-rebase:v20231005-383927a788
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prow_controller_manager_deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/prow-controller-manager:v20231005-383927a788
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
@@ -48,7 +48,7 @@ spec:
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -74,6 +74,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -118,6 +121,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/sinker_deployment.yaml
@@ -22,11 +22,11 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/sinker:v20231005-383927a788
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG
-          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig"
+          value: "/etc/kubeconfig/config:/etc/kubeconfig-build-test-infra-trusted/kubeconfig:/etc/kubeconfig-build-k8s-prow-builds/kubeconfig:/etc/kubeconfig-build-rules-k8s/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig::/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig"
         # AWS_ variables needed to assume role to access the prow-build-cluster EKS cluster.
         - name: AWS_ROLE_ARN
           value: arn:aws:iam::468814281478:role/Prow-EKS-Admin
@@ -52,6 +52,9 @@ spec:
           readOnly: true
         - mountPath: /etc/kubeconfig-eks-prow-build-cluster
           name: kubeconfig-eks-prow-build-cluster
+          readOnly: true
+        - mountPath: /etc/kubeconfig-k8s-infra-kops-prow-build
+          name: kubeconfig-k8s-infra-kops-prow-build
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -84,6 +87,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig-eks-prow-build-cluster
+      - name: kubeconfig-k8s-infra-kops-prow-build
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-k8s-infra-kops-prow-build
       - name: config
         configMap:
           name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/status-reconciler:v20231005-383927a788
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/tide:v20231005-383927a788
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20230927-4613add0a1
+        image: gcr.io/k8s-prow/exporter:v20231005-383927a788
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
@@ -14,7 +14,7 @@
 - op: remove
   path: /spec/template/spec/containers/0/env/1
 
-# removes volume and moint for aws-iam-token
+# removes volume and mount for aws-iam-token
 - op: remove
   path: /spec/template/spec/containers/0/volumeMounts/10
 - op: remove

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
@@ -16,7 +16,13 @@
 
 # removes volume and moint for aws-iam-token
 - op: remove
-  path: /spec/template/spec/containers/0/volumeMounts/9
+  path: /spec/template/spec/containers/0/volumeMounts/10
+- op: remove
+  path: /spec/template/spec/volumes/10
+
+  # removes kubeconfig-k8s-infra-kops-prow-build mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/5
 - op: remove
   path: /spec/template/spec/volumes/9
 

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/deck_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/deck_deployment.yaml
@@ -33,9 +33,15 @@
 
 # removes aws-iam-token mount
 - op: remove
-  path: /spec/template/spec/containers/0/volumeMounts/11
+  path: /spec/template/spec/containers/0/volumeMounts/12
 - op: remove
-  path: /spec/template/spec/volumes/11
+  path: /spec/template/spec/volumes/12
+
+# removes mount and volume for kubeconfig-k8s-infra-kops-prow-build
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/7
+- op: remove
+  path: /spec/template/spec/volumes/8
 
 # removes mount and volume for kubeconfig-eks-prow-build-cluster
 - op: remove

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/hook_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/hook_deployment.yaml
@@ -20,6 +20,12 @@
 
 # removes aws-iam-token mount and volume
 - op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/14
+- op: remove
+  path: /spec/template/spec/volumes/14
+
+# removes kubeconfig-k8s-infra-kops-prow-build mount and volume
+- op: remove
   path: /spec/template/spec/containers/0/volumeMounts/13
 - op: remove
   path: /spec/template/spec/volumes/13
@@ -29,3 +35,4 @@
   path: /spec/template/spec/containers/0/volumeMounts/12
 - op: remove
   path: /spec/template/spec/volumes/12
+

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow_controller_manager_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow_controller_manager_deployment.yaml
@@ -26,9 +26,15 @@
 
 # removes aws-iam-token mount and volume
 - op: remove
-  path: /spec/template/spec/containers/0/volumeMounts/7
+  path: /spec/template/spec/containers/0/volumeMounts/8
 - op: remove
-  path: /spec/template/spec/volumes/7
+  path: /spec/template/spec/volumes/8
+
+# removes kubeconfig-k8s-infra-kops-prow-build mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/5
+- op: remove
+  path: /spec/template/spec/volumes/5
 
 # removes kubeconfig-eks-prow-build-cluster mount and volume
 - op: remove

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/sinker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/sinker_deployment.yaml
@@ -26,12 +26,19 @@
 
 # removes aws-iam-token mount and volume
 - op: remove
-  path: /spec/template/spec/containers/0/volumeMounts/7
+  path: /spec/template/spec/containers/0/volumeMounts/8
 - op: remove
-  path: /spec/template/spec/volumes/7
+  path: /spec/template/spec/volumes/8
+
+# removes kubeconfig-k8s-infra-kops-prow-build mount and volume
+- op: remove
+  path: /spec/template/spec/containers/0/volumeMounts/5
+- op: remove
+  path: /spec/template/spec/volumes/5
 
 # removes kubeconfig-eks-prow-build-cluster mount and volume
 - op: remove
   path: /spec/template/spec/containers/0/volumeMounts/4
 - op: remove
   path: /spec/template/spec/volumes/4
+

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/tide_deployment.yaml
@@ -1,4 +1,4 @@
-# REmoves hisotry-uri and status-path which point to a
+# Removes history-uri and status-path which point to a
 # remote google storage location
 - op: remove
   path: /spec/template/spec/containers/0/args/7

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: prow-exporter
-        image: gcr.io/k8s-prow/exporter:v20230908-12387e8f71
+        image: gcr.io/k8s-prow/exporter:v20231005-383927a788
         imagePullPolicy: Always
         ports:
         - name: metrics

--- a/github/ci/prow-deploy/molecule/default/prepare.yml
+++ b/github/ci/prow-deploy/molecule/default/prepare.yml
@@ -104,7 +104,7 @@
 
     - name: copy production kustomize files
       synchronize:
-        src: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/{{ item }}'
+        src: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/{{ item }}'
         dest: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/{{ deploy_environment }}'
       delegate_to: '{{ inventory_hostname }}'
       loop:

--- a/hack/bump-prow.sh
+++ b/hack/bump-prow.sh
@@ -44,7 +44,7 @@ bump_utility_images(){
 bump_exporter(){
     local latest_prow_tag=$1
 
-    sed -i "s!image: gcr.io/k8s-prow/exporter:.*!image: gcr.io/k8s-prow/exporter:${latest_prow_tag}!" ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/overlays/ibmcloud-production/resources/prow-exporter-deployment.yaml
+    sed -i "s!image: gcr.io/k8s-prow/exporter:.*!image: gcr.io/k8s-prow/exporter:${latest_prow_tag}!" ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-deployment.yaml
 }
 
 bump_base_manifests_local_images(){


### PR DESCRIPTION
There was another kubeconfig `kubeconfig-k8s-infra-kops-prow-build` added to the prow service deployment specs - this change adds patches to remove the volumes and mounts for this new kubeconfig. 

This also included the prow bump from #3009 

Closes #3009 

/cc @dhiller @xpivarc 