### PR TITLE
Trigger the performance presubmit on monitoring changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.27-sig-performance
-    run_if_changed: ^cmd/.*|^rpm/.*|^tests/performance/.*|^hack/perftests.sh|^tools/perfscale-audit/.*|^bazel/.*|^third_party/.*|^staging/src/.*|^api/.*|^pkg/virt-.*|^pkg/controlller/.*
+    run_if_changed: ^cmd/.*|^rpm/.*|^tests/performance/.*|^hack/perftests.sh|^tools/perfscale-audit/.*|^bazel/.*|^third_party/.*|^staging/src/.*|^api/.*|^pkg/virt-.*|^pkg/controlller/.*|^pkg/monitoring/.*
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
The perf jobs rely heavily on the monitoring pkg so trigger the performance presubmit job when there are changes in that pkg.


```release-note
NONE
```
