### PR TITLE
prow, tide, priority: add configuration

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -52,6 +52,7 @@ larger set of contributors to apply/remove them.
 | <a id="kind/bug" href="#kind/bug">`kind/bug`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/deprecation" href="#kind/deprecation">`kind/deprecation`</a> | Indicates the PR/issue deprecates a feature that will be removed in a subsequent release.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/enhancement" href="#kind/enhancement">`kind/enhancement`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
+| <a id="kind/failing-test" href="#kind/failing-test">`kind/failing-test`</a> | Categorizes issue or PR as related to a failing test.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/flake" href="#kind/flake">`kind/flake`</a> | Categorizes issue or PR as related to a flaky test.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/question" href="#kind/question">`kind/question`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
@@ -60,6 +61,7 @@ larger set of contributors to apply/remove them.
 | <a id="lifecycle/frozen" href="#lifecycle/frozen">`lifecycle/frozen`</a> | Indicates that an issue or PR should not be auto-closed due to staleness.| prow |  [lifecycle](https://prow.ci.kubevirt.io/command-help#lifecycle) |
 | <a id="lifecycle/rotten" href="#lifecycle/rotten">`lifecycle/rotten`</a> | Denotes an issue or PR that has aged beyond stale and will be auto-closed.| prow |  [lifecycle](https://prow.ci.kubevirt.io/command-help#lifecycle) |
 | <a id="lifecycle/stale" href="#lifecycle/stale">`lifecycle/stale`</a> | Denotes an issue or PR has remained open with no activity and has become stale.| prow |  [lifecycle](https://prow.ci.kubevirt.io/command-help#lifecycle) |
+| <a id="priority/critical-urgent" href="#priority/critical-urgent">`priority/critical-urgent`</a> | Categorizes an issue or pull request as critical and of urgent priority.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/api" href="#sig/api">`sig/api`</a> | Denotes an issue or PR that relates to changes in api.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/buildsystem" href="#sig/buildsystem">`sig/buildsystem`</a> | Denotes an issue or PR that relates to changes in the build system.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/code-quality" href="#sig/code-quality">`sig/code-quality`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
@@ -137,7 +139,6 @@ larger set of contributors to apply/remove them.
 | <a id="for/users" href="#for/users">`for/users`</a> | |  | |
 | <a id="needs/documentation" href="#needs/documentation">`needs/documentation`</a> | |  | |
 | <a id="priority/backlog" href="#priority/backlog">`priority/backlog`</a> | |  | |
-| <a id="priority/critical-urgent" href="#priority/critical-urgent">`priority/critical-urgent`</a> | |  | |
 | <a id="release-blocker" href="#release-blocker">`release-blocker`</a> | Indicates that a PR or issue is blocking a release from a specific branch.| prow |  [release-blocker](https://prow.ci.kubevirt.io/command-help#release-blocker) |
 | <a id="research-needed" href="#research-needed">`research-needed`</a> | |  | |
 | <a id="topic/api" href="#topic/api">`topic/api`</a> | |  | |

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -223,6 +223,10 @@ tide:
         repos:
           kubernetes-nmstate:
             skip-unknown-contexts: true
+  priority:
+  - labels: [ "kind/flake", "priority/critical-urgent" ]
+  - labels: [ "kind/failing-test", "priority/critical-urgent" ]
+  - labels: [ "kind/bug", "priority/critical-urgent" ]
 
 slack_reporter_configs:
   '*':

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -102,6 +102,12 @@ default:
       addedBy: anyone
       prowPlugin: label
       description: Categorizes issue or PR as related to a flaky test.
+    - name: kind/failing-test
+      color: F70001
+      target: both
+      addedBy: anyone
+      prowPlugin: label
+      description: Categorizes issue or PR as related to a failing test.
     - name: kind/proposal
       color: bfd4f2
       target: both
@@ -336,6 +342,12 @@ default:
       target: issues
       prowPlugin: help
       addedBy: prow
+    - name: priority/critical-urgent
+      addedBy: anyone
+      color: d93f0b
+      description: Categorizes an issue or pull request as critical and of urgent priority.
+      prowPlugin: label
+      target: both
 repos:
   kubevirt/kubevirt:
     labels:
@@ -344,9 +356,6 @@ repos:
         target: both
       - name: priority/backlog
         color: fbca04
-        target: both
-      - name: priority/critical-urgent
-        color: d93f0b
         target: both
       - name: research-needed
         color: fef2c0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add configuration to prioritize pull requests by adding label `priority/critical-urgent`. This will take effect for the label combinations configured at `priority` segment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
