### PR TITLE
Move pull-cdi-goveralls to kubevirt-prow-workloads

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -36,7 +36,7 @@ presubmits:
     optional: true
     annotations:
       fork-per-release: "true"
-    cluster: kubevirt-prow-control-plane
+    cluster: kubevirt-prow-workloads
     decorate: true
     decoration_config:
       grace_period: 10m0s

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/kustomization.yaml
@@ -68,6 +68,12 @@ secretGenerator:
       # coverallsToken
       - token=secrets/kubevirtci-coveralls-token
     type: Opaque
+  - name: containerized-data-importer-coveralls-token
+    namespace: kubevirt-prow-jobs
+    files:
+      # coverallsToken for the containerized-data-importer repository
+      - token=secrets/containerized-data-importer-coveralls-token
+    type: Opaque
   - name: win-sysprep-001
     namespace: kubevirt-prow-jobs
     files:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We're seeing some flakes related to time which would not be trivial to refactor for proper time mocking:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_containerized-data-importer/3336/pull-cdi-goveralls/1809334945819136000
So for now, switching to the regular workload cluster which is known to rarely flake on unit tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
