### PR TITLE
Add periodic job to create bump PR for centos version in kubevirtci

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -95,3 +95,29 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-kubevirtci-bump-centos-version
+  cron: "50 1 * * 0"
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
+    workdir: true
+  labels:
+    preset-docker-mirror: "true"
+    preset-github-credentials: "true"
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
+      command: ["/bin/sh", "-c"]
+      args:
+      - GIT_ASKPASS=/usr/local/bin/git-askpass.sh git-pr.sh -c "./hack/bump-centos-version.sh" -r kubevirtci -b bump-centos-version -T main -p $(pwd)
+      resources:
+        requests:
+          memory: "200Mi"


### PR DESCRIPTION
From time to time old centos stream 9 images are removed and cleaned up,
this can cause publishes of kubevirtci[1] and presubmits to fail.

This change adds a periodic job that runs once a week to create a PR in the kubevirtci repo with the latest
published centos stream version.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-kubevirtci/1745004368974843904#1:build-log.txt%3A2263

/cc @dhiller @oshoval @xpivarc 