### PR TITLE
phased: Enable run_before_merge for phase 2 jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -801,6 +801,7 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits


### PR DESCRIPTION
Seems tide has a bug, it doesnt run the phase 2 for batches. 
A simple wa until it is fixed is to use `run_before_merge`, which force a batch to run it.

Real fix is to consider manually triggered jobs as well on this line at `presubmitsForBatch`
`shouldRun, err := ps.ShouldRun(baseBranch, c.changedFiles.batchChanges(prs), ps.RunBeforeMerge, false)`
The required logic exists on https://github.com/kubernetes/test-infra/pull/30191
