### PR TITLE
Prow jobs for publishing k8s provider multi arch images

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -44,11 +44,83 @@ postsubmits:
           - "/usr/local/bin/runner.sh"
           - "/bin/bash"
           - "-c"
-          - >
+          - |
             cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+            SHORT_SHA=$(git rev-parse --short HEAD) &&
             ./publish.sh &&
-            echo "$(git tag --points-at HEAD | head -1)" > latest &&
-            gsutil cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest
+            # Gets git tag created by above publish.sh run
+            KUBEVIRTCI_TAG=$(git tag --points-at HEAD | head -1) &&
+            echo "$KUBEVIRTCI_TAG" > latest &&
+            gsutil cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest &&
+            echo "$KUBEVIRTCI_TAG" > amd64-$SHORT_SHA &&
+            gsutil cp ./amd64-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-$SHORT_SHA
+          # docker-in-docker needs privileged mode
+          env:
+          - name: GIMME_GO_VERSION
+            value: "1.22.5"
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /dev
+            name: devices
+          resources:
+            requests:
+              memory: "29Gi"
+    - name: publish-kubevirtci-s390x
+      branches:
+      - main
+      always_run: true
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      decoration_config:
+        timeout: 2h
+      max_concurrency: 1
+      extra_refs:
+      - org: kubevirt
+        repo: project-infra
+        base_ref: main
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-gcs-credentials: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: prow-s390x-workloads
+      spec:
+        volumes:
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: devices
+        containers:
+        - image: quay.io/kubevirtci/golang:v20241213-57bd934
+          command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/bash"
+          - "-c"
+          - |
+            cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+            SHORT_SHA=$(git rev-parse --short HEAD) &&
+            GCS_FILE_PATH=release/kubevirt/kubevirtci/amd64-$SHORT_SHA &&
+            source /usr/local/bin/gcs_restapi.sh &&
+            CHECK_INTERVAL=30 &&
+            while true; do
+                if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH"; then
+                    echo "File $GCS_FILE_PATH is now available."
+                    break
+                else
+                    echo "File $GCS_FILE_PATH not found. Checking again in $CHECK_INTERVAL seconds."
+                    sleep $CHECK_INTERVAL
+                fi
+            done &&
+            KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH")
+            if [ $? -ne 0 ]; then
+                echo "Failed to fetch KUBEVIRTCI_TAG"
+                exit 1
+            fi
+            export KUBEVIRTCI_TAG &&
+            echo "Fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG" &&
+            ./publish.sh &&
+            rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
           # docker-in-docker needs privileged mode
           env:
           - name: GIMME_GO_VERSION


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds multi-arch publish jobs for centos9 and k8s provider images. 

As we've added s390x support in k8s provider (started with 1.30 slim), centos9 and gocli images as part of https://github.com/kubevirt/kubevirtci/pull/1252, this PR does changes required in project-infra repo to enable the prow jobs for the same.

**Special notes for your reviewer**:
This PR makes sense to be merged along with changes said above.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
