### PR TITLE
tests, kubevirt, flakes: add periodic flake checker

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2202,3 +2202,45 @@ periodics:
         privileged: true
     nodeSelector:
       type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+  cluster: kubevirt-prow-workloads
+  cron: 25 1,7,13,19 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 8h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  max_concurrency: 2
+  name: periodic-kubevirt-check-tests-for-flakes
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/sharded_repeated_test.sh
+      env:
+      - name: KUBEVIRT_E2E_PARALLEL
+        value: "true"
+      - name: KUBEVIRT_MEMORY_SIZE
+        value: 9216M
+      - name: KUBEVIRT_PSA
+        value: "true"
+      image: quay.io/kubevirtci/bootstrap:v20231219-bf5e580
+      name: ""
+      resources:
+        requests:
+          memory: 29Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external


### PR DESCRIPTION
Adds a new periodic lane that leverages the `repeated_test.sh` to run a subset or shard of the e2e tests from `kubevirt/kubevirt`. The logic which tests to run is based in `kubevirt/kubevirt`
`automation/sharded_repeated_test.sh`. See https://github.com/kubevirt/kubevirt/pull/11007.
 This way we collect more data about how flaky our e2e tests are currently.

/hold

Until https://github.com/kubevirt/kubevirt/pull/11007 has been merged.