### PR TITLE
fix: add -c param to kubevirt-tekton-tasks script

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/tekton-tasks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/tekton-tasks-periodics.yaml
@@ -26,9 +26,9 @@ periodics:
           KUBEVIRT_VERSION=$(curl -s https://api.github.com/repos/kubevirt/kubevirt/releases | \
             jq -r '[.[]|select(.prerelease==false) | .tag_name] | sort | last')
 
-          sed -i "s/FROM quay.io\/kubevirt\/libguestfs-tools:.*/FROM quay.io\/kubevirt\/libguestfs-tools:${KUBEVIRT_VERSION}/g" build/Containerfile.DiskVirt
+          command="sed -i "s/FROM quay.io\/kubevirt\/libguestfs-tools:.*/FROM quay.io\/kubevirt\/libguestfs-tools:${KUBEVIRT_VERSION}/g" build/Containerfile.DiskVirt"
           description="Automated update of libguestfs container version to ${KUBEVIRT_VERSION}\n\n\\\`\\\`\\\`release-note\nUpdated libguestfs container to ${KUBEVIRT_VERSION}\n\\\`\\\`\\\`"
-          git-pr.sh -p "${tt_dir}" -d "echo -e \"${description}\"" -r kubevirt-tekton-tasks -b update-libguestfs-container -T main
+          git-pr.sh -c "${command}" -p "${tt_dir}" -d "echo -e \"${description}\"" -r kubevirt-tekton-tasks -b update-libguestfs-container -T main
         resources:
           requests:
             memory: "200Mi"


### PR DESCRIPTION
**What this PR does / why we need it**:
fix: add -c param to kubevirt-tekton-tasks script

The git-pr.sh script requires -c parameter which holds the command. This commit updates the teton-tasks periodics script to pass the -c parameter to git-pr.sh script

**Which issue(s) this PR fixes**:
Fixes https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-update-libguestfs-container-version/1812668534048690176

**Release note**:
```
fix: add -c param to kubevirt-tekton-tasks script
```
