### PR TITLE
github-jira-proxy, prow, plugin: add plugin that checks github webhooks

### DIFF
--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -18,6 +18,9 @@ resources:
   - manifests/local/prow-phased-service.yaml
   - manifests/local/referee-deployment.yaml
   - manifests/local/referee-service.yaml
+  - manifests/local/github-jira-proxy-ingress.yaml
+  - manifests/local/github-jira-proxy-deployment.yaml
+  - manifests/local/github-jira-proxy-service.yaml
   - manifests/local/referee-servicemonitor.yaml
   - manifests/local/release-blocker_deployment.yaml
   - manifests/local/release-blocker_service.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/github-jira-proxy-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/github-jira-proxy-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-jira-proxy
+  labels:
+    app: github-jira-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-jira-proxy
+  template:
+    metadata:
+      labels:
+        app: github-jira-proxy
+    spec:
+      containers:
+        - name: github-jira-proxy
+          image: quay.io/alitman_storage_ocs/github-proxy:v0.0.3
+          args:
+            - '--github-webhook-secret-path=/etc/webhook-github/secret'
+            - '--jira-webhook-secret-path=/etc/webhook-jira/url'
+          ports:
+            - containerPort: 9900
+          volumeMounts:
+            - name: github-webhook-secret
+              mountPath: /etc/webhook-github
+              readOnly: true
+            - name: jira-webhook-url
+              mountPath: /etc/webhook-jira
+              readOnly: true
+      volumes:
+        - name: github-webhook-secret
+          secret:
+            secretName: github-webhook-secret
+        - name: jira-webhook-url
+          secret:
+            secretName: jira-webhook-url

--- a/github/ci/prow-deploy/kustom/base/manifests/local/github-jira-proxy-ingress.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/github-jira-proxy-ingress.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  name: github-jira-proxy
+  namespace: default
+spec:
+  tls:
+    - hosts:
+        - prow.proxy.kubevirt.io
+      secretName: github-jira-proxy-tls
+  rules:
+    - host: prow.proxy.kubevirt.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: github-jira-proxy-service
+                port:
+                  number: 80

--- a/github/ci/prow-deploy/kustom/base/manifests/local/github-jira-proxy-service.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/github-jira-proxy-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-jira-proxy-service
+spec:
+  selector:
+    app: github-jira-proxy
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9900

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -370,6 +370,16 @@ secretGenerator:
       # coverallsToken
       - token=secrets/kubevirtci-coveralls-token
     type: Opaque
+  - name: jira-webhook-url
+    namespace: kubevirt-prow
+    files:
+      - url=secrets/jira-webhook-url
+    type: Opaque
+  - name: github-webhook-secret
+    namespace: kubevirt-prow
+    files:
+      - secret=secrets/github-webhook-secret
+    type: Opaque
   - name: containerized-data-importer-coveralls-token
     namespace: kubevirt-prow-jobs
     files:

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -116,6 +116,16 @@
     content: '{{ githubBotreviewToken }}'
     dest: '{{ secrets_dir }}/botreview-oauth-token'
 
+- name: Create jira-webhook-url
+  copy:
+    content: '{{ jiraWebhookURL }}'
+    dest: '{{ secrets_dir }}/jira-webhook-url'
+
+- name: Create github-webhook-secret
+  copy:
+    content: '{{ githubWebhookToken }}'
+    dest: '{{ secrets_dir }}/github-webhook-secret'
+
 - name: Create coveralls token secret
   copy:
     content: '{{ coverallsToken }}'

--- a/github/ci/prow-deploy/tasks/tests.yml
+++ b/github/ci/prow-deploy/tasks/tests.yml
@@ -22,6 +22,7 @@
     - crier
     - prow-controller-manager
     - horologium
+    - github-jira-proxy
 
 - name: deploy ingress controller
   shell: |

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -43,3 +43,7 @@ windowsProductKeys:
 fossaToken: d3c481176ace1b6c5eb417b0d3dd01497
 
 prowKubevirtbotSSHPrivateKey: "fakie fake"
+
+githubWebhookToken: fd5d76ff40e470c0a6c92f2
+
+jiraWebhookURL: https://issues.kubevirt.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr added in order to make sure jira webhook secret url is private and no reachable by github repo maintainers outside of redhat. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Jira-ticket: https://issues.redhat.com/browse/CNV-45739

**Special notes for your reviewer**:
this service needs to have a public URL github can reach.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
