### PR TITLE
Added REST based API calls for GCS as gsutil isn't supported for s390x in bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -60,6 +60,7 @@ RUN dnf install -y \
     bind-utils \
     wget \
     which \
+    openssl \
     python3-jinja2 &&\
   dnf -y clean all
 
@@ -125,7 +126,7 @@ RUN ln -s /usr/bin/gzip /usr/local/bin/pigz
 # env PODMAN_IN_CONTAINER_ENABLED is set and similarly responsible for generating
 
 # .bazelrc files if bazel remote caching is enabled
-COPY ["entrypoint.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
+COPY ["entrypoint.sh", "gcs_restapi.sh", "runner.sh", "create_bazel_cache_rcs.sh", \
         "/usr/local/bin/"]
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/images/bootstrap/gcs_restapi.sh
+++ b/images/bootstrap/gcs_restapi.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Copyright 2024 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BASE_URL="https://storage.googleapis.com"
+
+# Function to validate GOOGLE_APPLICATION_CREDENTIALS and and set access_token global variable
+get_access_token() {
+    if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+        echo "GOOGLE_APPLICATION_CREDENTIALS is not set. Please set it to the path of your service account key file."
+        exit 1
+    fi
+
+    local sa_email=$(jq -r '.client_email' "$GOOGLE_APPLICATION_CREDENTIALS")
+    local sa_key=$(jq -r '.private_key' "$GOOGLE_APPLICATION_CREDENTIALS")
+    local jwt_header=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 -w 0 | tr '+/' '-_' | tr -d '=')
+    local jwt_claim=$(echo -n '{"iss":"'$sa_email'","scope":"https://www.googleapis.com/auth/cloud-platform","aud":"https://oauth2.googleapis.com/token","exp":'$(($(date +%s) + 3600))',"iat":'$(date +%s)'}' | base64 -w 0 | tr '+/' '-_' | tr -d '=')
+    local jwt_signature=$(echo -n "$jwt_header.$jwt_claim" | openssl dgst -binary -sha256 -sign <(echo "$sa_key") | base64 -w 0 | tr '+/' '-_' | tr -d '=')
+    local jwt="$jwt_header.$jwt_claim.$jwt_signature"
+
+    local response=$(curl -s -X POST https://oauth2.googleapis.com/token \
+         -H "Content-Type: application/x-www-form-urlencoded" \
+         -d "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=$jwt")
+
+    access_token=$(echo "$response" | jq -r '.access_token')
+
+    if [ -z "$access_token" ]; then
+        echo "Failed to obtain access token. Check your service account key file."
+        exit 1
+    fi
+}
+
+urlencode_path() {
+    local path="$1"
+    echo "$path" | sed 's/\//%2F/g'
+}
+
+# Function to upload a file to Google Cloud Storage
+upload_to_gcs() {
+    local source_file="$1"
+    local bucket_name="$2"
+    local destination_blob=$(urlencode_path "$3")
+    local content_type="application/octet-stream"
+
+    get_access_token
+
+    upload_response=$(curl -X POST \
+      --data-binary @"$source_file" \
+      -H "Authorization: Bearer $access_token" \
+      -H "Content-Type: $content_type" \
+      "${BASE_URL}/upload/storage/v1/b/$bucket_name/o?uploadType=media&name=$destination_blob")
+
+    if echo "$upload_response" | jq -e '.name' > /dev/null; then
+       echo "File $source_file uploaded successfully as $destination_blob"
+       return 0
+    else
+       echo "Upload failed. Response:"
+       echo "$upload_response" | jq '.'
+       return 1
+    fi
+}
+
+# Function to check if a file exists in GCS
+stat_gcs_file() {
+    local bucket_name="$1"
+    local gcs_file_path=$(urlencode_path "$2")
+
+    get_access_token
+
+    stat_response=$(curl -s -X GET \
+      -H "Authorization: Bearer $access_token" \
+      "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
+
+    if echo "$stat_response" | jq -e '.error' > /dev/null; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Function to read the content of a file from GCS
+cat_gcs_file() {
+    local bucket_name="$1"
+    local gcs_file_path=$(urlencode_path "$2")
+
+    get_access_token
+
+    file_content=$(curl -s -X GET \
+      -H "Authorization: Bearer $access_token" \
+      "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path?alt=media")
+
+    if [ -z "$file_content" ]; then
+        echo "Error: No content received"
+        return 1
+    else
+        echo "$file_content"
+        return 0
+    fi
+}
+
+# Function to delete a file from GCS
+rm_gcs_file() {
+    local bucket_name="$1"
+    local gcs_file_path=$(urlencode_path "$2")
+
+    get_access_token
+
+    delete_response=$(curl -s -X DELETE \
+      -H "Authorization: Bearer $access_token" \
+      "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
+
+    if [ -z "$delete_response" ]; then
+        echo "File $gcs_file_path deleted successfully."
+        return 0
+    else
+        echo "Failed to delete file. Response:"
+        echo "$delete_response" | jq '.'
+        return 1
+    fi
+}


### PR DESCRIPTION
This is a pre-requisite for enabling publishing jobs for k8s provider for s390x (#3566 ), as those jobs need to interact with gcs from s390x machines

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
