### PR TITLE
kubevirt,presubmits: Move build jobs to larger workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -508,7 +508,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -536,7 +536,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -433,7 +433,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -461,7 +461,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -437,7 +437,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -465,7 +465,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -496,7 +496,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-s390x
     decorate: true
     decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

The corresponding jobs for the main branch have been moved to the workloads cluster[1] and this has improved the stability of the jobs.

Move the build jobs from recent releases to the larger workloads cluster

[1] https://github.com/kubevirt/project-infra/pull/3249

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:#
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
