### PR TITLE
peribolos,org: increase job timeout

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -509,7 +509,7 @@ periodics:
     preset-github-credentials: "true"
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 2h30m
     grace_period: 5m
   extra_refs:
   - org: kubevirt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since we are approaching the timeout value [1] and had a failure due to timeout recently, we are increasing the timeout by 1/2 hour.

[1]: https://prow.ci.kubevirt.io/?type=periodic&job=*org*

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 