### PR TITLE
CAPK: bump golang to v1.22

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -33,6 +33,6 @@ presubmits:
           privileged: true
         env:
           - name: GIMME_GO_VERSION
-            value: "1.20"
+            value: "1.22"
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
