### PR TITLE
 release-tool: allow beta tags without --force

### DIFF
--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -1020,6 +1020,7 @@ func (r *releaseData) verifyTag() error {
 		re := []*regexp.Regexp{
 			regexp.MustCompile(`^v\d*\.\d*.\d*-rc.\d*$`),
 			regexp.MustCompile(`^v\d*\.\d*.\d*-alpha.\d*$`),
+			regexp.MustCompile(`^v\d*\.\d*.\d*-beta.\d*$`),
 		}
 
 		match := ""


### PR DESCRIPTION
adds new release configs