### PR TITLE
kubesecondarydns, presubmits: Add build and unit-tests for s390x

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -36,4 +36,29 @@ presubmits:
                 make cluster-up
                 make cluster-sync
                 make functest
-
+    - name: pull-kubesecondarydns-unit-test-s390x
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+      always_run: true
+      optional: false
+      decorate: true
+      cluster: prow-s390x-workloads
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 2h0m0s
+      spec:
+        containers:
+        - command:
+          - /usr/local/bin/runner.sh
+          - /bin/sh
+          - -c
+          - make test
+          image: quay.io/kubevirtci/golang:v20241014-80f340c
+          name: ""
+          resources:
+            requests:
+              memory: 500Mi
+          securityContext:
+            privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -62,3 +62,31 @@ presubmits:
               memory: 500Mi
           securityContext:
             privileged: true
+    - name: pull-kubesecondarydns-build-s390x
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+      always_run: true
+      optional: false
+      decorate: true
+      cluster: prow-s390x-workloads
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 2h0m0s
+      labels:
+        preset-podman-in-container-enabled: "true"
+      spec:
+        containers:
+        - command:
+          - /usr/local/bin/runner.sh
+          - /bin/sh
+          - -c
+          - make build
+          image: quay.io/kubevirtci/golang:v20241014-80f340c
+          name: ""
+          resources:
+            requests:
+              memory: 500Mi
+          securityContext:
+            privileged: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add testing for building and unit-tests on s390x to kubesecondarydns
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
