### PR TITLE
prow, rehearse, plugin: use git commit data for target repository of presubmit when creating rehearsal job

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20240213-bab947fa
+          image: quay.io/kubevirtci/rehearse:v20240227-454b0025
           imagePullPolicy: IfNotPresent
           args:
             - --dry-run=false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**TL;DR: when we rehearse a PR for a repo different from project-infra, we need
to set correct git commit information inside the `refs:` section of the
presubmit data, otherwise the rehearse will fail if the rehearsed job
relies on that information.**

Rehearsal is done basically by creating a new prowjob from the
definition, where a pull request is the source of the git data that
refers to the changes we are trying to test when creating presubmits.

Now, since we want to test whether our changed presubmit works, we have
to create an artificial pull request data object that has the data
pointing to the target repository that the presubmit is for.

The previous solution simplified this by just reusing the pull request
data of the project-infra pull request, which obviously points to the
wrong repository if the presubmit that is changed is targeting i.e. the
kubevirt/kubevirt repository.
It solved the missing target repository by simply adding an
`extra_ref` pointing at the target repository.

However, that didn't work in all cases, i.e. if the target repo uses
information from the presubmit, like i.e. environment variables injected
from prow.

One example is automation/test.sh from kubevirt/kubevirt, which relies on
PULL_BASE_SHA.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3273/rehearsal-pull-kubevirt-e2e-k8s-1.29-sig-monitoring/1762070277971251200#1:build-log.txt%3A33

The new solution uses an artificial PR instance per branch, which copies
the original data to preserve the pointers to the original PR, while
changing the ref data to the target repository. The extra_ref can be
removed, since it's no more necessary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey @assafad 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3273/rehearsal-pull-kubevirt-e2e-k8s-1.29-sig-monitoring/1762070277971251200#1:build-log.txt%3A32