### PR TITLE
Fix cni paths for 0.49 SRIOV presubmit lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -581,7 +581,7 @@ presubmits:
       priorityClassName: sriov
   - always_run: true
     annotations:
-      k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
+      k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.49
     cluster: kubevirt-prow-workloads


### PR DESCRIPTION
This was missed as part of https://github.com/kubevirt/project-infra/pull/2731

The pod fails to schedule without this update[1]

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/10622/pull-kubevirt-e2e-kind-1.22-sriov-0.49/1719636138815131648

/cc @EdDev @ormergi @dhiller 