### PR TITLE
Update bootstrap image of 0.49 sig-network lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -13,7 +13,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
@@ -28,7 +28,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.21-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220211-d7d6c59
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -267,7 +267,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
@@ -287,7 +287,7 @@ presubmits:
           value: NonRootExperimental
         - name: KUBEVIRT_NONROOT
           value: "true"
-        image: quay.io/kubevirtci/bootstrap:v20220211-d7d6c59
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1200,7 +1200,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
@@ -1215,7 +1215,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.22-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220211-d7d6c59
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:
@@ -1649,7 +1649,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
@@ -1664,7 +1664,7 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.23-sig-network
-        image: quay.io/kubevirtci/bootstrap:v20220211-d7d6c59
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
           requests:


### PR DESCRIPTION
0.49 network lanes are failing here due to a DNS issue[1] - an update of the bootstrap image resolves this DNS issue. 

[1] https://github.com/kubevirt/kubevirt/pull/10622