### PR TITLE
Add write permissions for project-infra to release team

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -838,6 +838,7 @@ orgs:
         - xpivarc
         repos:
           sig-release: write
+          project-infra: write
       rerun-jobs-hco:
         description: can rerun failed job in the hyperconverged-cluster-operator repository
         maintainers:


### PR DESCRIPTION
The release team require write permissions for project-infra to create release job configs as part of the kubevirt release. 

/cc @acardace @xpivarc 