### PR TITLE
common-instancetypes: Store artifacts in presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
         command:
         - "/bin/bash"
         - "-c"
-        - "make"
+        - "make && cp _build/* /logs/artifacts"
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
This allows to preview instancetypes and preferences in the artifacts of a presubmit job.