### PR TITLE
plugins: Introduce phased plugin

### DIFF
--- a/docs/infrastructure-components.md
+++ b/docs/infrastructure-components.md
@@ -45,7 +45,7 @@ kubevirt-prow-control-plane
 
 * Prow control plane: all the Prow components, including the main microservices
 (crier, deck, hook, horologium, prow-controller-manager, tide, sink), several
-external plugins (bot-review, rehearse, release-blocker) and secondary components
+external plugins (bot-review, rehearse, release-blocker, phased) and secondary components
 (cherrypicker, gcsweb, ghproxy, label-sync, needs-rebase, prow-exporter,
 pushgateway, statusreconciler).
 

--- a/external-plugins/phased/Makefile
+++ b/external-plugins/phased/Makefile
@@ -1,0 +1,17 @@
+
+.PHONY: all clean format test push
+all: format test push
+bazelbin := bazelisk
+
+build:
+	$(bazelbin) build //external-plugins/phased/plugin
+
+format:
+	gofmt -w .
+
+test:
+	$(bazelbin) test //external-plugins/phased/...
+
+push:
+	$(bazelbin) run --stamp --workspace_status_command="./hack/print-workspace-status-no-git-tag.sh" //external-plugins/phased/plugin:push
+	bash -x ../../hack/update-deployments-with-latest-image.sh quay.io/kubevirtci/phased

--- a/external-plugins/phased/plugin/BUILD.bazel
+++ b/external-plugins/phased/plugin/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/external-plugins/phased/plugin",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//external-plugins/phased/plugin/handler:go_default_library",
+        "//external-plugins/phased/plugin/server:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_test_infra//pkg/flagutil:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+        "@io_k8s_test_infra//prow/config/secret:go_default_library",
+        "@io_k8s_test_infra//prow/flagutil:go_default_library",
+        "@io_k8s_test_infra//prow/git/v2:go_default_library",
+        "@io_k8s_test_infra//prow/interrupts:go_default_library",
+        "@io_k8s_test_infra//prow/pluginhelp:go_default_library",
+        "@io_k8s_test_infra//prow/pluginhelp/externalplugins:go_default_library",
+    ],
+)
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "app",
+    base = "@infra-base//image",
+    embed = [":go_default_library"],
+)
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+
+container_push(
+    name = "push",
+    format = "Docker",
+    image = ":app",
+    registry = "quay.io",
+    repository = "kubevirtci/phased",
+    tag = "{DOCKER_TAG}",
+)
+
+go_binary(
+    name = "plugin",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "phased_suite_test.go",
+        "phased_test.go",
+    ],
+    deps = [
+        "//external-plugins/phased/plugin/handler:go_default_library",
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+        "@io_k8s_test_infra//prow/git/localgit:go_default_library",
+        "@io_k8s_test_infra//prow/git/v2:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
+        "@io_k8s_test_infra//prow/github/fakegithub:go_default_library",
+        "@io_k8s_test_infra//prow/labels:go_default_library",
+    ],
+)

--- a/external-plugins/phased/plugin/handler/BUILD.bazel
+++ b/external-plugins/phased/plugin/handler/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["handler.go"],
+    importpath = "kubevirt.io/project-infra/external-plugins/phased/plugin/handler",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+        "@io_k8s_test_infra//prow/git/v2:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
+        "@io_k8s_test_infra//prow/labels:go_default_library",
+        "@io_k8s_test_infra//prow/pjutil:go_default_library",
+    ],
+)

