### PR TITLE
plugins: Introduce test-subset plugin

### DIFF
--- a/docs/infrastructure-components.md
+++ b/docs/infrastructure-components.md
@@ -45,7 +45,7 @@ kubevirt-prow-control-plane
 
 * Prow control plane: all the Prow components, including the main microservices
 (crier, deck, hook, horologium, prow-controller-manager, tide, sink), several
-external plugins (bot-review, rehearse, release-blocker, phased) and secondary components
+external plugins (bot-review, rehearse, release-blocker, phased, test-subset) and secondary components
 (cherrypicker, gcsweb, ghproxy, label-sync, needs-rebase, prow-exporter,
 pushgateway, statusreconciler).
 

--- a/external-plugins/test-subset/Containerfile
+++ b/external-plugins/test-subset/Containerfile
@@ -1,0 +1,16 @@
+FROM quay.io/kubevirtci/golang:v20241213-57bd934 as builder
+ENV GOPROXY=https://proxy.golang.org|direct \
+    GOFLAGS="-mod=vendor -ldflags=-extldflags=\"-static\"" \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+ENV GIMME_GO_VERSION=1.23.4
+RUN mkdir kubevirt && \
+    cd kubevirt && \
+    git clone https://github.com/kubevirt/project-infra.git && \
+    cd project-infra && \
+    /usr/local/bin/runner.sh /bin/sh -c "env GOPROXY=off go build -tags netgo -o /go/bin/test-subset ./external-plugins/test-subset/main.go"
+
+FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
+COPY --from=builder /go/bin/test-subset /usr/bin/test-subset
+ENTRYPOINT ["/usr/bin/test-subset"]

--- a/external-plugins/test-subset/Makefile
+++ b/external-plugins/test-subset/Makefile
@@ -1,0 +1,19 @@
+
+.PHONY: all build test format push
+all: format push
+CONTAINER_TAG := $(shell ../../hack/container-tag.sh)
+CONTAINER_IMAGE := test-subset
+CONTAINER_REPO := quay.io/kubevirtci/$(CONTAINER_IMAGE)
+
+build:
+	go build ./...
+
+test:
+	go test -v ./...
+
+format:
+	gofmt -w .
+
+push:
+	podman build -f ../../images/$(CONTAINER_IMAGE)/Containerfile -t $(CONTAINER_REPO):$(CONTAINER_TAG) && podman push $(CONTAINER_REPO):$(CONTAINER_TAG)
+	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO) $(CONTAINER_TAG)

