### PR TITLE
[performance] Increase performance job memory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -972,7 +972,7 @@ periodics:
       - name: KUBEVIRT_STORAGE
         value: hpp
       - name: KUBEVIRT_MEMORY_SIZE
-        value: 12G
+        value: 16G
       - name: KUBEVIRT_NUM_NODES
         value: "4"
       - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -984,7 +984,7 @@ periodics:
       resources:
         requests:
           cpu: "12"
-          memory: 70Gi
+          memory: 73Gi
       securityContext:
         privileged: true
     nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -80,7 +80,7 @@ presubmits:
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
-          value: 15G
+          value: 16G
         - name: KUBEVIRT_NUM_NODES
           value: "4"
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -92,7 +92,7 @@ presubmits:
         resources:
           requests:
             cpu: "12"
-            memory: 70Gi
+            memory: 73Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
In PR https://github.com/kubevirt/project-infra/pull/3023 we considered 35M for each virt-launcher pod.
Actually, since the performance tests uses
guaranteed pod, the guest log container
will request 60M.
Thus, we need to increase more:
100*(60M-35M) = 100 * 25M = 2.5G
Let's round to 3Gi more.

Also, increase the KUBEVIRT_MEMORY_SIZE up to 16G.

Serial console container request function:
https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-controller/services/serialconsolelog.go#L65-L92

/cc @brianmcarey @tiraboschi @xpivarc @EdDev 