### PR TITLE
Remove filtering of needs-ok-to-test from retester query

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -24,7 +24,6 @@ periodics:
           label:lgtm label:approved
           status:failure
           -label:needs-rebase
-          -label:needs-ok-to-test
           repo:kubevirt/kubevirt
           repo:kubevirt/kubevirtci
       - --token=/etc/github/oauth


### PR DESCRIPTION
If the PR has been reviewed with lgtm and approve applied - it should be safe to retest the PR.

/cc @xpivarc @dhiller 