### PR TITLE
Create applications-aware-quota repo entry inside orgs.yaml

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -580,6 +580,11 @@ orgs:
         has_projects: true
         has_wiki: true
         has_issues: true
+      applications-aware-quota:
+        default_branch: main
+        has_projects: true
+        has_wiki: true
+        has_issues: true
     teams:
       QE:
         description: ""
@@ -997,6 +1002,13 @@ orgs:
           - vladikr
         repos:
           managed-tenant-quota: admin
+      applications-aware-quota:
+        description: members of the applications-aware-quota group
+        members:
+          - Barakmor1
+          - vladikr
+        repos:
+          applications-aware-quota: admin
       kubevirt.core-maintainers:
         description: Maintainers of kubevirt.core
         privacy: closed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
* Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
-->

**What this PR does / why we need it**:

This PR adds the repository applications-aware-quota to the KubeVirt organization.

**Why this repository is needed**:
In a multi-tenant environment, a cluster administrator creates a namespace for each tenant and controls the amount of resources that they can use by creating a ResourceQuota object within the namespace.

During the migration process, there is a hidden cost involved in creating a new virt-launcher pod before terminating the old one. This differs from how standard pods are moved and can result in unexpected resource utilization from the user's perspective. This poses a challenge where the hidden cost of live migration can prevent live migrating a VM for reasons not reflected to the VM creator / namespace owne

When upgrading KubeVirt, it is necessary to migrate VMIs to upgrade the virt-launcher pod. However, migrating a virtual machine in the presence of a resource quota can cause the migration to fail and subsequently cause the upgrade to fail.

This repository represent a new implementation to Resource Quota with additional logic which recognize the virtual resources required when running a VM and hide the additional resources needed for migration as this is a implementation detail and users shouldn't be charged for the additional resources required for infrastructure 

<!--
    Explain in detail what the repository will host, how it is related to KubeVirt and how it is beneficial for KubeVirt.
-->

**Which licensing model the repository is using or planning to use**:

<!--
    Explain which license model you are using or intending to use. Note that, since KubeVirt is a CNCF project, if the license model is in conflict with CNCF policies, this PR is not likely to get approved.
    Note: [CNCF is recommending Apache-2.0](https://www.cncf.io/blog/2017/02/01/cncf-recommends-aslv2/)
-->

**Maintainers who sponsor this repository**:

<!--
    A maintainer from https://github.com/kubevirt/community/blob/main/MAINTAINERS.md is required to sponsor the repository PR
-->

- @vladikr 

**New GitHub team[^1] within KubeVirt org for new repository**:

<!--
    Add a `team` section in `orgs.yaml` to give the people access to the repo that need it.
-->

GitHub team: `applications-aware-quota`

Repo maintainers:

- @vladikr 
- @Barakmor1 

Repo users:

- @vladikr 
- @Barakmor1 

[^1]: See [GitHub teams docs](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams)

**CI support is planned for**:

* [x] tide [^2]
* [x] prow jobs [^3]

**Note: Using [GitHub actions](https://docs.github.com/en/actions) might be an option if prow support is not available. However¸ KubeVirt CI maintainers will only support GitHub actions to the extent possible.**

[^2]: See [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md)
[^3]: See [How to onboard a repository to Prow](https://github.com/kubevirt/project-infra/blob/main/docs/how-to-onboard-a-repository.md)

CI maintainer sponsoring:

<!--
    A CI maintainer from [CI maintainers](../../OWNERS_ALIASES) is required to sponsor the repository PR if CI support is required.
-->

- @dhiller 

**KubeVirt mailing list announcement**: https://groups.google.com/g/kubevirt-dev/c/lZKEdyNqwsc/m/EKm9ldrJBgAJ

<!--
    Place a link to an email with announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) here
-->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close
the issue(s) when PR gets merged)*:
Fixes #

### Special notes for your reviewer

/cc @dhiller  @vladikr  @brianmcarey 