### PR TITLE
cdi,postsubmit: Update the push of CDI builder to only run when there are changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -161,9 +161,8 @@ postsubmits:
     - main
     - release-v\d+\.\d+
     cluster: kubevirt-prow-control-plane
-    always_run: true
-    optional: false
-    skip_report: true
+    always_run: false
+    run_if_changed: "hack/build/docker/builder/.*"
     annotations:
       testgrid-create-test-group: "false"
     decorate: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This will only run the publish of the CDI builder image when there have been changes merged for the builder image. 

It should remove the need for `git diff` checks in the underlying scripts[1[ which block us from publishing a fresh image by triggering the postsubmit manually. 

[1] https://github.com/kubevirt/containerized-data-importer/blob/40fd89cd3b8c9896a5049d8dfc90d33d3117b4b6/hack/build/bazel-build-builder.sh#L38

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @akalenyu @awels 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
