### PR TITLE
prow, referee: add retest metrics

### DIFF
--- a/external-plugins/referee/BUILD.bazel
+++ b/external-plugins/referee/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//external-plugins/referee/ghgraphql:go_default_library",
+        "//external-plugins/referee/metrics:go_default_library",
         "//external-plugins/referee/server:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/external-plugins/referee/BUILD.bazel
+++ b/external-plugins/referee/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -24,4 +24,14 @@ go_binary(
     name = "referee",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+    ],
 )

--- a/external-plugins/referee/README.md
+++ b/external-plugins/referee/README.md
@@ -1,0 +1,32 @@
+# referee - external plugin for prow
+
+Referee is an external plugin for [prow] that helps ci maintainers with enforcing specific rules that we have set to keep KubeVirt CI healthy.
+
+Currently it does the following:
+
+* place a `/hold` on pull requests that exceed a certain number of retests after the last change
+
+## Motivation
+
+We have noticed that at certain times pull requests are constantly retested without any chance of succeeding. Our reasoning is that if a pull request is retested a certain number of times without any changes this points to an instability or flakiness that people need to look at and fix.
+
+## Metrics
+
+### Retests
+
+> [!NOTE]
+> counters are reset after plugin restart
+
+Below is a copy of the generated metrics for retests with explanation:
+
+	# HELP referee_retests_org_repo_total The total number of retests for org_repo_total encountered so far
+	# TYPE referee_retests_org_repo_total counter
+	referee_retests_org_repo_total 1
+	# HELP referee_retests_total The total number of retests encountered so far
+	# TYPE referee_retests_total counter
+	referee_retests_total 1
+	# HELP referee_retests_org_repo_pr_since_last_commit The number of retests per PR since last commit in org/repo encountered so far
+	# TYPE referee_retests_org_repo_pr_since_last_commit gauge
+	referee_retests_org_repo_pr_since_last_commit{pull_request="1742"} 37
+
+[prow]: prow.ci.kubevirt.io

--- a/external-plugins/referee/ghgraphql/pullrequests.go
+++ b/external-plugins/referee/ghgraphql/pullrequests.go
@@ -26,12 +26,12 @@ import (
 )
 
 func (g gitHubGraphQLClient) FetchOpenApprovedAndLGTMedPRs(org string, repo string) (PullRequests, error) {
-	labels, err := g.fetchPRs(org, repo)
+	prs, err := g.fetchPRs(org, repo)
 	if err != nil {
 		return PullRequests{}, err
 	}
 	pullRequests := PullRequests{
-		PRs: labels,
+		PRs: prs,
 	}
 	return pullRequests, nil
 }

--- a/external-plugins/referee/main.go
+++ b/external-plugins/referee/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 	"kubevirt.io/project-infra/external-plugins/referee/ghgraphql"
+	"kubevirt.io/project-infra/external-plugins/referee/metrics"
 	"kubevirt.io/project-infra/external-plugins/referee/server"
 	"net/http"
 	"os"
