### PR TITLE
Revert "bootstrap: Set image proxy at the start of jobs (#3291)"

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -58,12 +58,6 @@ early_exit_handler() {
 # setup certificates before anything gets started
 setup_ca
 
-if [[ -n "$CONTAINER_HTTP_PROXY" && -n "$CONTAINER_HTTPS_PROXY" ]]; then
-    # enable docker-mirror-proxy
-    export HTTP_PROXY=${CONTAINER_HTTP_PROXY}
-    export HTTPS_PROXY=${CONTAINER_HTTPS_PROXY}
-fi
-
 # optionally enable ipv6
 export PODMAN_IN_CONTAINER_IPV6_ENABLED=${PODMAN_IN_CONTAINER_IPV6_ENABLED:-true}
 if [[ "${PODMAN_IN_CONTAINER_IPV6_ENABLED}" == "true" ]]; then
@@ -79,6 +73,8 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
     PODMAN_SOCKET_PATH=/run/podman
     PODMAN_SOCKET=${PODMAN_SOCKET_PATH}/podman.sock
     (
+        export HTTP_PROXY=${CONTAINER_HTTP_PROXY}
+        export HTTPS_PROXY=${CONTAINER_HTTPS_PROXY}
         export KIND_EXPERIMENTAL_PROVIDER="podman"
 
         mkdir -p ${PODMAN_SOCKET_PATH}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This reverts commit 471d8c9bc9ce8ff64cbd5ae94a716273582a6ee5.

Prow jobs had issues downloading dependencies when this change was applied to the job configs.

Bazel uses the same environment variables for proxy[1] so there may be a an issue there causing the image proxy cache getting overloaded.

Reverting this change so that it doesn't get added again through another bump of prow images

[1] https://bazel.build/external/advanced#using_proxies

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

I will investigate if there is another way of setting this proxy for podman but I think its best to undo this change in the meantime. 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
