### PR TITLE
common-instancetypes-periodics: Add sync jobs for release-1.0

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -22,7 +22,7 @@ periodics:
       - image: quay.io/kubevirtci/pr-creator:v20240305-cb764ec
         env:
         - name: COMMON_INSTANCETYPES_BRANCH
-          value: "main"
+          value: "release-1.0"
         - name: KUBEVIRT_BRANCH
           value: "main"
         - name: SSP_BRANCH
@@ -39,7 +39,7 @@ periodics:
         resources:
           requests:
             memory: "200Mi"
-  - name: periodic-update-common-instancetypes-bundles-release-0.4
+  - name: periodic-update-common-instancetypes-bundles-release-1.0
     cron: 0 4 * * 1
     annotations:
       testgrid-create-test-group: "false"
@@ -54,6 +54,43 @@ periodics:
       base_ref: release-1.2
     - org: kubevirt
       repo: ssp-operator
+      base_ref: release-v0.20
+    labels:
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20240305-cb764ec
+        env:
+          - name: COMMON_INSTANCETYPES_BRANCH
+            value: "release-1.0"
+          - name: KUBEVIRT_BRANCH
+            value: "release-1.2"
+          - name: SSP_BRANCH
+            value: "release-v0.20"
+        command: [ "/bin/bash", "-ce" ]
+        args:
+        - |
+          export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+          latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
+          description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+
+          git-pr.sh -c "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" -r kubevirt -b update-common-instancetypes-${KUBEVIRT_BRANCH} -T ${KUBEVIRT_BRANCH}
+          git-pr.sh -c "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"[${SSP_BRANCH}] ${description}\"" -r ssp-operator -b update-common-instancetypes-${SSP_BRANCH} -T ${SSP_BRANCH}
+        resources:
+          requests:
+            memory: "200Mi"
+  - name: periodic-update-common-instancetypes-bundles-release-0.4
+    cron: 0 4 * * 1
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 1
+    cluster: kubevirt-prow-control-plane
+    extra_refs:
+    - org: kubevirt
+      repo: ssp-operator
       base_ref: release-v0.19
     labels:
       preset-github-credentials: "true"
@@ -63,8 +100,6 @@ periodics:
         env:
           - name: COMMON_INSTANCETYPES_BRANCH
             value: "release-0.4"
-          - name: KUBEVIRT_BRANCH
-            value: "release-1.2"
           - name: SSP_BRANCH
             value: "release-v0.19"
         command: [ "/bin/bash", "-ce" ]
@@ -74,7 +109,6 @@ periodics:
           latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
           description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
 
-          git-pr.sh -c "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" -r kubevirt -b update-common-instancetypes-${KUBEVIRT_BRANCH} -T ${KUBEVIRT_BRANCH}
           git-pr.sh -c "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"[${SSP_BRANCH}] ${description}\"" -r ssp-operator -b update-common-instancetypes-${SSP_BRANCH} -T ${SSP_BRANCH}
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -1,6 +1,6 @@
 periodics:
   - name: periodic-update-common-instancetypes-bundles
-    cron: 0 2 * * 1
+    cron: 0 2 * * *
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
@@ -40,7 +40,7 @@ periodics:
           requests:
             memory: "200Mi"
   - name: periodic-update-common-instancetypes-bundles-release-1.0
-    cron: 0 4 * * 1
+    cron: 0 4 * * *
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
@@ -80,7 +80,7 @@ periodics:
           requests:
             memory: "200Mi"
   - name: periodic-update-common-instancetypes-bundles-release-0.4
-    cron: 0 4 * * 1
+    cron: 0 4 * * *
     annotations:
       testgrid-create-test-group: "false"
     decorate: true
@@ -114,7 +114,7 @@ periodics:
           requests:
             memory: "200Mi"
   - name: periodic-update-common-instancetypes-bundles-release-0.3
-    cron: 0 3 * * 1
+    cron: 0 3 * * *
     annotations:
       testgrid-create-test-group: "false"
     decorate: true


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

This change introduces a new sync job for release-1.0 to KubeVirt
release-1.2, replacing the previous release-0.4 sync. This moves us
inline with the versions shipped downstream by Red Hat.

Additionally the main sync job now also targets the release-1.0 branch
as we tagged v1.0.0 on this branch accidentally breaking the version
lookup logic of this job. In future we will avoid rc tags and will
branch directly from the release tag instead hopefully avoiding this.

This PR also reverts the move to a weekly sync schedule to allow us to catch up on things. This revert will itself be reverted once we are all caught up.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
