### PR TITLE
kubevirt, labels: rename code-quality into cleanup

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -50,6 +50,7 @@ larger set of contributors to apply/remove them.
 | <a id="kind/api-change" href="#kind/api-change">`kind/api-change`</a> | Categorizes issue or PR as related to adding, removing, or otherwise changing an API| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/blocker" href="#kind/blocker">`kind/blocker`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/bug" href="#kind/bug">`kind/bug`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
+| <a id="kind/cleanup" href="#kind/cleanup">`kind/cleanup`</a> | Categorizes issue or PR as related to cleaning up code, process, or technical debt. <br><br> This was previously `sig/code-quality`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/deprecation" href="#kind/deprecation">`kind/deprecation`</a> | Indicates the PR/issue deprecates a feature that will be removed in a subsequent release.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/enhancement" href="#kind/enhancement">`kind/enhancement`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="kind/failing-test" href="#kind/failing-test">`kind/failing-test`</a> | Categorizes issue or PR as related to a failing test.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
@@ -65,7 +66,6 @@ larger set of contributors to apply/remove them.
 | <a id="sig/api" href="#sig/api">`sig/api`</a> | Denotes an issue or PR that relates to changes in api.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/buildsystem" href="#sig/buildsystem">`sig/buildsystem`</a> | Denotes an issue or PR that relates to changes in the build system.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/ci" href="#sig/ci">`sig/ci`</a> | Denotes an issue or PR as being related to sig-ci, marks changes to the CI system.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
-| <a id="sig/code-quality" href="#sig/code-quality">`sig/code-quality`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/compute" href="#sig/compute">`sig/compute`</a> |  <br><br> This was previously `topic/virtualization`, `sig-virtualization`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/documentation" href="#sig/documentation">`sig/documentation`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/network" href="#sig/network">`sig/network`</a> |  <br><br> This was previously `topic/network`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -96,6 +96,15 @@ default:
       target: both
       addedBy: anyone
       prowPlugin: label
+    - name: kind/cleanup
+      color: ce23cf
+      target: both
+      prowPlugin: label
+      addedBy: anyone
+      description: Categorizes issue or PR as related to cleaning up code, process, or technical debt.
+      previously:
+      - name: sig/code-quality
+        color: ce23cf
     - name: kind/flake
       color: f7c5c7
       target: both
@@ -247,11 +256,6 @@ default:
           color: c5def5
         - name: sig-virtualization
           color: c5def5
-    - name: sig/code-quality
-      color: ce23cf
-      target: both
-      prowPlugin: label
-      addedBy: anyone
     - name: sig/release
       color: 2943CF
       target: both


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The label `sig/code-quality` is used to mark pull requests that target improvements to our code base[1]. However, the prefix `sig` gives the impression that there is a SIG that is actively caring for such PRs.

Given the fact that there's neither an entry inside sigs.yaml[2], nor a proper sig folder in the community repository, nor any publicly held meetings that are announced in the community calendar[3], we can assume that such a sig doesn't exist.

During the discussion at the community meeting[4] about this topic there was the suggestion to just rename the label into a `kind` label. Looking at Kubernetes labels provided a general label `kind/cleanup`[5] that matches a broader set of scenarios and seems to be well suited for covering all the code-quality PRs.

Therefore this PR renames the label `sig/code-quality` to `kind/cleanup`.

[1]: https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+is%3Aopen+label%3Asig%2Fcode-quality
[2]: https://github.com/kubevirt/community/blob/main/sigs.yaml
[3]: https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io
[4]: https://docs.google.com/document/d/1nE09vQWcCTW-9Ohe9oCldWrE0he-T_YFJ5D1xNzMtg4/edit#heading=h.8k5y3b9jfo4r
[5]: https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#kind/cleanup

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
