### PR TITLE
github, labels: add triage/infra-issue

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -84,6 +84,7 @@ larger set of contributors to apply/remove them.
 | <a id="spam" href="#spam">`spam`</a> | Categorizes issues or PRs as an invalid contribution| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="triage/accepted" href="#triage/accepted">`triage/accepted`</a> | Indicates an issue or PR is ready to be actively worked on.| org members |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="triage/duplicate" href="#triage/duplicate">`triage/duplicate`</a> | Indicates an issue is a duplicate of other open issue.| anyone | |
+| <a id="triage/infra-issue" href="#triage/infra-issue">`triage/infra-issue`</a> | Indicates an issue was caused by failures in the infrastructure.| anyone | |
 | <a id="triage/needs-information" href="#triage/needs-information">`triage/needs-information`</a> | Indicates an issue needs more information in order to work on it.| anyone | |
 | <a id="triage/not-reproducible" href="#triage/not-reproducible">`triage/not-reproducible`</a> | Indicates an issue can not be reproduced as described.| anyone | |
 | <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not or will not be resolved.| anyone | |

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -133,6 +133,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/launcher" href="#area/launcher">`area/launcher`</a> | |  | |
 | <a id="area/monitoring" href="#area/monitoring">`area/monitoring`</a> | |  | |
 | <a id="area/operator" href="#area/operator">`area/operator`</a> | |  | |
+| <a id="area/testing" href="#area/testing">`area/testing`</a> |  <br><br> This was previously `topic/testing`, |  | |
 | <a id="area/virtctl" href="#area/virtctl">`area/virtctl`</a> | |  | |
 | <a id="distro/kubernetes" href="#distro/kubernetes">`distro/kubernetes`</a> |  <br><br> This was previously `distro/kuberenetes`, |  | |
 | <a id="distro/openshift" href="#distro/openshift">`distro/openshift`</a> | |  | |
@@ -153,7 +154,6 @@ larger set of contributors to apply/remove them.
 | <a id="topic/integration" href="#topic/integration">`topic/integration`</a> | |  | |
 | <a id="topic/packaging" href="#topic/packaging">`topic/packaging`</a> | |  | |
 | <a id="topic/scheduling" href="#topic/scheduling">`topic/scheduling`</a> | |  | |
-| <a id="topic/testing" href="#topic/testing">`topic/testing`</a> | |  | |
 | <a id="wontfix" href="#wontfix">`wontfix`</a> | |  | |
 
 ## Labels that apply to kubevirt/kubevirt, only for issues

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -36,6 +36,11 @@ default:
       previously:
         - name: triage/build-officer
           color: 8452c9
+    - color: d455d0
+      description: Indicates an issue was caused by failures in the infrastructure.
+      name: triage/infra-issue
+      target: both
+      addedBy: anyone
     - color: c2e0c6
       name: release-note
       target: prs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds `triage/infra-issue` to the GitHub labels. 

Also syncs the labels.md with missing changes (which was seen after executing `make update-labels`)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3632

**Special notes for your reviewer**:
/cc @iholder101 @brianmcarey 
