### PR TITLE
kubevirt,vgpu: Bump vgpu lanes to use new kind-1.30-vgpu provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -520,7 +520,7 @@ periodics:
     preset-podman-shared-images: "true"
     vgpu: "true"
   max_concurrency: 1
-  name: periodic-kubevirt-e2e-kind-1.27-vgpu
+  name: periodic-kubevirt-e2e-kind-1.30-vgpu
   reporter_config:
     slack:
       job_states_to_report: []
@@ -547,7 +547,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: kind-1.27-vgpu
+        value: kind-1.30-vgpu
       image: quay.io/kubevirtci/golang:v20240923-918320b
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -121,7 +121,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       vgpu: "true"
     max_concurrency: 1
-    name: pull-kubevirt-e2e-kind-1.27-vgpu
+    name: pull-kubevirt-e2e-kind-1.30-vgpu
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -145,7 +145,7 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.27-vgpu
+          value: kind-1.30-vgpu
         image: quay.io/kubevirtci/bootstrap:v20240923-918320b
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

The vgpu lanes are currently testing against kubernetes v1.27 which is no longer supported on the main branch of kubevirt.

Update these lanes to use the new provider kind-1.30-vgpu.

This requires the following PR to be merged into kubevirt first: https://github.com/kubevirt/kubevirt/pull/12244

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
