### PR TITLE
HCO: fix nightly build

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -36,4 +36,4 @@ periodics:
         privileged: true
       resources:
         requests:
-          memory: "8Gi"
+          memory: "50Gi"


### PR DESCRIPTION
Increase the requested memory for the "periodic-hco-push-nightly-build-main" to 50G, to avoid the timeout and to allow functional test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
