### PR TITLE
Update bridge-marker release presubmits to use new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.6.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: prow-workloads
+      cluster: kubevirt-prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"


### PR DESCRIPTION
These jobs were missed in the initial move - these jobs currently remain in triggered state so need to be updated to move the new cluster

/cc @0xFelix @dhiller 