### PR TITLE
arm64 presubmit: revert pull-kubevirt-unit-test-arm64 bootstrap image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -466,7 +466,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/bootstrap:v20240711-f55d15c
+        image: quay.io/kubevirtci/bootstrap:v20240607-febc467
         name: ""
         resources:
           requests:


### PR DESCRIPTION
As the comments here, https://github.com/kubevirt/project-infra/pull/3526#issuecomment-2227851451, try to revert the bootstrap image to see if the test can pass.
Fix: #3558

**Release note**:
```release-note
NONE
```
