### PR TITLE
prow, labels, github: add new labels for sigs used in OWNERS

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -261,6 +261,23 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - name: sig/scale
+      color: aefcf3
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - name: sig/buildsystem
+      color: 73efeb
+      description: Denotes an issue or PR that relates to changes in the build system, touching either components or configuration of it.
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+    - name: sig/api
+      color: fcaebb
+      description: Denotes an issue or PR that relates to changes in api.
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: e11d21
       description: Indicates the PR's author has not DCO signed all their commits.
       name: "dco-signoff: no"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With https://groups.google.com/g/kubevirt-dev/c/-5TLpOcRkco it was proposed to create sigs to better distribute ownership.

We need to add the new labels for the sigs to the prow label configuration, otherwise we can not apply them to pull requests, i.e. as possible in OWNERS files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @EdDev @fabiand 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] ~Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)~
- [ ] ~Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [ ] ~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered - https://groups.google.com/g/kubevirt-dev/c/-5TLpOcRkco

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
