### PR TITLE
release-tool: Update phase 2 jobs to be considered phase 1 when forking a new branch

### DIFF
--- a/releng/release-tool/BUILD.bazel
+++ b/releng/release-tool/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "@com_github_google_go_github_v32//github:go_default_library",
         "@com_github_masterminds_semver//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
     ],
 )
@@ -49,5 +50,8 @@ go_test(
     name = "go_default_test",
     srcs = ["release-tool_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_google_go_github_v32//github:go_default_library"],
+    deps = [
+        "@com_github_google_go_github_v32//github:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+    ],
 )


### PR DESCRIPTION
During new release branch creation, we should convert phase 2 jobs
to be considered phase 1, by setting `always_run=true`,
because phased plugin is used only for main branch.


Note: we might want to consider https://github.com/kubevirt/project-infra/pull/3184 (by removing `run_before_merge` as well)
but since the jobs become phase 1 it shouldn't affect even if the field remains.
