### PR TITLE
Add Vamsikrishnasiddu to kubevirt members.

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -76,6 +76,7 @@ orgs:
       - sradco
       - stu-gott
       - tiraboschi
+      - vamsikrishna-siddu
       - vasiliy-ul
       - victortoso
       - VirrageS


### PR DESCRIPTION
Iam planning to add s390x support for the kubevirt builder. This will make us to enable CI/CD for the  kubevirt on s390x. My area of focus is to enable and maintain the CI/CD pipeline for kubevirt on s390x and make sure any new changes do not break the s390x support on kubevirt. In order to achieve this, I want myself to be added to the kubevirt community. 

### Github Username
@vamsikrishna-siddu 

**Requirements:**

- [x]  I have reviewed the community code of conduct (https://github.com/kubevirt/kubevirt/blob/master/CODE_OF_CONDUCT.md)
- [x]  I have enabled 2FA on my GitHub account (https://github.com/settings/security)
- [x]  I have subscribed to the kubevirt-dev e-mail list (https://groups.google.com/forum/#!forum/kubevirt-dev)
- [x]  I am actively contributing to KubeVirt
- [x]  I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
- [x]  I have spoken to my sponsors ahead of this application and they have agreed to sponsor my application
- [x]  I have publicly introduced myself to the community through one of the community communication channels
(https://github.com/kubevirt/community#socializing)

**Sponsors**

- @dhiller 
- @brianmcarey 

**List of contributions to the KubeVirt project**

- **PRs reviewed and/or authored.**

- https://github.com/kubevirt/kubevirt/pull/11097

**Note To Reviewer:**

- Member list was ordered alphabetically.
