### PR TITLE
prow, autobump: add config files, modify bump script

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -531,7 +531,7 @@ periodics:
       args:
       - "-ce"
       - |
-        hack/git-pr.sh -c "hack/bump-prow.sh /etc/github" -b prow-autobump -r project-infra -T main -B $'Bump Prow\n\n/cc @kubevirt/prow-job-taskforce'
+        hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main -B $'Bump Prow\n\n/cc @kubevirt/prow-job-taskforce'
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -511,6 +511,8 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-podman-in-container-enabled: "true"
+    preset-docker-mirror-proxy: "true"
     preset-github-credentials: "true"
   decorate: true
   decoration_config:
@@ -521,22 +523,20 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
   cluster: kubevirt-prow-control-plane
   spec:
-    securityContext:
-      runAsUser: 0
     containers:
-      - image: quay.io/kubevirtci/pr-creator:v20240305-cb764ec
-        command: ["/bin/sh"]
-        args:
-          - "-c"
-          - hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main -B $'Bump Prow\n\n/cc @kubevirt/prow-job-taskforce'
-        resources:
-          requests:
-            memory: "200Mi"
+    - image: quay.io/kubevirtci/pr-creator:v20240305-cb764ec
+      command: ["/bin/sh"]
+      args:
+      - "-ce"
+      - |
+        hack/git-pr.sh -c "hack/bump-prow.sh /etc/github" -b prow-autobump -r project-infra -T main -B $'Bump Prow\n\n/cc @kubevirt/prow-job-taskforce'
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "200Mi"
 - name: periodic-kubevirt-presubmit-requirer
   cron: "0 1 1 * *"
   max_concurrency: 1
@@ -563,7 +563,7 @@ periodics:
         args:
           - |
             git-pr.sh -c "bazel run //robots/cmd/kubevirt require presubmits -- --job-config-path-kubevirt-presubmits=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --github-token-path= --dry-run=false && bazel run //robots/cmd/kubevirt remove always_run -- --job-config-path-kubevirt-presubmits=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml --github-token-path= --dry-run=false" -r project-infra -b require-kubevirt-presubmits -T main -s 'Enable e2e lanes for latest kubernetes version' -B $'Enable lanes for latest kubernetes version and disable lanes with unsupported version\n\n/cc @kubevirt/prow-job-taskforce'
-            
+
         resources:
           requests:
             memory: "200Mi"

--- a/github/ci/prow-deploy/prow-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-autobump-config.yaml
@@ -5,6 +5,8 @@ includedConfigPaths:
   - "/config/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources"
   - "/config/github/ci/prow-deploy/kustom/base/manifests/local"
 excludedConfigPaths: []
+extraFiles:
+  - "/config/hack/bump-prow.sh"
 targetVersion: upstream
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 prefixes:

--- a/github/ci/prow-deploy/prow-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-autobump-config.yaml
@@ -1,0 +1,27 @@
+---
+gitHubToken: "/etc/github/oauth"
+includedConfigPaths:
+  - "/config/github/ci/prow-deploy/kustom/base/configs/current/config"
+  - "/config/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources"
+  - "/config/github/ci/prow-deploy/kustom/base/manifests/local"
+excludedConfigPaths: []
+targetVersion: upstream
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+prefixes:
+  - name: "Prow"
+    prefix: "gcr.io/k8s-prow/"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: true
+    consistentImages: true
+    consistentImageExceptions:
+      - "gcr.io/k8s-prow/alpine"
+      - "gcr.io/k8s-prow/analyze"
+      - "gcr.io/k8s-prow/commenter"
+      - "gcr.io/k8s-prow/configurator"
+      - "gcr.io/k8s-prow/gcsweb"
+      - "gcr.io/k8s-prow/gencred"
+      - "gcr.io/k8s-prow/git"
+      - "gcr.io/k8s-prow/issue-creator"
+      - "gcr.io/k8s-prow/label_sync"
+      - "gcr.io/k8s-prow/pr-creator"

--- a/github/ci/prow-deploy/prow-job-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-job-autobump-config.yaml
@@ -1,0 +1,12 @@
+---
+gitHubToken: "/etc/github/oauth"
+includedConfigPaths:
+  - "/config/github/ci/prow-deploy/files/jobs"
+excludedConfigPaths: []
+targetVersion: latest
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+prefixes:
+  - name: "Jobs"
+    prefix: "gcr.io/k8s-prow/"
+    summarise: true
+    consistentImages: false

--- a/hack/bump-prow.sh
+++ b/hack/bump-prow.sh
@@ -2,78 +2,23 @@
 
 set -euxo pipefail
 
