### PR TITLE
sigs, sync: extract sigs from OWNERS_ALIASES, create GitHub groups and labels for sigs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -275,3 +275,34 @@ postsubmits:
         resources:
           requests:
             memory: "200Mi"
+  - name: push-kubevirt-update-sig-teams-and-labels
+    branches:
+    - main
+    cluster: kubevirt-prow-control-plane
+    always_run: false
+    run_if_changed: "OWNERS_ALIASES"
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    extra_refs:
+    - org: kubevirt
+      repo: project-infra
+      base_ref: main
+    labels:
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20240305-cb764ec
+        env:
+        command: [ "/bin/sh", "-ce" ]
+        args:
+        - |
+          project_infra_dir=$(cd ../project-infra && pwd)
+          kubevirt_dir=$(cd ../kubevirt && pwd)
+          git-pr.sh -c "cd ../project-infra && bazel run //robots/cmd/sig-to-org-team-syncer -- --owners-aliases-path=${kubevirt_dir}/OWNERS_ALIASES --orgs-yaml-path=${project_infra_dir}/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml --target-org-name=kubevirt --labels-yaml-path=${project_infra_dir}/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml" -p ${sig_release_dir} -s 'Automated run of robots/cmd/sig-to-org-team-syncer' -r project-infra -b update-sig-teams-and-labels -T main
+        resources:
+          requests:
+            memory: "200Mi"

--- a/robots/cmd/sig-to-org-team-syncer/BUILD.bazel
+++ b/robots/cmd/sig-to-org-team-syncer/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/project-infra/robots/cmd/sig-to-org-team-syncer",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//robots/pkg/labels:go_default_library",
+        "//robots/pkg/sig:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/json:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+        "@io_k8s_test_infra//prow/config/org:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "sig-to-org-team-syncer",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/robots/cmd/sig-to-org-team-syncer/README.md
+++ b/robots/cmd/sig-to-org-team-syncer/README.md
@@ -1,0 +1,19 @@
+# sig-to-org-team-syncer
+
+Uses an `OWNERS_ALIASES` file as input to generate associated GitHub teams and GitHub labels with the respective configuration files.
+
+## Motivation
+
+There's no way to ping a group of people that are associated to a SIG on a pull request. But there's the ability to ping a GitHub team on a pull request. Thus this tool generates a GitHub team so that we can ping the group of people on a PR.
+
+Also since it is frequently forgotten that labels associated to OWNERS filters need to be added to the label_sync configuration file, this tool adds the respective labels if they do not exist.
+
+## How to run
+
+```bash
+go run robots/cmd/sig-to-org-team-syncer/main.go \
+    --owners-aliases-path $(cd ../kubevirt && pwd)/OWNERS_ALIASES \
+    --orgs-yaml-path=github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml \
+    --target-org-name=kubevirt \
+    --labels-yaml-path=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+```

