### PR TITLE
plugins: Introduce checklist plugin

### DIFF
--- a/docs/infrastructure-components.md
+++ b/docs/infrastructure-components.md
@@ -45,7 +45,7 @@ kubevirt-prow-control-plane
 
 * Prow control plane: all the Prow components, including the main microservices
 (crier, deck, hook, horologium, prow-controller-manager, tide, sink), several
-external plugins (bot-review, rehearse, release-blocker) and secondary components
+external plugins (bot-review, rehearse, release-blocker, checklist) and secondary components
 (cherrypicker, gcsweb, ghproxy, label-sync, needs-rebase, prow-exporter,
 pushgateway, statusreconciler).
 

--- a/external-plugins/checklist/Makefile
+++ b/external-plugins/checklist/Makefile
@@ -1,0 +1,17 @@
+
+.PHONY: all clean format test push
+all: format test push
+bazelbin := bazelisk
+
+build:
+	$(bazelbin) build //external-plugins/checklist/plugin
+
+format:
+	gofmt -w .
+
+test:
+	$(bazelbin) test //external-plugins/checklist/...
+
+push:
+	$(bazelbin) run --stamp --workspace_status_command="./hack/print-workspace-status-no-git-tag.sh" //external-plugins/checklist/plugin:push
+	bash -x ../../hack/update-deployments-with-latest-image.sh quay.io/kubevirtci/checklist

--- a/external-plugins/checklist/plugin/BUILD.bazel
+++ b/external-plugins/checklist/plugin/BUILD.bazel
@@ -1,0 +1,61 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/external-plugins/checklist/plugin",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//external-plugins/checklist/plugin/handler:go_default_library",
+        "//external-plugins/checklist/plugin/server:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_test_infra//pkg/flagutil:go_default_library",
+        "@io_k8s_test_infra//prow/config:go_default_library",
+        "@io_k8s_test_infra//prow/config/secret:go_default_library",
+        "@io_k8s_test_infra//prow/flagutil:go_default_library",
+        "@io_k8s_test_infra//prow/interrupts:go_default_library",
+        "@io_k8s_test_infra//prow/pluginhelp:go_default_library",
+        "@io_k8s_test_infra//prow/pluginhelp/externalplugins:go_default_library",
+    ],
+)
+
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "app",
+    base = "@infra-base//image",
+    embed = [":go_default_library"],
+)
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+
+container_push(
+    name = "push",
+    format = "Docker",
+    image = ":app",
+    registry = "quay.io",
+    repository = "kubevirtci/checklist",
+    tag = "{DOCKER_TAG}",
+)
+
+go_binary(
+    name = "plugin",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "checklist_suite_test.go",
+        "checklist_test.go",
+    ],
+    deps = [
+        "//external-plugins/checklist/plugin/handler:go_default_library",
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
+        "@io_k8s_test_infra//prow/github/fakegithub:go_default_library",
+    ],
+)

--- a/external-plugins/checklist/plugin/checklist_suite_test.go
+++ b/external-plugins/checklist/plugin/checklist_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestChecklist(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Checklist Suite")
+}

