### PR TITLE
Add mention of prow-job-taskforce to bump prow images periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -693,7 +693,7 @@ periodics:
       args:
       - |
         if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=prow-job-image-bump --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
-          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B $'Bump Prow Job images\n/cc none'
+          hack/git-pr.sh -c "hack/bump-prow-job-images.sh" -b prow-job-image-bump -r project-infra -T main -B $'Bump Prow Job images\n@kubevirt/prow-job-taskforce\n/cc none'
         fi
       resources:
         requests:


### PR DESCRIPTION
This should alert the members of this team that a bump prow images PR has been created by the periodic job.

/cc @dhiller 