### PR TITLE
Update run_if_changed for peribolos orgs.yaml presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -692,7 +692,7 @@ presubmits:
         - name: GIMME_GO_VERSION
           value: "1.20"
   - name: pull-kubevirt-org-github-config-updater
-    run_if_changed: '^github/ci/prow-deploy/files/orgs\.yaml$'
+    run_if_changed: '^github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs\.yaml$'
     annotations:
       testgrid-create-test-group: "false"
     labels:


### PR DESCRIPTION
Seems that the presubmit is not picking up changes to the orgs.yaml any more, maybe due to moving the file around.

/cc @brianmcarey 