### PR TITLE
prow-workloads: bump shared-images-controller to v20241105-ed1a7bc

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/resources/shared-images-controller.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/resources/shared-images-controller.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
       - name: shared-images-controller
-        image: quay.io/kubevirtci/shared-images-controller:v20231027-376988b
+        image: quay.io/kubevirtci/shared-images-controller:v20241105-ed1a7bc
         command: [ "/usr/local/bin/runner.sh", "/shared-images-controller"]
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a followup to https://github.com/kubevirt/project-infra/pull/3727

The image has been published successfully[1]

Bumping the image in order to include the changes.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-shared-images-controller-image/1853770763174154240#1:build-log.txt%3A335

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
