### PR TITLE
refactor, botreview: align result structs into one

### DIFF
--- a/external-plugins/botreview/review/BUILD.bazel
+++ b/external-plugins/botreview/review/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "bump_kubevirtci.go",
         "image_update.go",
         "prow_autobump.go",
+        "result.go",
         "review.go",
     ],
     importpath = "kubevirt.io/project-infra/external-plugins/botreview/review",

--- a/external-plugins/botreview/review/bump_kubevirtci_test.go
+++ b/external-plugins/botreview/review/bump_kubevirtci_test.go
@@ -71,7 +71,7 @@ func TestBumpKubevirtCI_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/kubevirtci-bump/hack_config-default.sh"],
 				},
 			},
-			want: newReviewResultWithData(bumpKubevirtCIApproveComment, bumpKubevirtCIDisapproveComment, nil, true, ""),
+			want: newReviewResultWithData(bumpKubevirtCIApproveComment, bumpKubevirtCIDisapproveComment, nil, ""),
 		},
 		{
 			name: "mixed image bump",
@@ -82,7 +82,7 @@ func TestBumpKubevirtCI_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"],
 				},
 			},
-			want: newReviewResultWithData(bumpKubevirtCIApproveComment, bumpKubevirtCIDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks}, true, ""),
+			want: newReviewResultWithData(bumpKubevirtCIApproveComment, bumpKubevirtCIDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks}, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/external-plugins/botreview/review/bump_kubevirtci_test.go
+++ b/external-plugins/botreview/review/bump_kubevirtci_test.go
@@ -55,7 +55,7 @@ func TestBumpKubevirtCI_Review(t1 *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   *BumpKubevirtCIResult
+		want   BotReviewResult
 	}{
 		{
 			name: "simple prow autobump",
@@ -71,7 +71,7 @@ func TestBumpKubevirtCI_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/kubevirtci-bump/hack_config-default.sh"],
 				},
 			},
-			want: &BumpKubevirtCIResult{},
+			want: newReviewResultWithData(bumpKubevirtCIApproveComment, bumpKubevirtCIDisapproveComment, nil, true, ""),
 		},
 		{
 			name: "mixed image bump",
@@ -82,9 +82,7 @@ func TestBumpKubevirtCI_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"],
 				},
 			},
-			want: &BumpKubevirtCIResult{
-				notMatchingHunks: map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks},
-			},
+			want: newReviewResultWithData(bumpKubevirtCIApproveComment, bumpKubevirtCIDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks}, true, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/external-plugins/botreview/review/image_update_test.go
+++ b/external-plugins/botreview/review/image_update_test.go
@@ -50,7 +50,7 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   *ProwJobImageUpdateResult
+		want   BotReviewResult
 	}{
 		{
 			name: "simple image bump",
@@ -60,7 +60,11 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/simple_bump-prow-job-images_sh.patch1"],
 				},
 			},
-			want: &ProwJobImageUpdateResult{},
+			want: &BasicReviewResult{
+				approveComment:    prowJobImageUpdateApproveComment,
+				disapproveComment: prowJobImageUpdateDisapproveComment,
+				canMerge:          true,
+			},
 		},
 		{
 			name: "mixed image bump",
@@ -69,14 +73,13 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"],
 				},
 			},
-			want: &ProwJobImageUpdateResult{
-				notMatchingHunks: map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": {diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks[0]}},
-			},
+			want: newReviewResultWithData(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": {diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks[0]}}, true, ""),
 		},
 	}
 	for _, tt := range tests {
 		t1.Run(tt.name, func(t1 *testing.T) {
 			t := &ProwJobImageUpdate{
+
 				relevantFileDiffs: tt.fields.relevantFileDiffs,
 			}
 			if got := t.Review(); !reflect.DeepEqual(got, tt.want) {

--- a/external-plugins/botreview/review/image_update_test.go
+++ b/external-plugins/botreview/review/image_update_test.go
@@ -60,11 +60,7 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/simple_bump-prow-job-images_sh.patch1"],
 				},
 			},
-			want: &BasicReviewResult{
-				approveComment:    prowJobImageUpdateApproveComment,
-				disapproveComment: prowJobImageUpdateDisapproveComment,
-				canMerge:          true,
-			},
+			want: NewCanMergeReviewResult(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment),
 		},
 		{
 			name: "mixed image bump",
@@ -73,7 +69,7 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"],
 				},
 			},
