### PR TITLE
common-instancetypes: Bump builder image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
-      - image: quay.io/kubevirtci/common-instancetypes-builder:v20231124-0bd5b70
+      - image: quay.io/kubevirtci/common-instancetypes-builder:v20231205-3b7ed7e
         command:
         - "/bin/bash"
         - "-c"


### PR DESCRIPTION
Bump the builder image used in the presubmits to v20231205-3b7ed7e.

Unblocks https://github.com/kubevirt/common-instancetypes/pull/132 and https://github.com/kubevirt/project-infra/pull/3109