### PR TITLE
prow, plugin, rehearse: fix case issue for user name

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler_test.go
+++ b/external-plugins/rehearse/plugin/handler/handler_test.go
@@ -531,7 +531,7 @@ Gna meh whatever
 					ExpectedCanUserRehearse: true,
 				},
 			),
-			Entry("user and author in org - user is a leaf approver - case in OWNERS and GitHub is different for user (1)",
+			Entry("user and author in org - user is a leaf approver - case in OWNERS and GitHub is different for user - OWNERS lowercase",
 				CanUserRehearseOrgAndUserTestData{
 					OrgMembers: map[string][]string{
 						"testorg": {
@@ -548,7 +548,7 @@ Gna meh whatever
 					ExpectedCanUserRehearse: true,
 				},
 			),
-			Entry("user and author in org - user is a leaf approver - case in OWNERS and GitHub is different for user (1)",
+			Entry("user and author in org - user is a leaf approver - case in OWNERS and GitHub is different for user - OWNERS uppercase",
 				CanUserRehearseOrgAndUserTestData{
 					OrgMembers: map[string][]string{
 						"testorg": {
@@ -596,7 +596,7 @@ Gna meh whatever
 					ExpectedCanUserRehearse: true,
 				},
 			),
-			Entry("only user in org - user is top level approver - case in OWNERS and GitHub don't match (1)",
+			Entry("only user in org - user is top level approver - case in OWNERS and GitHub don't match - topLeverApprovers lowercase",
 				CanUserRehearseOrgAndUserTestData{
 					OrgMembers: map[string][]string{
 						"testorg": {
@@ -610,7 +610,7 @@ Gna meh whatever
 					ExpectedCanUserRehearse: true,
 				},
 			),
-			Entry("only user in org - user is top level approver - case in OWNERS and GitHub don't match (2)",
+			Entry("only user in org - user is top level approver - case in OWNERS and GitHub don't match - topLeverApprovers uppercase",
 				CanUserRehearseOrgAndUserTestData{
 					OrgMembers: map[string][]string{
 						"testorg": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

If user name on GitHub handle differs from the user name in the OWNERS file, it is not properly recognized when validating if eligible for rehearsal.

Example: https://github.com/kubevirt/project-infra/pull/3383#issuecomment-2085123369

Thus we normalize to lower case when comparing it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey @RamLavi 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
