### PR TITLE
Adding mkdocs-redirect to the user-guide Dockerfile

### DIFF
--- a/images/kubevirt-user-guide/Dockerfile
+++ b/images/kubevirt-user-guide/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /src && cd /src && \
     npm install -g markdownlint-cli casperjs phantomjs-prebuilt yaspeller && \
     cd /src && bundle install && bundle update && cd && \
     pip install --upgrade pip && \
-    pip install mkdocs mkdocs-material mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin && \
+    pip install mkdocs mkdocs-material mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin mkdocs-redirects && \
     gem list && \
     rpm -e --nodeps libX11 libX11-common libXrender libXft && \
     dnf erase -y @development-tools gcc qt5-srpm-macros \


### PR DESCRIPTION
This is a stopgap until the Jekyll redirect issue is solved.
This just adds the mkdocs-redirects to the kubevirt-user-guide image Dockerfile

Related user-guide PR: https://github.com/kubevirt/user-guide/pull/802

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
