### PR TITLE
grafana: enable github oauth authentication

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -621,6 +621,8 @@ postsubmits:
               extract_secret 'grafanaUser' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/admin-user
               extract_secret 'grafanaPassword' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/admin-password
               extract_secret 'grafanaPromToken' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/prom_bearer_token
+              extract_secret 'grafanaClientID' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/client-id
+              extract_secret 'grafanaClientSecret' github/ci/services/grafana/secrets/kubevirt-prow-control-plane/grafana/client-secret
 
               ./github/ci/services/grafana/hack/deploy.sh kubevirt-prow-control-plane
           resources:

--- a/github/ci/services/grafana/manifests/grafana.yaml
+++ b/github/ci/services/grafana/manifests/grafana.yaml
@@ -30,6 +30,22 @@ spec:
                 secretKeyRef:
                   name: grafana
                   key: admin-password
+            - name: GF_AUTH_GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana
+                  key: client-id
+            - name: GF_AUTH_GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: grafana
+                  key: client-secret
+            - name: GF_AUTH_GITHUB_ENABLED
+              value: "true"
+            - name: GF_AUTH_GITHUB_ALLOWED_ORGANIZATIONS
+              value: "kubevirt"
+            - name: GF_AUTH_GITHUB_ROLE_ATTRIBUTE_PATH
+              value: "'Viewer'"
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource

--- a/github/ci/services/grafana/secrets/testing/grafana/client-id
+++ b/github/ci/services/grafana/secrets/testing/grafana/client-id
@@ -1,0 +1,1 @@
+client-id

--- a/github/ci/services/grafana/secrets/testing/grafana/client-secret
+++ b/github/ci/services/grafana/secrets/testing/grafana/client-secret
@@ -1,0 +1,1 @@
+client-secret


### PR DESCRIPTION
**What this PR does / why we need it**:

This should enable members of the kubevirt github org to access the KubeVirt Grafana instance as Viewers only.

https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/#steps

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
