### PR TITLE
common-instancetypes, release-1.2: Use kubevirt HEAD until 1.4 is released

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
@@ -45,7 +45,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
@@ -84,7 +84,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
@@ -123,7 +123,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
@@ -162,7 +162,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
@@ -201,7 +201,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
@@ -240,7 +240,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

Using the cluster-{up,sync,functest} targets uses the stable v1.3.1 that is missing various things that we require in release-1.2.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
