### PR TITLE
Revert "phased plugin: Enable from-branch-protection…"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -62,6 +62,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -105,6 +106,7 @@ presubmits:
         type: bare-metal-external
       priorityClassName: windows
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -176,6 +178,7 @@ presubmits:
           type: Directory
         name: audit
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
@@ -797,6 +800,7 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1339,6 +1343,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1382,6 +1387,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1423,6 +1429,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1512,6 +1519,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1555,6 +1563,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1598,6 +1607,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1639,6 +1649,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -1684,6 +1695,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
+    run_before_merge: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -219,10 +219,6 @@ tide:
           dashboard:
             skip-unknown-contexts: true
             from-branch-protection: true
-          kubevirt:
-            branches:
-              main:
-                from-branch-protection: true
       nmstate:
         repos:
           kubernetes-nmstate:


### PR DESCRIPTION
Reverts #3221 

This reverts commit a6702ffa26dfe8f2d15ce122bd3707cf82ffb6bf.

Tide doesn't act as a backstop when event is missed
(for example when labels were added when PR is drafted).
Until we fix it lets keep CI healthy.

The reason is that we enabled `FromBranchProtection`, so Tide won't include the PR as part of 
the merge queue until all required lanes are passed.
With this flag phase 2 are considered required.
Draft just shows a private case where we didn't trigger phase 2,
it can happen also due to missing events, rarely but happens.

In order to fully use `FromBranchProtection` we will need either to implement our
own controller so no missing events occur or to ask developers to run manually in case
an event is lost. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
5. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
