### PR TITLE
Update multus v4 lanes to test against kubernetes 1.29

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1127,7 +1127,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
+  name: periodic-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1150,7 +1150,7 @@ periodics:
       - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
-        value: k8s-1.26-centos9-sig-network
+        value: k8s-1.29-sig-network
       image: quay.io/kubevirtci/bootstrap:v20240109-6e61e3b
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -900,7 +900,7 @@ presubmits:
       preset-shared-images: "true"
       rehearsal.allowed: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
+    name: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -913,7 +913,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.26-centos9-sig-network
+          value: k8s-1.29-sig-network
         - name: KUBEVIRT_WITH_MULTUS_V3
           value: "false"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY


### PR DESCRIPTION
Kubernetes 1.26 is no longer a supported version for main branch kubevirt - update these lanes to test against 1.29

/cc @ormergi @EdDev @dhiller 