### PR TITLE
kubevirt,presubmits: Remove goveralls jobs from recent release job configs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -585,46 +585,6 @@ presubmits:
     branches:
     - release-1.0
     cluster: kubevirt-prow-control-plane
-    context: pull-kubevirt-goveralls
-    decorate: true
-    decoration_config:
-      grace_period: 10m0s
-      timeout: 1h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    name: pull-kubevirt-goveralls-1.0
-    optional: true
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then make goveralls; fi
-        env:
-        - name: COVERALLS_TOKEN_FILE
-          value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /root/.docker/secrets/coveralls
-          name: kubevirtci-coveralls
-          readOnly: true
-      volumes:
-      - name: kubevirtci-coveralls
-        secret:
-          secretName: kubevirtci-coveralls-token
-  - always_run: true
-    branches:
-    - release-1.0
-    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -508,45 +508,6 @@ presubmits:
     branches:
     - release-1.1
     cluster: kubevirt-prow-control-plane
-    context: pull-kubevirt-goveralls
-    decorate: true
-    decoration_config:
-      grace_period: 10m0s
-      timeout: 1h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-goveralls-1.1
-    optional: true
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then make goveralls; fi
-        env:
-        - name: COVERALLS_TOKEN_FILE
-          value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /root/.docker/secrets/coveralls
-          name: kubevirtci-coveralls
-          readOnly: true
-      volumes:
-      - name: kubevirtci-coveralls
-        secret:
-          secretName: kubevirtci-coveralls-token
-  - always_run: true
-    branches:
-    - release-1.1
-    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -543,46 +543,6 @@ presubmits:
     branches:
     - release-1.2
     cluster: kubevirt-prow-control-plane
-    context: pull-kubevirt-goveralls
-    decorate: true
-    decoration_config:
-      grace_period: 10m0s
-      timeout: 1h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-goveralls-1.2
-    optional: true
-    skip_report: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then
-          make goveralls; fi
-        env:
-        - name: COVERALLS_TOKEN_FILE
-          value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20240118-315742b
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /root/.docker/secrets/coveralls
-          name: kubevirtci-coveralls
-          readOnly: true
-      volumes:
-      - name: kubevirtci-coveralls
-        secret:
-          secretName: kubevirtci-coveralls-token
-  - always_run: true
-    branches:
-    - release-1.2
-    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -542,45 +542,6 @@ presubmits:
     branches:
     - release-1.3
     cluster: kubevirt-prow-control-plane
-    context: pull-kubevirt-goveralls
-    decorate: true
-    decoration_config:
-      grace_period: 10m0s
-      timeout: 1h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-    name: pull-kubevirt-goveralls-1.3
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then
-          make goveralls; fi
-        env:
-        - name: COVERALLS_TOKEN_FILE
-          value: /root/.docker/secrets/coveralls/token
-        image: quay.io/kubevirtci/bootstrap:v20240607-febc467
-        name: ""
-        resources:
-          requests:
-            memory: 8Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /root/.docker/secrets/coveralls
-          name: kubevirtci-coveralls
-          readOnly: true
-      volumes:
-      - name: kubevirtci-coveralls
-        secret:
-          secretName: kubevirtci-coveralls-token
-  - always_run: true
-    branches:
-    - release-1.3
-    cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -600,7 +600,7 @@ presubmits:
           privileged: true
   - always_run: true
     annotations:
-      fork-per-release: "true"
+      fork-per-release: "false"
     cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

The goveralls test lane consistently fails against the release branches
these jobs were previously set to not report[1] but there is no point in
  running them - lets remove the jobs from the release configs.

This also updates the main branch config to stop the goveralls test lane being included in new release branch forks. 

[1] https://github.com/kubevirt/project-infra/pull/3457

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