@@ -125,6 +126,7 @@ func main() {
 	mux.Handle("/", pluginServer)
 	externalplugins.ServeExternalPluginHelp(mux, log, server.HelpProvider)
 	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
+	metrics.AddMetricsHandler(mux)
 	defer interrupts.WaitForGracefulShutdown()
 	interrupts.ListenAndServe(httpServer, 5*time.Second)
 

--- a/external-plugins/referee/main_test.go
+++ b/external-plugins/referee/main_test.go
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+var _ = Describe("main", func() {
+	Context("options", func() {
+		When("initialRetestRepositories", func() {
+			const errorExpected = true
+			const noErrorExpected = false
+			DescribeTable("validation",
+				func(o options, errorExpected bool) {
+					actual := o.Validate()
+					if errorExpected {
+						Expect(actual).ToNot(BeNil())
+					} else {
+						Expect(actual).ToNot(HaveOccurred())
+					}
+				},
+				Entry("one repo, wrong identifier",
+					options{initialRetestRepositories: "kubevirt"},
+					errorExpected,
+				),
+				Entry("one repo, correct identifier",
+					options{initialRetestRepositories: "kubevirt/kubevirt"},
+					noErrorExpected,
+				),
+				Entry("two repos, incorrect identifier",
+					options{initialRetestRepositories: "kubevirt/kubevirt,kubevirt//project-infra"},
+					errorExpected,
+				),
+				Entry("two repos, correct identifiers",
+					options{initialRetestRepositories: "kubevirt/kubevirt,kubevirt/project-infra"},
+					noErrorExpected,
+				),
+			)
+			DescribeTable("repo identifiers",
+				func(o options, expectedRepos []RepoIdentifier) {
+					repositories := o.InitialRetestRepositories()
+					for index, expectedRepoId := range expectedRepos {
+						Expect(repositories[index].Org).To(BeEquivalentTo(expectedRepoId.Org), "org doesn't match")
+						Expect(repositories[index].Repo).To(BeEquivalentTo(expectedRepoId.Repo), "repo doesn't match")
+					}
+				},
+				Entry("one incomplete identifier",
+					options{initialRetestRepositories: "kubevirt"},
+					nil,
+				),
+				Entry("one complete identifier",
+					options{initialRetestRepositories: "kubevirt/kubevirt"},
+					[]RepoIdentifier{
+						{Org: "kubevirt", Repo: "kubevirt"},
+					},
+				),
+				Entry("two incomplete identifiers",
+					options{initialRetestRepositories: "kubevirt/kubevirt,kubevirt//project-infra"},
+					nil,
+				),
+				Entry("two complete identifiers",
+					options{initialRetestRepositories: "kubevirt/kubevirt,kubevirt/project-infra"},
+					[]RepoIdentifier{
+						{Org: "kubevirt", Repo: "kubevirt"},
+						{Org: "kubevirt", Repo: "project-infra"},
+					},
+				),
+			)
+		})
+	})
+})
+
+func TestMainSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
+}

--- a/external-plugins/referee/metrics/BUILD.bazel
+++ b/external-plugins/referee/metrics/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "retests.go",
+    ],
+    importpath = "kubevirt.io/project-infra/external-plugins/referee/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "metrics_suite_test.go",
+        "retests_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_onsi_ginkgo_v2//:go_default_library",
+        "@com_github_onsi_gomega//:go_default_library",
+    ],
+)

--- a/external-plugins/referee/metrics/BUILD.bazel
+++ b/external-plugins/referee/metrics/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "metrics.go",
         "retests.go",
     ],
     importpath = "kubevirt.io/project-infra/external-plugins/referee/metrics",
@@ -11,6 +12,7 @@ go_library(
     deps = [
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
     ],
 )
 
@@ -18,11 +20,13 @@ go_test(
     name = "go_default_test",
     srcs = [
         "metrics_suite_test.go",
+        "metrics_test.go",
         "retests_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "@com_github_onsi_ginkgo_v2//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
 )

--- a/external-plugins/referee/metrics/doc.go
+++ b/external-plugins/referee/metrics/doc.go
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+/*
+Package metrics contains the relevant metrics that the referee plugin tracks.
+
+# Retest metrics
+
+Retest rate shows the stability of the current test situation. We have observed that whenever there is a surge in retests, a stability problem has occurred. Examples recalled:
+
+  - sudden rise in retests shown after a test got flaky
+  - sudden rise in retests after an infrastructure issue occurred (i.e. quay outage)
+  - sudden rise in retests after an instability inside a PR surfaced, which was not properly investigated
+
+The latter is distinct from the former since the issuing of the retest
+occurs on one specific PR, thus the rate increase in general is not that high
+
+# Goals
+
+  - Be alerted if the rate of retests suddenly rises
+  - Have an overview of the current state per PR
+
+# Approach
+
+To achieve the goals it makes sense to monitor two kinds of metrics:
+
+  - the rate of observed retest commands will give an overview of stability, an alert on a sudden surge will make us aware that a problem is present
+  - the current state per PR will give an overview if there’s a more specific issue with using retests, i.e. a dedicated instability caused by changes from a PR - an alert beyond the magic boundary will make us aware that there’s a problem
+*/
+package metrics

--- a/external-plugins/referee/metrics/metrics.go
+++ b/external-plugins/referee/metrics/metrics.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"net/http"
+)
+
+const (
+	metricsPath   = "/metrics"
+	promNamespace = "referee"
+)
+
+func AddMetricsHandler(mux *http.ServeMux) {
+	mux.Handle(metricsPath, promhttp.Handler())
+}

