### PR TITLE
Add slim mode to check-provision-k8s-1.30-s390x prow job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -442,6 +442,9 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.31 && ../provision.sh
+        env:
+        - name: SLIM
+          value: true
         image: quay.io/kubevirtci/golang:v20240923-918320b
         name: ""
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -444,7 +444,7 @@ presubmits:
         - cd cluster-provision/k8s/1.31 && ../provision.sh
         env:
         - name: SLIM
-          value: true
+          value: "true"
         image: quay.io/kubevirtci/golang:v20240923-918320b
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently if check-provision-k8s-1.30-s390x  runs on s390x PR [#1252](https://github.com/kubevirt/kubevirtci/pull/1252), it fails as part of that PR only 1.30 k8s provider in SLIM mode is enabled. So, added SLIM=true env variable, so that check-provision-k8s-1.30-s390x runs in slim mode.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered


```release-note
NONE
```
