### PR TITLE
bump network lanes to using 3 nodes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -823,6 +823,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
         image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
         name: ""
         resources:
@@ -868,6 +870,8 @@ presubmits:
           value: "false"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
         image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
         name: ""
         resources:
@@ -1408,6 +1412,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
         image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
         name: ""
         resources:
@@ -1616,6 +1622,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
         image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
         name: ""
         resources:
@@ -1836,6 +1844,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
         image: quay.io/kubevirtci/bootstrap:v20240308-8fac017
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps network lanes to using 3 nodes.
It is needed when running two or more VMs in parallel which have a higher memory requirement.

The issue was accidentally discovered during the work on https://github.com/kubevirt/kubevirt/pull/11659.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
