### PR TITLE
CHANGELOG: Store in repo instead of git tag

### DIFF
--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -37,13 +37,14 @@ type releaseData struct {
 	name      string
 	newBranch string
 
-	tagBranch        string
-	tag              string
-	promoteRC        string
-	promoteRCTime    time.Time
-	previousTag      string
-	releaseNotesFile string
-	skipReleaseNotes bool
+	tagBranch          string
+	tag                string
+	promoteRC          string
+	promoteRCTime      time.Time
+	previousTag        string
+	releaseNotesFile   string
+	releaseNotesReadme string
+	skipReleaseNotes   bool
 
 	force bool
 
@@ -92,6 +93,7 @@ func (r *releaseData) generateReleaseNotes() error {
 
 	releaseNotesDir := path.Join(r.repoDir, "CHANGELOG")
 	r.releaseNotesFile = path.Join(releaseNotesDir, fmt.Sprintf("CHANGELOG-%s.md", r.tag))
+	r.releaseNotesReadme = path.Join(releaseNotesDir, "README.md")
 
 	err := os.Mkdir(releaseNotesDir, 0755)
 	if err != nil && !os.IsExist(err) {
@@ -212,6 +214,19 @@ func (r *releaseData) generateReleaseNotes() error {
 	f.WriteString("```\n")
 
 	f.WriteString(additionalResources)
+
+	g, err := os.Create(r.releaseNotesReadme)
+	if err != nil {
+		return err
+	}
+	defer g.Close()
+
+	g.WriteString(fmt.Sprintf("# %s release notes\n", r.name))
+	g.WriteString("\n")
+	g.WriteString(fmt.Sprintf("The most recent release is [%s](CHANGELOG-%s.md).\n", r.tag, r.tag))
+
+	// TODO list past releases too
+
 	return nil
 }
 
@@ -329,6 +344,11 @@ func (r *releaseData) makeTag(branch string) error {
 	}
 
 	_, err = gitCommand("-C", r.repoDir, "add", r.releaseNotesFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = gitCommand("-C", r.repoDir, "add", r.releaseNotesReadme)
 	if err != nil {
 		return err
 	}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -79,18 +79,13 @@ func _gitCommand(arg ...string) (string, error) {
 
 func (r *releaseData) generateReleaseNotes() error {
 	additionalResources := fmt.Sprintf(`
-Additional Resources
---------------------
-- Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
-- Slack: <https://kubernetes.slack.com/messages/virtualization>
-- An easy to use demo: <https://github.com/%s/demo>
-- [How to contribute][contributing]
-- [License][license]
+## Additional Resources
 
-
-[contributing]: https://github.com/%s/%s/blob/main/CONTRIBUTING.md
-[license]: https://github.com/%s/%s/blob/main/LICENSE
----
+- Mailing list: https://groups.google.com/forum/#!forum/kubevirt-dev
+- Slack: https://kubernetes.slack.com/messages/virtualization
+- An easy to use demo: https://github.com/%s/demo
+- How to contribute: https://github.com/%s/%s/blob/main/CONTRIBUTING.md
+- License: https://github.com/%s/%s/blob/main/LICENSE
 `, r.org, r.org, r.repo, r.org, r.repo)
 
 	tagUrl := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", r.org, r.repo, r.tag)
@@ -180,21 +175,24 @@ Additional Resources
 	numContributors := len(contributorList)
 	typeOfChanges = strings.TrimSpace(typeOfChanges)
 
-	f.WriteString(fmt.Sprintf("This release follows %s and consists of %d changes, contributed by %d people, leading to %s.\n", r.previousTag, numChanges, numContributors, typeOfChanges))
+	f.WriteString(fmt.Sprintf("# %s %s\n", r.name, r.tag))
+	f.WriteString("\n")
+	f.WriteString(fmt.Sprintf("This release follows %s and consists of %d changes, leading to %s.", r.previousTag, numChanges, typeOfChanges))
 	if r.promoteRC != "" {
-		f.WriteString(fmt.Sprintf("%s is a promotion of release candidate %s which was originally published %s", r.tag, r.promoteRC, r.promoteRCTime.Format("2006-01-02")))
+		f.WriteString("  \n")
+		f.WriteString(fmt.Sprintf("%s is a promotion of release candidate %s, which was originally published on %s.", r.tag, r.promoteRC, r.promoteRCTime.Format("2006-01-02")))
 	}
 	f.WriteString("\n")
-	f.WriteString(fmt.Sprintf("The source code and selected binaries are available for download at: %s.\n", tagUrl))
 	f.WriteString("\n")
-	f.WriteString(fmt.Sprintf("The primary release artifact of %s is the git tree. The release tag is\n", r.name))
+	f.WriteString(fmt.Sprintf("The primary release artifact of %s is the git tree. The release tag is ", r.name))
 	f.WriteString(fmt.Sprintf("signed and can be verified using `git tag -v %s`.\n", r.tag))
 	f.WriteString("\n")
-	f.WriteString(fmt.Sprintf("Pre-built containers are published on Quay and can be viewed at: <https://quay.io/%s/>.\n", r.org))
+	f.WriteString(fmt.Sprintf("The source code and selected binaries are available for download at: %s  \n", tagUrl))
+	f.WriteString(fmt.Sprintf("Pre-built containers are published on Quay and can be viewed at: https://quay.io/%s/\n", r.org))
 	f.WriteString("\n")
 
 	if len(releaseNotes) > 0 {
-		f.WriteString("Notable changes\n---------------\n")
+		f.WriteString("## Notable changes\n")
 		f.WriteString("\n")
 		for _, note := range releaseNotes {
 			f.WriteString(fmt.Sprintf("- %s\n", note))
@@ -202,12 +200,16 @@ Additional Resources
 	}
 
 	f.WriteString("\n")
-	f.WriteString("Contributors\n------------\n")
-	f.WriteString(fmt.Sprintf("%d people contributed to this release:\n\n", numContributors))
+	f.WriteString("## Contributors\n")
+	f.WriteString("\n")
+	f.WriteString(fmt.Sprintf("%d people contributed to this release:\n", numContributors))
+	f.WriteString("\n")
 
+	f.WriteString("```\n")
 	for _, contributor := range contributorList {
 		f.WriteString(fmt.Sprintf("%s\n", strings.TrimSpace(contributor)))
 	}
+	f.WriteString("```\n")
 
 	f.WriteString(additionalResources)
 	return nil
@@ -408,7 +410,7 @@ func (r *releaseData) getReleaseNote(number int) (string, error) {
 				note = strings.TrimPrefix(note, "-")
 				// best effort at catching "none" if the label didn't catch it
 				if note != "" && !strings.Contains(note, "NONE") && strings.ToLower(note) != "none" && strings.ToLower(note) != "n/a" {
-					note = fmt.Sprintf("[PR #%d][%s] %s", number, *pr.User.Login, note)
+					note = fmt.Sprintf("[#%d](https://github.com/%s/%s/pull/%d) ([@%s](https://github.com/%s)) %s", number, r.org, r.repo, number, *pr.User.Login, *pr.User.Login, note)
 					return note, nil
 				}
 			}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -336,7 +336,7 @@ func (r *releaseData) makeTag(branch string) error {
 		return err
 	}
 
-	_, err = gitCommand("-C", r.repoDir, "tag", "-s", r.tag, "-F", r.releaseNotesFile)
+	_, err = gitCommand("-C", r.repoDir, "tag", "-s", "-m", fmt.Sprintf("%s %s", r.name, r.tag), r.tag)
 	if err != nil {
 		return err
 	}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -76,7 +76,8 @@ func _gitCommand(arg ...string) (string, error) {
 }
 
 func (r *releaseData) generateReleaseNotes() error {
-	additionalResources := fmt.Sprintf(`Additional Resources
+	additionalResources := fmt.Sprintf(`
+Additional Resources
 --------------------
 - Mailing list: <https://groups.google.com/forum/#!forum/kubevirt-dev>
 - Slack: <https://kubernetes.slack.com/messages/virtualization>
@@ -150,7 +151,17 @@ func (r *releaseData) generateReleaseNotes() error {
 		return err
 	}
 
-	contributorList := strings.Split(contributorStr, "\n")
+	contributorList := []string{}
+	for _, line := range strings.Split(contributorStr, "\n") {
+		if line == "" {
+			continue
+		}
+		if strings.Contains(line, "kubevirt-bot") {
+			// skip the bot
+			continue
+		}
+		contributorList = append(contributorList, line)
+	}
 
 	typeOfChanges, err := gitCommand("-C", r.repoDir, "diff", "--shortstat", span)
 	if err != nil {
@@ -187,10 +198,6 @@ func (r *releaseData) generateReleaseNotes() error {
 	f.WriteString(fmt.Sprintf("%d people contributed to this release:\n\n", numContributors))
 
 	for _, contributor := range contributorList {
-		if strings.Contains(contributor, "kubevirt-bot") {
-			// skip the bot
-			continue
-		}
 		f.WriteString(fmt.Sprintf("%s\n", strings.TrimSpace(contributor)))
 	}
 

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -326,6 +326,16 @@ func (r *releaseData) makeTag(branch string) error {
 		return err
 	}
 
+	_, err = gitCommand("-C", r.repoDir, "add", r.releaseNotesFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = gitCommand("-C", r.repoDir, "commit", "-s", "-m", fmt.Sprintf("CHANGELOG: Add release notes for %s", r.tag))
+	if err != nil {
+		return err
+	}
+
 	_, err = gitCommand("-C", r.repoDir, "tag", "-s", r.tag, "-F", r.releaseNotesFile)
 	if err != nil {
 		return err

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"sort"
 	"strconv"
@@ -94,7 +95,13 @@ Additional Resources
 
 	tagUrl := fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", r.org, r.repo, r.tag)
 
-	r.releaseNotesFile = fmt.Sprintf("%s/%s-release-notes.txt", r.repoDir, r.tag)
+	releaseNotesDir := path.Join(r.repoDir, "CHANGELOG")
+	r.releaseNotesFile = path.Join(releaseNotesDir, fmt.Sprintf("CHANGELOG-%s.md", r.tag))
+
+	err := os.Mkdir(releaseNotesDir, 0755)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
 
 	f, err := os.Create(r.releaseNotesFile)
 	if err != nil {

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -383,7 +383,7 @@ func (r *releaseData) getReleaseNote(number int) (string, error) {
 				note = strings.TrimPrefix(note, "- ")
 				note = strings.TrimPrefix(note, "-")
 				// best effort at catching "none" if the label didn't catch it
-				if !strings.Contains(note, "NONE") && strings.ToLower(note) != "none" {
+				if note != "" && !strings.Contains(note, "NONE") && strings.ToLower(note) != "none" && strings.ToLower(note) != "n/a" {
 					note = fmt.Sprintf("[PR #%d][%s] %s", number, *pr.User.Login, note)
 					return note, nil
 				}

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -313,9 +313,15 @@ func (r *releaseData) makeTag(branch string) error {
 		}
 	}
 
-	r.generateReleaseNotes()
+	err := r.generateReleaseNotes()
+	if err != nil {
+		return err
+	}
 
-	_, err := gitCommand("-C", r.repoDir, "tag", "-s", r.tag, "-F", r.releaseNotesFile)
+	_, err = gitCommand("-C", r.repoDir, "tag", "-s", r.tag, "-F", r.releaseNotesFile)
+	if err != nil {
+		return err
+	}
 
 	if !r.dryRun {
 		_, err = gitCommand("-C", r.repoDir, "push", r.repoUrl, r.tag)
@@ -1107,7 +1113,10 @@ func (r *releaseData) cutNewTag() error {
 		return err
 	}
 
-	r.makeTag(r.tagBranch)
+	err = r.makeTag(r.tagBranch)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -1127,6 +1127,8 @@ func (r *releaseData) printData() {
 	log.Printf("\torg: %s", r.org)
 	log.Printf("\trepo: %s", r.repo)
 	log.Printf("\tforce: %t", r.force)
+	log.Printf("\tgitUser: %s", r.gitUser)
+	log.Printf("\tgitEmail: %s", r.gitEmail)
 	log.Printf("\tgithubTokenFile: %s", r.githubTokenPath)
 }
 

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -439,6 +439,7 @@ func TestNewTag(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo checkout release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo pull origin release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo add %s/fake-org/https-fake-repo/CHANGELOG/CHANGELOG-v0.2.0.md]", r.cacheDir, r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo add %s/fake-org/https-fake-repo/CHANGELOG/README.md]", r.cacheDir, r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo commit -s -m CHANGELOG: Add release notes for v0.2.0]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s -m FakeName v0.2.0 v0.2.0]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo push https://fake-token@github.com/fake-org/fake-repo.git v0.2.0]", r.cacheDir))

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -429,6 +429,8 @@ func TestNewTag(t *testing.T) {
 	r.tagBranch = "release-0.2"
 
 	r.dryRun = false
+	r.skipReleaseNotes = true
+
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [clone https://fake-token@github.com/fake-org/fake-repo.git %s/fake-org/https-fake-repo]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.name fake-user]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -438,7 +438,7 @@ func TestNewTag(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo checkout release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo pull origin release-0.2]", r.cacheDir))
-	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s v0.2.0 -F %s/fake-org/https-fake-repo/v0.2.0-release-notes.txt]", r.cacheDir, r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s v0.2.0 -F %s/fake-org/https-fake-repo/CHANGELOG/CHANGELOG-v0.2.0.md]", r.cacheDir, r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo push https://fake-token@github.com/fake-org/fake-repo.git v0.2.0]", r.cacheDir))
 
 	seenGitCommands := []string{}

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -17,6 +17,7 @@ func standardCleanup(r *releaseData) {
 func standardSetup() releaseData {
 	repo := "fake-repo"
 	org := "fake-org"
+	name := "FakeName"
 	token := "fake-token"
 	cacheDir, err := ioutil.TempDir("/tmp", "release-tool-unit-test")
 	if err != nil {
@@ -71,6 +72,7 @@ func standardSetup() releaseData {
 	r := releaseData{
 		org:              org,
 		repo:             repo,
+		name:             name,
 		allReleases:      releases,
 		allBranches:      branches,
 		blockerListCache: blockerListCache,

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -440,7 +440,7 @@ func TestNewTag(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo pull origin release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo add %s/fake-org/https-fake-repo/CHANGELOG/CHANGELOG-v0.2.0.md]", r.cacheDir, r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo commit -s -m CHANGELOG: Add release notes for v0.2.0]", r.cacheDir))
-	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s v0.2.0 -F %s/fake-org/https-fake-repo/CHANGELOG/CHANGELOG-v0.2.0.md]", r.cacheDir, r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s -m FakeName v0.2.0 v0.2.0]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo push https://fake-token@github.com/fake-org/fake-repo.git v0.2.0]", r.cacheDir))
 
 	seenGitCommands := []string{}

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -438,6 +438,8 @@ func TestNewTag(t *testing.T) {
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo config user.email fake-email@fake.fake]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo checkout release-0.2]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo pull origin release-0.2]", r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo add %s/fake-org/https-fake-repo/CHANGELOG/CHANGELOG-v0.2.0.md]", r.cacheDir, r.cacheDir))
+	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo commit -s -m CHANGELOG: Add release notes for v0.2.0]", r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo tag -s v0.2.0 -F %s/fake-org/https-fake-repo/CHANGELOG/CHANGELOG-v0.2.0.md]", r.cacheDir, r.cacheDir))
 	expectedGitCommands = append(expectedGitCommands, fmt.Sprintf("git [-C %s/fake-org/https-fake-repo push https://fake-token@github.com/fake-org/fake-repo.git v0.2.0]", r.cacheDir))
 


### PR DESCRIPTION
Previously discussed [here](https://groups.google.com/g/kubevirt-dev/c/FvtVEAIVjo0/m/2Ekis79eAQAJ) and [here](https://groups.google.com/g/kubevirt-dev/c/lxqXb2wIqUk/m/yelXQYTUBAAJ).

Marking as draft because I haven't actually tested any of this O:-)

Also, before it can be merged, someone should populate the `CHANGELOG/` directory with release notes for past versions. I can take care of that if the approach proposed here is considered acceptable.