### PR TITLE
Fix typo in cluster name in 0.49 sig-compute presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -1298,7 +1298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: ikubevirt-prow-workloads
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:


### PR DESCRIPTION
This causes the job to remain in a triggered state - never getting run. 

/cc @dhiller 