--- a/external-plugins/phased/plugin/handler/handler.go
+++ b/external-plugins/phased/plugin/handler/handler.go
@@ -1,0 +1,367 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
+	gitv2 "k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pjutil"
+)
+
+var log *logrus.Logger
+
+func init() {
+	log = logrus.New()
+	log.SetOutput(os.Stdout)
+}
+
+type GitHubEvent struct {
+	Type    string
+	GUID    string
+	Payload []byte
+}
+
+type githubClientInterface interface {
+	GetPullRequest(string, string, int) (*github.PullRequest, error)
+	CreateComment(org, repo string, number int, comment string) error
+	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+}
+
+type loadConfigBytesFunc func(h *GitHubEventsHandler, org, repo string) ([]byte, []byte, error)
+
+var LoadConfigBytesFunc loadConfigBytesFunc = loadConfigBytes
+
+type GitHubEventsHandler struct {
+	eventsChan       <-chan *GitHubEvent
+	logger           *logrus.Logger
+	ghClient         githubClientInterface
+	gitClientFactory gitv2.ClientFactory
+	prowConfigPath   string
+	jobsConfigBase   string
+	prowLocation     string
+}
+
+func NewGitHubEventsHandler(
+	eventsChan <-chan *GitHubEvent,
+	logger *logrus.Logger,
+	ghClient githubClientInterface,
+	prowConfigPath string,
+	jobsConfigBase string,
+	prowLocation string,
+	gitClientFactory gitv2.ClientFactory) *GitHubEventsHandler {
+
+	return &GitHubEventsHandler{
+		eventsChan:       eventsChan,
+		logger:           logger,
+		ghClient:         ghClient,
+		prowConfigPath:   prowConfigPath,
+		jobsConfigBase:   jobsConfigBase,
+		prowLocation:     prowLocation,
+		gitClientFactory: gitClientFactory,
+	}
+}
+
+func (h *GitHubEventsHandler) Handle(incomingEvent *GitHubEvent) {
+	log.Infoln("GitHub events handler started")
+	eventLog := log.WithField("event-guid", incomingEvent.GUID)
+	switch incomingEvent.Type {
+	case "pull_request":
+		eventLog.Infoln("Handling pull request event")
+		var event github.PullRequestEvent
+		if err := json.Unmarshal(incomingEvent.Payload, &event); err != nil {
+			eventLog.WithError(err).Error("Could not unmarshal event.")
+			return
+		}
+		h.handlePullRequestEvent(eventLog, &event)
+	default:
+		log.Infoln("Dropping irrelevant:", incomingEvent.Type, incomingEvent.GUID)
+	}
+}
+
+// For unit tests, as we create a local git NewFakeClient
+func (h *GitHubEventsHandler) SetLocalConfLoad() {
+	LoadConfigBytesFunc = loadLocalConfigBytes
+}
+
+func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, event *github.PullRequestEvent) {
+	log.Infof("Handling updated pull request: %s [%d]", event.Repo.FullName, event.PullRequest.Number)
+
+	if !h.shouldActOnPREvent(event) {
+		return
+	}
+
+	org, repo, err := gitv2.OrgRepo(event.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get org/repo from the event")
+		return
+	}
+
+	shouldRun, err := h.shouldRunPhase2(org, repo, event.Label.Name, event.PullRequest.Number)
+	if err != nil || !shouldRun {
+		return
+	}
+
+	pr, err := h.ghClient.GetPullRequest(org, repo, event.PullRequest.Number)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get PR number %d", event.PullRequest.Number)
+		return
+	}
+
+	presubmits, err := h.loadPresubmits(*pr)
+	if err != nil {
+		log.WithError(err).Errorf("loadPresubmits failed")
+		return
+	}
+
+	if presubmits == nil {
+		return
+	}
+
+	toTest, err := listRequiredManual(h.ghClient, *pr, presubmits)
+	if err != nil {
+		log.WithError(err).Errorf("listRequiredManual failed")
+		return
+	}
+
+	err = testRequested(h.ghClient, *pr, toTest)
+	if err != nil {
+		log.WithError(err).Errorf("testRequested failed")
+		return
+	}
+}
+
+func (h *GitHubEventsHandler) loadPresubmits(pr github.PullRequest) ([]config.Presubmit, error) {
+	if pr.Base.Ref != "main" && pr.Base.Ref != "master" {
+		return nil, nil
+	}
+
+	pc, err := h.loadProwConfig(pr.Base.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not load prow config")
+		return nil, err
+	}
+
+	org, repo, err := gitv2.OrgRepo(pr.Base.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not parse repo name: %s", pr.Base.Repo.FullName)
+		return nil, err
+	}
+
+	orgRepo := org + "/" + repo
+	var presubmits []config.Presubmit
+	for index, jobs := range pc.PresubmitsStatic {
+		if index != orgRepo {
+			continue
+		}
+		for _, job := range jobs {
+			presubmits = append(presubmits, job)
+		}
+	}
+
+	return presubmits, nil
+}
+
+func generateJobConfigURL(org, repo, prowLocation, jobsConfigBase string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s-presubmits.yaml",
+		prowLocation, jobsConfigBase, org, repo, repo)
+}
+
+func (h *GitHubEventsHandler) shouldActOnPREvent(event *github.PullRequestEvent) bool {
+	return event.Action == github.PullRequestActionLabeled
+}
+
+func (h *GitHubEventsHandler) shouldRunPhase2(org, repo, eventLabel string, prNum int) (bool, error) {
+	l, err := h.ghClient.GetIssueLabels(org, repo, prNum)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get PR labels")
+		return false, err
+	}
+
+	return (eventLabel == labels.LGTM && github.HasLabel(labels.Approved, l)) ||
+		(eventLabel == labels.Approved && github.HasLabel(labels.LGTM, l)), nil
+}
+
+func catFile(log *logrus.Logger, gitDir, file, refspec string) ([]byte, int) {
+	cmd := exec.Command("git", "-C", gitDir, "cat-file", "-p", fmt.Sprintf("%s:%s", refspec, file))
+	log.Debugf("Executing git command: %+v", cmd.Args)
+	out, _ := cmd.CombinedOutput()
+	return out, cmd.ProcessState.ExitCode()
+}
+
+func writeTempFile(log *logrus.Logger, basedir string, content []byte) (string, error) {
+	tmpfile, err := ioutil.TempFile(basedir, "job-config")
+	if err != nil {
+		log.WithError(err).Errorf("Could not create temp file for job config.")
+		return "", err
+	}
+	defer tmpfile.Close()
+	_, err = tmpfile.Write(content)
+	if err != nil {
+		log.WithError(err).Errorf("Could not write data to file: %s", tmpfile.Name())
+		return "", err
+	}
+	tmpfile.Sync()
+	return tmpfile.Name(), nil
+}
+
+func fetchRemoteFile(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed with status: %v", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func listRequiredManual(ghClient githubClientInterface, pr github.PullRequest, presubmits []config.Presubmit) ([]config.Presubmit, error) {
+	if pr.Draft || pr.Merged || pr.State != "open" {
+		return nil, nil
+	}
+
+	if pr.Mergable != nil && !*pr.Mergable {
+		return nil, nil
+	}
+
+	org, repo, number, branch := pr.Base.Repo.Owner.Login, pr.Base.Repo.Name, pr.Number, pr.Base.Ref
+	changes := config.NewGitHubDeferredChangedFilesProvider(ghClient, org, repo, number)
+	toTest, err := pjutil.FilterPresubmits(manualRequiredFilter, changes, branch, presubmits, log)
+	if err != nil {
+		return nil, err
+	}
+
+	return toTest, nil
+}
+
+func manualRequiredFilter(p config.Presubmit) (bool, bool, bool) {
+	cond := !p.Optional && !p.AlwaysRun && p.RegexpChangeMatcher.RunIfChanged == "" &&
+		p.RegexpChangeMatcher.SkipIfOnlyChanged == ""
+	return cond, cond, false
+}
+
+func testRequested(ghClient githubClientInterface, pr github.PullRequest, requestedJobs []config.Presubmit) error {
+	org, repo, err := gitv2.OrgRepo(pr.Base.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not parse repo name: %s", pr.Base.Repo.FullName)
+		return err
+	}
+
+	// Until we update k8s.io/test-infra which allows to read require_manually_triggered_jobs policy
+	if !(org == "kubevirt" && repo == "kubevirt") {
+		return nil
+	}
+
+	var result string
+	for _, job := range requestedJobs {
+		result += "/test " + job.Name + "\n"
+		log.Debugf("Found presubmit %s", job.Name)
+	}
+
+	if result != "" {
+		if err := ghClient.CreateComment(org, repo, pr.Number, result); err != nil {
+			log.WithError(err).Errorf("CreateComment failed PR %d", pr.Number)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func loadLocalConfigBytes(h *GitHubEventsHandler, org, repo string) ([]byte, []byte, error) {
+	git, err := h.gitClientFactory.ClientFor(org, repo)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get client for git")
+		return nil, nil, err
+	}
+
+	prowConfigBytes, ret := catFile(log, git.Directory(), h.prowConfigPath, "HEAD")
+	if ret != 0 {
+		log.WithError(err).Errorf("Could not load Prow config %s", h.prowConfigPath)
+		return nil, nil, err
+	}
+
+	jobConfigBytes, ret := catFile(log, git.Directory(), h.jobsConfigBase, "HEAD")
+	if ret != 0 {
+		log.WithError(err).Errorf("Could not load Prow config %s", h.jobsConfigBase)
+		return nil, nil, err
+	}
+
+	return prowConfigBytes, jobConfigBytes, nil
+}
+
+func loadConfigBytes(h *GitHubEventsHandler, org, repo string) ([]byte, []byte, error) {
+	prowConfigUrl := h.prowLocation + "/" + h.prowConfigPath
+	prowConfigBytes, err := fetchRemoteFile(prowConfigUrl)
+	if err != nil {
+		log.WithError(err).Errorf("Could not fetch prow config from %s", prowConfigUrl)
+		return nil, nil, err
+	}
+
+	jobConfigUrl := generateJobConfigURL(org, repo, h.prowLocation, h.jobsConfigBase)
+	jobConfigBytes, err := fetchRemoteFile(jobConfigUrl)
+	if err != nil {
+		log.WithError(err).Errorf("Could not fetch prow config from %s", jobConfigUrl)
+		return nil, nil, err
+	}
+
+	return prowConfigBytes, jobConfigBytes, nil
+}
+
+func (h *GitHubEventsHandler) loadProwConfig(prFullName string) (*config.Config, error) {
+	tmpdir, err := ioutil.TempDir("", "prow-configs")
+	if err != nil {
+		log.WithError(err).Error("Could not create a temp directory to store configs.")
+		return nil, err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	org, repo, err := gitv2.OrgRepo(prFullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not parse repo name: %s", prFullName)
+		return nil, err
+	}
+
+	prowConfigBytes, jobConfigBytes, err := LoadConfigBytesFunc(h, org, repo)
+	if err != nil {
+		log.WithError(err).Errorf("Could not load prow config")
+		return nil, err
+	}
+
+	prowConfigTmp, err := writeTempFile(log, tmpdir, prowConfigBytes)
+	if err != nil {
+		log.WithError(err).Errorf("Could not write temporary Prow config.")
+		return nil, err
+	}
+
+	jobConfigTmp, err := writeTempFile(log, tmpdir, jobConfigBytes)
+	if err != nil {
+		log.WithError(err).Errorf("Could not write temporary Job config file")
+		return nil, err
+	}
+
+	pc, err := config.Load(prowConfigTmp, jobConfigTmp, nil, "")
+	if err != nil {
+		log.WithError(err).Errorf("Could not load prow config")
+		return nil, err
+	}
+
+	return pc, nil
+}

--- a/external-plugins/phased/plugin/main.go
+++ b/external-plugins/phased/plugin/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pluginhelp"
+
+	"kubevirt.io/project-infra/external-plugins/phased/plugin/handler"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config/secret"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+
+	"kubevirt.io/project-infra/external-plugins/phased/plugin/server"
+)
+
+type options struct {
+	dryRun         bool
+	hmacSecretFile string
+	endpoint       string
+	port           int
+	prowConfigPath string
+	jobsConfigBase string
+	cacheDir       string
+	prowLocation   string
+	github         prowflagutil.GitHubOptions
+}
+
+func (o *options) validate() {
+	var errs []error
+	if o.prowConfigPath == "" {
+		errs = append(errs, fmt.Errorf("prow-config-path can't be empty"))
+	}
+	if o.jobsConfigBase == "" {
+		errs = append(errs, fmt.Errorf("jobs-config-path can't be empty"))
+	}
+	if o.cacheDir == "" {
+		errs = append(errs, fmt.Errorf("cache-dir can't be empty"))
+	}
+	if o.prowLocation == "" {
+		errs = append(errs, fmt.Errorf("prow-location can't be empty"))
+	}
+	err := o.github.Validate(o.dryRun)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		for _, err := range errs {
+			logrus.WithError(err).Error("entry validation failure")
+		}
+		logrus.Fatalf("Arguments validation failed!")
+	}
+}
+
+func gatherOptions() *options {
+	o := &options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port,
+		"port",
+		9900,
+		"Port to listen on.")
+	fs.StringVar(&o.endpoint,
+		"endpoint",
+		"/",
+		"Endpoint to listen on.")
+	fs.BoolVar(&o.dryRun,
+		"dry-run",
+		false,
+		"If set, dump the job config to stdout.")
+	fs.StringVar(&o.hmacSecretFile,
+		"hmac-secret-file",
+		"/etc/webhook/hmac",
+		"Path to the file containing the GitHub HMAC secret.")
+	fs.StringVar(&o.prowConfigPath,
+		"prow-config-path",
+		"",
+		"Path to Prow configuration (required).")
+	fs.StringVar(&o.jobsConfigBase,
+		"jobs-config-base",
+		"",
+		"Base path to a directory with Prow job configs (required).")
+	fs.StringVar(&o.cacheDir,
+		"cache-dir",
+		"",
+		"Directory to store git repos cache in.")
+	fs.StringVar(&o.prowLocation,
+		"prow-location",
+		"",
+		"Prow raw git location")
+	for _, group := range []flagutil.OptionGroup{&o.github} {
+		group.AddFlags(fs)
+	}
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func clientFactoryCacheDirOpt(cacheDir string) func(opts *git.ClientFactoryOpts) {
+	return func(cfo *git.ClientFactoryOpts) {
+		cfo.CacheDirBase = &cacheDir
+	}
+}
+
+func main() {
+	opts := gatherOptions()
+	opts.validate()
+
+	logger := setupLogger()
+	logger.Infoln("Setting up events server")
+
+	err := secret.Add(opts.github.TokenPath, opts.hmacSecretFile)
+	mustSucceed(err, "Failed to start secrets agent")
+
+	githubClient, err := opts.github.GitHubClient(opts.dryRun)
+	mustSucceed(err, "Could not instantiate github client")
+
+	gitClientFactory, err := git.NewClientFactory(clientFactoryCacheDirOpt(opts.cacheDir))
+	mustSucceed(err, "Could not instantiate git client factory")
+
+	eventsChan := make(chan *handler.GitHubEvent)
+
+	eventsHandler := handler.NewGitHubEventsHandler(
+		eventsChan,
+		logger,
+		githubClient,
+		opts.prowConfigPath,
+		opts.jobsConfigBase,
+		opts.prowLocation,
+		gitClientFactory)
+
+	eventsServer := server.NewGitHubEventsServer(secret.GetTokenGenerator(opts.hmacSecretFile), eventsHandler)
+
+	serverMux := http.NewServeMux()
+	serverMux.Handle(opts.endpoint, eventsServer)
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", opts.port), Handler: serverMux}
+	interrupts.ListenAndServe(srv, 5*time.Second)
+	logger.Infoln("Events server is listening on port:", opts.port)
+	externalplugins.ServeExternalPluginHelp(serverMux, logger.WithField("plugin-help", ""), helpProvider)
+	interrupts.WaitForGracefulShutdown()
+	logger.Println("Phased server was gracefully shut down")
+}
+
+func helpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: `The Phased plugin is used to trigger phase 2 jobs when PR is ready for merging.`,
+	}
+	return pluginHelp, nil
+}
+
+func mustSucceed(err error, message string) {
+	if err != nil {
+		logrus.WithError(err).Fatal(message)
+	}
+}
+
+func setupLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetFormatter(&logrus.TextFormatter{FullTimestamp: true, TimestampFormat: time.RFC1123Z})
+	l.SetLevel(logrus.TraceLevel)
+	l.SetOutput(os.Stdout)
+	return l
+}

