### PR TITLE
kubevirtci,publish: Publish kubevirtci using podman

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -114,22 +114,19 @@ periodics:
   labels:
     preset-docker-mirror: "true"
     preset-github-credentials: "true"
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-kubevirtci-quay-credential: "true"
   cluster: kubevirt-prow-workloads
   spec:
     containers:
-    - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+    - image: quay.io/kubevirtci/pr-creator:v20230103-9f4e101
       command:
       - "/usr/local/bin/runner.sh"
       - "/bin/bash"
       - "-c"
       - >
-        cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io && PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh &&
-        docker run -v $(pwd):/kubevirtci -v /etc/github:/etc/github -v $(pwd)/../project-infra:/project-infra -e GIT_ASKPASS=/project-infra/hack/git-askpass.sh quay.io/kubevirtci/pr-creator:v20240305-cb764ec
-      env:
-      - name: GIMME_GO_VERSION
-        value: "1.19.9"
+        cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+        GIT_ASKPASS=../project-infra/hack/git-askpass.sh ../project-infra/hack/git-pr.sh -c "PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh" -r kubevirtci -b bump-centos-stream -T main -p $(pwd) -s "Automatic bump of CentOS Stream to latest"
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -15,7 +15,7 @@ postsubmits:
         repo: project-infra
         base_ref: main
       labels:
-        preset-dind-enabled: "true"
+        preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
@@ -35,21 +35,17 @@ postsubmits:
           type: bare-metal-external
         volumes:
         - hostPath:
-            path: /lib/modules
-            type: Directory
-          name: modules
-        - hostPath:
             path: /dev
             type: Directory
           name: devices
         containers:
-        - image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        - image: quay.io/kubevirtci/golang:v20240306-cfcbc5c
           command:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"
           - "-c"
           - >
-            cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io &&
+            cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
             ./publish.sh &&
             echo "$(git tag --points-at HEAD | head -1)" > latest &&
             gsutil cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest
@@ -60,9 +56,6 @@ postsubmits:
           securityContext:
             privileged: true
           volumeMounts:
-          - mountPath: /lib/modules
-            name: modules
-            readOnly: true
           - mountPath: /dev
             name: devices
           resources:


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Previously kubevirtci providers that were published with podman used to break `make cluster-up` for docker users. This was due to an empty `/run/.containerenv` being added to the image when published with podman. This broke some IF statements that setup the iptables rules to communicate with the VM.

This should be fixed when
https://github.com/kubevirt/kubevirtci/pull/1149 is merged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
