### PR TITLE
phased plugin: Enable from-branch-protection for kubevirt/kubevirt main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -62,7 +62,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -106,7 +105,6 @@ presubmits:
         type: bare-metal-external
       priorityClassName: windows
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -178,7 +176,6 @@ presubmits:
           type: Directory
         name: audit
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
@@ -800,7 +797,6 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1343,7 +1339,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1387,7 +1382,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1429,7 +1423,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1519,7 +1512,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1563,7 +1555,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1607,7 +1598,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1649,7 +1639,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1695,7 +1684,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -219,6 +219,10 @@ tide:
           dashboard:
             skip-unknown-contexts: true
             from-branch-protection: true
+          kubevirt:
+            branches:
+              main:
+                from-branch-protection: true
       nmstate:
         repos:
           kubernetes-nmstate:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Enable `from-branch-protection`.
Removes `run_before_merge` workaround.
Now that Tide bug was solved, Tide should detect manually required jobs
as required with those fixes, as if they had `run_before_merge`.

To be merged only when we update tide to a version that includes
https://github.com/kubernetes/test-infra/pull/31687 (done)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
