### PR TITLE
golangci-lint: disallow automatic updating of go.mod

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,7 @@
+run:
+  modules-download-mode: readonly
+output:
+  show-stats: true
 linters:
   # initially we disable all linters, since this is an old code base with quite a lot of issues
   disable-all: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently builds of `make lint` are failing when trying to dowload stuff [1] 

The changed setting will make golangci-lint fail instead of implicitly updating if go.mod requires that.

See https://golangci-lint.run/usage/configuration/#run-configuration

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3824/pull-project-infra-lint/1869719164365574144

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
