### PR TITLE
prow, referee: notify PR author instead of commenter

### DIFF
--- a/external-plugins/referee/server/server.go
+++ b/external-plugins/referee/server/server.go
@@ -190,7 +190,7 @@ func (s *Server) handlePullRequestComment(ic github.IssueCommentEvent) error {
 	repo := ic.Repo.Name
 	num := ic.Issue.Number
 	action := ic.Action
-	user := ic.Comment.User.Login
+	commentAuthor := ic.Comment.User.Login
 
 	pullRequestURL := fmt.Sprintf("https://github.com/%s/%s/pull/%d", org, repo, num)
 	log := s.Log.WithField("pull_request_url", pullRequestURL)
@@ -198,7 +198,7 @@ func (s *Server) handlePullRequestComment(ic github.IssueCommentEvent) error {
 	switch action {
 	case github.IssueCommentActionCreated:
 	default:
-		log.Debugf("skipping for action %s by %s", action, user)
+		log.Debugf("skipping for action %s by %s", action, commentAuthor)
 		return nil
 	}
 
@@ -256,9 +256,10 @@ func (s *Server) handlePullRequestComment(ic github.IssueCommentEvent) error {
 	}
 
 	if !s.DryRun {
+		prAuthor := ic.Issue.User.Login
 		var output bytes.Buffer
 		err := tooManyRetestsCommentTemplate.Execute(&output, TooManyRequestsData{
-			Author: user,
+			Author: prAuthor,
 			Team:   s.Team,
 		})
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since the commenter might be a bot user, we need to notify the PR author that their PR is held. Otherwise they might miss the notification about the PR being held (example [1])

[1]: https://github.com/kubevirt/kubevirt/pull/12383#issuecomment-2240907431

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
