### PR TITLE
needs-approver-review: enable management by GH team

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -852,6 +852,26 @@ orgs:
          - vasiliy-ul
          - rthallisey
          - aburdenthehand
+      needs-approver-review-label:
+        description: "Users who can manage needs-approver-review label to any PR inside the KubeVirt org"
+        members:
+         - 0xFelix
+         - aburdenthehand
+         - acardace
+         - alicefr
+         - davidvossel
+         - dhiller
+         - EdDev
+         - enp0s3
+         - fabiand
+         - fossedihelm
+         - iholder101
+         - jean-edouard
+         - lyarwood
+         - mhenriks
+         - stu-gott
+         - vladikr
+         - xpivarc
       kubevirtkubevirt-label:
         description: "Users who can apply restricted labels to any issue inside the kubevirt/kubevirt repo"
         members:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -743,6 +743,8 @@ label:
     'kubevirt':
     - allowed_users:
       - kubevirt-bot
+      allowed_teams:
+      - needs-approver-review-label
       label: needs-approver-review
     - allowed_teams:
       - kubevirtorg-label


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently the only user who can apply or remove the label `needs-approver-review` is the `kubevirt-bot` user.

This change introduces a new GitHub team under the KubeVirt org that contains the people who will be allowed to apply or remove the label - changing the orgs.yaml to achieve this.

Then the `label` config is extended to allow above created group to manage the label - changing plugins.yaml.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @vladikr @iholder101 @alicefr @aburdenthehand 
