### PR TITLE
Enable goveralls in containerized-data-importer

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -156,47 +156,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-  - name: push-containerized-data-importer-goveralls
-    cluster: kubevirt-prow-control-plane
-    branches:
-      - main
-    annotations:
-      testgrid-create-test-group: "false"
-    always_run: false  # TODO: Make true after we're confident it's working
-    optional: true     # TODO: Make false after we're confident it's working
-    skip_reporting: true
-    decorate: true
-    decoration_config:
-      timeout: 1h
-      grace_period: 10m
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
-    spec:
-      containers:
-        - image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
-          env:
-            - name: COVERALLS_TOKEN_FILE
-              value: /root/.docker/secrets/coveralls/token
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make goveralls"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "8Gi"
-          volumeMounts:
-            - name: kubevirtci-coveralls
-              mountPath: /root/.docker/secrets/coveralls
-              readOnly: true
-      volumes:
-        - name: kubevirtci-coveralls
-          secret:
-            secretName: kubevirtci-coveralls-token
   - name: push-containerized-data-importer-builder
     branches:
     - main

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -156,6 +156,47 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
+  - name: push-containerized-data-importer-goveralls
+    cluster: kubevirt-prow-control-plane
+    branches:
+      - main
+    annotations:
+      testgrid-create-test-group: "false"
+    always_run: false  # TODO: Make true after we're confident it's working
+    optional: true     # TODO: Make false after we're confident it's working
+    skip_reporting: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 10m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-bazel-cache: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
+          env:
+            - name: COVERALLS_TOKEN_FILE
+              value: /root/.docker/secrets/coveralls/token
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "cp /etc/bazel.bazelrc ./ci.bazelrc && make goveralls"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "8Gi"
+          volumeMounts:
+            - name: kubevirtci-coveralls
+              mountPath: /root/.docker/secrets/coveralls
+              readOnly: true
+      volumes:
+        - name: kubevirtci-coveralls
+          secret:
+            secretName: kubevirtci-coveralls-token
   - name: push-containerized-data-importer-builder
     branches:
     - main

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -31,6 +31,47 @@ presubmits:
           resources:
             requests:
               memory: "8Gi"
+  - name: pull-kubevirt-goveralls
+    always_run: false # TODO: Make true after we're confident it's working
+    optional: true    # TODO: Make false after we're confident it's working
+    annotations:
+      fork-per-release: "true"
+    cluster: kubevirt-prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 10m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then
+          make goveralls; fi
+        env:
+        - name: COVERALLS_TOKEN_FILE
+          value: /root/.docker/secrets/coveralls/token
+        image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /root/.docker/secrets/coveralls
+          name: kubevirtci-coveralls
+          readOnly: true
+      volumes:
+      - name: kubevirtci-coveralls
+        secret:
+          secretName: kubevirtci-coveralls-token
   - name: pull-cdi-generate-verify
     skip_branches:
       - release-v1.38

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
     optional: true    # TODO: Make false after we're confident it's working
     annotations:
       fork-per-release: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
       grace_period: 10m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
           resources:
             requests:
               memory: "8Gi"
-  - name: pull-kubevirt-goveralls
+  - name: pull-cdi-goveralls
     always_run: false # TODO: Make true after we're confident it's working
     optional: true    # TODO: Make false after we're confident it's working
     annotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Enables Coveralls report for the copntainerised-data-importer repo, wich has not made any upload since early 2021. https://coveralls.io/github/kubevirt/containerized-data-importer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes CNV-22942

**Special notes for your reviewer**:
The idea is to merge this optional job now and test it in some PR of mine, and iterate until we're confident it works. Then I'll set alwaysRun=true and optional=false, although the latter may require some tweaking to avoid being too overbearing.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
