### PR TITLE
prow-deploy, fix: Role and RoleBinding for statusreconciler

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_rbac.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/statusreconciler_rbac.yaml
@@ -17,6 +17,19 @@ rules:
     verbs:
       - create
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: statusreconciler
+rules:
+- apiGroups:
+  - "prow.k8s.io"
+  resources:
+  - prowjobs
+  verbs:
+  - create
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -29,3 +42,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: statusreconciler
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: test-pods
+  name: statusreconciler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: statusreconciler
+subjects:
+- kind: ServiceAccount
+  name: statusreconciler
+  namespace: default

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/admin-rbac.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/admin-rbac.yaml
@@ -9,9 +9,6 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
-    name: rmohr@redhat.com
-  - apiGroup: rbac.authorization.k8s.io
-    kind: User
     name: dhiller@redhat.com
   - apiGroup: rbac.authorization.k8s.io
     kind: User


### PR DESCRIPTION
Role and RoleBinding for statusreconciler are only present in kubevirt-prow, but prowjob objects are created in kubevirt-prow-jobs ns.

We therefore add the missing things for test-pods ns, which is then changed to kubevirt-prow-jobs during deployment kustomization.

Aside from that we remove an admin account from the setup, since that account is inactive for quite a while now.

/cc @brianmcarey 