### PR TITLE
per-test-execution: run with set k8s version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -114,7 +114,7 @@ periodics:
       - |
         report_dir="/tmp/per-test-results/last-six-months"
         mkdir -p "${report_dir}"
-        go run ./robots/cmd/per-test-execution --months 6 --output-directory "${report_dir}"
+        go run ./robots/cmd/per-test-execution --kubernetes-version 1.31 --months 6 --output-directory "${report_dir}"
         gsutil cp "${report_dir}/*" "gs://kubevirt-prow/reports/per-test-results/kubevirt/kubevirt/last-six-months/"
       command:
       - /usr/local/bin/runner.sh

--- a/robots/cmd/per-test-execution/main.go
+++ b/robots/cmd/per-test-execution/main.go
@@ -61,7 +61,7 @@ var (
 	htmlTemplate                 *template.Template
 
 	k8sVersionRegex              = regexp.MustCompile(`^[0-9]\.[1-9][0-9]*$`)
-	k8sStableReleaseVersionRegex = regexp.MustCompile(`^v([0-9]\.[1-9][0-9]*)\.[1-9][0-9]*$`)
+	k8sStableReleaseVersionRegex = regexp.MustCompile(`^v([0-9]\.[1-9][0-9]*)\.(0|[1-9][0-9]*)$`)
 )
 
 type Config struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

1.32 stable release has happened, but since we don't have a lot of data for periodics on 1.32 we are fixing the version to 1.31 as there's more data to report over.

Background is that the k8s version is auto retrieved, which currently doesn't make sense for us.

Also there's a bug in the k8s regexp that disallows v1.32.0 to pass: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-gcp-cluster-deprovision/1867113551571718144

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 