### PR TITLE
go-metrics: add a go-metrics make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,9 @@ test:
 
 update-labels:
 	./hack/labels/update.sh
+
+install-metrics-binaries:
+	if ! command -V gocyclo; then go install github.com/fzipp/gocyclo/cmd/gocyclo@latest ; fi
+
+go-metrics: install-metrics-binaries
+	gocyclo -over 10 .


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds the `go-metrics` make target, which will initially call gocyclo with a `-over 10` flag, making it exit with non-zero error code if any func has a [ccn] of > 10.

/wg code-quality

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

[ccn]: https://en.wikipedia.org/wiki/Cyclomatic_complexity