--- a/external-plugins/checklist/plugin/checklist_test.go
+++ b/external-plugins/checklist/plugin/checklist_test.go
@@ -1,0 +1,145 @@
+package main_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+
+	"kubevirt.io/project-infra/external-plugins/checklist/plugin/handler"
+)
+
+const (
+	org      = "kubevirt"
+	repo     = "kubevirt"
+	baseRef  = "main"
+	orgRepo  = org + "/" + repo
+	prNumber = 17
+)
+
+var _ = Describe("Checklist", func() {
+	Context("A valid pull request event", func() {
+		Context("PR is opened with empty checklist", func() {
+			It("Should label the PR with incomplete checklist label", func() {
+				gh := fakegithub.NewFakeClient()
+
+				var event github.PullRequestEvent
+				By("Generating a fake pull request event and registering it to the github client", func() {
+					event = github.PullRequestEvent{
+						Action: github.PullRequestActionOpened,
+						GUID:   "guid",
+						Repo: github.Repo{
+							FullName: orgRepo,
+						},
+						Sender: github.User{
+							Login: "testuser",
+						},
+						PullRequest: github.PullRequest{
+							Number: prNumber,
+							State:  "open",
+							Body:   "- [ ] Design: abc",
+						},
+					}
+
+					gh.PullRequests = map[int]*github.PullRequest{
+						prNumber: &event.PullRequest,
+					}
+				})
+
+				By("Sending the event to the checklist plugin server", func() {
+					fakelog := logrus.New()
+					eventsChan := make(chan *handler.GitHubEvent)
+					eventsHandler := handler.NewGitHubEventsHandler(
+						eventsChan,
+						fakelog,
+						gh)
+
+					handlerEvent, err := makeHandlerPullRequestEvent(&event)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					eventsHandler.Handle(handlerEvent)
+
+					Expect(len(gh.IssueLabelsAdded)).To(Equal(1), "Expected github labels to be added")
+					Expect(gh.IssueLabelsAdded[0]).To(Equal(fmt.Sprintf("%s#%d:do-not-merge/incomplete-checklist", orgRepo, prNumber)))
+				})
+
+			})
+
+		})
+
+		Context("PR is edited, label exists, checklist is fully done", func() {
+			It("Should remove the label from the PR", func() {
+				gh := fakegithub.NewFakeClient()
+				gh.IssueLabelsExisting = append(gh.IssueLabelsExisting, issueLabels(handler.IncompleteChecklistLabel)...)
+
+				var event github.PullRequestEvent
+				By("Generating a fake pull request event and registering it to the github client", func() {
+					event = github.PullRequestEvent{
+						Action: github.PullRequestActionEdited,
+						GUID:   "guid",
+						Repo: github.Repo{
+							FullName: orgRepo,
+						},
+						Sender: github.User{
+							Login: "testuser",
+						},
+						PullRequest: github.PullRequest{
+							Number: prNumber,
+							State:  "open",
+							Body:   "- [x] Design: abc",
+						},
+					}
+
+					gh.PullRequests = map[int]*github.PullRequest{
+						prNumber: &event.PullRequest,
+					}
+				})
+
+				By("Sending the event to the checklist plugin server", func() {
+					fakelog := logrus.New()
+					eventsChan := make(chan *handler.GitHubEvent)
+					eventsHandler := handler.NewGitHubEventsHandler(
+						eventsChan,
+						fakelog,
+						gh)
+
+					handlerEvent, err := makeHandlerPullRequestEvent(&event)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					eventsHandler.Handle(handlerEvent)
+
+					Expect(len(gh.IssueLabelsRemoved)).To(Equal(1), "Expected github labels to be removed")
+					Expect(gh.IssueLabelsRemoved[0]).To(Equal(fmt.Sprintf("%s#%d:do-not-merge/incomplete-checklist", orgRepo, prNumber)))
+				})
+
+			})
+
+		})
+	})
+
+})
+
+func makeHandlerPullRequestEvent(event *github.PullRequestEvent) (*handler.GitHubEvent, error) {
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	handlerEvent := &handler.GitHubEvent{
+		Type:    "pull_request",
+		GUID:    event.GUID,
+		Payload: eventBytes,
+	}
+	return handlerEvent, nil
+}
+
+func issueLabels(labels ...string) []string {
+	var ls []string
+	for _, label := range labels {
+		ls = append(ls, fmt.Sprintf("%s#%d:%s", orgRepo, prNumber, label))
+	}
+	return ls
+}

--- a/external-plugins/checklist/plugin/handler/BUILD.bazel
+++ b/external-plugins/checklist/plugin/handler/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["handler.go"],
+    importpath = "kubevirt.io/project-infra/external-plugins/checklist/plugin/handler",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_test_infra//prow/git/v2:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
+    ],
+)

