### PR TITLE
Explicitly set REGISTRY env in ovs-cni jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-postsubmits.yaml
@@ -18,8 +18,10 @@ postsubmits:
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
-              - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && make docker-build docker-push"
+              - "-ce"
+              - |
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io
+                make REGISTRY=quay.io/kubevirt docker-build docker-push
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -46,7 +48,7 @@ postsubmits:
                 cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io
                 # Only push images on tags
                 COMMIT_TAG=$(git tag --points-at HEAD | head -1)
-                [ -z "$COMMIT_TAG" ] || make docker-build docker-push IMAGE_TAG=$COMMIT_TAG
+                [ -z "$COMMIT_TAG" ] || make REGISTRY=quay.io/kubevirt IMAGE_TAG=$COMMIT_TAG docker-build docker-push
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Explicitly set REGISTRY env in ovs-cni jobs
This change is required because default registry in the Makefile in the ovs-cni repo was changed to ghcr.io/k8snetworkplumbingwg.


**Special notes for your reviewer**:

Context: https://github.com/k8snetworkplumbingwg/ovs-cni/pull/307
Example of a failed job https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/main-ovs-cni/1781239529819082752
```release-note
NONE
```

@phoracek Do we want to continue push to quay in addition to GH registry? If yes, then I believe that this patch will fix the push jobs.
