### PR TITLE
Add sysctl to bootstrap image as needed by runner script

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -44,6 +44,7 @@ RUN dnf install -y \
     make \
     mercurial \
     patch \
+    procps-ng \
     protobuf-compiler \
     python3-devel \
     python-unversioned-command \


### PR DESCRIPTION
`sysctl` is used as part of the runner.sh script[1] - this is no longer available in the bootstrap image[2] so the install of `procps-ng`, which provides sysctl, needs to be included.

```
procps-ng-4.0.3-4.fc39.x86_64 : System and process monitoring utilities
Repo        : fedora
Matched from:
Provide    : /sbin/sysctl
Filename    : /usr/sbin/sysctl
```

[1] https://github.com/kubevirt/project-infra/blob/39b00ed5d81df148e5c05e3855d17d61d510d472/images/bootstrap/runner.sh#L66
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-build/1742892493294276608#1:build-log.txt%3A11

/cc @dhiller @xpivarc 