--- a/robots/cmd/sig-to-org-team-syncer/main.go
+++ b/robots/cmd/sig-to-org-team-syncer/main.go
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config/org"
+	"kubevirt.io/project-infra/robots/pkg/sig"
+	"os"
+	"regexp"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	debug             bool
+	orgsYamlPath      string
+	targetOrgName     string
+	ownersAliasesPath string
+	sigHandleMatcher  = regexp.MustCompile(`^sig-(.*)(-(approvers|reviewers))$`)
+)
+
+func main() {
+	flag.StringVar(&ownersAliasesPath, "owners-aliases-path", "", "path to the OWNERS_ALIASES file")
+	flag.StringVar(&orgsYamlPath, "orgs-yaml-path", "", "path to the orgs.yaml file that is the input configuration file for peribolos")
+	flag.StringVar(&targetOrgName, "target-org-name", "", "name of the org inside orgs.yaml file that should be synced")
+	flag.BoolVar(&debug, "debug", false, "whether debug output should be printed")
+	flag.Parse()
+
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
+
+	if ownersAliasesPath == "" {
+		log.Fatal("owners-aliases-path is required")
+	}
+	raw, err := os.ReadFile(ownersAliasesPath)
+	if err != nil {
+		log.Fatalf("failed to read file %q: %v", ownersAliasesPath, err)
+	}
+	var ownersAliases sig.OwnersAliases
+	err = yaml.Unmarshal(raw, &ownersAliases)
+	if err != nil {
+		log.Fatalf("failed to unmarshall file %q: %v", ownersAliasesPath, err)
+	}
+	if orgsYamlPath == "" {
+		log.Fatal("orgs-yaml-path is required")
+	}
+	raw, err = os.ReadFile(orgsYamlPath)
+	if err != nil {
+		log.Fatalf("failed to read file %q: %v", ownersAliasesPath, err)
+	}
+	var fullConfig *org.FullConfig
+	err = yaml.Unmarshal(raw, &fullConfig)
+	if err != nil {
+		log.Fatalf("failed to unmarshall file %q: %v", ownersAliasesPath, err)
+	}
+	if _, ok := fullConfig.Orgs[targetOrgName]; !ok {
+		log.Fatalf("org %q not found in config %q", targetOrgName, orgsYamlPath)
+	}
+
+	sigs := make(map[string]sets.Set[string])
+	labels := sets.Set[string]{}
+	for aliasName, gitHubHandles := range ownersAliases.Aliases {
+		if !sigHandleMatcher.MatchString(aliasName) {
+			continue
+		}
+		bareSigName := sigHandleMatcher.FindStringSubmatch(aliasName)[1]
+		if _, ok := sigs[bareSigName]; !ok {
+			sigs[bareSigName] = sets.Set[string]{}
+		}
+		sigs[bareSigName].Insert(gitHubHandles...)
+		labels.Insert(fmt.Sprintf("sig/%s", bareSigName))
+	}
+	log.Debugf("sigs: %v", sigs)
+	log.Debugf("labels: %v", labels)
+}

--- a/robots/pkg/labels/BUILD.bazel
+++ b/robots/pkg/labels/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["labels.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/labels",
+    visibility = ["//visibility:public"],
+)

--- a/robots/pkg/labels/labels.go
+++ b/robots/pkg/labels/labels.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the Kubernetes Authors.
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package labels
+
+import "time"
+
+// originally from k8s.io/test-infra/label_sync
+
+// LabelTarget specifies the intent of the label (PR or issue)
+type LabelTarget string
+
+const (
+	prTarget    LabelTarget = "prs"
+	issueTarget LabelTarget = "issues"
+	bothTarget  LabelTarget = "both"
+)
+
+// Label holds declarative data about the label.
+type Label struct {
+	// Name is the current name of the label
+	Name string `yaml:"name"`
+	// Color is rrggbb or color
+	Color string `yaml:"color"`
+	// Description is brief text explaining its meaning, who can apply it
+	Description string `yaml:"description,omitempty"`
+	// Target specifies whether it targets PRs, issues or both
+	Target LabelTarget `yaml:"target,omitempty"`
+	// ProwPlugin specifies which prow plugin add/removes this label
+	ProwPlugin string `yaml:"prowPlugin,omitempty"`
+	// IsExternalPlugin specifies if the prow plugin is external or not
+	IsExternalPlugin bool `yaml:"isExternalPlugin,omitempty"`
+	// AddedBy specifies whether human/munger/bot adds the label
+	AddedBy string `yaml:"addedBy,omitempty"`
+	// Previously lists deprecated names for this label
+	Previously []Label `yaml:"previously,omitempty"`
+	// DeleteAfter specifies the label is retired and a safe date for deletion
+	DeleteAfter *time.Time `yaml:"deleteAfter,omitempty"`
+	parent      *Label     // Current name for previous labels (used internally)
+}
+
+// Configuration is a list of Repos defining Required Labels to sync into them
+// There is also a Default list of labels applied to every Repo
+type Configuration struct {
+	Default RepoConfig            `yaml:"default"`
+	Repos   map[string]RepoConfig `yaml:"repos,omitempty"`
+	Orgs    map[string]RepoConfig `yaml:"orgs,omitempty"`
+}
+
+// RepoConfig contains only labels for the moment
+type RepoConfig struct {
+	Labels []Label `yaml:"labels"`
+}

