### PR TITLE
kubevirt,presubmits: make 1.26 lanes optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1356,6 +1356,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-network
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1399,6 +1400,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-storage
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1482,6 +1484,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-compute
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1573,6 +1576,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.26-sig-operator
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Following the introduction of the phased plugin, required jobs that are manually triggered are allowed[1] - this leaves 1.26 jobs as required but not triggered on kubevirt PRs which is preventing merge queue PRs from being merged.

Updating these lanes to be explicitly optional so that they no longer appeared as required.

[1] https://github.com/kubevirt/project-infra/blob/0c8c659783c24fe4b5b939455169fb6535bf052a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml#L274

/cc @dhiller @oshoval 