### PR TITLE
prow, plugin, rehearse: restrict access to rehearsal to project-infra top level approvers and job approvers

### DIFF
--- a/external-plugins/rehearse/plugin/BUILD.bazel
+++ b/external-plugins/rehearse/plugin/BUILD.bazel
@@ -20,6 +20,8 @@ go_library(
         "@io_k8s_test_infra//prow/interrupts:go_default_library",
         "@io_k8s_test_infra//prow/pluginhelp:go_default_library",
         "@io_k8s_test_infra//prow/pluginhelp/externalplugins:go_default_library",
+        "@io_k8s_test_infra//prow/plugins/ownersconfig:go_default_library",
+        "@io_k8s_test_infra//prow/repoowners:go_default_library",
     ],
 )
 
@@ -56,10 +58,12 @@ go_test(
     ],
     deps = [
         "//external-plugins/rehearse/plugin/handler:go_default_library",
+        "//external-plugins/testutils:go_default_library",
         "@com_github_onsi_ginkgo_v2//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
         "@io_k8s_test_infra//prow/apis/prowjobs/v1:go_default_library",
         "@io_k8s_test_infra//prow/client/clientset/versioned/typed/prowjobs/v1/fake:go_default_library",

--- a/external-plugins/rehearse/plugin/handler/BUILD.bazel
+++ b/external-plugins/rehearse/plugin/handler/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@io_k8s_test_infra//prow/git/v2:go_default_library",
         "@io_k8s_test_infra//prow/github:go_default_library",
         "@io_k8s_test_infra//prow/pjutil:go_default_library",
+        "@io_k8s_test_infra//prow/repoowners:go_default_library",
     ],
 )
 
@@ -30,14 +31,17 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//external-plugins/testutils:go_default_library",
         "@com_github_onsi_ginkgo_v2//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_test_infra//prow/apis/prowjobs/v1:go_default_library",
         "@io_k8s_test_infra//prow/config:go_default_library",
         "@io_k8s_test_infra//prow/git/localgit:go_default_library",
         "@io_k8s_test_infra//prow/git/v2:go_default_library",
         "@io_k8s_test_infra//prow/github:go_default_library",
+        "@io_k8s_test_infra//prow/github/fakegithub:go_default_library",
     ],
 )

