### PR TITLE
project-infra, bazel: move presubmits to pure go

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -77,21 +77,21 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20240607-febc467
+      - image: quay.io/kubevirtci/golang:v20240607-febc467
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
-        - "-c"
+        - "-ce"
         - |
-          make gazelle-update-repos
-          bazelisk test //external-plugins/...
-        securityContext:
-          runAsUser: 0
+          go test ./external-plugins/...
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.21.6"
         resources:
           requests:
-            memory: "8Gi"
+            memory: "4Gi"
           limits:
-            memory: "8Gi"
+            memory: "4Gi"
   - name: pull-project-infra-test-github-ci-services
     run_if_changed: "github/ci/services/.*|WORKSPACE|go_third_party.bzl|go.mod"
     optional: false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -53,13 +53,16 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20240607-febc467
+      - image: quay.io/kubevirtci/golang:v20240607-febc467
         command:
-          - "/bin/bash"
-          - "-c"
-          - |
-            make gazelle-update-repos
-            bazel test //releng/...
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
+        - |
+          go test ./releng/...
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.21.6"
         resources:
           requests:
             memory: "4Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -28,22 +28,22 @@ presubmits:
       preset-bazel-cache: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/test-label-analyzer:v20230904-34e7ab5
+      - image: quay.io/kubevirtci/golang:v20240607-febc467
         command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
         - |
-          make gazelle-update-repos
-          bazelisk test //robots/...
+          GOBIN=/usr/local/bin/ go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2
+          go test ./robots/...
         env:
         - name: GIMME_GO_VERSION
-          value: "1.20"
+          value: "1.21.6"
         resources:
           requests:
-            memory: "8Gi"
+            memory: "4Gi"
           limits:
-            memory: "8Gi"
+            memory: "4Gi"
   - name: pull-project-infra-test-releng
     run_if_changed: "releng/.*|WORKSPACE|go_third_party.bzl|go.mod"
     optional: false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -24,8 +24,6 @@ presubmits:
     optional: false
     decorate: true
     cluster: kubevirt-prow-control-plane
-    labels:
-      preset-bazel-cache: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/golang:v20240607-febc467
@@ -49,8 +47,6 @@ presubmits:
     optional: false
     decorate: true
     cluster: kubevirt-prow-control-plane
-    labels:
-      preset-bazel-cache: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/golang:v20240607-febc467
@@ -73,8 +69,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     optional: false
     decorate: true
-    labels:
-      preset-bazel-cache: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/golang:v20240607-febc467
@@ -563,14 +557,12 @@ presubmits:
       preset-docker-mirror-proxy: "true"
     cluster: kubevirt-prow-workloads
     spec:
-      nodeSelector:
-        type: bare-metal-external
       containers:
-        - image: quay.io/kubevirtci/bootstrap:v20240607-febc467
+        - image: quay.io/kubevirtci/golang:v20240607-febc467
           command:
             - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-c"
+            - "/bin/sh"
+            - "-ce"
             - |
               # install kind
               curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
@@ -581,15 +573,18 @@ presubmits:
 
               ./github/ci/services/ci-search/hack/deploy.sh testing
 
-              bazelisk test //github/ci/services/ci-search/e2e:go_default_test --test_output=all --test_arg=-test.v
-          securityContext:
-            privileged: true
-            runAsUser: 0
+              go test ./github/ci/services/ci-search/e2e/...
+          env:
+          - name: GIMME_GO_VERSION
+            value: "1.21.6"
           resources:
             requests:
               memory: "16Gi"
             limits:
               memory: "16Gi"
+          securityContext:
+            privileged: true
+            runAsUser: 0
   - name: pull-project-infra-grafana-deploy-test
     optional: false
     run_if_changed: "github/ci/services/grafana/.*|github/ci/services/common/.*|WORKSPACE|go_third_party.bzl"

--- a/robots/pkg/validation/content.go
+++ b/robots/pkg/validation/content.go
@@ -62,7 +62,7 @@ func (j HTMLValidator) IsValid(content []byte) error {
 			return nil
 		case nil:
 		default:
-			return fmt.Errorf("Report:\n%s\n\nerror %v when trying to validate report file %v", err, stringContent)
+			return fmt.Errorf("Report:\n%s\n\nerror %v when trying to validate", err, stringContent)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adding to our effort to move away from bazel we are moving some presubmits towards pure go:

* pull-project-infra-test-robots
* pull-project-infra-test-releng
* pull-project-infra-test-external-plugins
* pull-project-infra-ci-search-deploy-test

(the latter still uses bazel k8s gitops rules, which needs to get converted to kustomize and kubectl apply, but testing is done via go)

Along the way we fix an error wrt formatting placeholder mismatch. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
