### PR TITLE
prow, referee, metrics: update metrics on open/close

### DIFF
--- a/external-plugins/referee/metrics/retests_test.go
+++ b/external-plugins/referee/metrics/retests_test.go
@@ -67,8 +67,7 @@ func (gv *fakeGaugeVecWrapper) SetWithLabelValues(value float64, labelValues ...
 
 func (gv *fakeGaugeVecWrapper) DeleteLabelValues(labelValues ...string) bool {
 	if !slices.Equal(labelValues, gv.LabelValues) {
-		//TODO implement me
-		panic("implement me")
+		panic("not implemented")
 	}
 	gv.LabelValues = nil
 	gv.Value = 0

--- a/external-plugins/referee/metrics/retests_test.go
+++ b/external-plugins/referee/metrics/retests_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
+	"slices"
 	"sync"
 	"sync/atomic"
 )
@@ -51,17 +52,27 @@ func (c fakeCounter) Inc() {
 }
 
 type fakeGaugeVecWrapper struct {
-	Values []string
-	Value  float64
+	LabelValues []string
+	Value       float64
 }
 
 func newFakeGaugeVecWrapper() *fakeGaugeVecWrapper {
 	return &fakeGaugeVecWrapper{}
 }
 
-func (gv *fakeGaugeVecWrapper) SetWithLabelValues(value float64, values ...string) {
-	gv.Values = values
+func (gv *fakeGaugeVecWrapper) SetWithLabelValues(value float64, labelValues ...string) {
+	gv.LabelValues = labelValues
 	gv.Value = value
+}
+
+func (gv *fakeGaugeVecWrapper) DeleteLabelValues(labelValues ...string) bool {
+	if !slices.Equal(labelValues, gv.LabelValues) {
+		//TODO implement me
+		panic("implement me")
+	}
+	gv.LabelValues = nil
+	gv.Value = 0
+	return true
 }
 
 var _ = Describe("retests", func() {
@@ -104,8 +115,15 @@ var _ = Describe("retests", func() {
 			SetForPullRequest("myorg", "myrepo", 1737, 42)
 			actual := gaugeVecs[fmt.Sprintf(retestsPerPRGaugeName, "myorg", "myrepo")].(*fakeGaugeVecWrapper)
 			Expect(actual).ToNot(BeNil())
-			Expect(actual.Values).To(BeEquivalentTo([]string{"1737"}))
+			Expect(actual.LabelValues).To(BeEquivalentTo([]string{"1737"}))
 			Expect(actual.Value).To(BeEquivalentTo(float64(42)))
+		})
+		It("pr gauge unset", func() {
+			SetForPullRequest("myorg", "myrepo", 1737, 42)
+			DeleteForPullRequest("myorg", "myrepo", 1737)
+			actual := gaugeVecs[fmt.Sprintf(retestsPerPRGaugeName, "myorg", "myrepo")].(*fakeGaugeVecWrapper)
+			Expect(actual).ToNot(BeNil())
+			Expect(actual.LabelValues).To(BeEmpty())
 		})
 		AfterEach(func() {
 			createCounter = defaultCreateCounterFunc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

![image](https://github.com/kubevirt/project-infra/assets/809335/b920d6e4-71dc-4349-831c-ec4cc30ede57)

This shows state from Friday around noon. There we clearly see that PRs that have already been merged at that time still appear in the dashboard.

Since we don't want to see metrics for merged (and closed) PRs, we remove the values for closed (or merged) PRs. When PRs are reopened we restore the metrics for those again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
