### PR TITLE
governance, kubevirt, org: remove inactive users

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -21,130 +21,46 @@ orgs:
       - 0xFelix
       - aburdenthehand
       - acardace
-      - AdamJ
-      - adityaramteke
       - aglitke
       - akalenyu
       - akrejcir
       - alicefr
       - alaypatel07
       - AlonaKaplan
-      - alonsadan
-      - alosadagrande
       - alromeros
       - andreabolognani
-      - andreyod
       - arnongilboa
-      - ArthurSens
       - assafad
-      - ashleyschuett
       - avlitman
       - awels
       - Barakmor1
-      - bardielle
-      - beanh66
-      - beekhof
-      - booxter
-      - borod108
-      - brybacki
       - codingben
-      - crobinso
       - cwilkers
-      - cynepco3hahue
-      - danielBelenky
-      - danielerez
       - dankenigsberg
-      - dcritch
-      - djzager
       - dollierp
       - dominikholler
-      - doron-fediuck
-      - dshchedr
-      - dteplits
-      - duyanyan
-      - e-minguez
       - EdDev
-      - eedri
       - enp0s3
-      - erkanerol
-      - ezrasilvera
-      - fabiendupont
-      - fedepaol
-      - fgimenez
       - fossedihelm
-      - gabrielecerami
-      - gbenhaim
       - geetikakay
       - germag
-      - gonzolino
       - gouyang
-      - gsr-shanks
-      - guy9050
-      - hritvi
-      - hroyrh
-      - ibesso-rh
-      - idanshaby
-      - ifireball
-      - igoihman
       - iholder101
-      - ILpinto
-      - InbarRose
-      - iranzo
-      - irosenzw
-      - isaacdorfman
-      - itamarh
-      - j-griffith
-      - jakub-dzon
       - jberkus
       - jcanocan
       - jean-edouard
-      - jelkosz
-      - jhernand
-      - JinjunXiong
-      - jniederm
       - jobbler
-      - jordigilh
-      - jparrill
-      - jtomasek
       - kbidarkar
-      - krsacme
       - ksimon1
       - kubevirt-commenter-bot
       - kvaps
-      - kwiesmueller
-      - lukas-bednar
-      - lveyde
       - lyarwood
-      - machacekondra
       - machadovilaca
       - maiqueb
-      - mansam
-      - marceloamaral
-      - mareklibra
-      - MarSik
-      - masayag
-      - matosatti
-      - matthewcarleton
-      - maya-r
-      - mazzystr
       - mfranczy
       - mhenriks
-      - michalskrivanek
-      - mlsorensen
-      - mmazur
-      - mmirecki
       - mrnold
-      - mshitrit
-      - myakove
-      - n1r1
-      - nellyc
-      - nelsonspbr
-      - nertpinx
-      - nirarg
-      - humblenginr
       - nunnatsa
-      - ohadlevy
-      - omeryahud
       - openshift-ci-robot
       - openshift-merge-robot
       - opokornyy
@@ -152,62 +68,20 @@ orgs:
       - orenc1
       - ormergi
       - oshoval
-      - pcbailey
-      - petrkotas
       - phoracek
-      - pkliczewski
-      - ptrnull
       - qinqon
-      - qwang1
       - RamLavi
-      - ravidbro
-      - rawagner
-      - razo7
-      - rgolangh
-      - rhrazdil
-      - rnetser
-      - rollandf
-      - ronensdeor
       - rthallisey
-      - sandrobonazzola
-      - sarahbx
-      - SchSeba
-      - scollier
-      - screeley44
-      - serenamarie125
-      - sgarbour
       - shellyka13
-      - shiywang
-      - shwetaap
-      - simon3z
-      - slintes
       - sradco
-      - sreichar
-      - stbenjam
-      - stoniko
       - stu-gott
-      - suomiy
-      - tareqalayan
-      - thetechnick
       - tiraboschi
-      - tomob
-      - usrbinkat
       - vasiliy-ul
-      - vatsalparekh
       - victortoso
       - VirrageS
       - vladikr
-      - vojtechszocs
-      - xphyr
       - xpivarc
-      - yanirq
-      - yossisegev
-      - yuhaohaoyu
-      - yuvalif
-      - yuvalturg
-      - zcahana
       - zhlhahaha
-      - zvikorn
     members_can_create_repositories: false
     name: KubeVirt
     repos:
@@ -588,22 +462,9 @@ orgs:
       QE:
         description: ""
         maintainers:
-          - nellyc
         members:
           - kbidarkar
-          - myakove
           - gouyang
