### PR TITLE
add periodic s390x cross-build nightly job.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -360,6 +360,80 @@ periodics:
       type: bare-metal-external
 - annotations:
     testgrid-create-test-group: "false"
+  cluster: kubevirt-prow-workloads
+  cron: 2 1 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
+    preset-kubevirtci-quay-credential: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-shared-images: "true"
+  max_concurrency: 1
+  name: periodic-kubevirt-push-nightly-build-main-s390x
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        build_date="$(date +%Y%m%d)"
+        cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+        export DOCKER_TAG="${build_date}_$(git show -s --format=%h)-s390x"
+        make
+        counter=3
+        retval=0
+        while [ $counter -gt 0 ]; do
+            set +e
+            make push
+            retval=$?
+            set -e
+            if [ $retval -eq 0 ]; then
+                break
+            fi
+            set +e
+            counter=$(expr $counter - 1)
+            set -e
+            sleep 120
+        done
+        if [ $retval -ne 0 ]; then
+            echo "push failed!"
+            exit 1
+        fi
+        # build functest currently does not support crossbuild, skip it
+        git show -s --format=%H > _out/commit
+        echo ${build_date} > _out/build_date
+        bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
+        gsutil cp ./_out/manifests/release/kubevirt-operator.yaml gs://$bucket_dir/kubevirt-operator-s390x.yaml
+        gsutil cp ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/kubevirt-cr-s390x.yaml
+        gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/testing-s390x
+        gsutil cp ./_out/commit gs://$bucket_dir/commit-s390x
+        gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-s390x
+      env:
+      - name: DOCKER_PREFIX
+        value: quay.io/kubevirt
+      - name: BUILD_ARCH
+        value: crossbuild-s390x
+      image: quay.io/kubevirtci/golang:v20240607-febc467
+      name: ""
+      resources:
+        requests:
+          memory: 8Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 2 15 */7 * *
   decorate: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR adds the s390x cross-build nightly prow job. It will cross build all the kubevirt images and manifests of s390x and pushes it to the upstream quay.io .

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
cc: @brianmcarey 
There is an ongoing work to enable cross-compilation of s390x on kubevirt This is the PR: https://github.com/kubevirt/kubevirt/pull/11991. Once the PR got merged, we have s390x cross compilation support on kubevirt.  Here i am adding the prow job that will utilize the cross-compilation and push the nightly images.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 add periodic s390x cross-build nightly job
```
