### PR TITLE
HCO: Fix K8s versions

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -27,10 +27,10 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.29 && automation/test.sh"
+            - "export TARGET=k8s-1.30 && automation/test.sh"
           env:
             - name: GIMME_GO_VERSION
-              value: "1.22.6"
+              value: "1.22.9"
             - name: GINKGO_LABELS
               value: '!OpenShift && !SINGLE_NODE_ONLY'
           # docker-in-docker needs privileged mode
@@ -66,10 +66,10 @@ presubmits:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"
             - "-c"
-            - "export TARGET=k8s-1.30 && automation/test.sh"
+            - "export TARGET=k8s-1.31 && automation/test.sh"
           env:
             - name: GIMME_GO_VERSION
-              value: "1.22.6"
+              value: "1.22.9"
             - name: GINKGO_LABELS
               value: '!OpenShift && !SINGLE_NODE_ONLY'
           # docker-in-docker needs privileged mode


### PR DESCRIPTION
The HCO pre-submit test lanes are with the right names but with the wrong K8s versions, that are not match to their name and too old.

This PR bumps the K8s versions, and make them match the lane names.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HCO: Bump K8s version
```
