### PR TITLE
prow-deploy: fix context name in reconcile webhook task

### DIFF
--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -56,7 +56,7 @@
       --config-path=$PROW_CONFIG_PATH \
       --github-token-path=$GITHUB_TOKEN_PATH \
       --kubeconfig=$KUBECONFIG \
-      --kubeconfig-context=ibm-prow-jobs \
+      --kubeconfig-context=kubevirt-prow-control-plane \
       --hmac-token-secret-namespace={{ prowNamespace }} \
       --hmac-token-secret-name=hmac-token \
       --hmac-token-key=hmac \


### PR DESCRIPTION
The ibm-prow-jobs cluster context no longer exists and causes the postsubmit prow deployment to fail[1].

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-kubevirt-prow-control-plane-deployment/1745118472339197952#1:build-log.txt%3A208

/cc @dhiller 