### PR TITLE
Update mirror-crio.sh to sync new cri-o repos

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -21,14 +21,8 @@ periodics:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20231115-51a244f
         env:
-          - name: OS
-            value: CentOS_8_Stream
           - name: BUCKET_DIR
             value: kubevirtci-crio-mirror
-          - name: LOCAL_MIRROR_DIR
-            value: opensuse-mirror
-          - name: BASE_REPOID
-            value: devel_kubic_libcontainers_stable
           - name: CRIO_VERSIONS
             value: "1.22,1.23,1.24,1.25,1.26,1.27,1.28"
         command: ["/bin/sh", "-ce"]

--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -6,34 +6,40 @@
 
 set -e
 
+LOCAL_MIRROR_DIR="crio-mirror"
+
 dnf install dnf-utils -y
 
 mirror_crio_repo_for_version () {
-    if [ -z "$1" ]
-    then
-        CRIO_SUBDIR=""
-        REPOID=$BASE_REPOID
-    elif [[ $1 = *":"* ]]
-    then    
-	CRIO_SUBDIR=":cri-o:$1"
-	REPOID_VER=$(echo $1 | sed 's/:/_/g')
-	REPOID="${BASE_REPOID}_cri-o_$REPOID_VER"
+    OLD_CRIO_REPO_VERSIONS="1.22,1.23,1.24,1.25,1.26,1.27"
+
+    if [[ $OLD_CRIO_REPO_VERSIONS == *"$1"* ]]; then
+        BASE_REPOID="devel_kubic_libcontainers_stable"
+        if [ -z "$1" ]; then
+            CRIO_SUBDIR=""
+            REPOID=$BASE_REPOID
+        else
+            CRIO_SUBDIR=":cri-o:$1"
+            REPOID="${BASE_REPOID}_cri-o_$1"
+        fi
+        # cri-o builds > v1.24.1 are broken for Centos_8_Stream
+        # cri-o > v1.24.2 is required to avoid https://github.com/cri-o/cri-o/issues/5889
+        # Use CentOS_8 build for cri-o v1.24
+        if [[ $1 = 1.24 ]]; then
+            OS="CentOS_8"
+        else
+            OS="CentOS_8_Stream"
+        fi
+        curl -L -o $REPOID.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable$CRIO_SUBDIR/$OS/devel:kubic:libcontainers:stable$CRIO_SUBDIR.repo
+        reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR -n --repoid=$REPOID --download-metadata
     else
-        CRIO_SUBDIR=":cri-o:$1"
-        REPOID="${BASE_REPOID}_cri-o_$1"
+        echo "Mirroring from new pkgs.k8s.io repos"
+        REPOID="isv_kubernetes_addons_cri-o_stable_v$1"
+        curl -L -o $REPOID.repo https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/stable:/v$1/rpm/isv:kubernetes:addons:cri-o:stable:v$1.repo
+        reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR -n --repoid=$REPOID --download-metadata
     fi
-    # cri-o builds > v1.24.1 are broken for Centos_8_Stream
-    # cri-o > v1.24.2 is required to avoid https://github.com/cri-o/cri-o/issues/5889
-    # Use CentOS_8 build for cri-o v1.24
-    if [[ $1 = 1.24 ]]
-    then
-        OS="CentOS_8"
-    else
-        OS="CentOS_8_Stream"
-    fi
-    curl -L -o $REPOID.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable$CRIO_SUBDIR/$OS/devel:kubic:libcontainers:stable$CRIO_SUBDIR.repo
-    reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR -n --repoid=$REPOID --download-metadata
 }
+
 
 # First mirror the shared stable repository
 mirror_crio_repo_for_version


### PR DESCRIPTION
cri-o have moved the location where they publish their rpms[1]. Update the mirror-crio.sh to reflect this change.

[1] https://kubernetes.io/blog/2023/10/10/cri-o-community-package-infrastructure/

/cc @dhiller 