### PR TITLE
istio,mirror: Fix istio mirror by adding gcloud to PATH

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -657,7 +657,9 @@ periodics:
             value: "1.10.0,1.13.0,1.14.0,1.15.0"
         command: ["/bin/sh", "-c"]
         args:
-          - ./hack/mirror-istioctl.sh
+          - |
+            source /google-cloud-sdk/path.bash.inc
+            ./hack/mirror-istioctl.sh
         resources:
           requests:
             memory: "2Gi"


### PR DESCRIPTION
**What this PR does / why we need it**:

The periodic job that updates the istio mirror is failing due to being unable to find the gcloud command[1]. Adding gcloud to PATH should fix this issue.

This is a similar change to what was done for the cri-o mirror job[2]

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-mirror-istioctl/1789829270676180992#1:build-log.txt%3A93
[2] https://github.com/kubevirt/project-infra/pull/3391

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
