### PR TITLE
prow-deploy: Update prow-deploy test lane to use latest provider

### DIFF
--- a/github/ci/prow-deploy/hack/test.sh
+++ b/github/ci/prow-deploy/hack/test.sh
@@ -14,9 +14,10 @@ export GIT_ASKPASS="${PROJECT_INFRA_ROOT}/hack/git-askpass.sh"
 
 KUBEVIRT_DIR=${KUBEVIRT_DIR:-/home/prow/go/src/github.com/kubevirt/kubevirt}
 export KUBEVIRT_MEMORY_SIZE=16384M
-export KUBEVIRT_PROVIDER=k8s-1.27
 
-cd $KUBEVIRT_DIR && make cluster-up
+cd $KUBEVIRT_DIR && export KUBEVIRT_PROVIDER=$(find cluster-up/cluster/k8s-1* -maxdepth 0 -type d -printf '%f\n' | sort -r |  head -1)
+
+make cluster-up
 
 export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous static kubevirtci provider has been removed causing the prow-deploy test lane to fail[1].

Update to use the latest available kubevirtci provider

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3410/pull-project-infra-prow-deploy-test/1788554621812215808#1:build-log.txt%3A26

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @lyarwood 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
