### PR TITLE
sig-release: create upcoming-changes.md periodically

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2202,3 +2202,39 @@ periodics:
         privileged: true
     nodeSelector:
       type: bare-metal-external
+- annotations:
+    testgrid-create-test-group: "false"
+  cluster: kubevirt-prow-control-plane
+  cron: 45 1 * * *
+  name: periodic-kubevirt-update-upcoming-changes
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  - org: kubevirt
+    repo: kubevirt
+    base_ref: main
+  - org: kubevirt
+    repo: sig-release
+    base_ref: main
+  labels:
+    preset-github-credentials: "true"
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
+      env:
+      command: [ "/bin/sh", "-ce" ]
+      args:
+      - |
+        project_infra_dir=$(cd ../project-infra && pwd)
+        kubevirt_dir=$(cd ../kubevirt && pwd)
+        sig_release_dir=$(cd ../sig-release && pwd)
+        git-pr.sh -c "cd ../project-infra && bazelisk run //releng/feature-announce -- --V=5 --output-file=${sig_release_dir}/upcoming-changes.md --org kubevirt --repo kubevirt --path-to-repository $kubevirt_dir --github-token-file /etc/github/oauth" -p ${sig_release_dir} -s 'Automated run of //releng/feature-announce' -r sig-release -b update-support-matrix -T main
+      resources:
+        requests:
+          memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2219,22 +2219,44 @@ periodics:
   - org: kubevirt
     repo: kubevirt
     base_ref: main
-  - org: kubevirt
-    repo: sig-release
-    base_ref: main
   labels:
     preset-github-credentials: "true"
   spec:
     containers:
-    - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
+    - image: quay.io/kubevirtci/bootstrap:v20231219-bf5e580
       env:
+      - name: GIT_AUTHOR_NAME
+        value: kubevirt-bot
+      - name: GIT_AUTHOR_EMAIL
+        value: kubevirtbot@redhat.com
+      - name: GIT_REPO_URL
+        value: https://kubevirt-bot@github.com/kubevirt/sig-release.git
       command: [ "/bin/sh", "-ce" ]
       args:
       - |
+        set -x
         project_infra_dir=$(cd ../project-infra && pwd)
         kubevirt_dir=$(cd ../kubevirt && pwd)
+        (
+          cd ..
+          git clone ${GIT_REPO_URL}
+          cd sig-release
+          git config user.email "$GIT_AUTHOR_EMAIL"
+          git config user.name "$GIT_AUTHOR_NAME"
+        )
         sig_release_dir=$(cd ../sig-release && pwd)
-        git-pr.sh -c "cd ../project-infra && bazelisk run //releng/feature-announce -- --V=5 --output-file=${sig_release_dir}/upcoming-changes.md --org kubevirt --repo kubevirt --path-to-repository $kubevirt_dir --github-token-file /etc/github/oauth" -p ${sig_release_dir} -s 'Automated run of //releng/feature-announce' -r sig-release -b update-support-matrix -T main
+        cd ${project_infra_dir}
+        bazelisk run //releng/feature-announce -- \
+            --V=5 \
+            --output-file=${sig_release_dir}/upcoming-changes.md \
+            --org kubevirt \
+            --repo kubevirt \
+            --path-to-repository $kubevirt_dir \
+            --github-token-file /etc/github/oauth
+        cd ${sig_release_dir}
+        git add upcoming-changes.md
+        git commit --signoff -m "robot //releng/feature-announce: update list of notable changes for next KubeVirt release"
+        git push ${GIT_REPO_URL} HEAD:main
       resources:
         requests:
           memory: "200Mi"

--- a/releng/feature-announce/BUILD.bazel
+++ b/releng/feature-announce/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["feature-announce.go"],
+    embedsrcs = ["upcoming-changes.gomd"],
+    importpath = "kubevirt.io/project-infra/releng/feature-announce",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_google_go_github//github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_test_infra//prow/config/secret:go_default_library",
+        "@org_golang_x_oauth2//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "feature-announce",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["feature-announce_test.go"],
+    embed = [":go_default_library"],
+)

