### PR TITLE
Deploy grafana instance to control plane cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -527,6 +527,46 @@ postsubmits:
               memory: "8Gi"
             limits:
               memory: "8Gi"
+    - name: post-project-infra-grafana-deployment
+      always_run: false
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      run_if_changed: "github/ci/services/grafana/.*"
+      branches:
+      - ^main$
+      labels:
+        preset-docker-mirror-proxy: "true"
+        preset-github-credentials: "true"
+        preset-pgp-bot-key: "true"
+      cluster: kubevirt-prow-control-plane
+      spec:
+        securityContext:
+          runAsUser: 0
+        containers:
+        - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-c"
+            - |
+              # install yq
+              curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+              chmod +x ./yq && mv ./yq /usr/local/bin/yq
+
+              source ./hack/manage-secrets.sh
+              decrypt_secrets
+              extract_secret 'kubeconfig' ~/.kube/config
+              extract_secret 'grafanaUser' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/admin-user
+              extract_secret 'grafanaPassword' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/admin-password
+              extract_secret 'grafanaPromToken' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/prom_bearer_token
+
+              ./github/ci/services/grafana/hack/deploy.sh kubevirt-prow-control-plane
+          resources:
+            requests:
+              memory: "8Gi"
+            limits:
+              memory: "8Gi"
     - name: post-project-infra-loki-deployment
       always_run: false
       annotations:

--- a/github/ci/services/grafana/BUILD.bazel
+++ b/github/ci/services/grafana/BUILD.bazel
@@ -5,6 +5,10 @@ TEST_CLUSTER = "kind-kind"
 
 TEST_USER = "kind-kind"
 
+PRODUCTION_CLUSTER_CONTROL_PLANE = "kubevirt-control-plane-cluster"
+
+PRODUCTION_USER_CONTROL_PLANE = "admin/cjmudnpd085ficevj8k0"
+
 [
     k8s_deploy(
         name = NAME,
@@ -20,5 +24,6 @@ TEST_USER = "kind-kind"
     )
     for NAME, CLUSTER, USER in [
         ("testing", TEST_CLUSTER, TEST_USER),
+        ("kubevirt-prow-control-plane", PRODUCTION_CLUSTER_CONTROL_PLANE, PRODUCTION_USER_CONTROL_PLANE),
     ]
 ]

--- a/github/ci/services/grafana/manifests/grafana.yaml
+++ b/github/ci/services/grafana/manifests/grafana.yaml
@@ -349,7 +349,7 @@ data:
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "Prometheus",
+          "datasource": "prometheus",
           "description": "Cache hit rates for Kubernetes's https://github.com/kubernetes/test-infra/tree/master/greenhouse deployment",
           "fill": 1,
           "gridPos": {

--- a/github/ci/services/grafana/manifests/ingress.yaml
+++ b/github/ci/services/grafana/manifests/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: grafana
   namespace: monitoring
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
   - host: grafana.ci.kubevirt.io
@@ -15,3 +17,7 @@ spec:
             name: grafana-service
             port:
               number: 3000
+  tls:
+  - hosts:
+    - grafana.ci.kubevirt.io
+    secretName: grafana-tls


### PR DESCRIPTION
Includes integration with the built in cluster-monitoring prometheus instance and a basic set of dashboards

/cc @dhiller @xpivarc 