### PR TITLE
`kubevirtci-bumper`: force target prerelease version for new provider

### DIFF
--- a/robots/cmd/kubevirtci-bumper/main.go
+++ b/robots/cmd/kubevirtci-bumper/main.go
@@ -39,6 +39,7 @@ type options struct {
 	endpoint               string
 	ensureLatest           bool
 	forceTargetMajorMinor  string
+	preReleaseVersion      string
 	ensureLatestThreeMinor string
 	ensureOnlyLatestThree  bool
 	major                  int
@@ -82,6 +83,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.BoolVar(&o.ensureLatest, "ensure-latest", false, "Ensure that we have a provider for the latest k8s release")
 	fs.StringVar(&o.forceTargetMajorMinor, "force-target-major-minor", "", `when using ensure-latest, override latest k8s release to use given target major.minor (i.e. "1.28"`)
+	fs.StringVar(&o.preReleaseVersion, "pre-release-version", "", `when using ensure-latest, add k8s pre release suffix (i.e. add alpha0 as in "1.28.0-alpha0"`)
 	fs.StringVar(&o.ensureLatestThreeMinor, "ensure-last-three-minor-of", "", "Ensure that the last three minor releases of the given major release are up to date (e.g. v1 or 2)")
 	fs.BoolVar(&o.ensureOnlyLatestThree, "ensure-only-latest-three", false, "Ensure that only the latest three minor releases of the given major release exist (aka remove older providers)")
 	fs.StringVar(&o.providerDir, "k8s-provider-dir", "", "The directory of the k8s providers")
@@ -148,6 +150,9 @@ func main() {
 		targetRelease := releases[0]
 		if o.forceTargetMajorMinor != "" {
 			tagName := fmt.Sprintf("v%s.0", o.forceTargetMajorMinor)
+			if o.preReleaseVersion != "" {
+				tagName += "-" + o.preReleaseVersion
+			}
 			targetRelease = &github.RepositoryRelease{
 				TagName: &tagName,
 			}

--- a/robots/pkg/kubevirtci/kubevirtci.go
+++ b/robots/pkg/kubevirtci/kubevirtci.go
@@ -40,7 +40,7 @@ func bumpRelease(providerDir string, release *github.RepositoryRelease) error {
 	for _, entry := range dirEntries {
 		if (isProviderDirectory(entry)) && (strings.Contains(entry.Name(), k8sVersion)) {
 			dir := filepath.Join(providerDir, entry.Name())
-			err = ioutil.WriteFile(filepath.Join(dir, "version"), []byte(r.String()), os.ModePerm)
+			err = os.WriteFile(filepath.Join(dir, "version"), []byte(strings.TrimPrefix(*release.TagName, "v")), os.ModePerm)
 			if err != nil {
 				return fmt.Errorf("Failed to bump the version file '%s': %v", filepath.Join(dir, "version"), err)
 			}

--- a/robots/pkg/querier/queries.go
+++ b/robots/pkg/querier/queries.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-github/github"
 )
 
-var SemVerRegex = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+var SemVerRegex = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.[0-9]+)?$`)
 var SemVerMajorRegex = regexp.MustCompile(`^[v]?([0-9]+)$`)
 var SemVerMinorRegex = regexp.MustCompile(`^[v]?([0-9]+)\.([0-9]+)$`)
 


### PR DESCRIPTION
Adds two new flags for `-ensure-latest`:

* `--force-target-major-minor` to override the target version without relying on the release k8s version
* `--pre-release-version` to add a suffix for a prerelease version inside the `version` file

This way 
```sh
bazel run //robots/cmd/kubevirtci-bumper -- \
        --ensure-latest=true \
        --force-target-major-minor '1.29' \
        --pre-release-version='alpha.3' \
        --github-token-path='' \
        --k8s-provider-dir=$PROJECTS/github.com/kubevirt.io/kubevirtci/cluster-provision/k8s \
        --cluster-up-dir=$PROJECTS/github.com/kubevirt.io/kubevirtci/cluster-up/cluster
```
generates manually a new provider without relying on any fetched versions with this content:

```sh
cat cluster-provision/k8s/1.29/version
1.29.0-alpha.3
```

See https://github.com/kubevirt/kubevirtci/pull/1093 as an example for a manual run.