### PR TITLE
common-instancetypes: Check for clean tree in presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
         command:
         - "/bin/bash"
         - "-c"
-        - "make && cp _build/* /logs/artifacts"
+        - "make check-tree-clean all && cp _build/* /logs/artifacts"
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
Run the check-clean-tree Makefile target in the presubmits of common-instancetypes.