--- a/external-plugins/checklist/plugin/handler/handler.go
+++ b/external-plugins/checklist/plugin/handler/handler.go
@@ -1,0 +1,138 @@
+package handler
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	gitv2 "k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
+)
+
+var log *logrus.Logger
+
+const IncompleteChecklistLabel = "do-not-merge/incomplete-checklist"
+
+func init() {
+	log = logrus.New()
+	log.SetOutput(os.Stdout)
+}
+
+type GitHubEvent struct {
+	Type    string
+	GUID    string
+	Payload []byte
+}
+
+type githubClientInterface interface {
+	GetPullRequest(string, string, int) (*github.PullRequest, error)
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	AddLabel(org, repo string, number int, label string) error
+	RemoveLabel(org, repo string, number int, label string) error
+}
+
+type GitHubEventsHandler struct {
+	eventsChan <-chan *GitHubEvent
+	logger     *logrus.Logger
+	ghClient   githubClientInterface
+}
+
+func NewGitHubEventsHandler(
+	eventsChan <-chan *GitHubEvent,
+	logger *logrus.Logger,
+	ghClient githubClientInterface) *GitHubEventsHandler {
+
+	return &GitHubEventsHandler{
+		eventsChan: eventsChan,
+		logger:     logger,
+		ghClient:   ghClient,
+	}
+}
+
+func (h *GitHubEventsHandler) Handle(incomingEvent *GitHubEvent) {
+	log.Infoln("GitHub events handler started")
+	eventLog := log.WithField("event-guid", incomingEvent.GUID)
+	switch incomingEvent.Type {
+	case "pull_request":
+		eventLog.Infoln("Handling pull request event")
+		var event github.PullRequestEvent
+		if err := json.Unmarshal(incomingEvent.Payload, &event); err != nil {
+			eventLog.WithError(err).Error("Could not unmarshal event.")
+			return
+		}
+		h.handlePullRequestEvent(eventLog, &event)
+	default:
+		return
+	}
+}
+
+func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, event *github.PullRequestEvent) {
+	log.Infof("Handling updated pull request: %s [%d]", event.Repo.FullName, event.PullRequest.Number)
+
+	if !h.shouldActOnPREvent(event) {
+		return
+	}
+
+	org, repo, err := gitv2.OrgRepo(event.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get org/repo from the event")
+		return
+	}
+
+	pr, err := h.ghClient.GetPullRequest(org, repo, event.PullRequest.Number)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get PR number %d", event.PullRequest.Number)
+		return
+	}
+
+	hasLabel, err := h.hasChecklistLabel(org, repo, event.PullRequest.Number)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get PR labels %d", event.PullRequest.Number)
+		return
+	}
+
+	if checkPRBody(pr) {
+		if hasLabel {
+			err = h.ghClient.RemoveLabel(org, repo, event.PullRequest.Number, IncompleteChecklistLabel)
+			if err != nil {
+				log.WithError(err).Errorf("Could not remove label from PR %d", event.PullRequest.Number)
+				return
+			}
+		}
+	} else {
+		if !hasLabel {
+			err = h.ghClient.AddLabel(org, repo, event.PullRequest.Number, IncompleteChecklistLabel)
+			if err != nil {
+				log.WithError(err).Errorf("Could not add label to PR %d", event.PullRequest.Number)
+				return
+			}
+		}
+	}
+}
+
+func (h *GitHubEventsHandler) shouldActOnPREvent(event *github.PullRequestEvent) bool {
+	return event.Action == github.PullRequestActionOpened || event.Action == github.PullRequestActionEdited
+}
+
+func checkPRBody(pr *github.PullRequest) bool {
+	list := []string{"Design", "PR", "Code", "Refactor", "Upgrade", "Testing", "Documentation", "Community"}
+	for _, item := range list {
+		item = "- [ ] " + item + ":"
+		if strings.Contains(pr.Body, item) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (h *GitHubEventsHandler) hasChecklistLabel(org, repo string, prNum int) (bool, error) {
+	l, err := h.ghClient.GetIssueLabels(org, repo, prNum)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get PR labels")
+		return false, err
+	}
+
+	return github.HasLabel(IncompleteChecklistLabel, l), nil
+}

--- a/external-plugins/checklist/plugin/main.go
+++ b/external-plugins/checklist/plugin/main.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pluginhelp"
+
+	"kubevirt.io/project-infra/external-plugins/checklist/plugin/handler"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/config/secret"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
+
+	"kubevirt.io/project-infra/external-plugins/checklist/plugin/server"
+)
+
+type options struct {
+	dryRun         bool
+	hmacSecretFile string
+	endpoint       string
+	port           int
+	jobsNs         string
+	github         prowflagutil.GitHubOptions
+}
+
+func (o *options) validate() {
+	var errs []error
+	err := o.github.Validate(o.dryRun)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		for _, err := range errs {
+			logrus.WithError(err).Error("entry validation failure")
+		}
+		logrus.Fatalf("Arguments validation failed!")
+	}
+}
+
+func gatherOptions() *options {
+	o := &options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port,
+		"port",
+		9900,
+		"Port to listen on.")
+	fs.StringVar(&o.endpoint,
+		"endpoint",
+		"/",
+		"Endpoint to listen on.")
+	fs.BoolVar(&o.dryRun,
+		"dry-run",
+		false,
+		"If set, dump the job config to stdout.")
+	fs.StringVar(&o.hmacSecretFile,
+		"hmac-secret-file",
+		"/etc/webhook/hmac",
+		"Path to the file containing the GitHub HMAC secret.")
+	for _, group := range []flagutil.OptionGroup{&o.github} {
+		group.AddFlags(fs)
+	}
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	opts := gatherOptions()
+	opts.validate()
+
+	logger := setupLogger()
+	logger.Infoln("Setting up events server")
+
+	if err := secret.Add(opts.github.TokenPath, opts.hmacSecretFile); err != nil {
+		logrus.WithError(err).Fatalf("Failed to start secrets agent.")
+	}
+
+	githubClient, err := opts.github.GitHubClient(opts.dryRun)
+	mustSucceed(err, "Could not instantiate github client.")
+
+	eventsChan := make(chan *handler.GitHubEvent)
+
+	eventsHandler := handler.NewGitHubEventsHandler(
+		eventsChan,
+		logger,
+		githubClient)
+
+	eventsServer := server.NewGitHubEventsServer(secret.GetTokenGenerator(opts.hmacSecretFile), eventsHandler)
+
+	serverMux := http.NewServeMux()
+	serverMux.Handle(opts.endpoint, eventsServer)
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", opts.port), Handler: serverMux}
+	interrupts.ListenAndServe(srv, 5*time.Second)
+	logger.Infoln("Events server is listening on port:", opts.port)
+	externalplugins.ServeExternalPluginHelp(serverMux, logger.WithField("plugin-help", ""), helpProvider)
+	interrupts.WaitForGracefulShutdown()
+	logger.Println("Checklist plugin server was gracefully shut down")
+}
+
+func helpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: `The Checklist plugin is used to trigger phase 2 jobs when PR is ready for merging.`,
+	}
+	return pluginHelp, nil
+}
+
+func mustSucceed(err error, message string) {
+	if err != nil {
+		logrus.WithError(err).Fatal(message)
+	}
+}
+
+func setupLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetFormatter(&logrus.TextFormatter{FullTimestamp: true, TimestampFormat: time.RFC1123Z})
+	l.SetLevel(logrus.TraceLevel)
+	l.SetOutput(os.Stdout)
+	return l
+}

