### PR TITLE
community,generate: add project-infra extra_ref

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
@@ -3,6 +3,10 @@ presubmits:
   - always_run: true
     cluster: kubevirt-prow-control-plane
     decorate: true
+    extra_refs:
+    - org: kubevirt
+      repo: project-infra
+      base_ref: main
     name: pull-community-make-generate
     spec:
       containers:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since we want to use the configuration files inside the project-infra to validate community documents as `sigs.yaml` we add an extra ref so that they are availabe when running the presubmit.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey @aburdenthehand 


See https://github.com/kubevirt/community/pull/350#issuecomment-2470970471
