### PR TITLE
bootstrap: Increase podman pids_limit to 4096

### DIFF
--- a/images/bootstrap/containers.conf
+++ b/images/bootstrap/containers.conf
@@ -3,6 +3,7 @@ netns="private"
 userns="host"
 ipcns="host"
 cgroupns="host"
+pids_limit=4096
 log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"


### PR DESCRIPTION
**What this PR does / why we need it**:

The nightly build jobs have been failing[1] due to default podman pids_limit (2048)[2] in the bootstrap image being too low.

Increasing this to 4096 allows the nightly build jobs to complete successfully[3].

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-main/1828599108043018240
[2] https://docs.podman.io/en/v5.2.2/markdown/podman-update.1.html#pids-limit-limit
[3] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-push-nightly-build-main/1828835977469104128

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
