### PR TITLE
prow,config: Update default bazel version v5.4.1

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -586,7 +586,7 @@ presets:
     preset-bazel-cache: "true"
   env:
     - name: BAZEL_VERSION
-      value: "5.3.1"
+      value: "5.4.1"
     - name: CACHE_HOST
       value: bazel-cache.kubevirt-prow
     - name: CACHE_PORT


### PR DESCRIPTION
**What this PR does / why we need it**:

A number of jobs have started to fail due ot having the wrong bazel version set[1]

The kubevirt repo now uses v5.4.1[2] - update the default to match.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/bump-kubevirt-rpms-weekly/1784708159516971008#1:build-log.txt%3A161
[2] https://github.com/kubevirt/kubevirt/blob/a37a2b317c335bc1a662d57bd9137d715f52e202/.bazelversion#L1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
