### PR TITLE
prow, plugin, help: add required labels, enable for kubevirtci and project-infra

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -317,9 +317,12 @@ default:
     - name: good-first-issue
       color: 128A0C
       target: issues
-      previously:
-      - name: good first issue
-        color: 128A0C
+    - name: good first issue
+      color: 128A0C
+      target: issues
+    - name: help wanted
+      color: 128A0C
+      target: issues
 repos:
   kubevirt/kubevirt:
     labels:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -309,6 +309,7 @@ plugins:
     - approve
     - lgtm
     - trigger
+    - help
 
   kubevirt/kvm-info-nfd-plugin:
     plugins:
@@ -369,6 +370,7 @@ plugins:
     - config-updater
     - lgtm
     - trigger
+    - help
 
   kubevirt/qe-tools:
     plugins:
@@ -719,3 +721,18 @@ label:
     - allowed_teams:
       - kubevirtproject-infra-label
       label: good-first-issue
+
+help:
+  help_guidelines_url: "https://www.github.com/kubevirt/community/tree/main/contributors/help-wanted.md"
+  help_guidelines_summary: |
+    - **No Barrier to Entry**
+    - **Clear Task**
+    - **Solution Explained**
+    - **Provides Context**
+    - **Identifies Relevant Code**
+    - **Gives Examples**
+    - **Ready to Test**    
+    - **Goldilocks priority**
+    - **Up-To-Date**
+
+    


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We add the labels that are required for the prow help plugin to work.
Also we enable them for the kubevirtci and the project-infra repos
and add the initial configuration.

This is related to the help-wanted doc added with [this PR](https://github.com/kubevirt/community/pull/269)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
