### PR TITLE
prow, plugin, botreview: use image sha

### DIFF
--- a/external-plugins/botreview/Makefile
+++ b/external-plugins/botreview/Makefile
@@ -2,6 +2,9 @@
 .PHONY: all clean format test push
 all: format test push
 bazelbin := bazelisk
+CONTAINER_TAG := $(shell ../../hack/container-tag.sh)
+CONTAINER_IMAGE := botreview
+CONTAINER_REPO := quay.io/kubevirtci/$(CONTAINER_IMAGE)
 
 build:
 	$(bazelbin) build //external-plugins/botreview/...
@@ -13,4 +16,5 @@ test:
 	$(bazelbin) test //external-plugins/botreview/...
 
 push:
-	podman build -f ../../images/botreview/Containerfile -t quay.io/kubevirtci/botreview:latest && podman push quay.io/kubevirtci/botreview:latest
+	podman build -f ../../images/$(CONTAINER_IMAGE)/Containerfile -t $(CONTAINER_REPO):$(CONTAINER_TAG) && podman push $(CONTAINER_REPO):$(CONTAINER_TAG)
+	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO)

--- a/github/ci/prow-deploy/kustom/base/manifests/local/botreview-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/botreview-deployment.yaml
@@ -18,8 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: botreview
-        # FIXME: change tag to proper version after initial testing is done and there's a postsubmit that updates botreview images
-        image: quay.io/kubevirtci/botreview:latest
+        image: quay.io/kubevirtci/botreview:v20240325-bfd7ddbd
         args:
         # FIXME: stay with dry run for now
         - --dry-run=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Use image sha when pushing new image version and for deployment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
