### PR TITLE
bootstrap: add explicit install of fuse-overlayfs

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -31,6 +31,7 @@ RUN dnf install -y \
     cpio \
     dnf-plugins-core \
     findutils \
+    fuse-overlayfs \
     gcc \
     gcc-c++ \
     gettext \


### PR DESCRIPTION
**What this PR does / why we need it**:

fuse-overlayfs is no longer dragged in as a dependency in the latest
bootstrap image. This causes the smaller jobs on the control-plane
cluster to fail.

Installing fuse-overlayfs allows these jobs to pass successfully

```
$ podman run -ti quay.io/kubevirtci/bootstrap:v20240709-bdabeda rpm -qa | grep fuse
fuse3-libs-3.16.2-3.fc40.x86_64
fuse-libs-2.9.9-21.fc40.x86_64
fuse-common-3.16.2-3.fc40.x86_64
fuse3-3.16.2-3.fc40.x86_64
$ podman run -ti quay.io/kubevirtci/bootstrap:v20240607-febc467 rpm -qa | grep fuse
fuse3-libs-3.16.2-3.fc40.x86_64
fuse-libs-2.9.9-21.fc40.x86_64
fuse-common-3.16.2-3.fc40.x86_64
fuse3-3.16.2-3.fc40.x86_64
fuse-overlayfs-1.13-1.fc40.x86_64
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This should unblock the bump prow image PR - https://github.com/kubevirt/project-infra/pull/3491

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