--- a/external-plugins/referee/metrics/metrics_suite_test.go
+++ b/external-plugins/referee/metrics/metrics_suite_test.go
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package metrics
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Phased Suite")
+}

--- a/external-plugins/referee/metrics/metrics_test.go
+++ b/external-plugins/referee/metrics/metrics_test.go
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"io"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var _ = Describe("metrics", func() {
+	Context("prometheus handler", func() {
+		const host = "localhost"
+		const port = 9798
+		var srv *http.Server
+		BeforeEach(func() {
+			l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(l.Close()).ToNot(HaveOccurred())
+			sm := http.NewServeMux()
+			reset()
+			AddMetricsHandler(sm)
+			srv = &http.Server{
+				Handler: sm,
+				Addr:    fmt.Sprintf("%s:%d", host, port),
+			}
+			go func() {
+				defer GinkgoRecover()
+				err := srv.ListenAndServe()
+				Expect(err).To(Equal(http.ErrServerClosed))
+			}()
+
+		})
+		AfterEach(func() {
+			err := srv.Shutdown(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+		})
+		type MetricsTestData struct {
+			ExpectedMatchedLinesInBody []*regexp.Regexp
+			Preparation                []func() error
+		}
+		DescribeTable("fetches metrics", func(td MetricsTestData) {
+
+			for _, prep := range td.Preparation {
+				Expect(prep()).ToNot(HaveOccurred())
+			}
+			client := http.Client{Timeout: 1 * time.Second}
+			defer client.CloseIdleConnections()
+			resp, err := client.Get(fmt.Sprintf("http://%s:%d%s", host, port, metricsPath))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+
+			bodyStr := string(body)
+			for _, expected := range td.ExpectedMatchedLinesInBody {
+				matched := false
+				for _, line := range strings.Split(bodyStr, "\n") {
+					if expected.MatchString(line) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					Fail(fmt.Sprintf("Matching value %q not found in exposed metrics %q", expected, bodyStr))
+				}
+			}
+		},
+			Entry("initial state - only the total retests counter exists", MetricsTestData{
+				ExpectedMatchedLinesInBody: []*regexp.Regexp{
+					regexp.MustCompile(fmt.Sprintf("^%s 0$", generateRetestsMetricsName(totalRetestsCounterName))),
+				},
+			}),
+			Entry("IncForRepository: org/repo counter is recorded, also total is increased", MetricsTestData{
+				Preparation: []func() error{
+					func() error {
+						IncForRepository("org", "repo")
+						return nil
+					},
+				},
+				ExpectedMatchedLinesInBody: []*regexp.Regexp{
+					regexp.MustCompile(fmt.Sprintf("^%s 1$", generateRetestsMetricsName(totalRetestsCounterName))),
+					regexp.MustCompile(fmt.Sprintf("^%s 1$", fmt.Sprintf(generateRetestsMetricsName(retestsPerRepoCounterName), "org", "repo"))),
+				},
+			}),
+			Entry("SetForPullRequest: org repo per pr gauge recorded", MetricsTestData{
+				Preparation: []func() error{
+					func() error {
+						SetForPullRequest("org", "repo1", 1742, 37)
+						SetForPullRequest("org", "repo1", 4217, 66)
+						SetForPullRequest("org", "repo2", 1234, 98)
+						SetForPullRequest("org", "repo2", 5678, 87)
+						return nil
+					},
+				},
+				ExpectedMatchedLinesInBody: []*regexp.Regexp{
+					regexp.MustCompile(fmt.Sprintf(`^%s{pull_request="1742"} 37$`, fmt.Sprintf(generateRetestsMetricsName(retestsPerPRGaugeName), "org", "repo1"))),
+					regexp.MustCompile(fmt.Sprintf(`^%s{pull_request="4217"} 66$`, fmt.Sprintf(generateRetestsMetricsName(retestsPerPRGaugeName), "org", "repo1"))),
+					regexp.MustCompile(fmt.Sprintf(`^%s{pull_request="1234"} 98$`, fmt.Sprintf(generateRetestsMetricsName(retestsPerPRGaugeName), "org", "repo2"))),
+					regexp.MustCompile(fmt.Sprintf(`^%s{pull_request="5678"} 87$`, fmt.Sprintf(generateRetestsMetricsName(retestsPerPRGaugeName), "org", "repo2"))),
+				},
+			}),
+		)
+	})
+})
+
+func generateRetestsMetricsName(simpleName string) string {
+	return fmt.Sprintf("%s_%s_%s", promNamespace, promSubsystemForRetests, simpleName)
+}

--- a/external-plugins/referee/metrics/retests.go
+++ b/external-plugins/referee/metrics/retests.go
@@ -1,0 +1,130 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package metrics
+
+import (
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"strconv"
+	"sync"
+)
+
+const (
+	totalRetestsCounterName   = "referee_retests_total"
+	retestsPerRepoCounterName = "referee_retests_%s_%s_repo_total"
+	retestsPerPRGaugeName     = "referee_retests_%s_%s_pr_since_last_commit"
+)
+
+type counter interface {
+	Inc()
+}
+
+type gaugeVec interface {
+	SetWithLabelValues(value float64, values ...string)
+}
+
+var (
+	totalRetests = createCounter(
+		"referee_retests_total",
+		"The total number of retests encountered so far",
+	)
+	retestsPerRepo             = map[string]counter{}
+	retestsPerRepoMutex        = sync.RWMutex{}
+	retestsPerPullRequest      = map[string]gaugeVecWrapper{}
+	retestsPerPullRequestMutex = sync.RWMutex{}
+	defaultCreateCounterFunc   = func(name, help string) counter {
+		return promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: "referee",
+			Subsystem: "retests",
+			Name:      name,
+			Help:      help,
+		})
+	}
+	createCounter             = defaultCreateCounterFunc
+	defaultCreateGaugeVecFunc = func(name, help string) gaugeVecWrapper {
+		return newGaugeVecWrapper(
+			promauto.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: "referee",
+				Subsystem: "retests",
+				Name:      name,
+				Help:      help,
+			},
+				[]string{
+					"pull_request",
+				},
+			),
+		)
+	}
+	createGaugeVec = defaultCreateGaugeVecFunc
+)
+
+type gaugeVecWrapper interface {
+	SetWithLabelValues(value float64, values ...string)
+}
+type simpleGaugeVecWrapper struct {
+	gaugeVec *prometheus.GaugeVec
+}
+
+func newGaugeVecWrapper(v *prometheus.GaugeVec) gaugeVecWrapper {
+	return simpleGaugeVecWrapper{gaugeVec: v}
+}
+
+func (w simpleGaugeVecWrapper) SetWithLabelValues(value float64, values ...string) {
+	w.gaugeVec.WithLabelValues(values...).Set(value)
+}
+
+func reset() {
+	totalRetests = createCounter(
+		totalRetestsCounterName,
+		"The total number of retests encountered so far",
+	)
+	retestsPerRepo = map[string]counter{}
+	retestsPerPullRequest = map[string]gaugeVecWrapper{}
+}
+
+// SetForPullRequest sets the number of retests for a pull request since the last commit.
+func SetForPullRequest(org, repo string, pr, value int) {
+	retestsPerPRKey := fmt.Sprintf(retestsPerPRGaugeName, org, repo)
+	retestsPerPullRequestMutex.Lock()
+	defer retestsPerPullRequestMutex.Unlock()
+	_, found := retestsPerPullRequest[retestsPerPRKey]
+	if !found {
+		retestsPerPullRequest[retestsPerPRKey] = createGaugeVec(retestsPerPRKey, fmt.Sprintf("The number of retests per PR since last commit in %s/%s encountered so far", org, repo))
+	}
+	retestsPerPullRequest[retestsPerPRKey].SetWithLabelValues(float64(value), strconv.Itoa(pr))
+}
+
+// IncForRepository increases the number of retests encountered inside pull requests for a repository.
+func IncForRepository(org, repo string) {
+	totalRetests.Inc()
+	increaseRetestsPerRepoCounter(org, repo)
+}
+
+func increaseRetestsPerRepoCounter(org string, repo string) {
+	retestsPerRepoKey := fmt.Sprintf(retestsPerRepoCounterName, org, repo)
+	retestsPerRepoMutex.Lock()
+	defer retestsPerRepoMutex.Unlock()
+	_, found := retestsPerRepo[retestsPerRepoKey]
+	if !found {
+		retestsPerRepo[retestsPerRepoKey] = createCounter(retestsPerRepoKey, fmt.Sprintf("The total number of retests for %s encountered so far", retestsPerRepoKey))
+	}
+	retestsPerRepo[retestsPerRepoKey].Inc()
+}

