### PR TITLE
kubectl-virt, presubmit: remove shellcheck since it's unreliable

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -33,34 +33,6 @@ presubmits:
         resources:
           requests:
             memory: "1Gi"
-  - name: pull-kubectl-virt-plugin-shellcheck
-    skip_branches:
-    - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-    always_run: true
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 1h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-shared-images: "true"
-    cluster: kubevirt-prow-control-plane
-    spec:
-      containers:
-      - image: quay.io/kubevirtci/kubectl-virt-builder@sha256:49045b159c711cf307bdabeb5fd8889dae26a44753ec8c74a3e32fa3ba5fcde1
-        command:
-        - "/usr/local/bin/runner.sh"
-        args:
-        - "/bin/sh"
-        - "-c"
-        - shellcheck -x $(find $(pwd) -type f -name '*.sh' -not -path '**/out/*' -print)
-        resources:
-          requests:
-            memory: "1Gi"
   - name: build-kubectl-virt-plugin-images
     skip_branches:
       - release-\d+\.\d+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Remove shellcheck presubmit, as it has never worked reliably [^1].

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey @xpivarc 

[^1]: https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubectl-virt-plugin-shellcheck