### PR TITLE
bootstrap: Set image proxy at the start of jobs

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -58,6 +58,12 @@ early_exit_handler() {
 # setup certificates before anything gets started
 setup_ca
 
+if [[ -n "$CONTAINER_HTTP_PROXY" && -n "$CONTAINER_HTTPS_PROXY" ]]; then
+    # enable docker-mirror-proxy
+    export HTTP_PROXY=${CONTAINER_HTTP_PROXY}
+    export HTTPS_PROXY=${CONTAINER_HTTPS_PROXY}
+fi
+
 # optionally enable ipv6
 export PODMAN_IN_CONTAINER_IPV6_ENABLED=${PODMAN_IN_CONTAINER_IPV6_ENABLED:-true}
 if [[ "${PODMAN_IN_CONTAINER_IPV6_ENABLED}" == "true" ]]; then
@@ -73,8 +79,6 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
     PODMAN_SOCKET_PATH=/run/podman
     PODMAN_SOCKET=${PODMAN_SOCKET_PATH}/podman.sock
     (
-        export HTTP_PROXY=${CONTAINER_HTTP_PROXY}
-        export HTTPS_PROXY=${CONTAINER_HTTPS_PROXY}
         export KIND_EXPERIMENTAL_PROVIDER="podman"
 
         mkdir -p ${PODMAN_SOCKET_PATH}


### PR DESCRIPTION
**What this PR does / why we need it**:

There are cases where we don't require to run the podman in container setup but we still want to use podman and the docker-mirror-proxy for caching images. Move the setup of the image cache proxy out of podman in container setup so that it is setup for every job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
