### PR TITLE
Update autoowners container file to use full qualified image name

### DIFF
--- a/images/autoowners/Dockerfile
+++ b/images/autoowners/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM docker.io/library/golang:1.22.4 as builder
 
 WORKDIR /go/src/github.com/openshift/ci-tools/
 RUN mkdir -p /go/src/github.com/openshift/ && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

During updating URLS of prow bumper [1] we noticed that the image build for autoowners is not working any more [2]

[1]: https://github.com/kubevirt/project-infra/pull/3587
[2]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3587/rehearsal-build-autoowners-image/1828001341071429632

This PR updates autoowners container file to use full qualified image name, also bumps the go version, since the source go.mod has been updated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
