### PR TITLE
Remove kind and molecule from prow-deploy image

### DIFF
--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubevirtci/golang:v20230502-bfaa042 as builder
+FROM quay.io/kubevirtci/golang:v20231115-51a244f as builder
 
 RUN git clone https://github.com/kubernetes/test-infra.git && \
   cd test-infra && \
@@ -10,7 +10,7 @@ RUN git clone https://github.com/kubernetes/test-infra.git && \
   /usr/local/bin/runner.sh /bin/sh -ce 'go build -o /usr/local/bin/hmac ./prow/cmd/hmac' && \
   hmac --help
 
-FROM quay.io/kubevirtci/bootstrap:v20230502-bfaa042
+FROM quay.io/kubevirtci/bootstrap:v20231115-51a244f
 
 COPY --from=builder /usr/local/bin/config-bootstrapper /usr/local/bin/phony /usr/local/bin/hmac /usr/local/bin/
 
@@ -22,10 +22,6 @@ RUN curl -Lo ./kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/rel
 RUN curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
   chmod a+x ./yq && \
   mv ./yq /usr/local/bin
-
-RUN curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.20.0/kind-linux-amd64 && \
-  chmod a+x ./kind && \
-  mv ./kind /usr/local/bin
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
   chmod a+x ./kubectl && \

--- a/images/prow-deploy/requirements.txt
+++ b/images/prow-deploy/requirements.txt
@@ -1,8 +1,6 @@
 ansible == 8.3.0
 kubernetes == 26.1.0
 kubernetes-validate == 1.27.0
-molecule == 6.0.2
-molecule-docker == 2.1.0
 openshift == 0.13.2
 selinux == 0.3.0
 pyyaml == 6.0.1


### PR DESCRIPTION
kind and molecule are no longer required in the prow-deploy image as the presubmit has been moved to use kubevirtci[1] for the test cluster

Also includes bump to base images.

[1] https://github.com/kubevirt/project-infra/pull/3061

/cc @dhiller @xpivarc 