### PR TITLE
kubevirt,releases: Add change to mdev module name in vgpu release presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -519,6 +519,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
+          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -211,6 +211,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
+          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -133,6 +133,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
+          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -135,6 +135,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
+          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET


### PR DESCRIPTION
**What this PR does / why we need it**:

These vgpu e2e lanes are failing due to missing a kernel module vfio_mdev[1] after the workloads cluster upgrade.

The mdev kernel module is already loaded on the nodes as the nvidia operator is installed.

This updates the vgpu providers on the release branches to laod the mdev
kernel module instead of vfio_mdev.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-e2e-kind-1.27-vgpu/1784918657499926528#1:build-log.txt%3A310


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc none

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
