### PR TITLE
arm64,conformance: enable reporting of the arm conformance presubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1042,7 +1042,6 @@ presubmits:
     optional: true
     skip_branches:
     - release-\d+\.\d+
-    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
The arm conformance lane has been very stable[1] in the last couple of weeks. We can start reporting the result of this lane on PRs.

[1] https://testgrid.kubernetes.io/kubevirt-presubmits#pull-kubevirt-conformance-arm64

/cc @zhlhahaha @dhiller 