### PR TITLE
common-instancetypes: Update functest jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
@@ -48,11 +48,14 @@ presubmits:
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+        env:
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 16G
         image: quay.io/kubevirtci/bootstrap:v20230607-07930d7
         name: ""
         resources:
           requests:
-            memory: 16Gi
+            memory: 20Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -26,7 +26,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "^common.*yaml"
+    run_if_changed: "instancetypes/.*|preferences/.*|scripts/functest.sh"
     cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
@@ -50,12 +50,12 @@ presubmits:
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
-          value: "8192"
+          value: 16G
         image: quay.io/kubevirtci/bootstrap:v20231115-51a244f
         name: ""
         resources:
           requests:
-            memory: 16Gi
+            memory: 20Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
Update the functest jobs to trigger on the correct changed files and provide the necessary resources for the tests to pass.