### PR TITLE
prow, botreview: enable botreview, hold image updates

### DIFF
--- a/external-plugins/botreview/review/image_update.go
+++ b/external-plugins/botreview/review/image_update.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	prowJobImageUpdateApproveComment    = `:thumbsup: This looks like a simple prow job image bump.`
-	prowJobImageUpdateDisapproveComment = `:thumbsdown: This doesn't look like a simple prow job image bump.`
+	prowJobImageUpdateApproveComment       = `:thumbsup: This looks like a simple prow job image bump.`
+	prowJobImageUpdateDisapproveComment    = `:thumbsdown: This doesn't look like a simple prow job image bump.`
+	prowJobImageUpdateShouldNotMergeReason = "image updates should be acked by the @kubevirt/prow-job-taskforce"
 )
 
 var (
@@ -78,7 +79,7 @@ func (t *ProwJobImageUpdate) AddIfRelevant(fileDiff *diff.FileDiff) {
 }
 
 func (t *ProwJobImageUpdate) Review() BotReviewResult {
-	result := NewCanMergeReviewResult(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment)
+	result := NewShouldNotMergeReviewResult(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, prowJobImageUpdateShouldNotMergeReason)
 
 	for _, fileDiff := range t.relevantFileDiffs {
 		fileName := strings.TrimPrefix(fileDiff.NewName, "b/")

--- a/external-plugins/botreview/review/image_update_test.go
+++ b/external-plugins/botreview/review/image_update_test.go
@@ -60,7 +60,7 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/simple_bump-prow-job-images_sh.patch1"],
 				},
 			},
-			want: NewCanMergeReviewResult(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment),
+			want: NewShouldNotMergeReviewResult(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, prowJobImageUpdateShouldNotMergeReason),
 		},
 		{
 			name: "mixed image bump",
@@ -69,7 +69,7 @@ func TestProwJobImageUpdate_Review(t1 *testing.T) {
 					diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"],
 				},
 			},
-			want: newReviewResultWithData(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": {diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks[0]}}, ""),
+			want: newReviewResultWithData(prowJobImageUpdateApproveComment, prowJobImageUpdateDisapproveComment, map[string][]*diff.Hunk{"github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml": {diffFilePathsToDiffs["testdata/mixed_bump_prow_job.patch0"].Hunks[0]}}, prowJobImageUpdateShouldNotMergeReason),
 		},
 	}
 	for _, tt := range tests {

--- a/github/ci/prow-deploy/kustom/base/manifests/local/botreview-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/botreview-deployment.yaml
@@ -21,8 +21,7 @@ spec:
         # FIXME: change tag to proper version after initial testing is done and there's a postsubmit that updates botreview images
         image: quay.io/kubevirtci/botreview:latest
         args:
-        # FIXME: stay with dry run for now
-        - --dry-run=true
+        - --dry-run=false
         - --port=9900
         - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://ghproxy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR enables the botreview which is currently configured to act on project-infra pull requests.

It also holds image update PRs for now, since CI tema still should ack them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
