### PR TITLE
use artifacts result directory to read pref/scale data

### DIFF
--- a/robots/cmd/perf-report-creator/main.go
+++ b/robots/cmd/perf-report-creator/main.go
@@ -331,7 +331,13 @@ func getDateForJob(ctx context.Context, client *storage.Client, jobID string, pe
 }
 
 func getVMIResult(ctx context.Context, client *storage.Client, jobID string, performanceJobName string) (*Result, error) {
-	reader, err := getAuditFileReaderForJob(ctx, client, jobID, performanceJobName, "VMI-perf-audit-results.json")
+	prefixedFileName := ""
+	if strings.Contains(performanceJobName, "density") {
+		prefixedFileName = "performance-density/perfscale-audit-results.json"
+	} else {
+		prefixedFileName = "performance/VMI-perf-audit-results.json"
+	}
+	reader, err := getAuditFileReaderForJob(ctx, client, jobID, performanceJobName, prefixedFileName)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +346,7 @@ func getVMIResult(ctx context.Context, client *storage.Client, jobID string, per
 }
 
 func getVMResult(ctx context.Context, client *storage.Client, jobID string, performanceJobName string) (*Result, error) {
-	reader, err := getAuditFileReaderForJob(ctx, client, jobID, performanceJobName, "VM-perf-audit-results.json")
+	reader, err := getAuditFileReaderForJob(ctx, client, jobID, performanceJobName, "performance/VM-perf-audit-results.json")
 	if err != nil {
 		log.Printf("job: %s, error getting BuildLogReaderForJob. %+v\n", jobID, err)
 		return nil, err
@@ -364,8 +370,8 @@ func getResult(reader io.Reader) (*Result, error) {
 	return r, nil
 }
 
-func getAuditFileReaderForJob(ctx context.Context, client *storage.Client, jobID, performanceJobName, fileName string) (io.Reader, error) {
-	objPath := filepath.Join("logs", performanceJobName, jobID, "artifacts", "performance", fileName)
+func getAuditFileReaderForJob(ctx context.Context, client *storage.Client, jobID, performanceJobName, prefixedFileName string) (io.Reader, error) {
+	objPath := filepath.Join("logs", performanceJobName, jobID, "artifacts", prefixedFileName)
 	return client.Bucket(BucketName).Object(objPath).NewReader(ctx)
 }
 

--- a/robots/cmd/perf-report-creator/main.go
+++ b/robots/cmd/perf-report-creator/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"flag"
@@ -10,7 +9,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -152,7 +150,7 @@ func runResults(r resultOpts) error {
 	since := time.Now().Add(-r.since)
 
 	// convert to perfStats
-	collection, err := extractCollectionFromLogs(ctx, storageClient, jobsDirs, since, r.performanceJobName)
+	collection, err := extractCollectionFromAuditFiles(ctx, storageClient, jobsDirs, since, r.performanceJobName)
 	if err != nil {
 		log.Printf("error getting job collection %+v\n", err)
 	}
@@ -257,7 +255,7 @@ func listAllRunsForJob(ctx context.Context, client *storage.Client, jobName stri
 	return jobDirs, nil
 }
 
-func extractCollectionFromLogs(ctx context.Context, storageClient *storage.Client, jobResults []string, since time.Time, performanceJobName string) (Collection, error) {
+func extractCollectionFromAuditFiles(ctx context.Context, storageClient *storage.Client, jobResults []string, since time.Time, performanceJobName string) (Collection, error) {
 	r := Collection{}
 	errs := []error{}
 	for _, j := range jobResults {
@@ -333,86 +331,42 @@ func getDateForJob(ctx context.Context, client *storage.Client, jobID string, pe
 }
 
 func getVMIResult(ctx context.Context, client *storage.Client, jobID string, performanceJobName string) (*Result, error) {
-	reader, err := getBuildLogReaderForJob(ctx, client, jobID, performanceJobName)
+	reader, err := getAuditFileReaderForJob(ctx, client, jobID, performanceJobName, "VMI-perf-audit-results.json")
 	if err != nil {
 		return nil, err
 	}
 
-	jsonText, err := readLinesAndMatchRegex(reader, "\"Values\": {", 0)
-	if err != nil {
-		return nil, err
-	}
-	return unmarshalJson(jsonText)
+	return getResult(reader)
 }
 
 func getVMResult(ctx context.Context, client *storage.Client, jobID string, performanceJobName string) (*Result, error) {
-	reader, err := getBuildLogReaderForJob(ctx, client, jobID, performanceJobName)
+	reader, err := getAuditFileReaderForJob(ctx, client, jobID, performanceJobName, "VM-perf-audit-results.json")
 	if err != nil {
 		log.Printf("job: %s, error getting BuildLogReaderForJob. %+v\n", jobID, err)
 		return nil, err
 	}
 
-	lines, err := readLinesAndMatchRegex(reader, "\"Values\": {", 1)
+	return getResult(reader)
+}
+
+func getResult(reader io.Reader) (*Result, error) {
+	data, err := io.ReadAll(reader)
 	if err != nil {
-		log.Printf("job: %s, error running readLinesAndMatchRegex. %+v\n", jobID, err)
 		return nil, err
 	}
-	return unmarshalJson(lines)
-}
 
-func getBuildLogReaderForJob(ctx context.Context, client *storage.Client, jobID string, performanceJobName string) (io.Reader, error) {
-	objPath := filepath.Join("logs", performanceJobName, jobID, "build-log.txt")
-	return client.Bucket(BucketName).Object(objPath).NewReader(ctx)
-}
-
-func readLinesAndMatchRegex(file io.Reader, valuesRegex string, instance int) (string, error) {
-	jsonEndRegex := "^\\}$"
-	startRegex := regexp.MustCompile(valuesRegex)
-	endRegex := regexp.MustCompile(jsonEndRegex)
-	scanner := bufio.NewScanner(file)
-	matchCount := 0
-
-	// Read each line of the file and compare it against the regular expression
-	for scanner.Scan() {
-		line := scanner.Text()
-		if startRegex.MatchString(line) {
-			if matchCount != instance {
-				matchCount += 1
-				continue
-			}
-			matchCount += 1
-			lines := []string{line}
-			for scanner.Scan() {
-				line := scanner.Text()
-				if !endRegex.MatchString(line) {
-					lines = append(lines, line)
-					continue
-				}
-				lines = append(lines, line)
-				break
-			}
-			// This is needed to make sure the starting of match is json object `{`
-			//lines = lines[3:]
-			jsonText := "{" + strings.ReplaceAll(strings.Join(lines, ""), "\\n", " ")
-			if err := scanner.Err(); err != nil {
-				return "", err
-			}
-			return strings.Trim(jsonText, "S"), nil
-		}
-	}
-
-	return "", nil
-}
-
-func unmarshalJson(jsonText string) (*Result, error) {
 	r := &Result{}
-	err := json.Unmarshal([]byte(jsonText), r)
+	err = json.Unmarshal(data, r)
 	if err != nil {
-		log.Printf("error unmarshaling json: %+v\ntext: %v\n", err, jsonText)
+		log.Printf("error unmarshaling json: %+v\ntext: %v\n", err, string(data))
 		return nil, err
 	}
-
 	return r, nil
+}
+
+func getAuditFileReaderForJob(ctx context.Context, client *storage.Client, jobID, performanceJobName, fileName string) (io.Reader, error) {
+	objPath := filepath.Join("logs", performanceJobName, jobID, "artifacts", "performance", fileName)
+	return client.Bucket(BucketName).Object(objPath).NewReader(ctx)
 }
 
 func getWeeklyVMResults(results *Collection) (map[YearWeek][]ResultWithDate, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft

2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR moves the perf/scale tool to read data from results directory json file, instead of grepping it from build log.

This is needed because a recent change in the build log output format broke the regex matching of build log files.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
