### PR TITLE
update-deployments-with-latest-image.sh: fix image_tag unbound var

### DIFF
--- a/hack/update-deployments-with-latest-image.sh
+++ b/hack/update-deployments-with-latest-image.sh
@@ -7,6 +7,7 @@ if ! command -V skopeo; then
     exit 1
 fi
 
+image_tag=""
 if [ $# -gt 1 ]; then
     image_tag="$2"
 fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

job periodic-project-infra-prow-deployment-image-bump is failing [1] due to unbound variable, this change assigns the empty string as default.

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-deployment-image-bump/1826058066550853632#1:build-log.txt%3A77

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