--- a/external-plugins/test-subset/plugin/handler/handler.go
+++ b/external-plugins/test-subset/plugin/handler/handler.go
@@ -1,0 +1,372 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	k8s_v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "sigs.k8s.io/prow/pkg/client/clientset/versioned/typed/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
+	gitv2 "sigs.k8s.io/prow/pkg/git/v2"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/pjutil"
+
+	pi_github "kubevirt.io/project-infra/robots/pkg/github"
+)
+
+var log *logrus.Logger
+var testSubsetCommentRe = regexp.MustCompile(`^/test-subset (\S+) (\S+|\(.*\))$`)
+
+func init() {
+	log = logrus.New()
+	log.SetOutput(os.Stdout)
+	log.SetFormatter(&logrus.JSONFormatter{})
+}
+
+type GitHubEvent struct {
+	Type    string
+	GUID    string
+	Payload []byte
+}
+
+type githubClientInterface interface {
+	IsMember(string, string) (bool, error)
+	GetPullRequest(string, string, int) (*github.PullRequest, error)
+}
+
+type loadConfigFn func(h *GitHubEventsHandler, org, repo string) ([]byte, []byte, error)
+
+var loadConfigBytesFn loadConfigFn = loadConfigBytes
+
+type GitHubEventsHandler struct {
+	eventsChan       <-chan *GitHubEvent
+	logger           *logrus.Logger
+	prowClient       v1.ProwJobInterface
+	ghClient         githubClientInterface
+	gitClientFactory gitv2.ClientFactory
+	prowConfigPath   string
+	jobsConfigBase   string
+	prowLocation     string
+}
+
+func NewGitHubEventsHandler(
+	eventsChan <-chan *GitHubEvent,
+	logger *logrus.Logger,
+	prowClient v1.ProwJobInterface,
+	ghClient githubClientInterface,
+	prowConfigPath string,
+	jobsConfigBase string,
+	prowLocation string,
+	gitClientFactory gitv2.ClientFactory) *GitHubEventsHandler {
+
+	return &GitHubEventsHandler{
+		eventsChan:       eventsChan,
+		logger:           logger,
+		prowClient:       prowClient,
+		ghClient:         ghClient,
+		prowConfigPath:   prowConfigPath,
+		jobsConfigBase:   jobsConfigBase,
+		prowLocation:     prowLocation,
+		gitClientFactory: gitClientFactory,
+	}
+}
+
+func (h *GitHubEventsHandler) Handle(incomingEvent *GitHubEvent) {
+	log.Infoln("GitHub events handler started")
+	eventLog := log.WithField("event-guid", incomingEvent.GUID)
+	switch incomingEvent.Type {
+	case "issue_comment":
+		logrus.Infoln("Handling issue comment event")
+		var event github.IssueCommentEvent
+		if err := json.Unmarshal(incomingEvent.Payload, &event); err != nil {
+			log.WithError(err).Error("Could not unmarshal event.")
+			return
+		}
+		h.handlePullRequestEvent(eventLog, &event)
+	default:
+		log.Infoln("Dropping irrelevant:", incomingEvent.Type, incomingEvent.GUID)
+	}
+}
+
+// For unit tests, as we create a local git NewFakeClient
+func (h *GitHubEventsHandler) SetLocalConfLoad() {
+	loadConfigBytesFn = loadLocalConfigBytes
+}
+
+func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, event *github.IssueCommentEvent) {
+	if !h.shouldActOnIssueComment(event) {
+		return
+	}
+
+	org, repo, err := pi_github.OrgRepo(event.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get OrgRepo %s", event.Repo.FullName)
+		return
+	}
+
+	if !(org == "kubevirt" && repo == "kubevirt") {
+		return
+	}
+
+	pr, err := h.ghClient.GetPullRequest(org, repo, event.Issue.Number)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get PR number %d", event.Issue.Number)
+		return
+	}
+
+	if !isOpenUnmerged(*pr) {
+		return
+	}
+
+	if !h.canUserTrigger(org, event.Comment.User.Login) {
+		return
+	}
+
+	if !testSubsetCommentRe.MatchString(event.Comment.Body) {
+		log.Errorf("Comment does not match the expected syntax, %s", event.Comment.Body)
+		return
+	}
+
+	matches := testSubsetCommentRe.FindStringSubmatch(event.Comment.Body)
+	// extra precaution, not mandatory due to the regex
+	if len(matches) < 3 {
+		return
+	}
+
+	jobName := matches[1]
+	labels := matches[2]
+	if !strings.HasPrefix(labels, "(") {
+		labels = "(" + labels + ")"
+	}
+
+	presubmits, err := h.loadPresubmits(*pr)
+	if err != nil {
+		log.WithError(err).Errorf("loadPresubmits failed")
+		return
+	}
+
+	if presubmits == nil {
+		return
+	}
+
+	var presubmit config.Presubmit
+	for _, p := range presubmits {
+		if p.Name != jobName {
+			continue
+		}
+		presubmit = p
+		break
+	}
+
+	if presubmit.Name == "" {
+		return
+	}
+
+	presubmit.Spec.Containers[0].Env = append(presubmit.Spec.Containers[0].Env,
+		k8s_v1.EnvVar{Name: "KUBEVIRT_LABEL_FILTER", Value: labels})
+
+	job := pjutil.NewPresubmit(*pr, pr.Base.SHA, presubmit, event.GUID, map[string]string{})
+	if job.Labels == nil {
+		job.Labels = make(map[string]string)
+	}
+	job.Labels["test-subset"] = "true"
+	testSubsetName := strings.Join([]string{"test-subset", job.Spec.Job}, "-")
+	job.Spec.Job = testSubsetName
+	job.Spec.Context = testSubsetName
+	_, err = h.prowClient.Create(context.Background(), &job, metav1.CreateOptions{})
+	if err != nil {
+		log.WithError(err).Errorf("Error creating prow job")
+		return
+	}
+}
+
+func (h *GitHubEventsHandler) loadPresubmits(pr github.PullRequest) ([]config.Presubmit, error) {
+	if pr.Base.Ref != "main" && pr.Base.Ref != "master" {
+		return nil, nil
+	}
+
+	pc, err := h.loadProwConfig(pr.Base.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not load prow config")
+		return nil, err
+	}
+
+	org, repo, err := pi_github.OrgRepo(pr.Base.Repo.FullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get OrgRepo %s", pr.Base.Repo.FullName)
+		return nil, err
+	}
+
+	orgRepo := org + "/" + repo
+	var presubmits []config.Presubmit
+	for index, jobs := range pc.PresubmitsStatic {
+		if index != orgRepo {
+			continue
+		}
+		presubmits = append(presubmits, jobs...)
+	}
+
+	return presubmits, nil
+}
+
+func generateJobConfigURL(org, repo, prowLocation, jobsConfigBase string) string {
+	return fmt.Sprintf("%s/%s/%s/%s/%s-presubmits.yaml",
+		prowLocation, jobsConfigBase, org, repo, repo)
+}
+
+func catFile(log *logrus.Logger, gitDir, file, refspec string) ([]byte, int) {
+	cmd := exec.Command("git", "-C", gitDir, "cat-file", "-p", fmt.Sprintf("%s:%s", refspec, file))
+	log.Debugf("Executing git command: %+v", cmd.Args)
+	out, _ := cmd.CombinedOutput()
+	return out, cmd.ProcessState.ExitCode()
+}
+
+func writeTempFile(log *logrus.Logger, basedir string, content []byte) (string, error) {
+	tmpfile, err := os.CreateTemp(basedir, "job-config")
+	if err != nil {
+		log.WithError(err).Errorf("Could not create temp file for job config.")
+		return "", err
+	}
+	defer tmpfile.Close()
+	_, err = tmpfile.Write(content)
+	if err != nil {
+		log.WithError(err).Errorf("Could not write data to file: %s", tmpfile.Name())
+		return "", err
+	}
+	tmpfile.Sync()
+	return tmpfile.Name(), nil
+}
+
+func fetchRemoteFile(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed with status: %v", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func isOpenUnmerged(pr github.PullRequest) bool {
+	if pr.Merged || pr.State != "open" {
+		return false
+	}
+
+	if pr.Mergable != nil && !*pr.Mergable {
+		return false
+	}
+
+	return true
+}
+
+func loadLocalConfigBytes(h *GitHubEventsHandler, org, repo string) ([]byte, []byte, error) {
+	git, err := h.gitClientFactory.ClientFor(org, repo)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get client for git")
+		return nil, nil, err
+	}
+
+	prowConfigBytes, ret := catFile(log, git.Directory(), h.prowConfigPath, "HEAD")
+	if ret != 0 {
+		log.WithError(err).Errorf("Could not load Prow config %s", h.prowConfigPath)
+		return nil, nil, err
+	}
+
+	jobConfigBytes, ret := catFile(log, git.Directory(), h.jobsConfigBase, "HEAD")
+	if ret != 0 {
+		log.WithError(err).Errorf("Could not load Prow config %s", h.jobsConfigBase)
+		return nil, nil, err
+	}
+
+	return prowConfigBytes, jobConfigBytes, nil
+}
+
+func loadConfigBytes(h *GitHubEventsHandler, org, repo string) ([]byte, []byte, error) {
+	prowConfigUrl := h.prowLocation + "/" + h.prowConfigPath
+	prowConfigBytes, err := fetchRemoteFile(prowConfigUrl)
+	if err != nil {
+		log.WithError(err).Errorf("Could not fetch prow config from %s", prowConfigUrl)
+		return nil, nil, err
+	}
+
+	jobConfigUrl := generateJobConfigURL(org, repo, h.prowLocation, h.jobsConfigBase)
+	jobConfigBytes, err := fetchRemoteFile(jobConfigUrl)
+	if err != nil {
+		log.WithError(err).Errorf("Could not fetch prow config from %s", jobConfigUrl)
+		return nil, nil, err
+	}
+
+	return prowConfigBytes, jobConfigBytes, nil
+}
+
+func (h *GitHubEventsHandler) loadProwConfig(prFullName string) (*config.Config, error) {
+	tmpdir, err := os.MkdirTemp("", "prow-configs")
+	if err != nil {
+		log.WithError(err).Error("Could not create a temp directory to store configs.")
+		return nil, err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	org, repo, err := pi_github.OrgRepo(prFullName)
+	if err != nil {
+		log.WithError(err).Errorf("Could not get OrgRepo %s", prFullName)
+		return nil, err
+	}
+
+	prowConfigBytes, jobConfigBytes, err := loadConfigBytesFn(h, org, repo)
+	if err != nil {
+		log.WithError(err).Errorf("Could not load prow config files")
+		return nil, err
+	}
+
+	prowConfigTmp, err := writeTempFile(log, tmpdir, prowConfigBytes)
+	if err != nil {
+		log.WithError(err).Errorf("Could not write temporary Prow config.")
+		return nil, err
+	}
+
+	jobConfigTmp, err := writeTempFile(log, tmpdir, jobConfigBytes)
+	if err != nil {
+		log.WithError(err).Errorf("Could not write temporary Job config file")
+		return nil, err
+	}
+
+	pc, err := config.Load(prowConfigTmp, jobConfigTmp, nil, "")
+	if err != nil {
+		log.WithError(err).Errorf("Could not load prow config")
+		return nil, err
+	}
+
+	return pc, nil
+}
+
+func (h *GitHubEventsHandler) shouldActOnIssueComment(event *github.IssueCommentEvent) bool {
+	return event.Issue.IsPullRequest() && event.Issue.State == "open" && event.Action == github.IssueCommentActionCreated
+}
+
+func (h *GitHubEventsHandler) canUserTrigger(org string, userName string) bool {
+	isMember, err := h.ghClient.IsMember(org, userName)
+	if err != nil {
+		log.WithError(err).Errorln("Could not validate PR author with the repo org")
+		return false
+	}
+	return isMember
+}

--- a/external-plugins/test-subset/plugin/main.go
+++ b/external-plugins/test-subset/plugin/main.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	v1 "sigs.k8s.io/prow/pkg/client/clientset/versioned/typed/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/pluginhelp"
+
+	"kubevirt.io/project-infra/external-plugins/test-subset/plugin/handler"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	gitv2 "sigs.k8s.io/prow/pkg/git/v2"
+	"sigs.k8s.io/prow/pkg/interrupts"
+	"sigs.k8s.io/prow/pkg/pluginhelp/externalplugins"
+
+	"kubevirt.io/project-infra/external-plugins/test-subset/plugin/server"
+)
+
+type options struct {
+	dryRun         bool
+	hmacSecretFile string
+	endpoint       string
+	port           int
+	prowConfigPath string
+	jobsConfigBase string
+	kubeconfig     string
+	jobsNs         string
+	cacheDir       string
+	prowLocation   string
+	github         flagutil.GitHubOptions
+}
+
+func (o *options) validate() {
+	var errs []error
+	if o.prowConfigPath == "" {
+		errs = append(errs, fmt.Errorf("prow-config-path can't be empty"))
+	}
+	if o.jobsConfigBase == "" {
+		errs = append(errs, fmt.Errorf("jobs-config-path can't be empty"))
+	}
+	if o.jobsNs == "" {
+		errs = append(errs, fmt.Errorf("jobs-namespace can't be empty"))
+	}
+	if o.cacheDir == "" {
+		errs = append(errs, fmt.Errorf("cache-dir can't be empty"))
+	}
+	if o.prowLocation == "" {
+		errs = append(errs, fmt.Errorf("prow-location can't be empty"))
+	}
+	err := o.github.Validate(o.dryRun)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		for _, err := range errs {
+			logrus.WithError(err).Error("entry validation failure")
+		}
+		logrus.Fatalf("Arguments validation failed!")
+	}
+}
+
+func gatherOptions() *options {
+	o := &options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port,
+		"port",
+		9900,
+		"Port to listen on.")
+	fs.StringVar(&o.endpoint,
+		"endpoint",
+		"/",
+		"Endpoint to listen on.")
+	fs.BoolVar(&o.dryRun,
+		"dry-run",
+		false,
+		"If set, dump the job config to stdout.")
+	fs.StringVar(&o.hmacSecretFile,
+		"hmac-secret-file",
+		"/etc/webhook/hmac",
+		"Path to the file containing the GitHub HMAC secret.")
+	fs.StringVar(&o.kubeconfig,
+		"kubeconfig",
+		"",
+		"Path to kubeconfig. If empty, will try to use K8s defaults.")
+	fs.StringVar(&o.prowConfigPath,
+		"prow-config-path",
+		"",
+		"Path to Prow configuration (required).")
+	fs.StringVar(&o.jobsConfigBase,
+		"jobs-config-base",
+		"",
+		"Base path to a directory with Prow job configs (required).")
+	fs.StringVar(&o.jobsNs,
+		"jobs-namespace",
+		"",
+		"The namespace in which Prow jobs should be created.")
+	fs.StringVar(&o.cacheDir,
+		"cache-dir",
+		"",
+		"Directory to store git repos cache in.")
+	fs.StringVar(&o.prowLocation,
+		"prow-location",
+		"",
+		"Prow raw git location")
+	for _, group := range []flagutil.OptionGroup{&o.github} {
+		group.AddFlags(fs)
+	}
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func clientFactoryCacheDirOpt(cacheDir string) func(opts *gitv2.ClientFactoryOpts) {
+	return func(cfo *gitv2.ClientFactoryOpts) {
+		cfo.CacheDirBase = &cacheDir
+	}
+}
+
+func main() {
+	opts := gatherOptions()
+	opts.validate()
+
+	logger := setupLogger()
+	logger.Infoln("Setting up events server")
+
+	var config *rest.Config
+	var err error
+	if opts.kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", opts.kubeconfig)
+		mustSucceed(err, "Could not instantiate K8s config from the given kubeconfig.")
+	} else {
+		config, err = rest.InClusterConfig()
+		mustSucceed(err, "Could not instantiate K8s config from the in cluster config.")
+	}
+	prowClient, err := v1.NewForConfig(config)
+	mustSucceed(err, "Could not instantiate a Prow client from the given kubeconfig.")
+
+	if err := secret.Add(opts.github.TokenPath, opts.hmacSecretFile); err != nil {
+		logrus.WithError(err).Fatalf("Failed to start secrets agent.")
+	}
+
+	githubClient, err := opts.github.GitHubClient(opts.dryRun)
+	mustSucceed(err, "Could not instantiate github client.")
+
+	gitClientFactory, err := gitv2.NewClientFactory(clientFactoryCacheDirOpt(opts.cacheDir))
+	mustSucceed(err, "Could not instantiate git client factory")
+
+	eventsChan := make(chan *handler.GitHubEvent)
+
+	eventsHandler := handler.NewGitHubEventsHandler(
+		eventsChan,
+		logger,
+		prowClient.ProwJobs(opts.jobsNs),
+		githubClient,
+		opts.prowConfigPath,
+		opts.jobsConfigBase,
+		opts.prowLocation,
+		gitClientFactory)
+
+	eventsServer := server.NewGitHubEventsServer(secret.GetTokenGenerator(opts.hmacSecretFile), eventsHandler)
+
+	serverMux := http.NewServeMux()
+	serverMux.Handle(opts.endpoint, eventsServer)
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", opts.port), Handler: serverMux}
+	interrupts.ListenAndServe(srv, 5*time.Second)
+	logger.Infoln("Events server is listening on port:", opts.port)
+	externalplugins.ServeExternalPluginHelp(serverMux, logger.WithField("plugin-help", ""), helpProvider)
+	interrupts.WaitForGracefulShutdown()
+	logger.Println("Test-subset plugin server was gracefully shut down")
+}
+
+func helpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: `The Test-subset plugin is used to trigger a job that runs custom subset of the tests.
+		<br>A pull request is considered trusted if the author is a member of the 'trusted organization' for the repository.
+        <br>The arguments are the job name and the requested filter.
+		<br>This allows runnign subset of the tests without changing the code.`,
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/test-subset <job_name> <filter>",
+		Description: "Triggering job with the selected filter.",
+		Featured:    true,
+		WhoCanUse:   "Members of the trusted organization for the repo.",
+		Examples:    []string{"/test-subset pull-kubevirt-e2e-k8s-1.30-sig-network (USB)"},
+	})
+	return pluginHelp, nil
+}
+
+func mustSucceed(err error, message string) {
+	if err != nil {
+		logrus.WithError(err).Fatal(message)
+	}
+}
+
+func setupLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetFormatter(&logrus.JSONFormatter{})
+	l.SetLevel(logrus.TraceLevel)
+	l.SetOutput(os.Stdout)
+	return l
+}

