### PR TITLE
Enable NodeRestriction fg for 1.30 lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -855,6 +855,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_NUM_NODES
           value: "3"
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
@@ -947,6 +949,8 @@ presubmits:
           value: rook-ceph-default
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
@@ -1787,6 +1791,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
@@ -1876,6 +1882,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_NUM_NODES
           value: "3"
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
@@ -1917,6 +1925,8 @@ presubmits:
           value: k8s-1.30-sig-storage
         - name: KUBEVIRT_PSA
           value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
@@ -1962,6 +1972,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
@@ -2005,6 +2017,8 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
         image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable NodeRestriction fg for 1.30 lanes
This allow us to get wider feedback on the
feature.

Ref https://github.com/kubevirt/kubevirt/pull/12009

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
