### PR TITLE
presubmit,windows: update windows presubmit to run with etcd in memory

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -128,6 +128,8 @@ presubmits:
         env:
         - name: TARGET
           value: windows2016
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20240109-6e61e3b
         name: ""
         resources:


### PR DESCRIPTION
The windows presubmit lane fails occassionally with etcd timeouts[1] - moving this to run with etcd in memory should stop these these failures and reduce retests.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/11016/pull-kubevirt-e2e-windows2016/1746816193127256064

/cc @dhiller @xpivarc 