+[ -d "$1" ] || ( echo "$1 is not a directory, should contain the oauth for github bot account"; exit 1 )
+
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
-PROJECT_INFRA_MANIFESTS_ROOT=${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/base
-TEST_INFRA_ROOT=$(readlink --canonicalize ${PROJECT_INFRA_ROOT}/../../kubernetes/test-infra)
-TEST_INFRA_MANIFESTS_ROOT=${TEST_INFRA_ROOT}/config/prow/cluster
+GITHUB_TOKEN_PATH="$1"
 
-copy_files(){
-    curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
-        chmod a+x ./yq && \
-        mv ./yq /usr/local/bin
-
-    local target_files=$(yq r ${PROJECT_INFRA_MANIFESTS_ROOT}/kustomization.yaml resources | grep test_infra | sed 's/^- \(.*\)/\1/')
-
-    for base_target_file in ${target_files}; do
-        local target_dir_name=$(dirname ${base_target_file})
-        local target_file=${PROJECT_INFRA_MANIFESTS_ROOT}/${base_target_file}
-
-        mkdir -p ${PROJECT_INFRA_MANIFESTS_ROOT}/${target_dir_name}
-
-        local source_file=${TEST_INFRA_MANIFESTS_ROOT}/${base_target_file/manifests\/test_infra\/current\//}
-
-        cp ${source_file} ${target_file}
-    done
-}
-
-get_latest_prow_tag(){
-    echo $(grep gcr.io/k8s-prow/ ${TEST_INFRA_MANIFESTS_ROOT}/prow_controller_manager_deployment.yaml | cut -d ':' -f 3)
-}
-
-bump_utility_images(){
-    local latest_prow_tag=$1
-
-    local utility_images=(clonerefs initupload entrypoint sidecar)
-
-    for utility_image in ${utility_images[@]}; do
-        sed -i "s!${utility_image}: \"gcr.io/k8s-prow/${utility_image}:.*\"!${utility_image}: \"gcr.io/k8s-prow/${utility_image}:${latest_prow_tag}\"!" ${PROJECT_INFRA_MANIFESTS_ROOT}/configs/current/config/config.yaml
-    done
-}
-
-bump_exporter(){
-    local latest_prow_tag=$1
-
-    sed -i "s!image: gcr.io/k8s-prow/exporter:.*!image: gcr.io/k8s-prow/exporter:${latest_prow_tag}!" ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources/prow-exporter-deployment.yaml
-}
-
-bump_base_manifests_local_images(){
-    local latest_prow_tag=$1
-
-    find ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/kustom/base/manifests/local -type f -name '*.yaml' | xargs sed -i "s!image: gcr.io/k8s-prow/\(.*\):.*!image: gcr.io/k8s-prow/\\1:${latest_prow_tag}!"
-}
-
-bump_job_images(){
-    local latest_prow_tag=$1
-
-    find ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/files/jobs -type f -name '*.yaml' | xargs sed -i "s!image: gcr.io/k8s-prow/\(.*\):.*!image: gcr.io/k8s-prow/\\1:${latest_prow_tag}!"
+autobump() {
+    relative_config_path="$1"
+    # the below is necessary since running the autobumper inside a pod fails because of a failing git command
+    (
+        podman run -v ${PROJECT_INFRA_ROOT}/:/config:z -v ${GITHUB_TOKEN_PATH}:/etc/github -it gcr.io/k8s-prow/generic-autobumper --config /config/${relative_config_path} --skip-pullrequest
+    ) || true
 }
 
 main(){
-    copy_files
-
-    local latest_prow_tag=$(get_latest_prow_tag)
-    if [ -z "${latest_prow_tag}" ]; then
-        echo "Could not find latest prow tag"
-        exit 1
-    fi
-
-    echo latest_prow_tag: $latest_prow_tag
-
-    bump_utility_images "${latest_prow_tag}"
-    bump_exporter "${latest_prow_tag}"
-    bump_base_manifests_local_images "${latest_prow_tag}"
-    bump_job_images "${latest_prow_tag}"
+    autobump github/ci/prow-deploy/prow-autobump-config.yaml
+    autobump github/ci/prow-deploy/prow-job-autobump-config.yaml
 }
 
 main "${@}"

--- a/hack/bump-prow.sh
+++ b/hack/bump-prow.sh
@@ -2,17 +2,20 @@
 
 set -euxo pipefail
 
-[ -d "$1" ] || ( echo "$1 is not a directory, should contain the oauth for github bot account"; exit 1 )
+GITHUB_TOKEN_PATH="${1:-/etc/github}"
+if [ ! -d "$GITHUB_TOKEN_PATH" ]; then
+    echo "$GITHUB_TOKEN_PATH is not a directory, should contain the oauth for github bot account"
+    exit 1
+fi
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
-GITHUB_TOKEN_PATH="$1"
 
 autobump() {
     relative_config_path="$1"
     # the below is necessary since running the autobumper inside a pod fails because of a failing git command
     (
-        podman run -v ${PROJECT_INFRA_ROOT}/:/config:z -v ${GITHUB_TOKEN_PATH}:/etc/github -it gcr.io/k8s-prow/generic-autobumper --config /config/${relative_config_path} --skip-pullrequest
+        podman run -v ${PROJECT_INFRA_ROOT}/:/config:z -v ${GITHUB_TOKEN_PATH}:/etc/github -it gcr.io/k8s-prow/generic-autobumper:v20240419-d3bf92f82 --config /config/${relative_config_path} --skip-pullrequest
     ) || true
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since prow moved to it's own repository (see https://github.com/kubernetes/test-infra/issues/31728), our update automation updated images for commenter with non-existing image tags, and we had to revert bump PRs. See https://github.com/kubernetes-sigs/prow/issues/121#issue-2252926381 for details. This was caused since the images for commenter etc. were created in another job (see [comment](https://github.com/kubernetes-sigs/prow/issues/121#issuecomment-2067220948)). Therefore we need to adapt our update mechanism, so it's a good time to switch to using the [`gcr.io/k8s-prow/generic-autobumper`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/generic-autobumper).

`generic-autobumper` needs configuration files per update. We create two, one for the prow components and another one for the jobs.

Also we modify the bump script so that it runs the autobumper twice, once per configuration, as a pod. For that we need to add the podman in container preset.

Successfully tested on my fork, resulting PR here: https://github.com/kubevirt/project-infra/pull/3363

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes CNV-41102

**Special notes for your reviewer**:
/cc @brianmcarey @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
update periodic-project-infra-prow-bump after prow move
```
