### PR TITLE
Add default community health files repository and team

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -214,6 +214,8 @@ orgs:
     members_can_create_repositories: false
     name: KubeVirt
     repos:
+      .github:
+        description: Default Community health files.
       ansible-kubevirt-modules:
         allow_merge_commit: false
         allow_rebase_merge: false
@@ -666,6 +668,14 @@ orgs:
           - rmohr
         repos:
           api: admin
+      community-health-files-maintainers:
+        description: Default Community health files.
+        maintainers:
+          - dhiller
+          - brianmcarey
+          - aburdenthehand
+        repos:
+          .github: admin
       cloud-provider-kubevirt-maintainers:
         maintainers:
           - nirarg


### PR DESCRIPTION
This PR is for creating a repository for default community health files such as `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, etc.

This will help in streamlining the process of maintaining standard files, it is discussed in this [issue](https://github.com/kubevirt/community/issues/235) and for reference [here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) is the link to github docs.