### PR TITLE
Add kubectl installation to bootstrap image for s390x

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -90,6 +90,15 @@ RUN if test "${ARCH}" != s390x; then \
         rm -rf /root/.cache/bazel; \
     fi
 
+# As gcloud isn't supported on s390x, rather than installing kubectl via gcloud as in above RUN,
+# we are installing its binary as described in the kubernetes official docs.
+RUN if test "${ARCH}" == s390x; then \
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/s390x/kubectl" && \
+        install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+        rm -f kubectl && \
+        kubectl version --client; \
+    fi
+
 #
 # BEGIN: PODMAN IN CONTAINER SETUP
 #


### PR DESCRIPTION
**What this PR does / why we need it**:
In bootstrap image for s390x, iinstall kubectl. kubectl is already getting installed for non-s390x. 

As for jobs like check-provision-k8s-1.30-**s390x**, the golang image(based on bootstrap) needs to execute kubectl commands as given in cluster-up/cluster/k8s-provider-common.sh, this is required to be installed for s390x as well.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
