### PR TITLE
kubevirt,periodic: Update bump-rpms job to use bootstrap image instead of the builder

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -602,8 +602,7 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
@@ -612,11 +611,12 @@ periodics:
   spec:
     containers:
     - command:
+      - /usr/local/bin/runner.sh
       - /bin/bash
       - -c
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main -R
-      image: quay.io/kubevirt/builder:2212180911-8818abcfa
+      image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
       name: ""
       resources:
         requests:


### PR DESCRIPTION
**What this PR does / why we need it**:

The bump-rpms-weekly periodic job is failing currently due to it having an old builder image[1]. Its better to rely on the default builder image that is in kubevirt main branch.

Successful run here with these changes - https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/bump-kubevirt-rpms-weekly/1789947081960460288

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/bump-kubevirt-rpms-weekly/1789781454918520832

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
