### PR TITLE
HCO: add ginkgo filter by labels

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -31,6 +31,8 @@ presubmits:
         env:
           - name: GIMME_GO_VERSION
             value: "1.21.6"
+          - name: GINKGO_LABELS
+            value: '!OpenShift && !SINGLE_NODE_ONLY'
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -68,6 +70,8 @@ presubmits:
           env:
             - name: GIMME_GO_VERSION
               value: "1.21.6"
+            - name: GINKGO_LABELS
+              value: '!OpenShift && !SINGLE_NODE_ONLY'
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
## What this PR does / why we need it
Add filter by labels to HCO. will start working after https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2860 PR will be merged, but until then, it will just run all tests, as done now.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
