### PR TITLE
shared-images: Wait for currently running jobs to complete before deleting old images

### DIFF
--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -81,11 +81,7 @@ func pullRequiredImages(ctx context.Context, tag string) error {
 		log.Infoln("Kubevirt Provider version: ", version)
 
 		name := fmt.Sprintf("%sk8s-%s:%s", kubevirtci_repo, version, tag)
-		// k8s-1.26 kubevirtci provider was renamed to k8s-1.26-centos9
-		// to track the change to CentOS Stream 9
-		if version == "1.26" {
-			name = fmt.Sprintf("%sk8s-%s-centos9:%s", kubevirtci_repo, version, tag)
-		}
+
 		if _, exists := imageNames[name]; exists {
 			log.Infoln("Image already present:", name)
 			continue

--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -150,6 +150,8 @@ func main() {
 		if err != nil {
 			log.WithError(err).Errorf("Failed to fetch image names")
 		}
+		// Allow time for currently running jobs with old images to complete successfully before deleting old images
+		time.Sleep(period * time.Hour)
 		err = cleanOldImages(connText, tag)
 		if err != nil {
 			log.WithError(err).Errorf("Failure occured when deleting old images")


### PR DESCRIPTION
**What this PR does / why we need it**:

After a bump-kubevirtci PR is merged - the shared images controller will
pull the new images and delete the old images however this can cause
problems for the currently running e2e jobs as they are running with the
old image.

These jobs fail at the very end when trying to clean up the kubevirtci
containers because the old image layers are no longer available.

Adding a delay before cleaning up the old images to allow these running
jobs to complete should resolve this.

This PR also cleans up custom handling for the old 1.26 provider

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
