### PR TITLE
project-infra, labels: add group to allow applying labels

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -998,6 +998,13 @@ orgs:
          - vasiliy-ul
          - acardace
          - alicefr
+      kubevirtproject-infra-label:
+        description: "Users who can apply restricted labels to any issue inside the kubevirt/project-infra repo"
+        members:
+         - dhiller
+         - brianmcarey
+         - enp0s3
+         - xpivarc
       sig-scale:
         description: members of the scale and performance group
         members:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -701,3 +701,7 @@ label:
     - allowed_teams:
       - kubevirtkubevirt-label
       label: good-first-issue
+    'kubevirt/project-infra':
+    - allowed_teams:
+      - kubevirtproject-infra-label
+      label: good-first-issue


### PR DESCRIPTION
Currently only maintainers (i.e. the folks inside kubevirtorg-label) can apply good-first-issue to project-infra issues.

Symptom: https://github.com/kubevirt/project-infra/issues/3031#issuecomment-1867689102

Adds a group that can apply good-first-issue to project-infra issues.