### PR TITLE
report, flake-stats: filter root lanes from report

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1996,6 +1996,7 @@ periodics:
         output_file=/tmp/flake-stats-14days.html
         copy_file="flake-stats-14days-$(date +%Y-%m-%d).html"
         go run ./robots/cmd/flake-stats/main.go \
+          '--filter-lane-regex=.*-root' \
           --output-file ${output_file} \
           --overwrite-output-file=true
         gsutil cp ${output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/


### PR DESCRIPTION
Since our reports are currently polluted from the sig-storage-root lanes we add a filter regex to exclude them from the report.

/cc @brianmcarey 