### PR TITLE
phased plugin: Add intro to bot comments

### DIFF
--- a/external-plugins/phased/plugin/handler/handler.go
+++ b/external-plugins/phased/plugin/handler/handler.go
@@ -18,6 +18,8 @@ import (
 
 var log *logrus.Logger
 
+const Intro = "Required labels detected, running phase 2 presubmits:\n"
+
 func init() {
 	log = logrus.New()
 	log.SetOutput(os.Stdout)
@@ -276,6 +278,7 @@ func testRequested(ghClient githubClientInterface, pr github.PullRequest, reques
 	}
 
 	if result != "" {
+		result = Intro + result
 		if err := ghClient.CreateComment(org, repo, pr.Number, result); err != nil {
 			log.WithError(err).Errorf("CreateComment failed PR %d", pr.Number)
 			return err

--- a/external-plugins/phased/plugin/phased_test.go
+++ b/external-plugins/phased/plugin/phased_test.go
@@ -165,7 +165,9 @@ var _ = Describe("Phased", func() {
 
 					if tc.ExpectComment {
 						Expect(len(gh.IssueCommentsAdded)).To(Equal(1), "Expected github comment to be added")
-						Expect(gh.IssueCommentsAdded[0]).To(Equal(fmt.Sprintf("%s#%d:/test job_always_run_false\n", orgRepo, prNumber)))
+						Expect(gh.IssueCommentsAdded[0]).To(Equal(
+							fmt.Sprintf("%s#%d:%s/test job_always_run_false\n", orgRepo, prNumber,
+								handler.Intro)))
 					} else {
 						Expect(len(gh.IssueCommentsAdded)).To(Equal(0), "Expect no github comment to be added")
 					}


### PR DESCRIPTION
In order to make the bot more self explanatory,
add a comment describing why it trigger jobs.