### PR TITLE
Doc: change namespace for token export

### DIFF
--- a/docs/how-to-add-a-prow-cluster.md
+++ b/docs/how-to-add-a-prow-cluster.md
@@ -60,7 +60,7 @@ type: kubernetes.io/service-account-token
 EOF
 # export secret token data to add to user later on
 kubectl get secret prow-workloads-cluster-automation \
-    -n "default" -o yaml | \
+    -n "kubevirt-prow-jobs" -o yaml | \
     yq -r '.data.token' | \
     base64 -d
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

While following the guide to add a prow cluster, exporting the secret token data happens in the default namespace even though `prow-workloads-cluster-automation` is created in the `kubevirt-prow-jobs` namespace

---

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
