### PR TITLE
Move priority/backlog to global label definition

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -61,6 +61,7 @@ larger set of contributors to apply/remove them.
 | <a id="lifecycle/frozen" href="#lifecycle/frozen">`lifecycle/frozen`</a> | Indicates that an issue or PR should not be auto-closed due to staleness.| prow |  [lifecycle](https://prow.ci.kubevirt.io/command-help#lifecycle) |
 | <a id="lifecycle/rotten" href="#lifecycle/rotten">`lifecycle/rotten`</a> | Denotes an issue or PR that has aged beyond stale and will be auto-closed.| prow |  [lifecycle](https://prow.ci.kubevirt.io/command-help#lifecycle) |
 | <a id="lifecycle/stale" href="#lifecycle/stale">`lifecycle/stale`</a> | Denotes an issue or PR has remained open with no activity and has become stale.| prow |  [lifecycle](https://prow.ci.kubevirt.io/command-help#lifecycle) |
+| <a id="priority/backlog" href="#priority/backlog">`priority/backlog`</a> | Indicate that the issue or PR is a lower priority and can be worked on in the future| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="priority/critical-urgent" href="#priority/critical-urgent">`priority/critical-urgent`</a> | Categorizes an issue or pull request as critical and of urgent priority.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/api" href="#sig/api">`sig/api`</a> | Denotes an issue or PR that relates to changes in api.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/buildsystem" href="#sig/buildsystem">`sig/buildsystem`</a> | Denotes an issue or PR that relates to changes in the build system.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
@@ -141,7 +142,6 @@ larger set of contributors to apply/remove them.
 | <a id="for/developers" href="#for/developers">`for/developers`</a> | |  | |
 | <a id="for/users" href="#for/users">`for/users`</a> | |  | |
 | <a id="needs/documentation" href="#needs/documentation">`needs/documentation`</a> | |  | |
-| <a id="priority/backlog" href="#priority/backlog">`priority/backlog`</a> | |  | |
 | <a id="release-blocker" href="#release-blocker">`release-blocker`</a> | Indicates that a PR or issue is blocking a release from a specific branch.| prow |  [release-blocker](https://prow.ci.kubevirt.io/command-help#release-blocker) |
 | <a id="research-needed" href="#research-needed">`research-needed`</a> | |  | |
 | <a id="topic/api" href="#topic/api">`topic/api`</a> | |  | |

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -359,14 +359,17 @@ default:
       description: Categorizes an issue or pull request as critical and of urgent priority.
       prowPlugin: label
       target: both
+    - name: priority/backlog
+      addedBy: anyone
+      color: fbca04
+      description: Indicate that the issue or PR is a lower priority and can be worked on in the future 
+      prowPlugin: label 
+      target: both
 repos:
   kubevirt/kubevirt:
     labels:
       - name: needs/documentation
         color: d4c5f9
-        target: both
-      - name: priority/backlog
-        color: fbca04
         target: both
       - name: research-needed
         color: fef2c0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Move priority/backlog to global label definition adjacent to [priority/critical-urgent](https://file+.vscode-resource.vscode-cdn.net/home/anishbista/project-infra/docs/labels.md#priority/critical-urgent)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3654

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
