### PR TITLE
images: Update path to latest kubevirtci tag in shared-images 

### DIFF
--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func getLatestTag() (tag string, err error) {
-	resp, err := http.Get("https://raw.githubusercontent.com/kubevirt/kubevirt/main/cluster-up/version.txt")
+	resp, err := http.Get("https://raw.githubusercontent.com/kubevirt/kubevirt/main/kubevirtci/cluster-up/version.txt")
 	if err != nil {
 		log.WithError(err).Errorf("Failed to get latest kubevirtci tag")
 		return "", err

--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -142,20 +142,22 @@ func main() {
 		log.WithError(err).Fatalf("Could not connect to podman socket %d", socket)
 	}
 	for {
+		log.Infof("Waiting for %d hours before checking again", period)
+		time.Sleep(period * time.Hour)
+
 		tag, err := getLatestTag()
 		if err != nil {
 			log.WithError(err).Errorf("Failed to get latest kubevirtci tag")
+			continue
 		}
 		err = pullRequiredImages(connText, tag)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to fetch image names")
+			continue
 		}
 		err = cleanOldImages(connText, tag)
 		if err != nil {
 			log.WithError(err).Errorf("Failure occured when deleting old images")
 		}
-		log.Infof("Waiting for %d hours before checking again", period)
-		time.Sleep(period * time.Hour)
-
 	}
 }


### PR DESCRIPTION


**What this PR does / why we need it**:

The location of the latest kubevirtci tag in the kubevirt repo has been
updated[1] resulting in the shared-images-controller trying to pull an
empty tag.

Update this path to the new location.

[1] https://github.com/kubevirt/kubevirt/commit/92624b1a351420f8cc2b587a64ba4ac6dd97bac1

Move sleep to start of loop in shared-images-controller and add continues when errors occur during the loop so that dependent tasks are skipped.




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
