### PR TITLE
e2e, arm64: skip NoACPI test on Arm64 e2e test

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -768,6 +768,8 @@ periodics:
         value: "1"
       - name: KUBEVIRT_E2E_FOCUS
         value: arm64
+      - name: KUBEVIRT_E2E_SKIP
+        value: \[NoACPI\]
       image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1020,6 +1020,8 @@ presubmits:
           value: "1"
         - name: KUBEVIRT_E2E_FOCUS
           value: arm64
+        - name: KUBEVIRT_E2E_SKIP
+          value: \[NoACPI\]
         image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip no ACPI test cases on Arm64 e2e test, as ACPI is needed for UEFI boot on Arm64 platform

Fixes https://github.com/kubevirt/kubevirt/issues/13501

**Release note**:
```release-note
NONE
```
