### PR TITLE
kubevirt,presubmits: increase memory requests for prow-control-plane jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -322,7 +322,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -353,7 +353,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -382,7 +382,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -414,7 +414,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -472,7 +472,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -504,7 +504,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -537,7 +537,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -567,7 +567,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -639,7 +639,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -676,7 +676,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -705,7 +705,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -735,7 +735,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -764,7 +764,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -793,7 +793,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1156,7 +1156,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           privileged: true
   - always_run: false


### PR DESCRIPTION
When there is a large number of jobs kicked off at once, we can see that the control-plane cluster gets overwhelmed and jobs fail early to start the podman socket[1].

![Screenshot from 2024-01-19 08-56-02](https://github.com/kubevirt/project-infra/assets/21010464/13cd2a02-baab-4095-b840-836747e3dcc3)


Doubling the memory request will reduce the number of running jobs by half and should help with this problem.

These jobs are generally very short so this should not really impact feedback time.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/11041/pull-kubevirt-verify-go-mod/1748262393516920832

/cc @dhiller @xpivarc 