### PR TITLE
common-instancetypes-periodics: Pass branch in main sync job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -34,8 +34,8 @@ periodics:
           latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
           description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
 
-          git-pr.sh -c "cd ../kubevirt && hack/bump-common-instancetypes.sh" -d "echo -e \"${description}\"" -r kubevirt -b update-common-instancetypes-main -T ${KUBEVIRT_BRANCH}
-          git-pr.sh -c "cd ../ssp-operator && hack/bump-common-instancetypes.sh" -d "echo -e \"${description}\"" -r ssp-operator -b update-common-instancetypes-main -T ${SSP_BRANCH}
+          git-pr.sh -c "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"${description}\"" -r kubevirt -b update-common-instancetypes-main -T ${KUBEVIRT_BRANCH}
+          git-pr.sh -c "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"${description}\"" -r ssp-operator -b update-common-instancetypes-main -T ${SSP_BRANCH}
         resources:
           requests:
             memory: "200Mi"


### PR DESCRIPTION
**What this PR does / why we need it**:

This was missed in 03ab998980 and leads to the sync scripts within kubevirt and ssp-operator looking for a release on main.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
