### PR TITLE
Revert "bootstrap: Add workaround for corrupted image pulls with podman (#3639)"

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -118,9 +118,6 @@ RUN mkdir -p /etc/setup.mixin.d/ && mkdir -p /etc/teardown.mixin.d/
 # Trust git repositories used for e2e jobs
 RUN git config --global --add safe.directory '*'
 
-# FIXME: Workaround for issue pulling images with podman on Fedora 40 - https://github.com/containers/podman/issues/23822
-RUN ln -s /usr/bin/gzip /usr/local/bin/pigz
-
 # note the runner is also responsible for making podman in container function if
 # env PODMAN_IN_CONTAINER_ENABLED is set and similarly responsible for generating
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The fix for the issue that this workaround was added for has been included in Fedora 40.
https://bugzilla.redhat.com/show_bug.cgi?id=2307237

```
[root@b873a1829fa1 /]# cat /etc/redhat-release
Fedora release 40 (Forty)
[root@b873a1829fa1 /]# rpm -qa | grep zlib-ng
zlib-ng-compat-2.1.7-2.fc40.x86_64
```

This reverts commit 16816d317dbe52c99d80c652c46d0ee7e7c0e115.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
