### PR TITLE
update sig-scale automation with 1.29 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -973,6 +973,9 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
+  # note: when the provider is updated, the `robots/cmd/perf-report-creator/graph.sh` and
+  #       `robots/cmd/perf-report-creator/scrape.sh` needs to be updated as well, refer to this
+  #       https://github.com/kubevirt/project-infra/pull/3032 for the needed changes
   name: periodic-kubevirt-e2e-k8s-1.29-sig-performance
   reporter_config:
     slack:

--- a/robots/cmd/perf-report-creator/graph.sh
+++ b/robots/cmd/perf-report-creator/graph.sh
@@ -1,10 +1,10 @@
 OUTPUT_DIR=${1}
 
 
-# plot sig-performance 1.25 weekly vmi
+# plot sig-performance 1.29 weekly vmi
 perf-report-creator weekly-graph \
   --resource=vmi \
-  --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.27-sig-performance \
+  --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.29-sig-performance \
   --plotly-html=true \
   --since=2022-11-29 \
   --metrics-list=vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count
@@ -12,12 +12,12 @@ perf-report-creator weekly-graph \
 ## plot 100-density-test results
 perf-report-creator weekly-graph \
   --resource=vm \
-  --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.27-sig-performance \
+  --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.29-sig-performance \
   --plotly-html=true \
   --since=2022-11-29 \
   --metrics-list=vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count
 #
-## plot sig-performance 1.25 weekly vm
+## plot sig-performance 1.29 weekly vm
 perf-report-creator weekly-graph \
   --resource=vmi \
   --weekly-reports-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-performance-cluster-100-density-test \

--- a/robots/cmd/perf-report-creator/scrape.sh
+++ b/robots/cmd/perf-report-creator/scrape.sh
@@ -2,14 +2,14 @@ CREDENTIALS_FILE=${1}
 BENCHMARKS_DIR=${2}
 OUTPUT_DIR=${3:-output}
 
-# scrape sig-performance 1.27 results
-perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-e2e-k8s-1.27-sig-performance
+# scrape sig-performance 1.29 results
+perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-e2e-k8s-1.29-sig-performance
 # scrape 100 density test results
 perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-performance-cluster-100-density-test
 
-# aggregate sig-performance 1.27 results in weekly directory
-perf-report-creator weekly-report --output-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.27-sig-performance \
-  --results-dir=${OUTPUT_DIR}/results/periodic-kubevirt-e2e-k8s-1.27-sig-performance \
+# aggregate sig-performance 1.29 results in weekly directory
+perf-report-creator weekly-report --output-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-k8s-1.29-sig-performance \
+  --results-dir=${OUTPUT_DIR}/results/periodic-kubevirt-e2e-k8s-1.29-sig-performance \
   --vmi-metrics-list=vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count \
   --vm-metrics-list vmiCreationToRunningSecondsP50,vmiCreationToRunningSecondsP95,LIST-virtualmachineinstances-count,LIST-pods-count,LIST-nodes-count,LIST-virtualmachineinstancemigrations-count,LIST-endpoints-count,GET-virtualmachineinstances-count,GET-pods-count,GET-nodes-count,GET-virtualmachineinstancemigrations-count,GET-endpoints-count,CREATE-virtualmachineinstances-count,CREATE-pods-count,CREATE-nodes-count,CREATE-virtualmachineinstancemigrations-count,CREATE-endpoints-count,PATCH-virtualmachineinstances-count,PATCH-pods-count,PATCH-nodes-count,PATCH-virtualmachineinstancemigrations-count,PATCH-endpoints-count,UPDATE-virtualmachineinstances-count,UPDATE-pods-count,UPDATE-nodes-count,UPDATE-virtualmachineinstancemigrations-count,UPDATE-endpoints-count
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
update sig-scale automation for 1.29 provider change


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Added a note for future updates to cover sig-scale automation as well

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update sig-scale automation for 1.29 provider change
```

cc @brianmcarey @dhiller @rthallisey 
