### PR TITLE
kubevirt,presubmits: Make 1.29 lanes required

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2113,7 +2113,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-network
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2157,7 +2156,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-storage
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2199,7 +2197,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-compute
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2245,7 +2242,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-operator
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
The lanes have been running for the last week without issue - update them to be required.

/cc @dhiller 