### PR TITLE
Add export PLATFORMS=all to post-submit jobs for bridge-marker

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
@@ -19,7 +19,10 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && make docker-build docker-push"
+              - |
+                export PLATFORMS=all &&
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io &&
+                make docker-build docker-push
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -43,6 +46,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
+                export PLATFORMS=all &&
                 cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io &&
                 # Only push images on tags
                 COMMIT_TAG=$(git tag --points-at HEAD | head -1)


### PR DESCRIPTION
This update ensures that the PLATFORMS environment variable is set to "all" before executing the `make docker-build docker-push` command in both `main-bridge-marker` and `release-bridge-marker` jobs. This change enables building multi-platform supported bridge marker image.

**What this PR does / why we need it**:
This commit ([892ccdd](https://github.com/kubevirt/bridge-marker/commit/892ccddb8ba33a687d42de425810605eb6f71625)) enables multi-platform support. By default, the image is built based on the host architecture. To build a multi-platform image that supports amd64, arm64, and s390x, the PLATFORMS=all environment variable needs to be exported before running the make docker-build command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note
None
```
