### PR TITLE
feat: add kubevirt-snyk user as an admin to kubevirt org

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -11,6 +11,7 @@ orgs:
       - rmohr
       - stoniko
       - thelinuxfoundation
+      - kubevirt-snyk
     billing_email: fdeutsch@redhat.com
     company: ""
     default_repository_permission: read


### PR DESCRIPTION
feat: add kubevirt-snyk user as an admin to kubevirt org
Snyk is a platform to perform security scans. The snyk integration requires a special github user to able to do scans of PRs and repos.