--- a/external-plugins/referee/metrics/retests_test.go
+++ b/external-plugins/referee/metrics/retests_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 	"sync/atomic"
 )
@@ -35,6 +36,14 @@ func newFakeCounter() *fakeCounter {
 	return &fakeCounter{
 		CounterValue: &atomic.Int32{},
 	}
+}
+
+func (c fakeCounter) Describe(_ chan<- *prometheus.Desc) {
+	//not implemented
+}
+
+func (c fakeCounter) Collect(_ chan<- prometheus.Metric) {
+	//not implemented
 }
 
 func (c fakeCounter) Inc() {

--- a/external-plugins/referee/metrics/retests_test.go
+++ b/external-plugins/referee/metrics/retests_test.go
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package metrics
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sync"
+	"sync/atomic"
+)
+
+type fakeCounter struct {
+	CounterValue *atomic.Int32
+}
+
+func newFakeCounter() *fakeCounter {
+	return &fakeCounter{
+		CounterValue: &atomic.Int32{},
+	}
+}
+
+func (c fakeCounter) Inc() {
+	c.CounterValue.Add(1)
+}
+
+type fakeGaugeVecWrapper struct {
+	Values []string
+	Value  float64
+}
+
+func newFakeGaugeVecWrapper() *fakeGaugeVecWrapper {
+	return &fakeGaugeVecWrapper{}
+}
+
+func (gv *fakeGaugeVecWrapper) SetWithLabelValues(value float64, values ...string) {
+	gv.Values = values
+	gv.Value = value
+}
+
+var _ = Describe("retests", func() {
+	Context("counters", func() {
+		var counters map[string]counter
+		var countersMutex sync.RWMutex
+		var gaugeVecs map[string]gaugeVec
+		var gaugeVecsMutex sync.RWMutex
+		BeforeEach(func() {
+			counters = make(map[string]counter)
+			countersMutex = sync.RWMutex{}
+			createCounter = func(name, help string) counter {
+				countersMutex.Lock()
+				defer countersMutex.Unlock()
+				counters[name] = newFakeCounter()
+				return counters[name]
+			}
+			gaugeVecs = make(map[string]gaugeVec)
+			gaugeVecsMutex = sync.RWMutex{}
+			createGaugeVec = func(name, help string) gaugeVecWrapper {
+				gaugeVecsMutex.Lock()
+				defer gaugeVecsMutex.Unlock()
+				gaugeVecs[name] = newFakeGaugeVecWrapper()
+				return gaugeVecs[name]
+			}
+			reset()
+		})
+		It("total counter increased", func() {
+			IncForRepository("myorg", "myrepo")
+			actual := counters[totalRetestsCounterName].(*fakeCounter)
+			Expect(actual.CounterValue.Load()).To(BeEquivalentTo(1))
+		})
+		It("repo counter created and increased", func() {
+			IncForRepository("myorg", "myrepo")
+			actual := counters[fmt.Sprintf(retestsPerRepoCounterName, "myorg", "myrepo")].(*fakeCounter)
+			Expect(actual).ToNot(BeNil())
+			Expect(actual.CounterValue.Load()).To(BeEquivalentTo(1))
+		})
+		It("pr gauge created and set", func() {
+			SetForPullRequest("myorg", "myrepo", 1737, 42)
+			actual := gaugeVecs[fmt.Sprintf(retestsPerPRGaugeName, "myorg", "myrepo")].(*fakeGaugeVecWrapper)
+			Expect(actual).ToNot(BeNil())
+			Expect(actual.Values).To(BeEquivalentTo([]string{"1737"}))
+			Expect(actual.Value).To(BeEquivalentTo(float64(42)))
+		})
+		AfterEach(func() {
+			createCounter = defaultCreateCounterFunc
+			createGaugeVec = defaultCreateGaugeVecFunc
+		})
+	})
+})

--- a/external-plugins/referee/server/BUILD.bazel
+++ b/external-plugins/referee/server/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//external-plugins/referee/ghgraphql:go_default_library",
+        "//external-plugins/referee/metrics:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_test_infra//prow/config:go_default_library",
         "@io_k8s_test_infra//prow/github:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We add metrics that capture the total number of retests encountered and the current state of retests per PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
