### PR TITLE
Enable PodSecurityAdmission for remaining lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1294,6 +1294,8 @@ periodics:
         value: "true"
       - name: KUBEVIRT_QUARANTINE
         value: "true"
+      - name: KUBEVIRT_PSA
+        value: "true"
       - name: TARGET
         value: k8s-1.26-centos9-sig-storage
       - name: FEATURE_GATES

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -315,6 +315,8 @@ presubmits:
         - -c
         - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
         env:
+        - name: KUBEVIRT_PSA
+          value: "true"
         - name: KUBEVIRT_E2E_PARALLEL
           value: "true"
         - name: KUBEVIRT_MEMORY_SIZE
@@ -1446,6 +1448,8 @@ presubmits:
         - -c
         - automation/test.sh
         env:
+        - name: KUBEVIRT_PSA
+          value: "true"
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
         - name: FEATURE_GATES


### PR DESCRIPTION
We want to have PodSecurityAdmission enabled by default, therefore we add it to the lanes that are missing it.

I.e. this is the reason why the virtiofs unprivileged test cases are failing.

/cc @brianmcarey @xpivarc