### PR TITLE
bootstrap,s390x: Add s390x support to multiarch bootstrap build

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -24,6 +24,7 @@ ENV WORKSPACE=/workspace \
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}
+ARG ARCH
 
 # Install packages
 RUN dnf install -y \
@@ -60,20 +61,33 @@ RUN dnf install -y \
     python3-jinja2 &&\
   dnf -y clean all
 
-# Install gcloud
-ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \
-    CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
-RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
-    tar xzf google-cloud-sdk.tar.gz -C / && \
-    rm google-cloud-sdk.tar.gz && \
-    /google-cloud-sdk/install.sh \
-        --disable-installation-options \
-        --bash-completion=false \
-        --path-update=false \
-        --usage-reporting=false && \
-    gcloud components install alpha beta kubectl && \
-    gcloud info | tee /workspace/gcloud-info.txt
+RUN if test "${ARCH}" != s390x; then \
+        export PATH=/google-cloud-sdk/bin:/workspace:${PATH} && \
+        export CLOUDSDK_CORE_DISABLE_PROMPTS=1 && \
+        wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \
+        tar xzf google-cloud-sdk.tar.gz -C / && \
+        rm google-cloud-sdk.tar.gz && \
+        /google-cloud-sdk/install.sh \
+            --disable-installation-options \
+            --bash-completion=false \
+            --path-update=false \
+            --usage-reporting=false && \
+        gcloud components install alpha beta kubectl && \
+        gcloud info | tee /workspace/gcloud-info.txt; \
+        # Cache the most commonly used bazel versions in the container
+        curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH} && \
+        chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
+        cd /usr/local/bin && ln -s bazelisk bazel; \
+
+        # Cache the most commonly used bazel versions inside the image
+        # and remove resulting cache directories to save a few hundred MB
+        USE_BAZEL_VERSION=4.1.0 bazel version && \
+        USE_BAZEL_VERSION=4.2.1 bazel version && \
+        USE_BAZEL_VERSION=5.3.1 bazel version && \
+        USE_BAZEL_VERSION=5.4.1 bazel version && \
+        rm -rf /root/.cache/bazel; \
+        fi
 
 #
 # BEGIN: PODMAN IN CONTAINER SETUP
@@ -100,19 +114,6 @@ ENV _CONTAINERS_USERNS_CONFIGURED=""
 # END: PODMAN IN CONTAINER SETUP
 #
 
-# Cache the most commonly used bazel versions in the container
-ARG ARCH
-RUN  curl -Lo ./bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-${ARCH} && \
-     chmod +x ./bazelisk && mv ./bazelisk /usr/local/bin/bazelisk && \
-     cd /usr/local/bin && ln -s bazelisk bazel
-
-# Cache the most commonly used bazel versions inside the image
-# and remove resulting cache directories to save a few hundred MB
-RUN USE_BAZEL_VERSION=4.1.0 bazel version && \
-    USE_BAZEL_VERSION=4.2.1 bazel version && \
-    USE_BAZEL_VERSION=5.3.1 bazel version && \
-    USE_BAZEL_VERSION=5.4.1 bazel version && \
-    rm -rf /root/.cache/bazel
 
 # create mixin directories
 RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -82,12 +82,10 @@ RUN if test "${ARCH}" != s390x; then \
 
         # Cache the most commonly used bazel versions inside the image
         # and remove resulting cache directories to save a few hundred MB
-        USE_BAZEL_VERSION=4.1.0 bazel version && \
-        USE_BAZEL_VERSION=4.2.1 bazel version && \
         USE_BAZEL_VERSION=5.3.1 bazel version && \
         USE_BAZEL_VERSION=5.4.1 bazel version && \
         rm -rf /root/.cache/bazel; \
-        fi
+    fi
 
 #
 # BEGIN: PODMAN IN CONTAINER SETUP

--- a/images/publish_multiarch_image.sh
+++ b/images/publish_multiarch_image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -xe
-archs=(amd64 arm64)
+archs=(amd64 arm64 s390x)
 
 main() {
     local build_only local_base_image


### PR DESCRIPTION
There is an effort to enable support for s390x for KubeVirt[1].

This adds an s390x bootstrap image to our multiarch publish flow.

This bootstrap image does not include bazel as it will have to rely on
the s390x builder image[2] for bazel.

This image will allow us to run native s390x builds and unit tests on a
s390x cluster[3].

[1] https://github.com/kubevirt/kubevirt/pull/10490
[2] https://github.com/kubevirt/kubevirt/pull/11097
[3] https://github.com/kubevirt/project-infra/issues/3140