### PR TITLE
kind,e2e: Update kind lanes to use podman in container setup

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -598,7 +598,7 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
-    preset-dind-enabled: "true"
+    preset-podman-in-container-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   name: periodic-kubevirt-e2e-kind-sriov
@@ -634,7 +634,7 @@ periodics:
         value: "true"
       - name: TARGET
         value: kind-sriov
-      image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+      image: quay.io/kubevirtci/golang:v20241014-80f340c
       name: ""
       resources:
         requests:
@@ -642,9 +642,8 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - mountPath: /lib/modules
-        name: modules
-        readOnly: true
+      - mountPath: /var/log/audit
+        name: audit
       - mountPath: /sys/fs/cgroup
         name: cgroup
       - mountPath: /dev/vfio/
@@ -654,9 +653,9 @@ periodics:
     priorityClassName: sriov
     volumes:
     - hostPath:
-        path: /lib/modules
+        path: /var/log/audit
         type: Directory
-      name: modules
+      name: audit
     - hostPath:
         path: /sys/fs/cgroup
         type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -188,7 +188,7 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-unnested: "true"
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
       rehearsal.allowed: "true"
@@ -224,7 +224,7 @@ presubmits:
         env:
         - name: TARGET
           value: kind-sriov
-        image: quay.io/kubevirtci/bootstrap-legacy:v20220810-a8f2e6c
+        image: quay.io/kubevirtci/bootstrap:v20241014-80f340c
         name: ""
         resources:
           requests:
@@ -232,9 +232,8 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
+        - mountPath: /var/log/audit
+          name: audit
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /dev/vfio/
@@ -244,9 +243,9 @@ presubmits:
       priorityClassName: sriov
       volumes:
       - hostPath:
-          path: /lib/modules
+          path: /var/log/audit
           type: Directory
-        name: modules
+        name: audit
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       rehearsal.allowed: "true"
       sriov-pod: "true"
@@ -50,7 +50,7 @@ presubmits:
           value: "true"
         - name: SONOBUOY_EXTRA_ARGS
           value: --plugin-env kubevirt-conformance.E2E_FOCUS=SRIOV
-        image: quay.io/kubevirtci/golang-legacy:v20220810-a8f2e6c
+        image: quay.io/kubevirtci/golang:v20241014-80f340c
         name: ""
         resources:
           requests:
@@ -58,9 +58,8 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
+        - mountPath: /var/log/audit
+          name: audit
         - mountPath: /sys/fs/cgroup
           name: cgroup
         - mountPath: /dev/vfio/
@@ -70,9 +69,9 @@ presubmits:
       priorityClassName: sriov
       volumes:
       - hostPath:
-          path: /lib/modules
+          path: /var/log/audit
           type: Directory
-        name: modules
+        name: audit
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -87,7 +86,7 @@ presubmits:
     decoration_config:
       timeout: 3h0m0s
     labels:
-      preset-dind-enabled: "true"
+      preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       rehearsal.allowed: "true"
     max_concurrency: 1
@@ -106,7 +105,7 @@ presubmits:
         env:
         - name: GIMME_GO_VERSION
           value: 1.22.3
-        image: quay.io/kubevirtci/golang-legacy:v20240523-1a2c9b8
+        image: quay.io/kubevirtci/golang:v20241014-80f340c
         name: ""
         resources:
           requests:
@@ -114,16 +113,15 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
+        - mountPath: /var/log/audit
+          name: audit
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
       - hostPath:
-          path: /lib/modules
+          path: /var/log/audit
           type: Directory
-        name: modules
+        name: audit
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -152,7 +150,7 @@ presubmits:
         - name: KUBEVIRT_PROVIDER
           value: kind-1.28
         - name: KUBEVIRT_NUM_NODES
-          value: "1"
+          value: "2"
         - name: KUBEVIRT_MEMORY_SIZE
           value: 11264M
         image: quay.io/kubevirtci/golang:v20241014-80f340c


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Following an update of the workloads cluster to cgroups v2 - multinode
kind clusters are now working under the podman in container setup
available from the main bootstrap image.

This allows us to fully move off of the legacy docker-in-docker
bootstrap.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2335

**Special notes for your reviewer**:


**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
