### PR TITLE
Upgrade shared-images daemonset to latest released image

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/resources/shared-images-controller.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/resources/shared-images-controller.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: shared-images-controller
-        image: quay.io/kubevirtci/shared-images-controller:v20221208-a669d6f
+        image: quay.io/kubevirtci/shared-images-controller:v20231027-376988b
         command: [ "/usr/local/bin/runner.sh", "/shared-images-controller"]
         resources:
           requests:


### PR DESCRIPTION
This upgrades the shared-images-controller daemonset to `quay.io/kubevirtci/shared-images-controller:v20231027-376988b`

This image includes changes from https://github.com/kubevirt/project-infra/pull/3036

/cc @xpivarc @dhiller 