### PR TITLE
prow, labels: update help wanted and good first issue

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -89,9 +89,9 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="good first issue" href="#good first issue">`good first issue`</a> | |  | |
-| <a id="good-first-issue" href="#good-first-issue">`good-first-issue`</a> | |  | |
-| <a id="help wanted" href="#help wanted">`help wanted`</a> | |  | |
+| <a id="good first issue" href="#good first issue">`good first issue`</a> | Identifies an issue that has been specifically created or selected for first-time contributors.| prow |  [help](https://prow.ci.kubevirt.io/command-help#help) |
+| <a id="good-first-issue" href="#good-first-issue">`good-first-issue`</a> | Identifies an issue that has been specifically created or selected for first-time contributors.|  | |
+| <a id="help wanted" href="#help wanted">`help wanted`</a> | Identifies an issue that has been specifically created or selected for new contributors.| prow |  [help](https://prow.ci.kubevirt.io/command-help#help) |
 | <a id="triage/build-watcher" href="#triage/build-watcher">`triage/build-watcher`</a> | Discovered by a kubevirt build-watcher. Pay attention to these issues to keep CI healthy. <br><br> This was previously `triage/build-officer`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 
 ## Labels that apply to all repos, only for PRs

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -322,13 +322,20 @@ default:
       addedBy: prow
     - name: good-first-issue
       color: 128A0C
+      description: Identifies an issue that has been specifically created or selected for first-time contributors.
       target: issues
     - name: good first issue
       color: 128A0C
+      description: Identifies an issue that has been specifically created or selected for first-time contributors.
       target: issues
+      prowPlugin: help
+      addedBy: prow
     - name: help wanted
       color: 128A0C
+      description: Identifies an issue that has been specifically created or selected for new contributors.
       target: issues
+      prowPlugin: help
+      addedBy: prow
 repos:
   kubevirt/kubevirt:
     labels:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Updates the description of the labels `help wanted` and `good first issue`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
