### PR TITLE
Remove acardace from OWNERS as not required

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ filters:
   ".*":
     reviewers:
       - ci-maintainers
-      - acardace
       - aglitke
       - davidvossel
       - phoracek
@@ -11,7 +10,6 @@ filters:
       - vladikr
     approvers:
       - ci-maintainers
-      - acardace
       - aglitke
       - davidvossel
       - phoracek


### PR DESCRIPTION
Antonio was added to the project-infra OWNERS file[1] in order to get write permissions on project-infra which are required to carry out kubevirt releases. The release team was given write permissions[2] so Antonio no longer needs to be in the OWNERS file.

Discussed this with Antonio and he is happy to be removed.

[1] https://github.com/kubevirt/project-infra/pull/3026
[2] https://github.com/kubevirt/project-infra/pull/3028

/cc @acardace @xpivarc @dhiller 