### PR TITLE
Move root CI lanes to 1.31

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1434,7 +1434,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.29-sig-storage-root
+  name: periodic-kubevirt-e2e-k8s-1.31-sig-storage-root
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1451,7 +1451,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.29-sig-storage
+        value: k8s-1.31-sig-storage
       - name: FEATURE_GATES
         value: Root
       image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
@@ -1484,7 +1484,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.29-sig-compute-root
+  name: periodic-kubevirt-e2e-k8s-1.31-sig-compute-root
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1501,7 +1501,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.29-sig-compute
+        value: k8s-1.31-sig-compute
       - name: FEATURE_GATES
         value: Root
       image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
@@ -1534,7 +1534,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.29-sig-operator-root
+  name: periodic-kubevirt-e2e-k8s-1.31-sig-operator-root
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1551,7 +1551,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.29-sig-operator
+        value: k8s-1.31-sig-operator
       - name: FEATURE_GATES
         value: Root
       image: quay.io/kubevirtci/bootstrap:v20241213-57bd934

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1324,7 +1324,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
+    name: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1337,7 +1337,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.29-sig-storage
+          value: k8s-1.31-sig-storage
         - name: FEATURE_GATES
           value: Root
         image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
@@ -1367,7 +1367,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
+    name: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1380,7 +1380,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.29-sig-compute
+          value: k8s-1.31-sig-compute
         - name: FEATURE_GATES
           value: Root
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS


### PR DESCRIPTION
**What this PR does / why we need it**:
Move Root CI lanes to 1.31 k8s provider

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:

```release-note
NONE
```
