### PR TITLE
chore: enable branch protection for kubevirt-tekton-tasks

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -121,6 +121,7 @@ tide:
     kubevirt/node-labeller: squash
     kubevirt/kubevirt-template-validator: squash
     kubevirt/kubevirt-ssp-operator: squash
+    kubevirt/kubevirt-tekton-tasks: merge
     kubevirt/csi-driver: squash
     kubevirt/ssp-operator: merge
     kubevirt/managed-tenant-quota: merge
@@ -194,6 +195,7 @@ tide:
     - kubevirt/kubevirt-template-validator
     - kubevirt/kubevirt-ssp-operator
     - kubevirt/ssp-operator
+    - kubevirt/kubevirt-tekton-tasks
     - kubevirt/managed-tenant-quota
     - kubevirt/application-aware-quota
     - kubevirt/must-gather
@@ -457,6 +459,10 @@ branch-protection:
         vm-console-proxy:
           protect: true
         ssp-operator:
+          branches:
+            main:
+              protect: true
+        kubevirt-tekton-tasks:
           branches:
             main:
               protect: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -273,6 +273,15 @@ plugins:
     plugins:
     - release-note
 
+  kubevirt/kubevirt-tekton-tasks:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+    - help
+
   kubevirt/kubevirt-ssp-operator:
     plugins:
     - approve
@@ -571,6 +580,7 @@ triggers:
   - kubevirt/kubevirt-ssp-operator
   - kubevirt/sig-release
   - kubevirt/ssp-operator
+  - kubevirt/kubevirt-tekton-tasks
   - kubevirt/must-gather
   - kubevirt/demo
   - kubevirt/cluster-network-addons-operator
@@ -638,6 +648,7 @@ approve:
   - kubevirt/kubevirt-template-validator
   - kubevirt/kubevirt-ssp-operator
   - kubevirt/ssp-operator
+  - kubevirt/kubevirt-tekton-tasks
   - kubevirt/must-gather
   - kubevirt/csi-driver
   - kubevirt/user-guide
@@ -697,6 +708,7 @@ lgtm:
   - kubevirt/kubevirt-template-validator
   - kubevirt/kubevirt-ssp-operator
   - kubevirt/ssp-operator
+  - kubevirt/kubevirt-tekton-tasks
   - kubevirt/must-gather
   - kubevirt/csi-driver
   - kubevirt/user-guide


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: enable branch protection for kubevirt-tekton-tasks


**Release note**:
```
NONE
```
