### PR TITLE
prow,preset: Set env variable to UNPRIV_TOKEN rather than GITHUB_TOKEN

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -638,7 +638,7 @@ presets:
 - labels:
     preset-unprivileged-github-credentials: "true"
   env:
-  - name: GITHUB_TOKEN
+  - name: UNPRIV_TOKEN
     value: /etc/github/oauth
   volumes:
   - name: unprivileged-oauth-token


### PR DESCRIPTION
**What this PR does / why we need it**:

The GITHUB_TOKEN env variable causes issues authenticating with github cli

It expects GITHUB_TOKEN to contain the actual token and not the path to the token.

[1] Attempt to authenticate with just the GITHUB_TOKEN set
[2] Attempt to login with gh auth login --with-token $GITHUB_TOKEN

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/11388/pull-kubevirt-e2e-k8s-1.29-sig-network/1763492073303969792#1:build-log.txt%3A43
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/11388/pull-kubevirt-e2e-k8s-1.29-sig-network/1763491302516723712#1:build-log.txt%3A33

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
