### PR TITLE
Minimize usage for full SemVer regex usage

### DIFF
--- a/robots/pkg/kubevirtci/kubevirtci.go
+++ b/robots/pkg/kubevirtci/kubevirtci.go
@@ -31,7 +31,7 @@ func BumpMinorReleaseOfProvider(providerDir string, minors []*github.RepositoryR
 }
 
 func bumpRelease(providerDir string, release *github.RepositoryRelease) error {
-	r := querier.ParseRelease(release)
+	r := querier.ParseReleaseFull(release)
 	dirEntries, err := os.ReadDir(providerDir)
 	if err != nil {
 		logrus.Infof("Failed to get contents of %s", providerDir)
@@ -40,11 +40,12 @@ func bumpRelease(providerDir string, release *github.RepositoryRelease) error {
 	for _, entry := range dirEntries {
 		if (isProviderDirectory(entry)) && (strings.Contains(entry.Name(), k8sVersion)) {
 			dir := filepath.Join(providerDir, entry.Name())
-			err = os.WriteFile(filepath.Join(dir, "version"), []byte(strings.TrimPrefix(*release.TagName, "v")), os.ModePerm)
+			fullVersion := strings.TrimPrefix(*release.TagName, "v")
+			err = os.WriteFile(filepath.Join(dir, "version"), []byte(fullVersion), os.ModePerm)
 			if err != nil {
 				return fmt.Errorf("Failed to bump the version file '%s': %v", filepath.Join(dir, "version"), err)
 			}
-			logrus.Infof("Minor version %s.%s updated to %v", r.Major, r.Minor, r)
+			logrus.Infof("Version %s.%s updated to %v", r.Major, r.Minor, fullVersion)
 		}
 	}
 	return nil
@@ -107,7 +108,7 @@ func EnsureProviderExists(providerDir string, clusterUpDir string, release *gith
 	if err != nil {
 		return err
 	}
-	semver := *querier.ParseRelease(release)
+	semver := *querier.ParseReleaseFull(release)
 
 	for _, rel := range existing {
 		cmp := rel.CompareMajorMinor(&semver)

--- a/robots/pkg/querier/queries.go
+++ b/robots/pkg/querier/queries.go
@@ -10,7 +10,8 @@ import (
 	"github.com/google/go-github/github"
 )
 
-var SemVerRegex = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.[0-9]+)?$`)
+var SemVerRegex = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)$`)
+var SemVerRegexFull = regexp.MustCompile(`^v([0-9]+)\.([0-9]+)\.([0-9]+)(-(alpha|beta|rc)\.[0-9]+)?$`)
 var SemVerMajorRegex = regexp.MustCompile(`^[v]?([0-9]+)$`)
 var SemVerMinorRegex = regexp.MustCompile(`^[v]?([0-9]+)\.([0-9]+)$`)
 
@@ -165,6 +166,15 @@ func (i *SemVer) String() string {
 
 func ParseRelease(release *github.RepositoryRelease) *SemVer {
 	matches := SemVerRegex.FindStringSubmatch(*release.TagName)
+	return &SemVer{
+		Major: matches[1],
+		Minor: matches[2],
+		Patch: matches[3],
+	}
+}
+
+func ParseReleaseFull(release *github.RepositoryRelease) *SemVer {
+	matches := SemVerRegexFull.FindStringSubmatch(*release.TagName)
 	return &SemVer{
 		Major: matches[1],
 		Minor: matches[2],


### PR DESCRIPTION
Since we don't want to accidentally slip pre-release versions into our automation we create another function to use it only where needed for the manual generation of pre-release candidates.