### PR TITLE
periodic,docker-proxy: Add check for docker mirror proxy CA certificate expiration

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -538,6 +538,35 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-project-infra-check-docker-proxy-ca-cert
+  cron: "25 8 * * 5"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-docker-mirror-proxy: "true"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/bootstrap:v20240607-febc467
+      command: ["/bin/sh"]
+      args:
+      - "-ce"
+      - |
+        dnf install -y openssl
+        hack/check-docker-proxy-ca-cert.sh
+      resources:
+        requests:
+          memory: "200Mi"
 - name: periodic-kubevirt-presubmit-requirer
   cron: "0 1 1 * *"
   max_concurrency: 1

--- a/hack/check-docker-proxy-ca-cert.sh
+++ b/hack/check-docker-proxy-ca-cert.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+CA_CERT_FILE=${CA_CERT_FILE:-"/etc/docker-mirror-proxy/ca.crt"}
+
+if ! command -v openssl &> /dev/null
+then
+    echo "This script requires openssl to be installed"
+    exit 1
+fi
+
+# 90 days in seconds = 7,776,000
+EXPIRE_IN_90_DAYS="7776000"
+
+openssl x509 -enddate -noout -in "$CA_CERT_FILE"  -checkend "$EXPIRE_IN_90_DAYS" | grep -q 'Certificate will expire'
+
+if [ $? == 0 ]
+then
+    echo "The docker-mirror-proxy CA certificate will expire within the next 90 days"
+    echo "Please plan a maintenance window to renew this certificate"
+    exit 1
+else
+    echo "Certificate check passed. The certificate will not expire in the next 90 days"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a recent issue where the CA certificate for the docker-mirror-proxy image cache expired causing the majority of the jobs that rely on the cache to pull images to fail[1].

This can have a big impact on CI and our ability to merge PRs.

This periodic check will start failing when the CA certificate will expire in the next 90 days. This should give us enough warning to plan for renewing this certificate

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3451/pull-project-infra-prow-deploy-test/1797955833284268032#1:build-log.txt%3A14

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