--- a/external-plugins/checklist/plugin/server/BUILD.bazel
+++ b/external-plugins/checklist/plugin/server/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["eventsserver.go"],
+    importpath = "kubevirt.io/project-infra/external-plugins/checklist/plugin/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external-plugins/checklist/plugin/handler:go_default_library",
+        "@io_k8s_test_infra//prow/github:go_default_library",
+    ],
+)

--- a/external-plugins/checklist/plugin/server/eventsserver.go
+++ b/external-plugins/checklist/plugin/server/eventsserver.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net/http"
+
+	"k8s.io/test-infra/prow/github"
+	"kubevirt.io/project-infra/external-plugins/checklist/plugin/handler"
+)
+
+type GitHubEventsServer struct {
+	tokenGenerator func() []byte
+	eventsHandler  *handler.GitHubEventsHandler
+}
+
+func NewGitHubEventsServer(tokenGenerator func() []byte, eventsChan *handler.GitHubEventsHandler) *GitHubEventsServer {
+	return &GitHubEventsServer{
+		tokenGenerator: tokenGenerator,
+		eventsHandler:  eventsChan,
+	}
+}
+
+func (s *GitHubEventsServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	eventType, eventGUID, eventPayload, eventOk, _ := github.ValidateWebhook(writer, request, s.tokenGenerator)
+
+	if !eventOk {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	event := &handler.GitHubEvent{
+		Type:    eventType,
+		GUID:    eventGUID,
+		Payload: eventPayload,
+	}
+	go s.eventsHandler.Handle(event)
+	writer.Write([]byte("Event received. Have a nice day."))
+}

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -26,6 +26,35 @@ postsubmits:
                 memory: "8Gi"
               limits:
                 memory: "8Gi"
+    - name: publish-checklist-plugin-image
+      always_run: false
+      run_if_changed: "external-plugins/checklist/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      cluster: kubevirt-prow-control-plane
+      max_concurrency: 1
+      labels:
+        preset-bazel-cache: "true"
+        preset-kubevirtci-quay-credential: "true"
+        preset-podman-in-container-enabled: "true"
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20231115-51a244f
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                make -C external-plugins/checklist push
+            resources:
+              requests:
+                memory: "8Gi"
+              limits:
+                memory: "8Gi"
+            securityContext:
+              privileged: true
     - name: publish-release-blocker-image
       always_run: false
       run_if_changed: "external-plugins/release-blocker/.*"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -208,6 +208,7 @@ tide:
     - do-not-merge/work-in-progress
     - do-not-merge/release-note-label-needed
     - do-not-merge/invalid-commit-message
+    - do-not-merge/incomplete-checklist
     - needs-rebase
     - "dco-signoff: no"
   pr_status_base_urls:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -528,6 +528,10 @@ external_plugins:
     endpoint: http://botreview:9900
     events:
       - pull_request
+  - name: checklist
+    endpoint: http://prow-checklist:9900
+    events:
+      - pull_request
 
 triggers:
 - repos:

--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - manifests/local/prow-rehearse-rbac.yaml
   - manifests/local/prow-rehearse-deployment.yaml
   - manifests/local/prow-rehearse-service.yaml
+  - manifests/local/prow-checklist-deployment.yaml
+  - manifests/local/prow-checklist-service.yaml
   - manifests/local/release-blocker_deployment.yaml
   - manifests/local/release-blocker_service.yaml
   - manifests/local/tide_rbac_prowjob.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-checklist-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-checklist-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: checklist
+  labels:
+    app: checklist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prow-checklist
+  template:
+    metadata:
+      labels:
+        app: prow-checklist
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: checklist
+          image: quay.io/kubevirtci/checklist:v20240104-c6defacb
+          imagePullPolicy: IfNotPresent
+          args:
+            - --github-token-path=/etc/github/oauth
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+          ports:
+            - name: http
+              containerPort: 9900
+          volumeMounts:
+            - name: hmac
+              mountPath: /etc/webhook
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+            - name: cache
+              mountPath: /var/run/cache
+              readOnly: false
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+        - name: oauth
+          secret:
+            secretName: oauth-token
+        - name: plugins
+          configMap:
+            name: plugins
+        - name: cache
+          emptyDir: {}

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-checklist-service.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-checklist-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prow-checklist
+spec:
+  ports:
+    - port: 9900
+      protocol: TCP
+      targetPort: 9900
+  selector:
+    app: prow-checklist
+  type: ClusterIP

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -31,6 +31,12 @@ patches:
       version: v1
       group: apps
       kind: Deployment
+      name: checklist
+    path: patches/JsonRFC6902/prow-checklist-deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
       name: gcsweb
     path: patches/JsonRFC6902/gcsweb-deployment.yaml
   - target:

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-checklist-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-checklist-deployment.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/1
+  value: --jobs-namespace=kubevirt-prow-jobs

--- a/images/checklist
+++ b/images/checklist
@@ -1,0 +1,1 @@
+../external-plugins/checklist


### PR DESCRIPTION
This plugin adds a new label that blocks merging `do-not-merge/incomplete-checklist`.
It monitors PR body [checklist](https://github.com/kubevirt/kubevirt/blob/main/.github/PULL_REQUEST_TEMPLATE.md).
In case any of the items exists and unchecked it will add the label.
It will remove it once all items that do exists, are checked.
Monitors PR Open and PR Edit events.

Note: Currently active on all repos, we might want to limit it for specific repos,
but on the other hand, since those repos don't have the template, the label won't be added.
