### PR TITLE
community,sigs: replace presubmit with make call

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
@@ -1,21 +1,27 @@
 presubmits:
   kubevirt/community:
-  - name: pull-community-generate-kubevirt-devstats-repo-sql
+  - always_run: true
     cluster: kubevirt-prow-control-plane
-    always_run: false
-    run_if_changed: "sigs.yaml"
     decorate: true
+    name: pull-community-make-generate
     spec:
       containers:
-        - image: quay.io/kubevirtci/kubevirt-infra-bootstrap:v20230508-844cfc0
-          command: [ "/usr/local/bin/runner.sh", "/bin/bash", "-c" ]
-          args:
-            - pip install ruamel.yaml && ./hack/generate-devstats-repo-sql.py
-          resources:
-            requests:
-              memory: "1Gi"
-            limits:
-              memory: "1Gi"
+      - args:
+        - |
+          make generate
+          git diff --exit-code || (
+            echo "ERROR: Unapplied changes detected - please run make generate and commit changes!" && exit 1
+          )
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
+        image: quay.io/kubevirtci/golang:v20241014-80f340c
+        resources:
+          requests:
+            memory: "1Gi"
+          limits:
+            memory: "1Gi"
   - name: pull-community-validate-sigs-yaml
     run_if_changed: "sigs.yaml"
     optional: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Replaces the previous python based check, which is obsolete after the changes to the generation of repo_groups.sql got merged, with a simple call to make generate and checking whether there's uncommitted changes.

This change will:
* allow us to bundle further checks below the make generate target, and
* remind us whenever we change i.e. `sigs.yaml` that we need to call `make generate`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @iholder101 @brianmcarey @aburdenthehand 