### PR TITLE
Fix flag for feature-announce call

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2247,7 +2247,7 @@ periodics:
         sig_release_dir=$(cd ../sig-release && pwd)
         cd ${project_infra_dir}
         bazelisk run //releng/feature-announce -- \
-            --V=5 \
+            --log-level=5 \
             --output-file=${sig_release_dir}/upcoming-changes.md \
             --org kubevirt \
             --repo kubevirt \


### PR DESCRIPTION
During code review the flag name for log-level <sup>[1]</sup> was changed to better reflect what it's doing, but it was forgotten to update the job definition, causing the periodic to fail <sup>[2]</sup>

This PR fixes the flag name in the job definition.

/cc @brianmcarey @aburdenthehand 

[1]: https://github.com/kubevirt/project-infra/blame/9c575a8f1e736d80c3e1f539d84688d2dbefa5d5/releng/feature-announce/feature-announce.go#L76
[2]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-update-upcoming-changes/1749609378622738432#1:build-log.txt%3A54