### PR TITLE
bootstrap: Add workaround for corrupted image pulls with podman

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -117,6 +117,9 @@ RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
 # Trust git repositories used for e2e jobs
 RUN git config --global --add safe.directory '*'
 
+# FIXME: Workaround for issue pulling images with podman on Fedora 40 - https://github.com/containers/podman/issues/23822
+RUN ln -s /usr/bin/gzip /usr/local/bin/pigz
+
 # note the runner is also responsible for making podman in container function if
 # env PODMAN_IN_CONTAINER_ENABLED is set and similarly responsible for generating
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There are a number of jobs that are failing to pull images due to corruption and a crc32mismatch[1]

There is an open issue for this problem in the podman repo[2] that suggests this change as a workaround.

This workaround should be removed when the related issues are resolved.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/12677/pull-kubevirt-e2e-k8s-1.31-sig-compute/1833657514537783296#1:build-log.txt%3A262
[2] https://github.com/containers/podman/issues/23822
[3] https://github.com/zlib-ng/zlib-ng/issues/1772


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
