### PR TITLE
Revert "kubevirt,presubmit: Set failing pull-kubevirt-apidocs to optional"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -516,7 +516,6 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-apidocs-1.1
-    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -551,7 +551,6 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-apidocs-1.2
-    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -550,7 +550,6 @@ presubmits:
     labels:
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-apidocs-1.3
-    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -717,7 +717,6 @@ presubmits:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-apidocs
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit 815faa80671f6c82a1006020e2d22affccd99256.

`pull-kubevirt-apidocs` is looking much more stable[1] since the change to using the swagger2markup-cli jar[2]

[1] https://prow.ci.kubevirt.io/?job=pull-kubevirt-apidocs
[2] https://github.com/kubevirt/kubevirt/pull/12552


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
