### PR TITLE
kubevirtci, ensure-only-latest-three: fix future provider removal

### DIFF
--- a/robots/pkg/kubevirtci/BUILD.bazel
+++ b/robots/pkg/kubevirtci/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//robots/pkg/querier:go_default_library",
         "@com_github_google_go_github//github:go_default_library",
+        "@com_github_masterminds_semver//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -445,6 +445,42 @@ func TestDropUnsupportedProviders(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "not yet supported providers should not get deleted",
+			args: args{
+				scenario: testScenario{
+					dirsBefore: []string{
+						"cluster-provision/k8s/1.20",
+						"cluster-provision/k8s/1.21",
+						"cluster-provision/k8s/1.22",
+						"cluster-up/cluster/k8s-1.20",
+						"cluster-up/cluster/k8s-1.21",
+						"cluster-up/cluster/k8s-1.22",
+					},
+					providerDirsAfter: []string{
+						"1.20",
+						"1.21",
+						"1.22",
+					},
+					clusterUpDirsAfter: []string{
+						"k8s-1.20",
+						"k8s-1.21",
+						"k8s-1.22",
+					},
+				},
+				providerDir:  "cluster-provision/k8s",
+				clusterUpDir: "cluster-up/cluster",
+				supportedReleases: []*github.RepositoryRelease{
+					{
+						TagName: strPointer("v1.20.2"),
+					},
+					{
+						TagName: strPointer("v1.21.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We currently add new providers when they are in beta state already. Therefore the bump automation that removes old providers needs to take into account that some of the "unsupported" providers are actually newer than the currently supported, so they won't get deleted. We add a comparison by version to check this.

See example PR [1]

[1]: https://github.com/kubevirt/kubevirtci/pull/1226

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @xpivarc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