--- a/robots/pkg/labels/labels.go
+++ b/robots/pkg/labels/labels.go
@@ -36,35 +36,35 @@ const (
 // Label holds declarative data about the label.
 type Label struct {
 	// Name is the current name of the label
-	Name string `yaml:"name"`
+	Name string `json:"name"`
 	// Color is rrggbb or color
-	Color string `yaml:"color"`
+	Color string `json:"color"`
 	// Description is brief text explaining its meaning, who can apply it
-	Description string `yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 	// Target specifies whether it targets PRs, issues or both
-	Target LabelTarget `yaml:"target,omitempty"`
+	Target LabelTarget `json:"target,omitempty"`
 	// ProwPlugin specifies which prow plugin add/removes this label
-	ProwPlugin string `yaml:"prowPlugin,omitempty"`
+	ProwPlugin string `json:"prowPlugin,omitempty"`
 	// IsExternalPlugin specifies if the prow plugin is external or not
-	IsExternalPlugin bool `yaml:"isExternalPlugin,omitempty"`
+	IsExternalPlugin bool `json:"isExternalPlugin,omitempty"`
 	// AddedBy specifies whether human/munger/bot adds the label
-	AddedBy string `yaml:"addedBy,omitempty"`
+	AddedBy string `json:"addedBy,omitempty"`
 	// Previously lists deprecated names for this label
-	Previously []Label `yaml:"previously,omitempty"`
+	Previously []Label `json:"previously,omitempty"`
 	// DeleteAfter specifies the label is retired and a safe date for deletion
-	DeleteAfter *time.Time `yaml:"deleteAfter,omitempty"`
+	DeleteAfter *time.Time `json:"deleteAfter,omitempty"`
 	parent      *Label     // Current name for previous labels (used internally)
 }
 
 // Configuration is a list of Repos defining Required Labels to sync into them
 // There is also a Default list of labels applied to every Repo
 type Configuration struct {
-	Default RepoConfig            `yaml:"default"`
-	Repos   map[string]RepoConfig `yaml:"repos,omitempty"`
-	Orgs    map[string]RepoConfig `yaml:"orgs,omitempty"`
+	Default RepoConfig            `json:"default"`
+	Repos   map[string]RepoConfig `json:"repos,omitempty"`
+	Orgs    map[string]RepoConfig `json:"orgs,omitempty"`
 }
 
 // RepoConfig contains only labels for the moment
 type RepoConfig struct {
-	Labels []Label `yaml:"labels"`
+	Labels []Label `json:"labels"`
 }

--- a/robots/pkg/sig/BUILD.bazel
+++ b/robots/pkg/sig/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "kubevirt.io/project-infra/robots/pkg/sig",
+    visibility = ["//visibility:public"],
+)

--- a/robots/pkg/sig/types.go
+++ b/robots/pkg/sig/types.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package sig
+
+type Person struct {
+	github  string `yaml:"github"`
+	name    string `yaml:"name"`
+	company string `yaml:"company"`
+}
+
+type Leadership struct {
+	Chairs    []Person `yaml:"chairs"`
+	TechLeads []Person `yaml:"tech_leads"`
+}
+
+type SpecialInterestGroups struct {
+	Dir              string     `yaml:"dir,omitempty"`
+	Name             string     `yaml:"name,omitempty"`
+	MissionStatement string     `yaml:"mission_statement,omitempty"`
+	Leadership       Leadership `yaml:"leadership"`
+}
+
+type OwnersAliases struct {
+	Aliases map[string][]string
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds a tool `robots/cmd/sig-to-org-team-syncer` that extracts the sigs and the sig members from a source `OWNERS_ALIASES` file, then adds or updates GitHub teams for SIGs in the target Peribolos configuration, and adds missing SIG labels in target label_sync configuration.

Also adds a postsubmit job that executes above mentioned tool and creates a pull request with the generated changes. Said job is triggered whenever the file `OWNERS_ALIASES` from repo kubevirt/kubevirt is modified.

Full example:

`OWNERS_ALIASES` from `kubevirt/kubevirt` contains:
```
...
   sig-buildsystem-approvers:
     dhiller
     ...
   sig-buildsystem-reviewers:
     dhiller
     ...
```

will create a GitHub team `sig-buildsystem` with privacy closed, whose members are all people from the above alias groups. Existing teams will be updated such that the missing GitHub handles will be added to the team.

That team can then be pinged on a PR with `@kubevirt/sig-buildsystem`

Also it will add a label `sig/buildsystem` that is then available for all pull requests.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @aburdenthehand @fabiand 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
