### PR TITLE
Make the 1.29 kubevirtci presubmit required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -228,7 +228,7 @@ presubmits:
           path: /dev
           type: Directory
         name: devices
-  - always_run: true
+  - always_run: false
     cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
@@ -332,7 +332,7 @@ presubmits:
             memory: 1Gi
         securityContext:
           privileged: true
-  - always_run: false
+  - always_run: true
     cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
With the introduction of the 1.29 provider[1] - the presubmit should become required.

The 1.26 presubmit is no longer required as this provider will be removed shortly.

[1] https://github.com/kubevirt/kubevirtci/pull/1094

/cc @dhiller 