### PR TITLE
prow, labels: fix label precheck

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -655,7 +655,7 @@ presubmits:
           requests:
             memory: "200Mi"
   - name: pull-prow-kubevirt-labels-update-precheck
-    run_if_changed: '^github/ci/prow-deploy/files/labels\.yaml$'
+    run_if_changed: '^github/ci/prow-deploy/kustom/base/configs/current/labels/labels\.yaml$'
     annotations:
       testgrid-create-test-group: "false"
     labels:
@@ -672,13 +672,13 @@ presubmits:
         image: gcr.io/k8s-prow/label_sync:v20240306-0b904de3b3
         command: [ "/ko-app/label_sync" ]
         args:
-        - --config=github/ci/prow-deploy/files/labels.yaml
+        - --config=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
         - --confirm=false
         - --orgs=kubevirt
         - --token=/etc/github/oauth
       restartPolicy: Never
   - name: pull-prow-nmstate-labels-update-precheck
-    run_if_changed: '^github/ci/prow-deploy/files/labels\.yaml$'
+    run_if_changed: '^github/ci/prow-deploy/kustom/base/configs/current/labels/labels\.yaml$'
     annotations:
       testgrid-create-test-group: "false"
     labels:
@@ -695,7 +695,7 @@ presubmits:
         image: gcr.io/k8s-prow/label_sync:v20240306-0b904de3b3
         command: [ "/ko-app/label_sync" ]
         args:
-        - --config=github/ci/prow-deploy/files/labels.yaml
+        - --config=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
         - --confirm=false
         - --only=nmstate/kubernetes-nmstate
         - --token=/etc/github/oauth


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

label-sync job is failing with:

```
$ k logs label-sync-kubevirt-28497557-xqksl -n kubevirt-prow
{"component":"label_sync","error":"invalid config: description for sig/buildsystem is too long","file":"k8s.io/test-infra/label_sync/main.go:757","func":"main.main","level":"fatal","msg":"failed to load --config=/etc/config/labels.yaml","severity":"fatal","time":"2024-03-07T23:17:48Z"}
```

Check was not triggered for linked files, therefore we update `run_if_changed` and config path in jobs to new locations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @brianmcarey 


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
