### PR TITLE
Fix namespace for botreview token

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -359,7 +359,7 @@ secretGenerator:
       - oauth=secrets/commenter-oauth-token
     type: Opaque
   - name: botreview-oauth-token
-    namespace: kubevirt-prow-jobs
+    namespace: kubevirt-prow
     # githubBotreviewToken
     files:
     - oauth=secrets/botreview-oauth-token


### PR DESCRIPTION
The botreview plugin is supposed to run in namespace `kubevirt-prow`, therefore we need the secret in that namespace.

/cc @brianmcarey 