### PR TITLE
prow, labels, github: fix configuration for `help-wanted` in prow config files

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -299,9 +299,17 @@ default:
       addedBy: prow
     - name: good-first-issue
       color: 128A0C
+      description: Denotes an issue ready for a new contributor.
       target: issues
       previously:
       - name: good first issue
+        color: 128A0C
+    - name: help-wanted
+      color: 128A0C
+      description: Denotes an issue that needs help from a contributor.
+      target: issues
+      previously:
+      - name: help wanted
         color: 128A0C
 repos:
   kubevirt/kubevirt:
@@ -330,12 +338,6 @@ repos:
       - name: for/users
         color: fef2c0
         target: both
-      - name: help-wanted
-        color: 128A0C
-        target: issues
-        previously:
-        - name: help wanted
-          color: 128A0C
       - name: distro/kubernetes
         color: fcb3ad
         target: both

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -702,11 +702,20 @@ label:
     - allowed_teams:
       - kubevirtorg-label
       label: good-first-issue
+    - allowed_teams:
+      - kubevirtorg-label
+      label: help-wanted
     'kubevirt/kubevirt':
     - allowed_teams:
       - kubevirtkubevirt-label
       label: good-first-issue
+    - allowed_teams:
+      - kubevirtkubevirt-label
+      label: help-wanted
     'kubevirt/project-infra':
     - allowed_teams:
       - kubevirtproject-infra-label
       label: good-first-issue
+    - allowed_teams:
+      - kubevirtproject-infra-label
+      label: help-wanted


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Moves the `help-wanted` label to the default section in the `labels.yaml`
configuration file, which denotes our GitHub label configuration for the
org.

Also adds a description to the `help-wanted` and to the `good-first-issue`
labels.

In oder to be usable with the prow `/label` command[^1], the labels
`good-first-issue` and `help-wanted` have to be added to the
restricted_labels configuration inside the prow configuration file for
plugins.

Changes `help-wanted` to be usable by `kubevirtorg-label`
GitHub team [^2], and also adds `help-wanted` to
`kubevirtkubevirt-label` and `kubevirtproject-infra-label` GitHub teams.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

[^1]: https://prow.ci.kubevirt.io/plugins
[^2]: https://github.com/kubevirt/project-infra/blob/d86102e2e8334e7da0cd453f50f2dad1607d4ed6/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml#L588