### PR TITLE
kubevirt,periodic: Increase etcd in mem capacity to 1G for storage periodics

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1799,6 +1799,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.29-sig-storage
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: "1G"
       image: quay.io/kubevirtci/bootstrap:v20241014-80f340c
       name: ""
       resources:
@@ -2057,6 +2059,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.30-sig-storage
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: "1G"
       image: quay.io/kubevirtci/bootstrap:v20241014-80f340c
       name: ""
       resources:
@@ -2253,6 +2257,8 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.31-sig-storage
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: "1G"
       image: quay.io/kubevirtci/bootstrap:v20241014-80f340c
       name: ""
       resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a followup to https://github.com/kubevirt/project-infra/pull/3710

The storage presubmit lanes already include this increase in etcd capacity[1] - including it here to keep the lanes consistent

[1] https://github.com/kubevirt/project-infra/blob/51c8fa2c0465e0f703eb9ffb70909b796c24f3e4/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml#L1549C1-L1550C22

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
