### PR TITLE
bootstrap,kubevirt: Revert changes introducing github cli to bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -79,7 +79,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-windows2016
     skip_branches:
@@ -120,7 +119,6 @@ presubmits:
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
-      preset-unprivileged-github-credentials: "true"
       vgpu: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-kind-1.27-vgpu
@@ -195,7 +193,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
       rehearsal.allowed: "true"
       sriov-pod: "true"
     max_concurrency: 10
@@ -819,7 +816,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-ipv6-sig-network
     skip_branches:
@@ -863,7 +859,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
       rehearsal.allowed: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
@@ -909,7 +904,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-compute-migrations
     skip_branches:
@@ -1142,7 +1136,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-swap-enabled
     optional: true
@@ -1186,7 +1179,6 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     name: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
     optional: true
     skip_branches:
@@ -1228,7 +1220,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-single-node
     optional: true
@@ -1279,7 +1270,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
     optional: true
@@ -1322,7 +1312,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
     optional: true
@@ -1370,7 +1359,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-network
     skip_branches:
@@ -1415,7 +1403,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-storage
     skip_branches:
@@ -1458,7 +1445,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-compute
     skip_branches:
@@ -1505,7 +1491,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
     skip_branches:
@@ -1550,7 +1535,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.27-sig-operator
     skip_branches:
@@ -1595,7 +1579,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.28-sig-network
     skip_branches:
@@ -1640,7 +1623,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.28-sig-storage
     skip_branches:
@@ -1683,7 +1665,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.28-sig-compute
     skip_branches:
@@ -1730,7 +1711,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.28-sig-operator
     skip_branches:
@@ -1807,7 +1787,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-network
     skip_branches:
@@ -1851,7 +1830,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-storage
     skip_branches:
@@ -1893,7 +1871,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-compute
     skip_branches:
@@ -1939,7 +1916,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.29-sig-operator
     skip_branches:
@@ -1983,7 +1959,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.30-sig-network
     optional: true
@@ -2028,7 +2003,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.30-sig-storage
     optional: true
@@ -2071,7 +2045,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.30-sig-compute
     optional: true
@@ -2118,7 +2091,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
-      preset-unprivileged-github-credentials: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.30-sig-operator
     optional: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -636,19 +636,6 @@ presets:
     - name: github-token
       mountPath: /etc/github
 - labels:
-    preset-unprivileged-github-credentials: "true"
-  env:
-  - name: GITHUB_TOKEN
-    value: /etc/github/oauth
-  volumes:
-  - name: unprivileged-oauth-token
-    secret:
-      secretName: unprivileged-oauth-token
-      defaultMode: 0400
-  volumeMounts:
-    - name: unprivileged-oauth-token
-      mountPath: /etc/github
-- labels:
     preset-gcs-credentials: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -33,7 +33,6 @@ RUN dnf install -y \
     gcc \
     gcc-c++ \
     gettext \
-    gh \
     git \
     glibc-devel \
     glibc-static \


### PR DESCRIPTION
**What this PR does / why we need it**:

gh is no longer required because we can get PR diff using `git diff
PULL_BASE_SHA...PULL_PULL_SHA`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @oshoval 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
