### PR TITLE
containerdisks: Update opensuse presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -228,7 +228,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/tumbleweed/.*"
+    run_if_changed: "artifacts/opensuse/tumbleweed/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-workloads
@@ -240,7 +240,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 11
-    name: pull-containerdisks-pipeline-tumbleweed
+    name: pull-containerdisks-pipeline-opensuse-tumbleweed
     spec:
       containers:
       - command:
@@ -252,7 +252,7 @@ presubmits:
         - name: GIMME_GO_VERSION
           value: "1.22.2"
         - name: FOCUS
-          value: "tumbleweed:*"
+          value: "opensuse-tumbleweed:*"
         image: quay.io/kubevirtci/golang:v20240308-8fac017
         name: ""
         resources:
@@ -263,7 +263,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/leap/.*"
+    run_if_changed: "artifacts/opensuse/leap/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-workloads
@@ -275,7 +275,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 11
-    name: pull-containerdisks-pipeline-leap
+    name: pull-containerdisks-pipeline-opensuse-leap
     spec:
       containers:
       - command:
@@ -287,7 +287,7 @@ presubmits:
         - name: GIMME_GO_VERSION
           value: "1.22.2"
         - name: FOCUS
-          value: "leap:*"
+          value: "opensuse-leap:*"
         image: quay.io/kubevirtci/golang:v20240308-8fac017
         name: ""
         resources:


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

The artifacts now live under an opensuse directory and have had opensuse pre appended to their names.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