-          - gsr-shanks
-          - lukas-bednar
-          - tareqalayan
-          - duyanyan
-          - InbarRose
-          - shiywang
-          - vatsalparekh
-          - ILpinto
-          - adityaramteke
-          - yossisegev
-          - dshchedr
           - dollierp
         privacy: closed
         repos:
@@ -613,7 +474,6 @@ orgs:
         description: "team for k8s-seccomp-generator repo"
         maintainers:
           - alicefr
-          - humblenginr
           - xpivarc
         privacy: secret
         repos:
@@ -675,11 +535,9 @@ orgs:
           ".github": admin
       cloud-provider-kubevirt-maintainers:
         maintainers:
-          - nirarg
           - davidvossel
           - rmohr
           - mfranczy
-          - rhrazdil
           - qinqon
         repos:
           cloud-provider-kubevirt: admin
@@ -692,10 +550,7 @@ orgs:
           - kubevirt-bot
         members:
           - vladikr
-          - slintes
-          - cynepco3hahue
           - stu-gott
-          - nellyc
           - kubevirt-commenter-bot
         privacy: closed
         repos:
@@ -735,15 +590,7 @@ orgs:
         maintainers:
           - rmohr
         members:
-          - booxter
-          - MarSik
-          - masayag
-          - j-griffith
-          - eedri
-          - slintes
-          - gonzolino
           - phoracek
-          - SchSeba
           - awels
           - aburdenthehand
           - acardace
@@ -768,8 +615,6 @@ orgs:
         maintainers:
           - rmohr
         members:
-          - pkliczewski
-          - mmirecki
           - nunnatsa
           - tiraboschi
         privacy: closed
@@ -781,8 +626,6 @@ orgs:
           - davidvossel
         members:
           - phoracek
-          - SchSeba
-          - mmirecki
         privacy: closed
         repos:
           bridge-marker: write
@@ -835,8 +678,6 @@ orgs:
           secrets: admin
       terraform-provider-kubevirt-maintainers:
         maintainers:
-          - nirarg
-          - isaacdorfman
         repos:
           terraform-provider-kubevirt: admin
       release-team:
@@ -860,7 +701,6 @@ orgs:
         description: ""
         maintainers:
           - fabiand
-          - stoniko
         privacy: closed
       ssp-maintainers:
         description: ""
@@ -887,8 +727,6 @@ orgs:
         maintainers:
           - fabiand
         members:
-          - serenamarie125
-          - beanh66
         privacy: closed
       tekton-tasks-operator-admin:
         description: "Administration group to maintain settings in tekton operator repo"
@@ -924,14 +762,6 @@ orgs:
         maintainers:
           - fabiand
         members:
-          - vojtechszocs
-          - jelkosz
-          - jtomasek
-          - rawagner
-          - suomiy
-          - jniederm
-          - pcbailey
-          - mareklibra
         privacy: closed
         repos:
           origin-web-console: admin

--- a/hack/remove-users-without-contributions.sh
+++ b/hack/remove-users-without-contributions.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+if [[ "$1" =~ -h ]]; then
+    cat << EOF
+usage: $0 <input-file>
+
+    Removes all users without contributions (taken from the input file) from the orgs.yaml
+
+    input file in csv format is manually fetched from KubeVirt devstats:
+    https://kubevirt.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=w&var-metric=activity&var-repogroup_name=All&var-users=All
+
+    then from the top panel select "Inspect" > "Data" and select "Download CSV"
+EOF
+    exit 0
+fi
+
+if [ ! -f "$1" ]; then
+    echo "file $1 doesn't exist"
+    exit 1
+fi
+input_csv_file="$1"
+
+# generate input file from csv where each user is in a separate line
+head -1 "$input_csv_file" \
+    | tr ',' "\n" \
+    | sed 's/"//g' \
+    | sort -u \
+    > /tmp/users-with-contributions.txt
+
+### we add some user accounts, so that they never get removed
+
+# bots (kubevirt, openshift, the linux foundation)
+cat << EOF >> /tmp/users-with-contributions.txt
+kubevirt-bot
+kubevirt-commenter-bot
+kubevirt-snyk
+openshift-ci-robot
+openshift-merge-robot
+thelinuxfoundation
+EOF
+
+# KubeVirt org admins (security measure so that we don't lose GitHub org access)
+cat << EOF >> /tmp/users-with-contributions.txt
+brianmcarey
+davidvossel
+dhiller
+fabiand
+rmohr
+EOF
+
+# users with invisible contributions (i.e. OSPO, KubeVirt community manager etc)
+cat << EOF >> /tmp/users-with-contributions.txt
+aburdenthehand
+jberkus
+EOF
+
+# iterate over org users (members and admins), grep over contributors list, remove every user not found
+(
+    for username in $(
+        { yq read github/ci/prow-deploy/files/orgs.yaml orgs.kubevirt.members & \
+          yq read github/ci/prow-deploy/files/orgs.yaml orgs.kubevirt.admins ; \
+        } | sed 's/^- //' | sort -u); do
+        echo $username "$(grep -i -c $username /tmp/users-with-contributions.txt)"
+    done
+) | grep ' 0$' \
+  | sed 's/ 0$//' \
+  > /tmp/users-without-contributions.txt
+
+# remove all users without contributions
+for user in $(cat /tmp/users-without-contributions.txt); do
+    sed -i -E '/\s+- '"$user"'/d' github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+done
+
+echo "Users without contributions:"
+cat /tmp/users-without-contributions.txt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Removes inactive users from the org.

