### PR TITLE
Stop adding large number of reviewers to bump prow images PR

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -693,7 +693,7 @@ periodics:
       args:
       - |
         if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
-          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B "Bump Prow Job images /cc @kubevirt/prow-job-taskforce"
+          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B $'Bump Prow Job images\n/cc none'
         fi
       resources:
         requests:


### PR DESCRIPTION
When the prow job image bump PR is created, reviews are requested from 15+ people. This can be annoying for these reviewers as it is not really relevant to them.

/cc @dhiller @xpivarc 