--- a/external-plugins/test-subset/plugin/server/eventsserver.go
+++ b/external-plugins/test-subset/plugin/server/eventsserver.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"net/http"
+
+	"sigs.k8s.io/prow/pkg/github"
+
+	"kubevirt.io/project-infra/external-plugins/test-subset/plugin/handler"
+)
+
+type GitHubEventsServer struct {
+	tokenGenerator func() []byte
+	eventsHandler  *handler.GitHubEventsHandler
+}
+
+func NewGitHubEventsServer(tokenGenerator func() []byte, eventsChan *handler.GitHubEventsHandler) *GitHubEventsServer {
+	return &GitHubEventsServer{
+		tokenGenerator: tokenGenerator,
+		eventsHandler:  eventsChan,
+	}
+}
+
+func (s *GitHubEventsServer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	eventType, eventGUID, eventPayload, eventOk, _ := github.ValidateWebhook(writer, request, s.tokenGenerator)
+
+	if !eventOk {
+		writer.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	event := &handler.GitHubEvent{
+		Type:    eventType,
+		GUID:    eventGUID,
+		Payload: eventPayload,
+	}
+	go s.eventsHandler.Handle(event)
+	writer.Write([]byte("Event received. Have a nice day."))
+}

--- a/external-plugins/test-subset/plugin/specify_suite_test.go
+++ b/external-plugins/test-subset/plugin/specify_suite_test.go
@@ -1,0 +1,13 @@
+package main_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSubset(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test-subset Suite")
+}

--- a/external-plugins/test-subset/plugin/specify_test.go
+++ b/external-plugins/test-subset/plugin/specify_test.go
@@ -1,0 +1,210 @@
+package main_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/testing"
+
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/client/clientset/versioned/typed/prowjobs/v1/fake"
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/git/localgit"
+	git2 "sigs.k8s.io/prow/pkg/git/v2"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/github/fakegithub"
+
+	"kubevirt.io/project-infra/external-plugins/test-subset/plugin/handler"
+)
+
+const (
+	org      = "kubevirt"
+	repo     = "kubevirt"
+	baseRef  = "main"
+	orgRepo  = org + "/" + repo
+	prNumber = 17
+)
+
+var _ = Describe("Test-subset", func() {
+	Context("A valid pull request comment event", func() {
+		var gitrepo *localgit.LocalGit
+		var gitClientFactory git2.ClientFactory
+
+		BeforeEach(func() {
+			var err error
+			gitrepo, gitClientFactory, err = localgit.NewV2()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if gitClientFactory != nil {
+				gitClientFactory.Clean()
+			}
+		})
+
+		Context("a member comments a test-subset command", func() {
+			It("Should run the specified prow jobs", func() {
+				By("Creating a fake git repo", func() {
+					makeRepoWithEmptyProwConfig(gitrepo, org, repo)
+				})
+
+				var baseref string
+				By("Generating a base commit with jobs", func() {
+					baseConfig, err := json.Marshal(&config.Config{
+						JobConfig: config.JobConfig{
+							PresubmitsStatic: map[string][]config.Presubmit{
+								orgRepo: {
+									{
+										JobBase: config.JobBase{
+											Name: "job1",
+											Spec: &v1.PodSpec{
+												Containers: []v1.Container{
+													{
+														Image: "image1",
+													},
+												},
+											},
+										},
+									},
+									{
+										JobBase: config.JobBase{
+											Name: "job2",
+											Spec: &v1.PodSpec{
+												Containers: []v1.Container{
+													{
+														Image: "image2",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					})
+					Expect(err).ShouldNot(HaveOccurred())
+					err = gitrepo.AddCommit(org, repo, map[string][]byte{
+						"jobs-config.yaml": baseConfig,
+					})
+					Expect(err).ShouldNot(HaveOccurred())
+					baseref, err = gitrepo.RevParse(org, repo, "HEAD")
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				gh := fakegithub.NewFakeClient()
+				testuser := "testuser"
+
+				By("Registering a user to the fake github client", func() {
+					gh.OrgMembers = map[string][]string{
+						repo: {testuser},
+					}
+				})
+
+				var event *github.IssueCommentEvent
+				By("Generating a fake pull request event and registering it to the github client", func() {
+					event = &github.IssueCommentEvent{
+						Action: github.IssueCommentActionCreated,
+						Comment: github.IssueComment{
+							Body: `/test-subset job1 "(label1)"`,
+							User: github.User{
+								Login: testuser,
+							},
+						},
+						GUID: "guid",
+						Repo: github.Repo{
+							FullName: orgRepo,
+						},
+						Issue: github.Issue{
+							Number: prNumber,
+							State:  "open",
+							User: github.User{
+								Login: testuser,
+							},
+							PullRequest: &struct{}{},
+						},
+					}
+
+					gh.PullRequests = map[int]*github.PullRequest{
+						prNumber: {
+							Number: prNumber,
+							State:  "open",
+							Base: github.PullRequestBranch{
+								Repo: github.Repo{
+									Name:     repo,
+									FullName: orgRepo,
+								},
+								Ref: baseRef,
+								SHA: baseref,
+							},
+							Head: github.PullRequestBranch{
+								Repo: github.Repo{
+									Name:     repo,
+									FullName: orgRepo,
+								},
+								Ref: baseRef,
+								SHA: baseref,
+							},
+						},
+					}
+				})
+
+				By("Sending the event to the test-subset plugin server", func() {
+					fakelog := logrus.New()
+					eventsChan := make(chan *handler.GitHubEvent)
+					prowc := &fake.FakeProwV1{
+						Fake: &testing.Fake{},
+					}
+					eventsHandler := handler.NewGitHubEventsHandler(
+						eventsChan,
+						fakelog,
+						prowc.ProwJobs("test-ns"),
+						gh,
+						"prowconfig.yaml",
+						"jobs-config.yaml",
+						"",
+						gitClientFactory)
+
+					handlerEvent, err := makeHandlerIssueCommentEvent(event)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					eventsHandler.SetLocalConfLoad()
+					eventsHandler.Handle(handlerEvent)
+
+					Expect(prowc.Actions()).Should(HaveLen(1))
+					pjAction := prowc.Actions()[0].GetResource()
+					Expect(pjAction).To(Equal(prowapi.SchemeGroupVersion.WithResource("prowjobs")))
+				})
+			})
+		})
+	})
+})
+
+func makeRepoWithEmptyProwConfig(lg *localgit.LocalGit, org, repo string) error {
+	err := lg.MakeFakeRepo(org, repo)
+	if err != nil {
+		return err
+	}
+	prowConfig, err := json.Marshal(&config.ProwConfig{})
+	if err != nil {
+		return err
+	}
+	return lg.AddCommit(org, repo, map[string][]byte{
+		"prowconfig.yaml": prowConfig,
+	})
+}
+
+func makeHandlerIssueCommentEvent(event *github.IssueCommentEvent) (*handler.GitHubEvent, error) {
+	eventBytes, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+	handlerEvent := &handler.GitHubEvent{
+		Type:    "issue_comment",
+		GUID:    event.GUID,
+		Payload: eventBytes,
+	}
+	return handlerEvent, nil
+}

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -58,6 +58,35 @@ postsubmits:
                 memory: "8Gi"
             securityContext:
               privileged: true
+    - name: publish-test-subset-plugin-image
+      always_run: false
+      run_if_changed: "external-plugins/test-subset/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      cluster: kubevirt-prow-control-plane
+      max_concurrency: 1
+      labels:
+        preset-bazel-cache: "true"
+        preset-kubevirtci-quay-credential: "true"
+        preset-podman-in-container-enabled: "true"
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                make -C external-plugins/test-subset push
+            resources:
+              requests:
+                memory: "8Gi"
+              limits:
+                memory: "8Gi"
+            securityContext:
+              privileged: true
     - name: publish-release-blocker-image
       always_run: false
       run_if_changed: "external-plugins/release-blocker/.*"

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -571,6 +571,10 @@ external_plugins:
     events:
       - issue_comment
       - pull_request
+  - name: test-subset
+    endpoint: http://test-subset:9900
+    events:
+      - issue_comment
 
 triggers:
 - repos:

--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -19,6 +19,9 @@ resources:
   - manifests/local/referee-deployment.yaml
   - manifests/local/referee-service.yaml
   - manifests/local/referee-servicemonitor.yaml
+  - manifests/local/test-subset-rbac.yaml
+  - manifests/local/test-subset-deployment.yaml
+  - manifests/local/test-subset-service.yaml
   - manifests/local/release-blocker_deployment.yaml
   - manifests/local/release-blocker_service.yaml
   - manifests/local/statusreconciler_rbac.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-subset
+  labels:
+    app: test-subset
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-subset
+  template:
+    metadata:
+      labels:
+        app: test-subset
+    spec:
+      serviceAccountName: test-subset
+      terminationGracePeriodSeconds: 180
+      containers:
+        - name: test-subset
+          image: quay.io/kubevirtci/test-subset:v20240108-87253b59
+          imagePullPolicy: IfNotPresent
+          args:
+            - --github-token-path=/etc/github/oauth
+            - --github-endpoint=http://ghproxy
+            - --github-endpoint=https://api.github.com
+            - --cache-dir=/var/run/cache
+            - --jobs-config-base=github/ci/prow-deploy/files/jobs
+            - --prow-config-path=github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+            - --prow-location=https://raw.githubusercontent.com/kubevirt/project-infra/main
+          ports:
+            - name: http
+              containerPort: 9900
+          volumeMounts:
+            - name: hmac
+              mountPath: /etc/webhook
+              readOnly: true
+            - name: oauth
+              mountPath: /etc/github
+              readOnly: true
+            - name: plugins
+              mountPath: /etc/plugins
+              readOnly: true
+            - name: cache
+              mountPath: /var/run/cache
+              readOnly: false
+      volumes:
+        - name: hmac
+          secret:
+            secretName: hmac-token
+        - name: oauth
+          secret:
+            secretName: commenter-oauth-token
+        - name: plugins
+          configMap:
+            name: plugins
+        - name: cache
+          emptyDir: {}

--- a/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-rbac.yaml
@@ -1,0 +1,30 @@
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: test-subset
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-subset
+rules:
+  - apiGroups:
+      - prow.k8s.io
+    resources:
+      - prowjobs
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: test-subset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  name: test-subset
+  kind: ClusterRole
+subjects:
+  - kind: ServiceAccount
+    name: test-subset
+    namespace: default

--- a/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-service.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-subset
+spec:
+  ports:
+    - port: 9900
+      protocol: TCP
+      targetPort: 9900
+  selector:
+    app: test-subset
+  type: ClusterIP

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -31,6 +31,12 @@ patches:
       version: v1
       group: apps
       kind: Deployment
+      name: test-subset
+    path: patches/JsonRFC6902/test-subset-deployment.yaml
+  - target:
+      version: v1
+      group: apps
+      kind: Deployment
       name: gcsweb
     path: patches/JsonRFC6902/gcsweb-deployment.yaml
   - target:
@@ -198,6 +204,12 @@ patches:
       version: v1
       kind: ClusterRoleBinding
       name: prow-rehearse
+    path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRoleBinding
+      name: test-subset
     path: patches/JsonRFC6902/rolebinding-subject-prow-namespace.yaml
   - target:
       group: rbac.authorization.k8s.io

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/test-subset-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/test-subset-deployment.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/1
+  value: --jobs-namespace=kubevirt-prow-jobs

--- a/images/test-subset
+++ b/images/test-subset
@@ -1,0 +1,1 @@
+../external-plugins/test-subset


### PR DESCRIPTION
Allows to run specific labels on a lane
`/test-subset <job-name> <labels>`

It will create a job, inject the label to its env var, and give it a unique suffix, so it won't
affect the official jobs.
Opposed to focus (which is also not encouraged, now that we have labels), the job won't fail if all lanes
pass, which reduce emails, comments, and the need to manually look on the job results on both cases.
