### PR TITLE
update bootstrap to include which pkg.

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -59,6 +59,7 @@ RUN dnf install -y \
     qemu-user-static \
     bind-utils \
     wget \
+    which \
     python3-jinja2 &&\
   dnf -y clean all
 


### PR DESCRIPTION
 <!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr updates the bootstrap image to include `which` package.
Why we need it?
The which pkg is required to fetch the installed kubectl path and set the KUBECTL variable for the external provider. Check here: https://github.com/kubevirt/kubevirt/blob/main/cluster-up/cluster/external/provider.sh#L29 . Since it is not there the s390x e2e job is not able to set the kubectl env variable and the access_test.go test files are getting skipped. 
These are the logs:
```
00:38:02: /home/prow/go/src/github.com/kubevirt/kubevirt/cluster-up//cluster/external/provider.sh: line 28: which: command not found
00:38:02: /home/prow/go/src/github.com/kubevirt/kubevirt/cluster-up//cluster/external/provider.sh: line 34: which: command not found 
```

[prow-job-link](https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-test-S390X/1833664318353182720/build-log.txt
)
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
