### PR TITLE
labels,sig/compute: migrate sig/virtualization

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -67,7 +67,7 @@ larger set of contributors to apply/remove them.
 | <a id="sig/api" href="#sig/api">`sig/api`</a> | Denotes an issue or PR that relates to changes in api.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/buildsystem" href="#sig/buildsystem">`sig/buildsystem`</a> | Denotes an issue or PR that relates to changes in the build system.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/ci" href="#sig/ci">`sig/ci`</a> | Denotes an issue or PR as being related to sig-ci, marks changes to the CI system.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
-| <a id="sig/compute" href="#sig/compute">`sig/compute`</a> |  <br><br> This was previously `topic/virtualization`, `sig-virtualization`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
+| <a id="sig/compute" href="#sig/compute">`sig/compute`</a> |  <br><br> This was previously `topic/virtualization`, `sig-virtualization`, `sig/virtualization`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/documentation" href="#sig/documentation">`sig/documentation`</a> | | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/network" href="#sig/network">`sig/network`</a> |  <br><br> This was previously `topic/network`, | anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="sig/observability" href="#sig/observability">`sig/observability`</a> | Denotes an issue or PR that relates to observability.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -261,6 +261,8 @@ default:
           color: c5def5
         - name: sig-virtualization
           color: c5def5
+        - name: sig/virtualization
+          color: c5def5
     - name: sig/release
       color: 2943CF
       target: both


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The label `sig/virtualization`i [1] seems to be a leftover from previous times - we should migrate it into the sig/compute label.

[1]: https://github.com/kubevirt/kubevirt/labels?q=sig%2Fvirtualization

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @iholder101 @vladikr @brianmcarey 
