### PR TITLE
Add export PLATFORMS=all to post-submit jobs for kubemacpool.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
@@ -19,7 +19,9 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && make container docker-push"
+              - |
+                export PLATFORMS=all &&
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && make container docker-push
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
@@ -43,6 +45,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
+                export PLATFORMS=all &&
                 cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io &&
                 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
                 [ "$BRANCH_NAME" != "HEAD" ] &&
@@ -70,6 +73,7 @@ postsubmits:
               - "/bin/bash"
               - "-c"
               - |
+                export PLATFORMS=all &&
                 cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io &&
                 # Only push images on tags
                 COMMIT_TAG=$(git tag --points-at HEAD | tail -1)


### PR DESCRIPTION
This update ensures that the PLATFORMS environment variable is set to "all" before executing the `make container docker-push` . This change enables building multi-platform images for kubemacpool cni.


**What this PR does / why we need it**:
Currently, we are only posting an amd64-supported image for the Kubemacpool CNI: [link to image](https://quay.io/repository/kubevirt/kubemacpool?tab=tags&tag=latest).

To build a multi-platform image that supports amd64, arm64, and s390x, the PLATFORMS=all environment variable must be exported before running the make container command.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
