### PR TITLE
project-infra, deployment, update: use generated tag

### DIFF
--- a/external-plugins/botreview/Makefile
+++ b/external-plugins/botreview/Makefile
@@ -17,4 +17,4 @@ test:
 
 push:
 	podman build -f ../../images/$(CONTAINER_IMAGE)/Containerfile -t $(CONTAINER_REPO):$(CONTAINER_TAG) && podman push $(CONTAINER_REPO):$(CONTAINER_TAG)
-	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO)
+	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO) $(CONTAINER_TAG)

--- a/external-plugins/referee/Makefile
+++ b/external-plugins/referee/Makefile
@@ -16,4 +16,4 @@ format:
 
 push:
 	podman build -f ../../images/$(CONTAINER_IMAGE)/Containerfile -t $(CONTAINER_REPO):$(CONTAINER_TAG) && podman push $(CONTAINER_REPO):$(CONTAINER_TAG)
-	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO)
+	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO) $(CONTAINER_TAG)

--- a/github/ci/prow-deploy/kustom/base/manifests/local/referee-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/referee-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: referee
-        image: quay.io/kubevirtci/referee:v20240711-fe5d4de1
+        image: quay.io/kubevirtci/referee:v20240726-4d5343c8
         args:
         - --dry-run=false
         - --port=9900

--- a/hack/update-deployments-with-latest-image.sh
+++ b/hack/update-deployments-with-latest-image.sh
@@ -8,22 +8,21 @@ if ! command -V skopeo; then
 fi
 
 if [ $# -gt 1 ]; then
-    if [ ! -d "$2" ]; then
-        echo "$2 is not a directory!"
-        exit 1
-    fi
-    deployment_dir="$2"
-else
-    deployment_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname "$0")" && pwd)"'/../github/ci/prow-deploy/kustom/base/manifests/local' && pwd)")"
+    image_tag="$2"
 fi
+deployment_dir="$(readlink --canonicalize "$(cd "$(cd "$(dirname "$0")" && pwd)"'/../github/ci/prow-deploy/kustom/base/manifests/local' && pwd)")"
 
 IMAGE_NAME="$1"
-latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("^v?[0-9]+-[a-z0-9]{7,9}$") )' | tail -1)
-if [ -z "$latest_image_tag" ]; then
-    echo "Couldn't find latest_image_tag"
-    exit 1
+if [ -z "$image_tag" ]; then
+    latest_image_tag=$(skopeo list-tags "docker://$IMAGE_NAME" | jq -r '.Tags[] | select( match("^v?[0-9]+-[a-z0-9]{7,9}$") )' | tail -1)
+    if [ -z "$latest_image_tag" ]; then
+        echo "Couldn't find latest_image_tag"
+        exit 1
+    fi
+    IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$latest_image_tag"
+else
+    IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$image_tag"
 fi
-IMAGE_NAME_WITH_TAG="$IMAGE_NAME:$latest_image_tag"
 
 replace_regex='s#'"$IMAGE_NAME"'(@sha256\:|:v?[a-z0-9]+-).*$#'"$IMAGE_NAME_WITH_TAG"'#g'
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Instead of fetching the tag from the image repository via skopeo
list-tags, which is error-prone [1], we add the generated tag as an
argument to the script, since we have tagged the pushed image with
exactly that tag anyway.

[1]: https://github.com/kubevirt/project-infra/pull/3554#issuecomment-2252217582

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
