### PR TITLE
common-instancetypes-periodics: Add initial job for release-1.1

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -41,6 +41,42 @@ periodics:
         resources:
           requests:
             memory: "200Mi"
+  - name: periodic-update-common-instancetypes-bundles-release-1.1
+    cron: 0 5 * * *
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 1
+    cluster: kubevirt-prow-control-plane
+    extra_refs:
+    - org: kubevirt
+      repo: kubevirt
+      base_ref: release-1.3
+    labels:
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20240305-cb764ec
+        env:
+          - name: COMMON_INSTANCETYPES_BRANCH
+            value: "release-1.0"
+          - name: KUBEVIRT_BRANCH
+            value: "release-1.3"
+        command: [ "/bin/bash", "-ce" ]
+        args:
+        - |
+          if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
+            export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+            latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
+            description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+
+            git-pr.sh -c "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" -d "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" -r kubevirt -b update-common-instancetypes-${KUBEVIRT_BRANCH} -T ${KUBEVIRT_BRANCH}
+          fi
+        resources:
+          requests:
+            memory: "200Mi"
   - name: periodic-update-common-instancetypes-bundles-release-1.0
     cron: 0 4 * * *
     annotations:


### PR DESCRIPTION
/cc @0xFelix 
/cc @brianmcarey 

**What this PR does / why we need it**:

For the time being this just syncs releases from release-1.0 to KubeVirt release-1.3 while we wait for the full v1.1.0 release of common-instancetypes.

This should keep these branches in line with the older release branches for now where we still sync release-1.0 releases.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
