### PR TITLE
sig-ci: run quarantined tests report in the morning

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1577,6 +1577,7 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
+  cron: 45 6 * * *
   decorate: true
   extra_refs:
   - base_ref: main
@@ -1586,7 +1587,6 @@ periodics:
   - base_ref: main
     org: kubevirt
     repo: kubevirt
-  interval: 24h
   labels:
     preset-gcs-credentials: "true"
   name: periodic-kubevirt-quarantined-tests-daily-report


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We want to have the report updated ahead of the sig-ci meetings. Thus we switch to using a cron expression instead of an interval.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @brianmcarey 