--- a/releng/feature-announce/feature-announce.go
+++ b/releng/feature-announce/feature-announce.go
@@ -1,0 +1,318 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ */
+
+package main
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"github.com/google/go-github/github"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+	"k8s.io/test-infra/prow/config/secret"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+type options struct {
+	dryRun          bool
+	logLevel        int
+	githubTokenFile string
+	org             string
+	repo            string
+	repositoryPath  string
+	outputFile      string
+}
+
+//go:embed "upcoming-changes.gomd"
+var upcomingChangesTemplate string
+
+func (o *options) Validate() error {
+	if o.org == "" {
+		return fmt.Errorf("org is required")
+	}
+	if o.repo == "" {
+		return fmt.Errorf("repo is required")
+	}
+	if o.githubTokenFile == "" {
+		return fmt.Errorf("github-token-file is required")
+	}
+	if o.repositoryPath == "" {
+		return fmt.Errorf("path-to-repository is required")
+	}
+	if o.outputFile == "" {
+		temp, err := os.CreateTemp("", "upcoming-changes-*.md")
+		if err != nil {
+			return err
+		}
+		o.outputFile = temp.Name()
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	flag.IntVar(&o.logLevel, "V", int(log.WarnLevel), "log level from logrus")
+	flag.StringVar(&o.org, "org", "", "The project org")
+	flag.StringVar(&o.repo, "repo", "", "The project repo")
+	flag.BoolVar(&o.dryRun, "dry-run", true, "Should this be a dry run")
+	flag.StringVar(&o.githubTokenFile, "github-token-file", "", "file containing the github token.")
+	flag.StringVar(&o.repositoryPath, "path-to-repository", "", "path to git repository")
+	flag.StringVar(&o.outputFile, "output-file", "", "path to output file, which will be overwritten if it exists")
+	flag.Parse()
+	return o
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		log.Fatalf("Invalid options: %v", err)
+	}
+
+	log.SetFormatter(&log.JSONFormatter{})
+	log.SetLevel(log.Level(o.logLevel))
+
+	logger := log.StandardLogger().WithField("app", "feature-announce")
+
+	if err := secret.Add(o.githubTokenFile); err != nil {
+		logger.WithError(err).Fatal("error starting secrets agent")
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: string(secret.GetSecret(o.githubTokenFile))},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	githubClient := github.NewClient(tc)
+
+	gitCli := gitCommandLine{
+		directory: o.repositoryPath,
+		logger:    logger,
+	}
+	announcer := featureAnnouncer{
+		githubClient: githubClient,
+		gitCli:       gitCli,
+		options:      o,
+		logger:       logger,
+	}
+
+	err := announcer.generateUpcomingChangesAnnouncement()
+	if err != nil {
+		logger.WithError(err).Fatalf("failed to create announcement")
+	}
+}
+
+type UpcomingChangesAnnouncementData struct {
+	UpcomingChanges []*ReleaseNote
+}
+
+type gitCommandLine struct {
+	directory string
+	logger    *log.Entry
+}
+
+func (g *gitCommandLine) execute(args ...string) (string, error) {
+	args = append([]string{"-C", g.directory}, args...)
+	g.logger.Debugf("executing 'git %v", args)
+	cmd := exec.Command("git", args...)
+	bytes, err := cmd.CombinedOutput()
+	output := string(bytes)
+	if err != nil {
+		return "", fmt.Errorf("git command %q failed: %w (%s)", args, err, output)
+	}
+	return output, nil
+}
+
+type featureAnnouncer struct {
+	options      options
+	gitCli       gitCommandLine
+	githubClient *github.Client
+	logger       *log.Entry
+}
+
+func (f *featureAnnouncer) generateUpcomingChangesAnnouncement() error {
+	latestReleaseTag, err := f.fetchLatestTag()
+	if err != nil {
+		return fmt.Errorf("error fetching latest tag: %w", err)
+	}
+	features, err := f.fetchCodeChanges(latestReleaseTag)
+	if err != nil {
+		return fmt.Errorf("error fetching code changes for tag %s: %w", latestReleaseTag, err)
+	}
+
+	return f.writeUpcomingChangesAnnouncement(features)
+}
+
+func (f *featureAnnouncer) fetchLatestTag() (string, error) {
+	// fetch latest tag from branch
+	//     a)										  b)						 c)
+	// 	  `git tag --list --sort="-version:refname" | grep -vE 'alpha|beta|rc' | head -1`
+	gitTagCmdOutput, err := f.gitCli.execute("tag", "--list", fmt.Sprintf("--sort=%s", "-version:refname"))
+	if err != nil {
+		return "", fmt.Errorf("error fetching tag: %w", err)
+	}
+	if gitTagCmdOutput == "" {
+		return "", fmt.Errorf("error fetching tag: no output")
+	}
+	gitTags := strings.Split(gitTagCmdOutput, "\n")
+	versionRegex := regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+$`)
+	for _, tag := range gitTags {
+		if !versionRegex.MatchString(tag) {
+			continue
+		}
+		return tag, nil
+	}
+	return "", fmt.Errorf("error fetching latest tag: no tag found")
+}
+
+func (f *featureAnnouncer) fetchCodeChanges(latestReleaseTag string) ([]*ReleaseNote, error) {
+	// 2. fetch pull request references from merge commits
+	//    `git logger --oneline --merges v1.1.0..`
+	logOutput, err := f.gitCli.execute("log", "--merges", "--oneline", fmt.Sprintf("%s..", latestReleaseTag))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching merge commit logs: %w", err)
+	}
+	mergeCommitLogLines := strings.Split(logOutput, "\n")
+	mergePRRegex := regexp.MustCompile(`Merge pull request #([0-9]+)`)
+
+	var features []*ReleaseNote
+	for _, line := range mergeCommitLogLines {
+		if !mergePRRegex.MatchString(line) {
+			continue
+		}
+		prRegexMatches := mergePRRegex.FindStringSubmatch(line)
+		prNumber, err := strconv.Atoi(prRegexMatches[1])
+		if err != nil {
+			return nil, fmt.Errorf("error fetching pull request number from %q: %w", line, err)
+		}
+		releaseNote, err := f.getReleaseNote(prNumber)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching pull request data from %q: %w", line, err)
+		}
+		if releaseNote == nil {
+			continue
+		}
+		features = append(features, releaseNote)
+	}
+	return features, nil
+}
+
+type ReleaseNote struct {
+	PullRequestNumber int
+	GitHubHandle      string
+	ReleaseNote       string
+}
+
+func (f *featureAnnouncer) getReleaseNote(prNumber int) (*ReleaseNote, error) {
+
+	f.logger.Debugf("Searching for release note for PR #%d", prNumber)
+	pr, _, err := f.githubClient.PullRequests.Get(context.Background(), f.options.org, f.options.repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, label := range pr.Labels {
+		if label.Name != nil && *label.Name == "release-note-none" {
+			return nil, nil
+		}
+	}
+
+	if pr.Body == nil || *pr.Body == "" {
+		return nil, err
+	}
+
+	body := strings.Split(*pr.Body, "\n")
+
+	return f.extractReleaseNoteContent(prNumber, body, *pr.User.Login)
+}
+
+func (f *featureAnnouncer) extractReleaseNoteContent(number int, body []string, gitHubHandle string) (*ReleaseNote, error) {
+	var releaseNoteLines []string
+	releaseNoteStarted := false
+	for _, line := range body {
+		switch releaseNoteStarted {
+		case false:
+			if strings.Contains(line, "```release-note") {
+				releaseNoteStarted = true
+			}
+		case true:
+			if !strings.Contains(line, "```") {
+				line = strings.TrimSpace(line)
+				line = strings.ReplaceAll(line, "\r", "")
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				releaseNoteLines = append(releaseNoteLines, line)
+				continue
+			}
+			note := strings.Join(releaseNoteLines, "\n")
+			if strings.Contains(strings.ToLower(note), "none") {
+				return nil, nil
+			}
+			return &ReleaseNote{
+				PullRequestNumber: number,
+				GitHubHandle:      gitHubHandle,
+				ReleaseNote:       note,
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *featureAnnouncer) writeUpcomingChangesAnnouncement(features []*ReleaseNote) error {
+
+	var sanitizedFeatures []*ReleaseNote
+	for _, feature := range features {
+		sanitizedFeatures = append(sanitizedFeatures, &ReleaseNote{
+			PullRequestNumber: feature.PullRequestNumber,
+			GitHubHandle:      feature.GitHubHandle,
+			ReleaseNote:       f.sanitizeForMarkdown(feature.ReleaseNote),
+		})
+	}
+
+	writer, err := os.OpenFile(f.options.outputFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return fmt.Errorf("failed to write to file %q: %w", f.options.outputFile, err)
+	}
+
+	upcomingChangesTemplateInstance, err := template.New("upcoming-changes").Parse(upcomingChangesTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse go template: %w", err)
+	}
+
+	err = upcomingChangesTemplateInstance.Execute(writer, UpcomingChangesAnnouncementData{
+		UpcomingChanges: sanitizedFeatures,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to write to file %q: %w", f.options.outputFile, err)
+	}
+	f.logger.Infof("output file written to %q", f.options.outputFile)
+	return nil
+}
+
+func (f *featureAnnouncer) sanitizeForMarkdown(input string) string {
+	input = strings.ReplaceAll(input, "\n", "<br>")
+	return input
+}

--- a/releng/feature-announce/feature-announce_test.go
+++ b/releng/feature-announce/feature-announce_test.go
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ */
+
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_featureAnnouncer_extractReleaseNoteContent(t *testing.T) {
+	type args struct {
+		number int
+		body   []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *ReleaseNote
+		wantErr bool
+	}{
+		{
+			name: "no release note",
+			args: args{
+				number: 1742,
+				body:   strings.Split(`NONE`, "\n"),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "release note NONE",
+			args: args{
+				number: 1742,
+				body: []string{
+					"```release-note",
+					"NONE",
+					"```",
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "release note MEH",
+			args: args{
+				number: 1742,
+				body: []string{
+					"```release-note",
+					"MEH",
+					"```",
+				},
+			},
+			want: &ReleaseNote{
+				PullRequestNumber: 1742,
+				GitHubHandle:      "someUser",
+				ReleaseNote:       "MEH",
+			},
+			wantErr: false,
+		},
+		{
+			name: "release note multiline",
+			args: args{
+				number: 1742,
+				body: []string{
+					"```release-note",
+					"",
+					" - documents steps to build the KubeVirt builder container",
+					"",
+					"```",
+				},
+			},
+			want: &ReleaseNote{
+				PullRequestNumber: 1742,
+				GitHubHandle:      "someUser",
+				ReleaseNote:       "- documents steps to build the KubeVirt builder container",
+			},
+			wantErr: false,
+		},
+		{
+			name: "release note multiline 2",
+			args: args{
+				number: 1742,
+				body: []string{
+					"```release-note",
+					`Added “adm” subcommand under “virtctl”, and “log-verbosity" subcommand under “adm”. The log-verbosity command is:
+- To show the log verbosity of one or more components.
+- To set the log verbosity of one or more components.
+- To reset the log verbosity of all components (reset to the default verbosity (2)).`,
+					"```",
+				},
+			},
+			want: &ReleaseNote{
+				PullRequestNumber: 1742,
+				GitHubHandle:      "someUser",
+				ReleaseNote: `Added “adm” subcommand under “virtctl”, and “log-verbosity" subcommand under “adm”. The log-verbosity command is:
+- To show the log verbosity of one or more components.
+- To set the log verbosity of one or more components.
+- To reset the log verbosity of all components (reset to the default verbosity (2)).`,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &featureAnnouncer{}
+			got, err := f.extractReleaseNoteContent(tt.args.number, tt.args.body, "someUser")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("extractReleaseNoteContent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractReleaseNoteContent() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/releng/feature-announce/upcoming-changes.gomd
+++ b/releng/feature-announce/upcoming-changes.gomd
@@ -1,0 +1,24 @@
+{{- /*
+
+    This file is part of the KubeVirt project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Copyright the KubeVirt Authors.
+
+*/ -}}
+{{- /* gotype: kubevirt.io/project-infra/releng/feature-announce.UpcomingChangesAnnouncementData */ -}}
+| Upcoming changes | PR                                                                   | Author                                          |
+|------------------|----------------------------------------------------------------------|-------------------------------------------------|
+{{ range $codeChange := $.UpcomingChanges }}| {{ $codeChange.ReleaseNote }}  | [#{{ $codeChange.PullRequestNumber }}](https://github.com/kubevirt/kubevirt/pull/{{ $codeChange.PullRequestNumber }}) | [{{ $codeChange.GitHubHandle }}](https://github.com/{{ $codeChange.GitHubHandle }}) |
+{{ end }}

--- a/releng/feature-announce/upcoming-changes.gomd
+++ b/releng/feature-announce/upcoming-changes.gomd
@@ -18,7 +18,20 @@
 
 */ -}}
 {{- /* gotype: kubevirt.io/project-infra/releng/feature-announce.UpcomingChangesAnnouncementData */ -}}
+---
+title: Noteworthy changes for the next KubeVirt release
+---
+
+# Noteworthy changes for the next KubeVirt release
+
+This list contains the noteworthy changes made after the latest KubeVirt release. The community expects these changes to be included in the next Kubevirt release.
+
+> [!WARNING]
+> **Please be aware that any of these might be excluded from the next release.**
+
 | Upcoming changes | PR                                                                   | Author                                          |
 |------------------|----------------------------------------------------------------------|-------------------------------------------------|
 {{ range $codeChange := $.UpcomingChanges }}| {{ $codeChange.ReleaseNote }}  | [#{{ $codeChange.PullRequestNumber }}](https://github.com/kubevirt/kubevirt/pull/{{ $codeChange.PullRequestNumber }}) | [{{ $codeChange.GitHubHandle }}](https://github.com/{{ $codeChange.GitHubHandle }}) |
 {{ end }}
+
+_This page is updated daily._


### PR DESCRIPTION
This PR adds two things:

1) a tool in `releng` folder that will fetch all merge commits since the last release tag, then it will fetch the release notes from the PRs and generate a markdown document.
2) a periodic job that executes the above tool and creates a PR to add the document to sig-release repo

Preview of the document generated here: https://github.com/kubevirt/sig-release/pull/18/files?short_path=bdbf887#diff-bdbf887f46278abcf7309f79a391ef07e23d20ee143b5a01389004dfead19a27

/cc @aburdenthehand @xpivarc @fabiand 