### PR TITLE
Enable multiarch builds for pr-creator image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -467,16 +467,14 @@ postsubmits:
               - |
                 cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
                 cd images
-                ./publish_image.sh pr-creator quay.io kubevirtci
+                ./publish_multiarch_image.sh pr-creator quay.io kubevirtci
             securityContext:
               privileged: true
             resources:
               requests:
-                memory: "16Gi"
-                cpu: "500m"
+                memory: "29Gi"
               limits:
-                memory: "16Gi"
-                cpu: "500m"
+                memory: "29Gi"
     - name: publish-vm-image-builder-image
       always_run: false
       run_if_changed: "images/vm-image-builder/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -419,16 +419,14 @@ presubmits:
             - "-c"
             - |
               cd images
-              ./publish_image.sh -b pr-creator quay.io kubevirtci
+              ./publish_multiarch_image.sh -b pr-creator quay.io kubevirtci
           securityContext:
             privileged: true
           resources:
             requests:
-              memory: "16Gi"
-              cpu: "500m"
+              memory: "29Gi"
             limits:
-              memory: "16Gi"
-              cpu: "500m"
+              memory: "29Gi"
   - name: build-vm-image-builder-image
     always_run: false
     run_if_changed: "images/bootstrap/.*"

--- a/images/pr-creator/Dockerfile
+++ b/images/pr-creator/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/kubevirtci/golang:v20240229-74549d5
+FROM quay.io/kubevirtci/golang:v20240814-9b6c4af
 
-ENV GIMME_GO_VERSION=1.21.6
+ENV GIMME_GO_VERSION=1.22.6
 
 RUN set -x && \
     git clone https://github.com/kubernetes/test-infra.git && \
@@ -15,10 +15,10 @@ RUN set -x && \
 RUN set -x && \
     git clone https://github.com/kubevirt/project-infra.git && \
     cd ./project-infra && \
-    cp ./hack/git-askpass.sh hack/git-pr.sh /usr/local/bin && \
+    cp ./hack/git-askpass.sh /usr/local/bin && \
+    cp ./hack/git-pr.sh /usr/local/bin && \
     chmod +x /usr/local/bin/git-askpass.sh /usr/local/bin/git-pr.sh && \
-    bazel build //robots/cmd/labels-checker:labels-checker && \
-    cp ./bazel-out/k8-fastbuild/bin/robots/cmd/labels-checker/labels-checker_/labels-checker /usr/local/bin && \
+    /usr/local/bin/runner.sh /bin/sh -ce 'go build -o /usr/local/bin/labels-checker ./robots/cmd/labels-checker' && \
     chmod +x /usr/local/bin/labels-checker && \
     cd .. && rm -rf ./project-infra
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates base image (golang) version and Go version to newer versions and mainly enables multi-arch images for pr-creator.

Multi-arch images for pr-creator are needed as now with #3566 we want to move PR creation part into periodic-kubevirtci-bump-centos-base-s390x. So that after x86 centos images are built, followed by s390x builds and manifest-list, we will create the PR in the s390x machine. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
