### PR TITLE
ci-search: Increase max-age for results to 28 days

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -537,11 +537,11 @@ presubmits:
             - "-ce"
             - |
               # install kind
-              curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+              curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
               chmod +x ./kind && mv ./kind /usr/local/bin/kind
 
               # create test cluster
-              kind create cluster --image quay.io/kubevirtci/kind:v1.21.1
+              kind create cluster --image quay.io/kubevirtci/kindest-node:v1.30.0
 
               ./github/ci/services/ci-search/hack/deploy.sh testing
 

--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -23,7 +23,7 @@ spec:
         - --debug-listen=localhost:6060
         - --config=/etc/ci-search/config.yaml
         - --interval=10m
-        - --max-age=28d
+        - --max-age=672h
         - --path=/var/lib/ci-search/
         - --deck-uri=https://prow.ci.kubevirt.io/
         - --job-uri-prefix=https://prow.ci.kubevirt.io/view/gs/

--- a/github/ci/services/ci-search/patches/statefulset.yaml
+++ b/github/ci/services/ci-search/patches/statefulset.yaml
@@ -23,6 +23,7 @@ spec:
         - --debug-listen=localhost:6060
         - --config=/etc/ci-search/config.yaml
         - --interval=10m
+        - --max-age=28d
         - --path=/var/lib/ci-search/
         - --deck-uri=https://prow.ci.kubevirt.io/
         - --job-uri-prefix=https://prow.ci.kubevirt.io/view/gs/


### PR DESCRIPTION
**What this PR does / why we need it**:

Some contributors have been looking for more history in ci-search to improve their ability of identifying trends with flaky tests.

Increasing the max age from the default 14 days[1] to 28 days

[1] https://github.com/openshift/ci-search/blob/6356b951587bd1ca473de97e41a2422ae02c7efd/cmd/search/main.go#L72

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
