### PR TITLE
kubevirtci,periodic: prowjob to publish new CentOS stream base

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -95,3 +95,40 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-kubevirtci-bump-centos-base
+  cron: "0 4 * * 2"
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
+    workdir: true
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+  labels:
+    preset-docker-mirror: "true"
+    preset-github-credentials: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-kubevirtci-quay-credential: "true"
+  cluster: kubevirt-prow-workloads
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
+      command:
+      - "/usr/local/bin/runner.sh"
+      - "/bin/bash"
+      - "-c"
+      - >
+        cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+        GIT_ASKPASS=../project-infra/hack/git-askpass.sh ../project-infra/hack/git-pr.sh -c "PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh" -r kubevirtci -b bump-centos-stream -T main -p $(pwd) -s "Automatic bump of CentOS Stream to latest"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "29Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -242,7 +242,14 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - cd cluster-provision/k8s/1.27 && KUBEVIRT_PSA='true' ../provision.sh
+        - cd cluster-provision/k8s/1.27 && ../provision.sh
+        env:
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: PHASES
+          value: "k8s"
+        - name: CHECK_CLUSTER
+          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:
@@ -268,7 +275,14 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - cd cluster-provision/k8s/1.28 && KUBEVIRT_PSA='true' ../provision.sh
+        - cd cluster-provision/k8s/1.28 && ../provision.sh
+        env:
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: PHASES
+          value: "k8s"
+        - name: CHECK_CLUSTER
+          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:
@@ -320,7 +334,14 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - cd cluster-provision/k8s/1.29 && KUBEVIRT_PSA='true' ../provision.sh
+        - cd cluster-provision/k8s/1.29 && ../provision.sh
+        env:
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: PHASES
+          value: "k8s"
+        - name: CHECK_CLUSTER
+          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:
@@ -347,7 +368,14 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - cd cluster-provision/k8s/1.30 && KUBEVIRT_PSA='true' ../provision.sh
+        - cd cluster-provision/k8s/1.30 && ../provision.sh
+        env:
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: PHASES
+          value: "k8s"
+        - name: CHECK_CLUSTER
+          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -233,6 +233,7 @@ presubmits:
       timeout: 3h0m0s
     labels:
       preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-check-provision-env: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.27
@@ -243,13 +244,6 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.27 && ../provision.sh
-        env:
-        - name: KUBEVIRT_PSA
-          value: "true"
-        - name: PHASES
-          value: "k8s"
-        - name: CHECK_CLUSTER
-          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:
@@ -266,6 +260,7 @@ presubmits:
       timeout: 3h0m0s
     labels:
       preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-check-provision-env: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.28
@@ -276,13 +271,6 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.28 && ../provision.sh
-        env:
-        - name: KUBEVIRT_PSA
-          value: "true"
-        - name: PHASES
-          value: "k8s"
-        - name: CHECK_CLUSTER
-          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:
@@ -325,6 +313,7 @@ presubmits:
       timeout: 3h0m0s
     labels:
       preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-check-provision-env: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.29
@@ -335,13 +324,6 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.29 && ../provision.sh
-        env:
-        - name: KUBEVIRT_PSA
-          value: "true"
-        - name: PHASES
-          value: "k8s"
-        - name: CHECK_CLUSTER
-          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:
@@ -358,6 +340,7 @@ presubmits:
       timeout: 3h0m0s
     labels:
       preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-check-provision-env: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: check-provision-k8s-1.30
@@ -369,13 +352,6 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.30 && ../provision.sh
-        env:
-        - name: KUBEVIRT_PSA
-          value: "true"
-        - name: PHASES
-          value: "k8s"
-        - name: CHECK_CLUSTER
-          value: "true"
         image: quay.io/kubevirtci/golang:v20240229-74549d5
         name: ""
         resources:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -607,6 +607,15 @@ presets:
     mountPath: /etc/kubevirtci-cred
     readOnly: true
 - labels:
+    preset-kubevirtci-check-provision-env: "true"
+  env:
+  - name: KUBEVIRT_PSA
+    value: "true"
+  - name: PHASES
+    value: "k8s"
+  - name: CHECK_CLUSTER
+    value: "true"
+- labels:
     preset-project-infra-kubevirtci-docker-credential: "true"
   env:
   - name: DOCKER_USER


### PR DESCRIPTION
**What this PR does / why we need it**:

This new periodic job will publish a new centos stream base image for kubevirtci every week and create a PR to update the tag in the kubevirtci repo.

This relies on https://github.com/kubevirt/kubevirtci/pull/1140 being merged into the kubevirtci repo

Also update the existing check-provision jobs to run just the kubernetes phase of provisioning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
