### PR TITLE
kubevirt,governance: improve script to remove inactive org users

### DIFF
--- a/hack/remove-users-without-contributions.sh
+++ b/hack/remove-users-without-contributions.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
+set -euo pipefail
 
-if [[ "$1" =~ -h ]]; then
+function usage() {
     cat << EOF
+
 usage: $0 <input-file>
 
     Removes all users without contributions (taken from the input file) from the orgs.yaml
@@ -13,14 +14,41 @@ usage: $0 <input-file>
 
     then from the top panel select "Inspect" > "Data" and select "Download CSV"
 EOF
+}
+
+if ! command -V yq; then
+    echo "yq is required!"
+    exit 1
+fi
+is_jq_wrapper="$(yq --help | grep -c 'jq wrapper for YAML documents')"
+
+if [ "$#" -lt 1 ]; then
+    echo "input-file is required"
+    usage
+    exit 1
+fi
+
+if [[ "$1" =~ -h ]]; then
+    usage
     exit 0
 fi
 
 if [ ! -f "$1" ]; then
-    echo "file $1 doesn't exist"
+    echo "input-file $1 doesn't exist"
+    usage
     exit 1
 fi
 input_csv_file="$1"
+
+set -x
+
+base_dir=$( cd $( dirname "${BASH_SOURCE[0]}") && pwd )
+
+orgs_yaml_path="${base_dir}/../github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml"
+if [ ! -f "$orgs_yaml_path" ]; then
+    echo "File $orgs_yaml_path not found!"
+    exit 1
+fi
 
 # generate input file from csv where each user is in a separate line
 head -1 "$input_csv_file" \
@@ -56,11 +84,19 @@ aburdenthehand
 jberkus
 EOF
 
+function get_yaml_elements() {
+    if (( is_jq_wrapper == 1 )); then
+        yq -r ".$1[]" "$orgs_yaml_path"
+    else
+        yq read "$orgs_yaml_path" "$1"
+    fi
+}
+
 # iterate over org users (members and admins), grep over contributors list, remove every user not found
 (
     for username in $(
-        { yq read github/ci/prow-deploy/files/orgs.yaml orgs.kubevirt.members & \
-          yq read github/ci/prow-deploy/files/orgs.yaml orgs.kubevirt.admins ; \
+        { get_yaml_elements orgs.kubevirt.members & \
+          get_yaml_elements orgs.kubevirt.admins ; \
         } | sed 's/^- //' | sort -u); do
         echo $username "$(grep -i -c $username /tmp/users-with-contributions.txt)"
     done
@@ -70,7 +106,7 @@ EOF
 
 # remove all users without contributions
 for user in $(cat /tmp/users-without-contributions.txt); do
-    sed -i -E '/\s+- '"$user"'/d' github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+    sed -i -E '/\s+- '"$user"'/d' "$orgs_yaml_path"
 done
 
 echo "Users without contributions:"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There's two tools with the same name `yq` and we are using both from time to time and their syntax of handling yaml files differs.

Therefore we need to check which version we're using from inside the script and adjust the usage of the tool accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