--- a/external-plugins/phased/plugin/phased_suite_test.go
+++ b/external-plugins/phased/plugin/phased_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPhased(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Phased Suite")
+}

--- a/external-plugins/phased/plugin/phased_test.go
+++ b/external-plugins/phased/plugin/phased_test.go
@@ -1,0 +1,233 @@
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/git/localgit"
+	git2 "k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/labels"
+
+	"kubevirt.io/project-infra/external-plugins/phased/plugin/handler"
+)
+
+const (
+	org      = "kubevirt"
+	repo     = "kubevirt"
+	baseRef  = "main"
+	orgRepo  = org + "/" + repo
+	prNumber = 17
+)
+
+type TestCase struct {
+	AddedLabel         string
+	ApproveLabelExists bool
+	LGTMLabelExists    bool
+	ExpectComment      bool
+}
+
+var _ = Describe("Phased", func() {
+	Context("A valid pull request event", func() {
+		var gitrepo *localgit.LocalGit
+		var gitClientFactory git2.ClientFactory
+		var baseref string
+
+		BeforeEach(func() {
+			var err error
+			gitrepo, gitClientFactory, err = localgit.NewV2()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		BeforeEach(func() {
+			baseConfig, err := json.Marshal(&config.Config{
+				JobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						orgRepo: {
+							{
+								AlwaysRun: true,
+								JobBase: config.JobBase{
+									Name: "job_always_run",
+									Spec: &v1.PodSpec{
+										Containers: []v1.Container{
+											{
+												Image: "image1",
+											},
+										},
+									},
+								},
+							},
+							{
+								JobBase: config.JobBase{
+									Name: "job_always_run_false",
+									Spec: &v1.PodSpec{
+										Containers: []v1.Container{
+											{
+												Image: "image2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+
+			makeRepoWithEmptyProwConfig(gitrepo, org, repo)
+
+			Expect(err).ShouldNot(HaveOccurred())
+			err = gitrepo.AddCommit(org, repo, map[string][]byte{
+				"jobs-config.yaml": baseConfig,
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			baseref, err = gitrepo.RevParse(org, repo, "HEAD")
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if gitClientFactory != nil {
+				gitClientFactory.Clean()
+			}
+		})
+
+		DescribeTable("Prow Job Commenting",
+			func(tc TestCase) {
+				gh := fakegithub.NewFakeClient()
+				if tc.ApproveLabelExists {
+					gh.IssueLabelsExisting = append(gh.IssueLabelsExisting, issueLabels(labels.Approved)...)
+				}
+				if tc.LGTMLabelExists {
+					gh.IssueLabelsExisting = append(gh.IssueLabelsExisting, issueLabels(labels.LGTM)...)
+				}
+				var event github.PullRequestEvent
+				By("Generating a fake pull request event and registering it to the github client", func() {
+					event = github.PullRequestEvent{
+						Action: github.PullRequestActionLabeled,
+						Label:  github.Label{Name: tc.AddedLabel},
+						GUID:   "guid",
+						Repo: github.Repo{
+							FullName: orgRepo,
+						},
+						Sender: github.User{
+							Login: "testuser",
+						},
+						PullRequest: github.PullRequest{
+							Number: prNumber,
+							State:  "open",
+							Base: github.PullRequestBranch{
+								Repo: github.Repo{
+									Name:     repo,
+									FullName: orgRepo,
+								},
+								Ref: baseRef,
+								SHA: baseref,
+							},
+							Head: github.PullRequestBranch{
+								Repo: github.Repo{
+									Name:     repo,
+									FullName: orgRepo,
+								},
+								Ref: baseRef,
+								SHA: baseref,
+							},
+						},
+					}
+
+					gh.PullRequests = map[int]*github.PullRequest{
+						prNumber: &event.PullRequest,
+					}
+				})
+
+				By("Sending the event to the phased plugin server", func() {
+					fakelog := logrus.New()
+					eventsChan := make(chan *handler.GitHubEvent)
+					eventsHandler := handler.NewGitHubEventsHandler(
+						eventsChan,
+						fakelog,
+						gh,
+						"prowconfig.yaml",
+						"jobs-config.yaml",
+						"",
+						gitClientFactory)
+
+					handlerEvent, err := makeHandlerPullRequestEvent(&event)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					eventsHandler.SetLocalConfLoad()
+					eventsHandler.Handle(handlerEvent)
+
+					if tc.ExpectComment {
+						Expect(len(gh.IssueCommentsAdded)).To(Equal(1), "Expected github comment to be added")
+						Expect(gh.IssueCommentsAdded[0]).To(Equal(fmt.Sprintf("%s#%d:/test job_always_run_false\n", orgRepo, prNumber)))
+					} else {
+						Expect(len(gh.IssueCommentsAdded)).To(Equal(0), "Expect no github comment to be added")
+					}
+				})
+			},
+			Entry("LGTM is added, Approve exists",
+				TestCase{
+					AddedLabel:         labels.LGTM,
+					ApproveLabelExists: true,
+					ExpectComment:      true}),
+			Entry("LGTM is added, Approve doesnt exist",
+				TestCase{
+					AddedLabel:         labels.LGTM,
+					ApproveLabelExists: false,
+					ExpectComment:      false}),
+			Entry("Approve is added, LGTM exists",
+				TestCase{
+					AddedLabel:      labels.Approved,
+					LGTMLabelExists: true,
+					ExpectComment:   true}),
+			Entry("Approve is added, LGTM doesnt exist",
+				TestCase{
+					AddedLabel:      labels.Approved,
+					LGTMLabelExists: false,
+					ExpectComment:   false}),
+		)
+
+	})
+
+})
+
+func makeRepoWithEmptyProwConfig(lg *localgit.LocalGit, org, repo string) error {
+	err := lg.MakeFakeRepo(org, repo)
+	if err != nil {
+		return err
+	}
+	prowConfig, err := json.Marshal(&config.ProwConfig{})
+	if err != nil {
+		return err
+	}
+	return lg.AddCommit(org, repo, map[string][]byte{
+		"prowconfig.yaml": prowConfig,
+	})
+}
+
+func makeHandlerPullRequestEvent(event *github.PullRequestEvent) (*handler.GitHubEvent, error) {
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	handlerEvent := &handler.GitHubEvent{
+		Type:    "pull_request",
+		GUID:    event.GUID,
+		Payload: eventBytes,
+	}
+	return handlerEvent, nil
+}
+
+func issueLabels(labels ...string) []string {
+	var ls []string
+	for _, label := range labels {
+		ls = append(ls, fmt.Sprintf("%s#%d:%s", orgRepo, prNumber, label))
+	}
+	return ls
+}

--- a/external-plugins/phased/plugin/server/BUILD.bazel
+++ b/external-plugins/phased/plugin/server/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["eventsserver.go"],
+    importpath = "kubevirt.io/project-infra/external-plugins/phased/plugin/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external-plugins/phased/plugin/handler:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
+    ],
+)

--- a/external-plugins/phased/plugin/server/eventsserver.go
+++ b/external-plugins/phased/plugin/server/eventsserver.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net/http"
+
+	"k8s.io/test-infra/prow/github"
+	"kubevirt.io/project-infra/external-plugins/phased/plugin/handler"
+)
+
+type GitHubEventsServer struct {
+	tokenGenerator func() []byte
+	eventsHandler  *handler.GitHubEventsHandler
+}
+
+func NewGitHubEventsServer(tokenGenerator func() []byte, eventsChan *handler.GitHubEventsHandler) *GitHubEventsServer {
+	return &GitHubEventsServer{
+		tokenGenerator: tokenGenerator,
+		eventsHandler:  eventsChan,
+	}
+}
+
+func (s *GitHubEventsServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	eventType, eventGUID, eventPayload, eventOk, _ := github.ValidateWebhook(writer, request, s.tokenGenerator)
+
+	if !eventOk {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	event := &handler.GitHubEvent{
+		Type:    eventType,
+		GUID:    eventGUID,
+		Payload: eventPayload,
+	}
+	go s.eventsHandler.Handle(event)
+	writer.Write([]byte("Event received. Have a nice day."))
+}

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -798,7 +798,7 @@ presubmits:
             memory: 4Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubevirt/kubevirt:
   - always_run: false
+    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1796,6 +1797,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -26,6 +26,35 @@ postsubmits:
                 memory: "8Gi"
               limits:
                 memory: "8Gi"
+    - name: publish-phased-plugin-image
+      always_run: false
+      run_if_changed: "external-plugins/phased/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      cluster: kubevirt-prow-control-plane
+      max_concurrency: 1
+      labels:
+        preset-bazel-cache: "true"
+        preset-kubevirtci-quay-credential: "true"
+        preset-podman-in-container-enabled: "true"
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20231115-51a244f
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                make -C external-plugins/phased push
+            resources:
+              requests:
+                memory: "8Gi"
+              limits:
+                memory: "8Gi"
+            securityContext:
+              privileged: true
     - name: publish-release-blocker-image
       always_run: false
       run_if_changed: "external-plugins/release-blocker/.*"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -270,6 +270,8 @@ branch-protection:
         kubevirt:
           protect: true
           branches:
+            main:
+              require_manually_triggered_jobs: true
             release-0.33:
               required_status_checks:
                 contexts:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -528,6 +528,11 @@ external_plugins:
     endpoint: http://botreview:9900
     events:
       - pull_request
+  kubevirt/kubevirt:
+  - name: phased
+    endpoint: http://prow-phased:9900
+    events:
+      - pull_request
 
 triggers:
 - repos:

--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - manifests/local/prow-rehearse-rbac.yaml
   - manifests/local/prow-rehearse-deployment.yaml
   - manifests/local/prow-rehearse-service.yaml
+  - manifests/local/prow-phased-deployment.yaml
+  - manifests/local/prow-phased-service.yaml
   - manifests/local/release-blocker_deployment.yaml
   - manifests/local/release-blocker_service.yaml
   - manifests/local/tide_rbac_prowjob.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phased
+  labels:
+    app: phased
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prow-phased
+  template:
+    metadata:
+      labels:
+        app: prow-phased
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: phased
+          image: quay.io/kubevirtci/phased:v20240115-b04789a7
+          imagePullPolicy: IfNotPresent
+          args:
+            - --github-token-path=/etc/github/oauth
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --cache-dir=/var/run/cache
+            - --jobs-config-base=github/ci/prow-deploy/files/jobs
+            - --prow-config-path=github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+            - --prow-location=https://raw.githubusercontent.com/kubevirt/project-infra/main
+          ports:
+            - name: http
+              containerPort: 9900
+          volumeMounts:
+            - name: hmac
+              mountPath: /etc/webhook
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+            - name: cache
+              mountPath: /var/run/cache
+              readOnly: false
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: plugins
+          configMap:
+            name: plugins
+        - name: cache
+          emptyDir: {}

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-service.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prow-phased
+spec:
+  ports:
+    - port: 9900
+      protocol: TCP
+      targetPort: 9900
+  selector:
+    app: prow-phased
+  type: ClusterIP

--- a/images/phased
+++ b/images/phased
@@ -1,0 +1,1 @@
+../external-plugins/phased


### PR DESCRIPTION
Phased plugin allows running jobs that will be considered as "phase 2"
only once both lgtm / approve are presented.

We are running 3 k8s versions for each sig on kubevirt, for each PR.
With this plugin we can declare the non latest one as "phase 2"
and run it only when the PR is entering the merge queue,
This will save CI resources.

A job will be declared as "phase 2",  if it has `always_run=false`, `optional=false`,
without additional conditions such as `run_if_changed`, `skip_if_only_changed`.

Since the jobs are `always_run=false` it means that a potential race condition might happen
between running the job and merging.
For this we use `require_manually_triggered_jobs` which will block the PR entering 
the merge queue / being merge by tide before all "phase 2" jobs finish.
It will also cause tide to auto run phase 2 when rerunning batches.

Notes: 
* Doesn't support branches, since for branches we consider everything as stable phase 1.
A follow-up [PR](https://github.com/kubevirt/project-infra/pull/3126) will update the job forking to update phase 2 to be considered phase 1 on new branches.
* Works only for `kubevirt/kubevirt`.
* `pull-kubevirt-e2e-k8s-1.27-ipv6-sig-network` was chosen as phase 2 candid.

