### PR TITLE
prow-deploy: Add virtci-gcs secret to the prow control plane cluster

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -303,6 +303,11 @@ secretGenerator:
     files:
       - secrets/service-account.json
     type: Opaque
+  - name: virtci-gcs
+    namespace: kubevirt-prow-jobs
+    files:
+      - secrets/virtci-service-account.json
+    type: Opaque
   - name: slack-token
     files:
       - token=secrets/slack-token

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -39,6 +39,11 @@
     src: '{{ gcsServiceAccount }}'
     dest: '{{ secrets_dir }}/service-account.json'
 
+- name: Create Virtualization CI GCS secret
+  copy:
+    content: '{{ virtciGCSServiceAccount }}'
+    dest: '{{ secrets_dir }}/virtci-service-account.json'
+
 - name: Create Slack secret
   copy:
     content: '{{ slackToken }}'

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/secrets.yml
@@ -5,6 +5,11 @@ githubBotreviewToken: "7b3aab6d73e1d77a5d7120671136259cf5adc789"
 deckUrl: deck.prowdeploy.ci
 gcswebUrl: gcsweb.prowdeploy.ci
 
+virtciGCSServiceAccount: |
+  {
+    "type": "service_account"
+  }
+
 prowNamespace: kubevirt-prow
 prowJobsNamespace: kubevirt-prow-jobs
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This secret is required to enable some cleanup in the google cloud account

The secret already exists in our secrets repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
