### PR TITLE
common-instancetypes: Add periodics to update kubevirt and ssp-operator

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -1,0 +1,46 @@
+periodics:
+  - name: update-common-instancetypes-bundles
+    cron: 0 2 * * *
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 1
+    cluster: kubevirt-prow-workloads
+    extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: main
+    - org: kubevirt
+      repo: ssp-operator
+      base_ref: main
+    labels:
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
+        env:
+        command: [ "/bin/bash", "-ce" ]
+        args:
+        - |
+          kv_dir=$(cd ../kubevirt && pwd)
+          kv_it_path="${kv_dir}/pkg/virt-operator/resource/generate/components/data/common-clusterinstancetypes-bundle.yaml"
+          kv_pref_path="${kv_dir}/pkg/virt-operator/resource/generate/components/data/common-clusterpreferences-bundle.yaml"
+
+          ssp_dir=$(cd ../ssp-operator && pwd)
+          ssp_it_path="${ssp_dir}/data/common-instancetypes-bundle/common-clusterinstancetypes-bundle.yaml"
+          ssp_pref_path="${ssp_dir}/data/common-instancetypes-bundle/common-clusterpreferences-bundle.yaml"
+
+          latest_version=$(curl -s https://api.github.com/repos/kubevirt/common-instancetypes/releases/latest | jq -r '.tag_name')
+          base_url="https://github.com/kubevirt/common-instancetypes/releases/download"
+          it_url="${base_url}/${latest_version}/common-clusterinstancetypes-bundle-${latest_version}.yaml"
+          pref_url="${base_url}/${latest_version}/common-clusterpreferences-bundle-${latest_version}.yaml"
+
+          export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+          description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+          git-pr.sh -c "curl -L ${it_url} -o ${kv_it_path} && curl -L ${pref_url} -o ${kv_pref_path}" -p "${kv_dir}" -d "echo -e \"${description}\"" -r kubevirt -b update-common-instancetypes -T main
+          git-pr.sh -c "curl -L ${it_url} -o ${ssp_it_path} && curl -L ${pref_url} -o ${ssp_pref_path}" -p "${ssp_dir}" -d "echo -e \"${description}\"" -r ssp-operator -b update-common-instancetypes -T main
+        resources:
+          requests:
+            memory: "200Mi"


### PR DESCRIPTION
Add a periodic job to update the vendored manifest bundles in kubevirt and ssp-operator to the latest released version of common-instancetypes.