-			want: newReviewResultWithData(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": {diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks[0]}}, true, ""),
+			want: newReviewResultWithData(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": {diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks[0]}}, ""),
 		},
 	}
 	for _, tt := range tests {

--- a/external-plugins/botreview/review/prow_autobump_test.go
+++ b/external-plugins/botreview/review/prow_autobump_test.go
@@ -54,7 +54,7 @@ func TestProwAutobump_Review(t1 *testing.T) {
 	tests := []struct {
 		name   string
 		fields fields
-		want   *ProwAutobumpResult
+		want   BotReviewResult
 	}{
 		{
 			name: "simple prow autobump",
@@ -78,7 +78,7 @@ func TestProwAutobump_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/prow-autobump/github_ci_prow-deploy_kustom_overlays_ibmcloud-production_resources_prow-exporter-deployment.yaml"],
 				},
 			},
-			want: &ProwAutobumpResult{},
+			want: newReviewResultWithData(prowAutobumpApproveComment, prowAutobumpDisapproveComment, nil, false, prowAutoBumpShouldNotMergeReason),
 		},
 		{
 			name: "prow autobump with crd update",
@@ -103,11 +103,9 @@ func TestProwAutobump_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/prow-autobump/github_ci_prow-deploy_kustom_overlays_ibmcloud-production_resources_prow-exporter-deployment.yaml"],
 				},
 			},
-			want: &ProwAutobumpResult{
-				notMatchingHunks: map[string][]*diff.Hunk{
-					"github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml": diffFilePathsToDiffs["testdata/prow-autobump/github_ci_prow-deploy_kustom_base_manifests_test_infra_current_prowjob-crd_prowjob_customresourcedefinition.yaml"].Hunks,
-				},
-			},
+			want: newReviewResultWithData(prowAutobumpApproveComment, prowAutobumpDisapproveComment, map[string][]*diff.Hunk{
+				"github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml": diffFilePathsToDiffs["testdata/prow-autobump/github_ci_prow-deploy_kustom_base_manifests_test_infra_current_prowjob-crd_prowjob_customresourcedefinition.yaml"].Hunks,
+			}, false, prowAutoBumpShouldNotMergeReason),
 		},
 	}
 	for _, tt := range tests {

--- a/external-plugins/botreview/review/prow_autobump_test.go
+++ b/external-plugins/botreview/review/prow_autobump_test.go
@@ -78,7 +78,7 @@ func TestProwAutobump_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/prow-autobump/github_ci_prow-deploy_kustom_overlays_ibmcloud-production_resources_prow-exporter-deployment.yaml"],
 				},
 			},
