### PR TITLE
prow,deploy,check: fix kubevirtci path

### DIFF
--- a/github/ci/prow-deploy/hack/test.sh
+++ b/github/ci/prow-deploy/hack/test.sh
@@ -15,11 +15,11 @@ export GIT_ASKPASS="${PROJECT_INFRA_ROOT}/hack/git-askpass.sh"
 KUBEVIRT_DIR=${KUBEVIRT_DIR:-/home/prow/go/src/github.com/kubevirt/kubevirt}
 export KUBEVIRT_MEMORY_SIZE=16384M
 
-cd $KUBEVIRT_DIR && export KUBEVIRT_PROVIDER=$(find cluster-up/cluster/k8s-1* -maxdepth 0 -type d -printf '%f\n' | sort -r |  head -1)
+cd $KUBEVIRT_DIR && export KUBEVIRT_PROVIDER=$(find kubevirtci/cluster-up/cluster/k8s-1* -maxdepth 0 -type d -printf '%f\n' | sort -r |  head -1)
 
 make cluster-up
 
-export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
+export KUBECONFIG=$(./kubevirtci/cluster-up/kubeconfig.sh)
 
 kubectl create ns kubevirt-prow && kubectl create ns kubevirt-prow-jobs
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since the move of kubevirtci from k/kubevirt into it's own folder the deployment check is failing [1] - we need to adjust the script to reckon that.

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3724/pull-project-infra-prow-deploy-test/1853793403578355712#1:build-log.txt%3A468

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 