### PR TITLE
Increase resources for performance lanes in 0.59 and 1.0

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -427,7 +427,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 12G
+          value: 15G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -439,7 +439,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 56Gi
+            memory: 70Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -158,7 +158,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 12G
+          value: 15G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -170,7 +170,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 56Gi
+            memory: 70Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
Resources had to be increased in the main branch presubmit[1][2] due to a change in memory overhead[3]

This change is being backported to 0.59 & 1.0 so the resources have to be increased there aswell

[1] https://github.com/kubevirt/project-infra/pull/3023
[2] https://github.com/kubevirt/project-infra/pull/3024
[3] https://github.com/kubevirt/kubevirt/pull/10566

/cc @xpivarc @fossedihelm @rthallisey 