### PR TITLE
cnao, presubmit: Bump bootstrap for release 0.85, 0.79

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
@@ -20,7 +20,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -50,7 +50,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -80,7 +80,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -111,7 +111,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -140,7 +140,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -171,7 +171,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -202,7 +202,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -233,7 +233,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -264,7 +264,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20220823-3fed276
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
@@ -20,7 +20,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -50,7 +50,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -80,7 +80,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -111,7 +111,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -140,7 +140,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -171,7 +171,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -202,7 +202,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -233,7 +233,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -264,7 +264,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -295,7 +295,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:
@@ -326,7 +326,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20230105-1dbefc0
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
To improve podman init timeout.

Note:
Older branches still use docker, so didnt change them.