### PR TITLE
Increase performance presubmit node size

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -80,7 +80,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 12G
+          value: 15G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS


### PR DESCRIPTION
Forgotten in https://github.com/kubevirt/project-infra/pull/3023/

Increasing by 3G per 4 nodes = 12G. Now the total is 15G per 4 nodes = 60G and we are running with 70G requests.