### PR TITLE
Add jschintag to kubevirt members

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -50,6 +50,7 @@ orgs:
       - jcanocan
       - jean-edouard
       - jobbler
+      - jschintag
       - kbidarkar
       - ksimon1
       - kubevirt-commenter-bot


### PR DESCRIPTION
# GitHub Username
@jschintag

## Requirements

- [x] I have reviewed the community code of conduct (https://github.com/kubevirt/kubevirt/blob/master/CODE_OF_CONDUCT.md)<br>
- [x] I have enabled 2FA on my GitHub account (https://github.com/settings/security)<br>
- [x] I have subscribed to the kubevirt-dev e-mail list (https://groups.google.com/forum/#!forum/kubevirt-dev)<br>
- [x] I am actively contributing to KubeVirt<br>
- [x] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines<br>
- [x] I have spoken to my sponsors ahead of this application and they have agreed to sponsor my application<br>
- [x] I have publicly introduced myself to the community through one of the community communication channels<br>

(https://github.com/kubevirt/community#socializing)

## Sponsors

* @brianmcarey 
* @dhiller 

## List of contributions to the KubeVirt project

* PRs reviewed and/or authored
- https://github.com/kubevirt/kubevirt/pull/10490
- https://github.com/kubevirt/kubevirt/pull/10836
- https://github.com/kubevirt/kubevirt/pull/11047
- https://github.com/kubevirt/kubevirt/pull/11493
- https://github.com/kubevirt/kubevirt/pull/11602
- https://github.com/kubevirt/kubevirt/pull/11097
* Issues responded to
- https://github.com/kubevirt/kubevirt/issues/8765
-
-

## Reason for joining

I am currently working on enabling kubevirt to run on the s390x architecture. For that reason i would like to join the kubevirt org to be able to better maintain the s390x support, as well as general multi-arch support.

> [!IMPORTANT]
> After this pull request has been merged, an invitation to the KubeVirt GitHub organization will be automatically sent to the new member. The new member needs to accept the invitation to receive member status.