### PR TITLE
CDI: Fix amd64 nightly build

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -178,7 +178,7 @@ periodics:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       - name: BUILD_ARCH
-        value: amd64
+        value: x86_64
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"


### PR DESCRIPTION
**What this PR does / why we need it**:

(Followup #3739)

bazel failed to build with BUILD_ARCH=amd64, as it's not supported. 

See failure here: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-containerized-data-importer-push-nightly-AMD64/1853996433422684160

This PR changes the arch to `x86_64`, instead.

**Release note**:
```release-note
None
```
