### PR TITLE
update the unit tests to run using bazel.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -425,18 +425,25 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
-      preset-bazel-unnested: "true"
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+      preset-kubevirt-s390x-icr-credential: "true"
     name: pull-kubevirt-unit-test-s390x
     skip_branches:
     - release-\d+\.\d+
     spec:
       containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - make go-test
-        image: quay.io/kubevirtci/golang:v20240923-918320b
+      - image: quay.io/kubevirtci/golang:v20240923-918320b
+        env:
+        - name: KUBEVIRT_BUILDER_IMAGE
+          value: icr.io/kubevirt/builder:2409300832-cb0dc925db-s390x
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - >
+            cat $ICR_PASSWORD | podman login icr.io --username $(cat $ICR_USER) --password-stdin=true &&
+            make test
         name: ""
         resources:
           requests:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -617,6 +617,22 @@ presets:
   - name: bazeluserroot
     mountPath: /tmp/cache/bazel
 - labels:
+    preset-kubevirt-s390x-icr-credential: "true"
+  env:
+  - name: ICR_USER
+    value: /etc/kubevirt-icr-cred/username
+  - name: ICR_PASSWORD
+    value: /etc/kubevirt-icr-cred/password
+  volumes:
+  - name: kubevirt-icr-cred
+    secret:
+      defaultMode: 0400
+      secretName: kubevirt-icr-credential
+  volumeMounts:
+  - name: kubevirt-icr-cred
+    mountPath: /etc/kubevirt-icr-cred
+    readOnly: true
+- labels:
     preset-kubevirtci-quay-credential: "true"
   env:
   - name: QUAY_USER


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This pr updates the existing s390x kubevirt unit tests to run using bazel. The builder image is maintained in the IBM Cloud container Registry and the required credentials to access the image is provided to the prow job by this new label preset-kubevirt-icr-credential which will pull the username and password from a Kubernetes secret.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```
