### PR TITLE
Add acardace to OWNERS of project-infra

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ filters:
   ".*":
     reviewers:
       - ci-maintainers
+      - acardace
       - aglitke
       - davidvossel
       - phoracek
@@ -10,6 +11,7 @@ filters:
       - vladikr
     approvers:
       - ci-maintainers
+      - acardace
       - aglitke
       - davidvossel
       - phoracek


### PR DESCRIPTION
The automation for creating kubevirt releases requires write access to proeject-infra to create the job configs for the release branches.

Antonio is part of the release team and requires write access to project-infra as a result.

/cc @davidvossel @fabiand @xpivarc 