### PR TITLE
Prow jobs for publishing centos9 multi arch image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -113,10 +113,11 @@ periodics:
     repo: project-infra
     base_ref: main
   labels:
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-github-credentials: "true"
     preset-podman-in-container-enabled: "true"
     preset-kubevirtci-quay-credential: "true"
+    preset-gcs-credentials: "true"
   cluster: kubevirt-prow-workloads
   spec:
     containers:
@@ -125,10 +126,75 @@ periodics:
       - "/usr/local/bin/runner.sh"
       - "/bin/bash"
       - "-c"
-      - >
+      - |
         cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
         ./hack/bump-centos-version.sh &&
-        GIT_ASKPASS=../project-infra/hack/git-askpass.sh ../project-infra/hack/git-pr.sh -c "PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh" -r kubevirtci -b bump-centos-stream -T main -p $(pwd) -s "Automatic bump of CentOS Stream to latest"
+        SHORT_SHA=$(git rev-parse --short HEAD) &&
+        GIT_ASKPASS=../project-infra/hack/git-askpass.sh ../project-infra/hack/git-pr.sh -c "PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh" -r kubevirtci -b bump-centos-stream -T main -p $(pwd) -s "Automatic bump of CentOS Stream to latest" &&
+        # For passing centos image tag to dependent (s390x) prow job
+        image_tag=$(cat cluster-provision/k8s/base-image | cut -d ':' -f 2) &&
+        echo "$image_tag" > amd64-centos9-$SHORT_SHA &&
+        gsutil cp ./amd64-centos9-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-centos9-$SHORT_SHA
+      # docker-in-docker needs privileged mode
+      env:
+      - name: GIMME_GO_VERSION
+        value: "1.22.5"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "29Gi"
+- name: periodic-kubevirtci-bump-centos-base-s390x
+  cron: "0 4 * * 2" #Triggered at same time as x86 job so that both will run on same commit
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
+    workdir: true
+  labels:
+    preset-podman-in-container-enabled: "true"
+    preset-kubevirtci-quay-credential: "true"
+    preset-gcs-credentials: "true"
+  cluster: prow-s390x-workloads
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/golang:v20241014-80f340c
+      command:
+      - "/usr/local/bin/runner.sh"
+      - "/bin/bash"
+      - "-c"
+      - |
+        # For getting centos image tag from amd64 prow job and use same for s390x and manifest-list images
+        SHORT_SHA=$(git rev-parse --short HEAD) &&
+        GCS_FILE_PATH=release/kubevirt/kubevirtci/amd64-centos9-$SHORT_SHA &&
+        CHECK_INTERVAL=30 &&
+        source /usr/local/bin/gcs_restapi.sh &&
+        while true; do
+            if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH"; then
+                echo "File $GCS_FILE_PATH is now available."
+                break
+            else
+                echo "File $GCS_FILE_PATH not found. Checking again in $CHECK_INTERVAL seconds."
+                sleep $CHECK_INTERVAL
+            fi
+        done
+        KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH")
+        if [ $? -ne 0 ]; then
+            echo "Failed to fetch KUBEVIRTCI_TAG"
+            exit 1
+        fi
+        export KUBEVIRTCI_TAG &&
+        echo "Fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG" &&
+        cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+        ./hack/bump-centos-version.sh &&
+        export PHASES=linux; export BYPASS_PMAN_CHANGE_CHECK=true; ./publish.sh &&
+        rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
       env:
       - name: GIMME_GO_VERSION
         value: "1.22.5"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds multi-arch publish jobs for centos9 images.
As we've added s390x support in k8s provider (started with 1.30 slim), centos9 and gocli images as part of https://github.com/kubevirt/kubevirtci/pull/1252, this PR does changes required in project-infra repo to enable the prow jobs for publishing centos9 multi-arch image.

There is another PR where publishing of multi-arch images of k8s provider is handled: https://github.com/kubevirt/project-infra/pull/3566


**Special notes for your reviewer**:
/cc @brianmcarey 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