--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -146,7 +146,7 @@ func (h *GitHubEventsHandler) handleIssueComment(log *logrus.Entry, event *githu
 	if err != nil {
 		log.WithError(err).Errorf("Could not get PR number %d", event.Issue.Number)
 	}
-	if !h.canUserRehearse(err, org, event.Comment.User.Login, pr) {
+	if !h.canUserRehearse(org, pr, event.Comment.User.Login) {
 		log.Infoln("Skipping event - user validation failed")
 		return
 	}
@@ -170,7 +170,7 @@ func (h *GitHubEventsHandler) shouldActOnIssueComment(event *github.IssueComment
 	return false
 }
 
-func (h *GitHubEventsHandler) canUserRehearse(err error, org string, userName string, pr *github.PullRequest) bool {
+func (h *GitHubEventsHandler) canUserRehearse(org string, pr *github.PullRequest, userName string) bool {
 	isAuthorMember, err := h.ghClient.IsMember(org, pr.User.Login)
 	if err != nil {
 		log.WithError(err).Errorln("Could not validate PR author with the repo org")
@@ -218,7 +218,7 @@ func (h *GitHubEventsHandler) handlePullRequestUpdateEvent(log *logrus.Entry, ev
 	if err != nil {
 		log.WithError(err).Errorf("Could not get PR number %d", event.PullRequest.Number)
 	}
-	if !h.canUserRehearse(err, org, event.Sender.Login, pr) {
+	if !h.canUserRehearse(org, pr, event.Sender.Login) {
 		log.Infoln("Skipping event. User is not authorized.")
 		return
 	}

--- a/external-plugins/rehearse/plugin/rehearse_test.go
+++ b/external-plugins/rehearse/plugin/rehearse_test.go
@@ -2,6 +2,8 @@ package main_test
 
 import (
 	"encoding/json"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"kubevirt.io/project-infra/external-plugins/testutils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -203,15 +205,13 @@ var _ = Describe("Rehearse", func() {
 					}
 					fakelog := logrus.New()
 					eventsChan := make(chan *handler.GitHubEvent)
-					eventsHandler := handler.NewGitHubEventsHandler(
-						eventsChan,
-						fakelog,
-						prowc.ProwJobs("test-ns"),
-						gh,
-						"prowconfig.yaml",
-						"",
-						true,
-						gitClientFactory)
+					foc := &testutils.FakeOwnersClient{
+						ExistingTopLevelApprovers: sets.NewString("testuser"),
+					}
+					froc := &testutils.FakeRepoownersClient{
+						Foc: foc,
+					}
+					eventsHandler := handler.NewGitHubEventsHandler(eventsChan, fakelog, prowc.ProwJobs("test-ns"), gh, "prowconfig.yaml", "", true, gitClientFactory, froc)
 
 					handlerEvent, err := makeHandlerPullRequestEvent(&event)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -344,15 +344,13 @@ var _ = Describe("Rehearse", func() {
 					}
 					fakelog := logrus.New()
 					eventsChan := make(chan *handler.GitHubEvent)
-					eventsHandler := handler.NewGitHubEventsHandler(
-						eventsChan,
-						fakelog,
-						prowc.ProwJobs("test-ns"),
-						gh,
-						"prowconfig.yaml",
-						"",
-						true,
-						gitClientFactory)
+					foc := &testutils.FakeOwnersClient{
+						ExistingTopLevelApprovers: sets.NewString("testuser"),
+					}
+					froc := &testutils.FakeRepoownersClient{
+						Foc: foc,
+					}
+					eventsHandler := handler.NewGitHubEventsHandler(eventsChan, fakelog, prowc.ProwJobs("test-ns"), gh, "prowconfig.yaml", "", true, gitClientFactory, froc)
 
 					handlerEvent, err := makeHandlerPullRequestEvent(&event)
 					eventsHandler.Handle(handlerEvent)
@@ -506,16 +504,14 @@ var _ = Describe("Rehearse", func() {
 						Fake: &testing.Fake{},
 					}
 					fakelog := logrus.New()
+					foc := &testutils.FakeOwnersClient{
+						ExistingTopLevelApprovers: sets.NewString("testuser"),
+					}
+					froc := &testutils.FakeRepoownersClient{
+						Foc: foc,
+					}
 					eventsChan := make(chan *handler.GitHubEvent)
-					eventsHandler := handler.NewGitHubEventsHandler(
-						eventsChan,
-						fakelog,
-						prowc.ProwJobs("test-ns"),
-						gh,
-						"prowconfig.yaml",
-						"",
-						true,
-						gitClientFactory)
+					eventsHandler := handler.NewGitHubEventsHandler(eventsChan, fakelog, prowc.ProwJobs("test-ns"), gh, "prowconfig.yaml", "", true, gitClientFactory, froc)
 					handlerEvent, err := makeHandlerPullRequestEvent(&event)
 					Expect(err).ShouldNot(HaveOccurred())
 					eventsHandler.Handle(handlerEvent)
@@ -684,15 +680,13 @@ var _ = Describe("Rehearse", func() {
 					}
 					fakelog := logrus.New()
 					eventsChan := make(chan *handler.GitHubEvent)
-					eventsHandler := handler.NewGitHubEventsHandler(
-						eventsChan,
-						fakelog,
-						prowc.ProwJobs("test-ns"),
-						gh,
-						"prowconfig.yaml",
-						"",
-						false,
-						gitClientFactory)
+					foc := &testutils.FakeOwnersClient{
+						ExistingTopLevelApprovers: sets.NewString("testuser"),
+					}
+					froc := &testutils.FakeRepoownersClient{
+						Foc: foc,
+					}
+					eventsHandler := handler.NewGitHubEventsHandler(eventsChan, fakelog, prowc.ProwJobs("test-ns"), gh, "prowconfig.yaml", "", false, gitClientFactory, froc)
 
 					handlerEvent, err := makeHandlerPullRequestEvent(&event)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -859,15 +853,13 @@ var _ = Describe("Rehearse", func() {
 					}
 					fakelog := logrus.New()
 					eventsChan := make(chan *handler.GitHubEvent)
-					eventsHandler := handler.NewGitHubEventsHandler(
-						eventsChan,
-						fakelog,
-						prowc.ProwJobs("test-ns"),
-						gh,
-						"prowconfig.yaml",
-						"",
-						true,
-						gitClientFactory)
+					foc := &testutils.FakeOwnersClient{
+						ExistingTopLevelApprovers: sets.NewString("testuser"),
+					}
+					froc := &testutils.FakeRepoownersClient{
+						Foc: foc,
+					}
+					eventsHandler := handler.NewGitHubEventsHandler(eventsChan, fakelog, prowc.ProwJobs("test-ns"), gh, "prowconfig.yaml", "", true, gitClientFactory, froc)
 
 					handlerEvent, err := makeHandlerPullRequestEvent(&event)
 					Expect(err).ShouldNot(HaveOccurred())
@@ -904,15 +896,13 @@ var _ = Describe("Rehearse", func() {
 				}
 				fakelog := logrus.New()
 				eventsChan := make(chan *handler.GitHubEvent)
-				eventsHandler := handler.NewGitHubEventsHandler(
-					eventsChan,
-					fakelog,
-					prowc.ProwJobs("test-ns"),
-					gh,
-					"prowconfig.yaml",
-					"",
-					true,
-					gitClientFactory)
+				foc := &testutils.FakeOwnersClient{
+					ExistingTopLevelApprovers: sets.NewString("testuser"),
+				}
+				froc := &testutils.FakeRepoownersClient{
+					Foc: foc,
+				}
+				eventsHandler := handler.NewGitHubEventsHandler(eventsChan, fakelog, prowc.ProwJobs("test-ns"), gh, "prowconfig.yaml", "", true, gitClientFactory, froc)
 
 				handlerEvent, err := makeHandlerIssueCommentEvent(event)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/external-plugins/rehearse/plugin/rehearse_test.go
+++ b/external-plugins/rehearse/plugin/rehearse_test.go
@@ -853,9 +853,7 @@ var _ = Describe("Rehearse", func() {
 					}
 					fakelog := logrus.New()
 					eventsChan := make(chan *handler.GitHubEvent)
-					foc := &testutils.FakeOwnersClient{
-						ExistingTopLevelApprovers: sets.NewString("testuser"),
-					}
+					foc := &testutils.FakeOwnersClient{}
 					froc := &testutils.FakeRepoownersClient{
 						Foc: foc,
 					}

--- a/external-plugins/testutils/fakegithub.go
+++ b/external-plugins/testutils/fakegithub.go
@@ -43,9 +43,9 @@ const (
 
 type FakeOwnersClient struct {
 	ExistingTopLevelApprovers sets.String
+	CurrentLeafApprovers      map[string]sets.String
 	owners                    map[string]string
 	approvers                 map[string]layeredsets.String
-	leafApprovers             map[string]sets.String
 	reviewers                 map[string]layeredsets.String
 	requiredReviewers         map[string]sets.String
 	leafReviewers             map[string]sets.String
@@ -70,7 +70,7 @@ func (foc *FakeOwnersClient) Approvers(path string) layeredsets.String {
 }
 
 func (foc *FakeOwnersClient) LeafApprovers(path string) sets.String {
-	return foc.leafApprovers[path]
+	return foc.CurrentLeafApprovers[path]
 }
 
 func (foc *FakeOwnersClient) FindApproverOwnersForFile(path string) string {


### PR DESCRIPTION
<!-- 1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Restricts access to job rehearsal creation to project-infra top level approvers and job approvers. In case the user that triggers the rehearsal is an org member, adds a comment telling the user who can help him.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
