### PR TITLE
Remove 'codingben' from the kubevirt organization

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/OWNERS
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/OWNERS
@@ -11,7 +11,6 @@ options: {}
 reviewers:
 - 0xfelix
 - akrejcir
-- codingben
 - jcanocan
 - ksimon1
 - lyarwood

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/OWNERS
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/OWNERS
@@ -14,7 +14,6 @@ options: {}
 reviewers:
 - 0xfelix
 - akrejcir
-- codingben
 - jcanocan
 - ksimon1
 - lyarwood

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/OWNERS
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/OWNERS
@@ -11,7 +11,6 @@ options: {}
 reviewers:
 - 0xfelix
 - akrejcir
-- codingben
 - jcanocan
 - ksimon1
 - lyarwood

--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -50,7 +50,6 @@ orgs:
       - booxter
       - borod108
       - brybacki
-      - codingben
       - crobinso
       - cwilkers
       - cynepco3hahue


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed `codingben` from the `kubevirt` organization.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
None
```
