### PR TITLE
kubevirt,vgpu: Remove modprobe of vfio_mdev from release vgpu test lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -560,7 +560,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
-          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
+          sed -i 's+/usr/sbin/modprobe vfio_mdev+# Remove loading of vfio_mdev as no longer present+' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -518,7 +518,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
-          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
+          sed -i 's+/usr/sbin/modprobe vfio_mdev+# Remove loading of vfio_mdev as no longer present+' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -211,7 +211,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
-          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
+          sed -i 's+/usr/sbin/modprobe vfio_mdev+# Remove loading of vfio_mdev as no longer present+' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -133,7 +133,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
-          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
+          sed -i 's+/usr/sbin/modprobe vfio_mdev+# Remove loading of vfio_mdev as no longer present+' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -135,7 +135,7 @@ presubmits:
         - /bin/bash
         - -ce
         - |
-          sed -i 's/vfio_mdev/mdev/' cluster-up/cluster/${TARGET}/provider.sh
+          sed -i 's+/usr/sbin/modprobe vfio_mdev+# Remove loading of vfio_mdev as no longer present+' cluster-up/cluster/${TARGET}/provider.sh
           automation/test.sh
         env:
         - name: TARGET


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous change[1] caused a reload of the mdev kernel module which causes the VGPU nodes to get a bad state and the vgpu test lanes to fail constantly.

This change just completely removes the modprobe from the script as has been done in the kubevirtci main branch[2].

[1] https://github.com/kubevirt/project-infra/commit/e6e653ec530d76dbbb0eed99226eb5e806d6de0c
[2] https://github.com/kubevirt/kubevirtci/commit/239678e4ccf7eac19748be3bb80def74c3956b6b

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
