### PR TITLE
Bump kubernetes-nmstate release 0.64 to go 1.17

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
@@ -23,7 +23,7 @@ presubmits:
               privileged: true
             env:
               - name: GIMME_GO_VERSION
-                value: "1.16"
+                value: "1.17"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -56,7 +56,7 @@ presubmits:
                 memory: "29Gi"
             env:
               - name: GIMME_GO_VERSION
-                value: "1.16"
+                value: "1.17"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -90,7 +90,7 @@ presubmits:
                 memory: "29Gi"
             env:
               - name: GIMME_GO_VERSION
-                value: "1.16"
+                value: "1.17"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"


### PR DESCRIPTION
This is needed to bump some of its dependencies.