### PR TITLE
Bump bootstrap image to fedora 39

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:38
+FROM fedora:39
 
 WORKDIR /workspace
 RUN mkdir -p /workspace


### PR DESCRIPTION
Fedora 39 was released recently[1]

[1] https://fedoramagazine.org/announcing-fedora-linux-39/

/cc @dhiller 