-			want: newReviewResultWithData(prowAutobumpApproveComment, prowAutobumpDisapproveComment, nil, false, prowAutoBumpShouldNotMergeReason),
+			want: NewShouldNotMergeReviewResult(prowAutobumpApproveComment, prowAutobumpDisapproveComment, prowAutoBumpShouldNotMergeReason),
 		},
 		{
 			name: "prow autobump with crd update",
@@ -105,7 +105,7 @@ func TestProwAutobump_Review(t1 *testing.T) {
 			},
 			want: newReviewResultWithData(prowAutobumpApproveComment, prowAutobumpDisapproveComment, map[string][]*diff.Hunk{
 				"github/ci/prow-deploy/kustom/base/manifests/test_infra/current/prowjob-crd/prowjob_customresourcedefinition.yaml": diffFilePathsToDiffs["testdata/prow-autobump/github_ci_prow-deploy_kustom_base_manifests_test_infra_current_prowjob-crd_prowjob_customresourcedefinition.yaml"].Hunks,
-			}, false, prowAutoBumpShouldNotMergeReason),
+			}, prowAutoBumpShouldNotMergeReason),
 		},
 	}
 	for _, tt := range tests {

--- a/external-plugins/botreview/review/result.go
+++ b/external-plugins/botreview/review/result.go
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ */
+
+package review
+
+import (
+	"fmt"
+	"github.com/sourcegraph/go-diff/diff"
+)
+
+// BotReviewResult describes the interface of a review result for a pull request.
+type BotReviewResult interface {
+	String() string
+
+	// IsApproved states if the review has only expected changes
+	IsApproved() bool
+
+	// CanMerge states if the pull request can get merged without any further action
+	CanMerge() bool
+
+	// ShouldNotMergeReason returns the reason why the pull request should not get merged without a human review, if any
+	ShouldNotMergeReason() string
+
+	// AddReviewFailure stores the data of a hunk of code that failed review
+	AddReviewFailure(fileName string, hunks ...*diff.Hunk)
+
+	// ShortString provides a short description of the review result
+	ShortString() string
+}
+
+type ShouldNotMergeReason string
+
+func NewCanMergeReviewResult(approveComment string, disapproveComment string) BotReviewResult {
+	return &BasicReviewResult{
+		approveComment:    approveComment,
+		disapproveComment: disapproveComment,
+		canMerge:          true,
+	}
+}
+
+func NewShouldNotMergeReviewResult(approveComment string, disapproveComment string, reason string) BotReviewResult {
+	return &BasicReviewResult{
+		approveComment:       approveComment,
+		disapproveComment:    disapproveComment,
+		canMerge:             false,
+		shouldNotMergeReason: reason,
+	}
+}
+
+func newReviewResultWithData(approveComment string, disapproveComment string, notMatchingHunks map[string][]*diff.Hunk, canMerge bool, shouldNotMergeReason string) BotReviewResult {
+	return &BasicReviewResult{
+		approveComment:       approveComment,
+		disapproveComment:    disapproveComment,
+		notMatchingHunks:     notMatchingHunks,
+		canMerge:             canMerge,
+		shouldNotMergeReason: shouldNotMergeReason,
+	}
+}
+
+// BasicReviewResult is the default implementation to store the relevant data for creation of a PR comment.
+type BasicReviewResult struct {
+	approveComment       string
+	disapproveComment    string
+	notMatchingHunks     map[string][]*diff.Hunk
+	canMerge             bool
+	shouldNotMergeReason string
+}
+
+func (r *BasicReviewResult) String() string {
+	if r.IsApproved() {
+		return r.approveComment
+	} else {
+		comment := r.disapproveComment
+		for fileName, hunks := range r.notMatchingHunks {
+			comment += fmt.Sprintf("\nFile: `%s`", fileName)
+			for _, hunk := range hunks {
+				comment += fmt.Sprintf("\n```\n%s\n```", string(hunk.Body))
+			}
+		}
+		return comment
+	}
+}
+
+func (r *BasicReviewResult) IsApproved() bool {
+	return len(r.notMatchingHunks) == 0
+}
+
+func (r *BasicReviewResult) CanMerge() bool {
+	return r.canMerge
+}
+
+func (r *BasicReviewResult) ShouldNotMergeReason() string {
+	return r.shouldNotMergeReason
+}
+
+func (r *BasicReviewResult) AddReviewFailure(fileName string, hunks ...*diff.Hunk) {
+	if r.notMatchingHunks == nil {
+		r.notMatchingHunks = make(map[string][]*diff.Hunk)
+	}
+	if _, exists := r.notMatchingHunks[fileName]; !exists {
+		r.notMatchingHunks[fileName] = hunks
+	} else {
+		r.notMatchingHunks[fileName] = append(r.notMatchingHunks[fileName], hunks...)
+	}
+}
+
+func (r *BasicReviewResult) ShortString() string {
+	if r.IsApproved() {
+		return r.approveComment
+	} else {
+		comment := r.disapproveComment
+		comment += fmt.Sprintf("\nFiles:")
+		for fileName := range r.notMatchingHunks {
+			comment += fmt.Sprintf("\n* `%s`", fileName)
+		}
+		return comment
+	}
+}

--- a/external-plugins/botreview/review/result.go
+++ b/external-plugins/botreview/review/result.go
@@ -30,9 +30,6 @@ type BotReviewResult interface {
 	// IsApproved states if the review has only expected changes
 	IsApproved() bool
 
-	// CanMerge states if the pull request can get merged without any further action
-	CanMerge() bool
-
 	// ShouldNotMergeReason returns the reason why the pull request should not get merged without a human review, if any
 	ShouldNotMergeReason() string
 
@@ -43,13 +40,10 @@ type BotReviewResult interface {
 	ShortString() string
 }
 
-type ShouldNotMergeReason string
-
 func NewCanMergeReviewResult(approveComment string, disapproveComment string) BotReviewResult {
 	return &BasicReviewResult{
 		approveComment:    approveComment,
 		disapproveComment: disapproveComment,
-		canMerge:          true,
 	}
 }
 
@@ -57,17 +51,15 @@ func NewShouldNotMergeReviewResult(approveComment string, disapproveComment stri
 	return &BasicReviewResult{
 		approveComment:       approveComment,
 		disapproveComment:    disapproveComment,
-		canMerge:             false,
 		shouldNotMergeReason: reason,
 	}
 }
 
-func newReviewResultWithData(approveComment string, disapproveComment string, notMatchingHunks map[string][]*diff.Hunk, canMerge bool, shouldNotMergeReason string) BotReviewResult {
+func newReviewResultWithData(approveComment string, disapproveComment string, notMatchingHunks map[string][]*diff.Hunk, shouldNotMergeReason string) BotReviewResult {
 	return &BasicReviewResult{
 		approveComment:       approveComment,
 		disapproveComment:    disapproveComment,
 		notMatchingHunks:     notMatchingHunks,
-		canMerge:             canMerge,
 		shouldNotMergeReason: shouldNotMergeReason,
 	}
 }
@@ -77,7 +69,6 @@ type BasicReviewResult struct {
 	approveComment       string
 	disapproveComment    string
 	notMatchingHunks     map[string][]*diff.Hunk
-	canMerge             bool
 	shouldNotMergeReason string
 }
 
@@ -98,10 +89,6 @@ func (r *BasicReviewResult) String() string {
 
 func (r *BasicReviewResult) IsApproved() bool {
 	return len(r.notMatchingHunks) == 0
-}
-
-func (r *BasicReviewResult) CanMerge() bool {
-	return r.canMerge
 }
 
 func (r *BasicReviewResult) ShouldNotMergeReason() string {

--- a/external-plugins/botreview/review/review.go
+++ b/external-plugins/botreview/review/review.go
@@ -165,7 +165,9 @@ func (r *Reviewer) AttachReviewComments(botReviewResults []BotReviewResult, gith
 	shortBotReviewComments := make([]string, 0, len(botReviewResults))
 	for _, reviewResult := range botReviewResults {
 		isApproved = isApproved && reviewResult.IsApproved()
-		shouldNotMergeReasons = append(shouldNotMergeReasons, reviewResult.ShouldNotMergeReason())
+		if reviewResult.ShouldNotMergeReason() != "" {
+			shouldNotMergeReasons = append(shouldNotMergeReasons, reviewResult.ShouldNotMergeReason())
+		}
 		botReviewComments = append(botReviewComments, fmt.Sprintf("%s", reviewResult))
 		shortBotReviewComments = append(shortBotReviewComments, fmt.Sprintf(reviewResult.ShortString()))
 	}

--- a/external-plugins/botreview/review/review.go
+++ b/external-plugins/botreview/review/review.go
@@ -160,11 +160,11 @@ func (r *Reviewer) AttachReviewComments(botReviewResults []BotReviewResult, gith
 		return fmt.Errorf("error while fetching user data: %v", err)
 	}
 	shouldNotMergeReasons := []string{}
-	isApproved, canMerge := true, true
+	isApproved := true
 	botReviewComments := make([]string, 0, len(botReviewResults))
 	shortBotReviewComments := make([]string, 0, len(botReviewResults))
 	for _, reviewResult := range botReviewResults {
-		isApproved, canMerge = isApproved && reviewResult.IsApproved(), canMerge && reviewResult.CanMerge()
+		isApproved = isApproved && reviewResult.IsApproved()
 		shouldNotMergeReasons = append(shouldNotMergeReasons, reviewResult.ShouldNotMergeReason())
 		botReviewComments = append(botReviewComments, fmt.Sprintf("%s", reviewResult))
 		shortBotReviewComments = append(shortBotReviewComments, fmt.Sprintf(reviewResult.ShortString()))


### PR DESCRIPTION
There was lots of duplication wrt storing review result data, i.e. there was a struct specialized holding the result data per review strategy. This was unnecessary since all these were doing the same thing, like storing hunks that were special and storing whether the result would be mergable right away.

These structs all have been replaced by the `BasicReviewResult` struct that is used for every review strategy now.

Furthermore the `BasicReviewResult` itself and the result interface have been moved to their own file.

/cc @brianmcarey 