### PR TITLE
fix,bootstrap: Fix sed to change to permissive for short-name-mode

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -87,7 +87,7 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
 
         ln -s ${PODMAN_SOCKET} /var/run/docker.sock
         # Set podman short-name-mode to permissive
-        sed -i 's/short-name-mode="enforcing"/short-name-mode="permissive"/g' /etc/containers/registries.conf
+        sed -i 's/short-name-mode = "enforcing"/short-name-mode = "permissive"/g' /etc/containers/registries.conf
     )
     # the service can be started but the socket not ready, wait for ready
     WAIT_N=0

--- a/images/publish_multiarch_image.sh
+++ b/images/publish_multiarch_image.sh
@@ -84,7 +84,7 @@ build_image() {
     local image_name="${3:?}"
     local base_image="${4:?}"
     # add qemu-user-static
-    podman run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    podman run --rm --privileged docker.io/multiarch/qemu-user-static --reset -p yes
     # build multi-arch images
     for arch in ${archs[*]};do
         if [[ $local_base_image == false ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a recent change in how the containers-common rpm is built[1] which led to a slight formatting change to registries.conf.

This results in short-name-mode remaining in enforcing mode which breaks a number of jobs that still do not use full names for images[2]

[1] https://github.com/containers/common/commit/5c5b1120aaa2970d1b6c961ba2d48996fb240c6a
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1209/check-provision-alpine-with-test-tooling/1812792004837380096#1:build-log.txt%3A792

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
