### PR TITLE
Skip Kubevirt conformance tests temporarily for check-provision-k8s-1.30-s390x job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -418,6 +418,11 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.30 && ../provision.sh
         image: quay.io/kubevirtci/golang:v20240923-918320b
+        env:
+        - name: SLIM
+          value: "true"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "false"
         name: ""
         resources:
           requests:
@@ -442,9 +447,6 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.31 && ../provision.sh
-        env:
-        - name: SLIM
-          value: "true"
         image: quay.io/kubevirtci/golang:v20240923-918320b
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

Skips Kubevirt conformance tests temporarily for check-provision-k8s-1.30-s390x job.

To allow presubmit job of checking k8s 1.30 provider on s390x (i.e.,check-provision-k8s-1.30-s390x) to pass, only conformance tests are failing on [PR](https://github.com/kubevirt/kubevirtci/pull/1252). As these failing tests are being looked into separately and needs enabling other parts of kubevirt for s390x, skipping them temporarily on check-provision-k8s-1.30-**s390x** and same would enabled in follow-up PRs.

P.S: This PR also fixes incorrect SLIM=true env variable on check-provision-k8s-1.31 (which I only introduced in wrong job in my [earlier PR](https://github.com/kubevirt/project-infra/pull/3688)) and now added the same variable to correct job i.e., check-provision-k8s-1.30-s390x.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