[Announcement to kubevirt-dev](https://groups.google.com/g/kubevirt-dev/c/TFyLNxFQG-s/m/VMdgplqJAAAJ)

Also adds a script that can be used to automate the process of removing
users from the org that have no contributions according to the input
file.

List of removed users:
```
AdamJ
adityaramteke
alonsadan
alosadagrande
andreyod
ArthurSens
ashleyschuett
bardielle
beanh66
beekhof
booxter
borod108
brybacki
crobinso
cynepco3hahue
danielBelenky
danielerez
dcritch
djzager
doron-fediuck
dshchedr
dteplits
duyanyan
eedri
e-minguez
erkanerol
ezrasilvera
fabiendupont
fedepaol
fgimenez
gabrielecerami
gbenhaim
gonzolino
gsr-shanks
guy9050
hritvi
hroyrh
humblenginr
ibesso-rh
idanshaby
ifireball
igoihman
ILpinto
InbarRose
iranzo
irosenzw
isaacdorfman
itamarh
jakub-dzon
jelkosz
j-griffith
jhernand
JinjunXiong
jniederm
jordigilh
jparrill
jtomasek
krsacme
kwiesmueller
lukas-bednar
lveyde
machacekondra
mansam
marceloamaral
mareklibra
MarSik
masayag
matosatti
matthewcarleton
maya-r
mazzystr
michalskrivanek
mlsorensen
mmazur
mmirecki
mshitrit
myakove
n1r1
nellyc
nelsonspbr
nertpinx
nirarg
ohadlevy
omeryahud
pcbailey
petrkotas
pkliczewski
ptrnull
qwang1
ravidbro
rawagner
razo7
rgolangh
rhrazdil
rnetser
rollandf
ronensdeor
sandrobonazzola
sarahbx
SchSeba
scollier
screeley44
serenamarie125
sgarbour
shiywang
shwetaap
simon3z
slintes
sreichar
stbenjam
stoniko
suomiy
tareqalayan
thetechnick
tomob
usrbinkat
vatsalparekh
vojtechszocs
xphyr
yanirq
yossisegev
yuhaohaoyu
yuvalif
yuvalturg
zcahana
zvikorn
```

## Inactive members

[_Members are active contributors in the community._](https://github.com/kubevirt/community/blob/main/membership_policy.md#member)

A core principle in maintaining a healthy community is encouraging active
participation. It is inevitable that people's focuses will change over time and
they are not expected to be actively contributing forever.

However, being a member of the KubeVirt GitHub organization comes with
an elevated set of permissions. These capabilities should not be used by those
that are not familiar with the current state of the KubeVirt project.

Therefore members with an extended period away from the project with no activity
will be removed from the KubeVirt GitHub Organizations and will be required to
go through the org membership process again after re-familiarizing themselves
with the current state.

### How inactivity is measured

Inactive members are defined as members of the KubeVirt Organization
with **no** contributions in any repository within 12 months. This is
measured by the [CNCF DevStats project](https://kubevirt.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=w&var-metric=activity&var-repogroup_name=All&var-users=All).

**Note:** Devstats does not take into account non-code contributions. If a
non-code contributing member is accidentally removed this way, they may open an
issue to quickly be re-instated.

After an extended period away from the project with no activity
those members would need to re-familiarize themselves with the current state
before being able to contribute effectively.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- ~[ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required~
- [x] PR: The PR description is expressive enough and will help future contributors
- ~[ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)~
- ~[ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~
- ~[ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- ~[ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test~
- ~[ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
chore: remove inactive members
```
