### PR TITLE
Fix: CDI goveralls job must use its repository's token

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -66,12 +66,12 @@ presubmits:
           privileged: true
         volumeMounts:
         - mountPath: /root/.docker/secrets/coveralls
-          name: kubevirtci-coveralls
+          name: containerized-data-importer-coveralls
           readOnly: true
       volumes:
-      - name: kubevirtci-coveralls
+      - name: containerized-data-importer-coveralls
         secret:
-          secretName: kubevirtci-coveralls-token
+          secretName: containerized-data-importer-coveralls-token
   - name: pull-cdi-generate-verify
     skip_branches:
       - release-v1.38

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -121,6 +121,11 @@
     content: '{{ coverallsToken }}'
     dest: '{{ secrets_dir }}/kubevirtci-coveralls-token'
 
+- name: Create containerized-data-importer coveralls token
+  copy:
+    content: '{{ containerizedDataImporterCoverallsToken }}'
+    dest: '{{ secrets_dir }}/containerized-data-importer-coveralls-token'
+
 - name: Create win-sysprep-001 secret
   copy:
     content: '{{ windowsProductKeys["sysprep-001"] }}'

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -116,9 +116,9 @@
     content: '{{ githubBotreviewToken }}'
     dest: '{{ secrets_dir }}/botreview-oauth-token'
 
-- name: Create kubevirt coveralls token secret
+- name: Create coveralls token secret
   copy:
-    content: '{{ kubevirtCoverallsToken }}'
+    content: '{{ coverallsToken }}'
     dest: '{{ secrets_dir }}/kubevirtci-coveralls-token'
 
 - name: Create containerized-data-importer coveralls token

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -116,9 +116,9 @@
     content: '{{ githubBotreviewToken }}'
     dest: '{{ secrets_dir }}/botreview-oauth-token'
 
-- name: Create coveralls token secret
+- name: Create kubevirt coveralls token secret
   copy:
-    content: '{{ coverallsToken }}'
+    content: '{{ kubevirtCoverallsToken }}'
     dest: '{{ secrets_dir }}/kubevirtci-coveralls-token'
 
 - name: Create containerized-data-importer coveralls token

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -26,7 +26,7 @@ masterClusterContext: kubernetes-admin@kubernetes
 
 installerPullToken: '{}'
 
-coverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
+kubevirtCoverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
 containerizedDataImporterCoverallsToken: crUjghdXLBHQ9If442uUjULtjTH1gAu8I
 
 bootstrap_full_config: true

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -26,7 +26,7 @@ masterClusterContext: kubernetes-admin@kubernetes
 
 installerPullToken: '{}'
 
-kubevirtCoverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
+coverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
 containerizedDataImporterCoverallsToken: crUjghdXLBHQ9If442uUjULtjTH1gAu8I
 
 bootstrap_full_config: true

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -27,6 +27,7 @@ masterClusterContext: kubernetes-admin@kubernetes
 installerPullToken: '{}'
 
 coverallsToken: d3c481176ace1b6c5eb417b0d3dd01497
+containerizedDataImporterCoverallsToken: crUjghdXLBHQ9If442uUjULtjTH1gAu8I
 
 bootstrap_full_config: true
 reconcile_github_webhooks: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently, PR #3350 enabled goveralls in kubevirt/containerized-data-importer.
I tested it in this PR https://github.com/kubevirt/containerized-data-importer/pull/3197 and the report went to the `kubevirt/kubevirt` project ([see report](https://coveralls.io/jobs/141056711)) instead of `kubevirt/containerized-data-importer`.

I tracked down the issue and the problem is that each repository has its own unique coveralls token. This PR adds this token to the secrets and makes the CDI job use it.

**Special notes for your reviewer**:
You can check out a repository's coveralls token by going to coveralls, logging in with your GitHub account, and going to the URL https://coveralls.io/github/kubevirt/containerized-data-importer (replace the URL accordingly). You must be in the organization in order to see the token.

I ran the job manually with the token hard-coded and successfully uploaded a coverage report: https://coveralls.io/builds/67129015

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
