### PR TITLE
phased plugin: Use commenter bot token

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
@@ -49,7 +49,7 @@ spec:
             secretName: hmac-token
         - name: oauth
           secret:
-            secretName: oauth-token
+            secretName: commenter-oauth-token
         - name: plugins
           configMap:
             name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: phased
-          image: quay.io/kubevirtci/phased:v20240115-b04789a7
+          image: quay.io/kubevirtci/phased:v20240116-76557cdb
           imagePullPolicy: IfNotPresent
           args:
             - --github-token-path=/etc/github/oauth


### PR DESCRIPTION
Seems the kubevirt-bot isnt allowed to trigger /test commands.
Lets use the commenter bot that does it usually.

Also updated the image, based on the new bootstrap to fix the [glibc](https://github.com/kubevirt/project-infra/pull/3175) error.
Thanks @brianmcarey 