### PR TITLE
Change pull-kubevirt-e2e-kind-sriov to use a non-legacy image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -226,7 +226,7 @@ presubmits:
         env:
         - name: TARGET
           value: kind-sriov
-        image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+        image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
         name: ""
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of using the legacy image `quay.io/kubevirtci/bootstrap-legacy`, the SRIOV lane would be using `quay.io/kubevirtci/bootstrap`.

**Special notes for your reviewer**:
This PR https://github.com/kubevirt/kubevirt/pull/11659 is requiring Kubevirt's infra components to run on CP nodes by default. However, the `pull-kubevirt-e2e-kind-sriov` lane is failing since its single CP node has a NoShedule taint:
```yaml
"taints": [
    {
        "key": "node-role.kubernetes.io/control-plane",
        "effect": "NoSchedule"
    }
]
```

I **think** that the image itself is responsible for adding this taint.
And in general, it seems we have only two lanes running this legacy image:
```bash
> grep "image: " jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml | grep legacy | wc -l
2
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
