### PR TITLE
kumemacpool, postsubmit: Push stable branch latest commits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
@@ -23,6 +23,33 @@ postsubmits:
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
+    - name: stable-branch-kubemacpool
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      max_concurrency: 1
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-kubevirtci-quay-credential: "true"
+      branches:
+        - ^release-\d+\.\d+$
+      cluster: kubevirt-prow-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20240829-fb5890c
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io &&
+                BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+                [ "$BRANCH_NAME" != "HEAD" ] &&
+                make container docker-push IMAGE_TAG=${BRANCH_NAME}_latest
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
     - name: release-kubemacpool
       annotations:
         testgrid-create-test-group: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, kubemacpool pushes to QUAY only when a release tag is set, or for every main branch commit.
This behavior is wanted also for stable branch commits, in order to be able to consume them from latest commits by other repos.

Adding another postsubmit for stable branches.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
