### PR TITLE
periodics: Job to cleanup leftover machines in the Google Cloud account

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -662,7 +662,6 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
-
 - name: periodic-kubevirt-job-remover
   cron: "30 0 * * *"
   max_concurrency: 1
@@ -693,7 +692,6 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
-
 - name: periodic-project-infra-mirror-istioctl
   cron: "25 1 * * 1"
   decorate: true
@@ -728,7 +726,6 @@ periodics:
         resources:
           requests:
             memory: "2Gi"
-
 - name: periodic-project-infra-prow-job-image-bump
   cron: "30 0 * * *"
   max_concurrency: 1
@@ -797,6 +794,48 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-project-infra-gcp-cluster-deprovision
+  cron: "45 7 * * *"
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 4h
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: registry.ci.openshift.org/ci/ipi-deprovision:latest
+      imagePullPolicy: Always
+      command:
+      - hack/gcp-cluster-deprovision.sh
+      env:
+      - name: HOME
+        value: /tmp
+      - name: GCP_PROJECT
+        value: kubevirt-240711
+      - name: CLUSTER_TTL
+        value: 30 minutes ago
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/gcs/virtci-service-account.json
+      resources:
+        requests:
+          memory: "300Mi"
+      volumeMounts:
+      - name: virtci-gcs
+        mountPath: /etc/gcs
+        readOnly: true
+    volumes:
+    - name: virtci-gcs
+      secret:
+        secretName: virtci-gcs
+        defaultMode: 0400
 - annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane

--- a/hack/gcp-cluster-deprovision.sh
+++ b/hack/gcp-cluster-deprovision.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Source: https://github.com/openshift/release/blob/450e9c1f62f53999809c45c22c46417d1e11c1c9/core-services/ipi-deprovision/gcp.sh
+set -o errexit
+set -o nounset
+set -o pipefail
+
+trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
+
+function queue() {
+  local LIVE="$(jobs | wc -l)"
+  while [[ "${LIVE}" -ge 10 ]]; do
+    sleep 1
+    LIVE="$(jobs | wc -l)"
+  done
+  echo "${@}"
+  "${@}" &
+}
+
+function deprovision() {
+  WORKDIR="${1}"
+  timeout --signal=SIGQUIT 30m openshift-install --dir "${WORKDIR}" --log-level error destroy cluster && touch "${WORKDIR}/success" || touch "${WORKDIR}/failure"
+}
+
+logdir="/tmp/deprovision"
+mkdir -p "${logdir}"
+
+
+gce_cluster_age_cutoff="$(TZ=":America/Los_Angeles" date --date="${CLUSTER_TTL}-8 hours" '+%Y-%m-%dT%H:%M%z')"
+echo "deprovisioning clusters with a creationTimestamp before ${gce_cluster_age_cutoff} in GCE ..."
+export CLOUDSDK_CONFIG=/tmp/gcloudconfig
+mkdir -p "${CLOUDSDK_CONFIG}"
+gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+echo "GCP project: ${GCP_PROJECT}"
+
+export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND autoCreateSubnetworks=false AND name~'ci-'"
+for network in $( gcloud --project="${GCP_PROJECT}" compute networks list --filter "${FILTER}" --format "value(name)" ); do
+  infraID="${network%"-network"}"
+  region="$( gcloud --project="${GCP_PROJECT}" compute networks describe "${network}" --format="value(subnetworks[0])" | grep -Po "(?<=regions/)[^/]+" || true )"
+  if [[ -z "${region:-}" ]]; then
+    region=us-east1
+  fi
+  workdir="${logdir}/${infraID}"
+  mkdir -p "${workdir}"
+  cat <<EOF >"${workdir}/metadata.json"
+{
+  "infraID":"${infraID}",
+  "gcp":{
+    "region":"${region}",
+    "projectID":"${GCP_PROJECT}"
+  }
+}
+EOF
+  echo "will deprovision GCE cluster ${infraID} in region ${region}"
+done
+
+clusters=$( find "${logdir}" -mindepth 1 -type d )
+for workdir in $(shuf <<< ${clusters}); do
+  queue deprovision "${workdir}"
+done
+
+FAILED="$(find ${clusters} -name failure -printf '%H\n' | sort)"
+if [[ -n "${FAILED}" ]]; then
+  echo "Deprovision failed on the following clusters:"
+  xargs --max-args 1 basename <<< $FAILED
+  exit 1
+fi
+
+echo "Deprovision finished successfully"


### PR DESCRIPTION


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
