### PR TITLE
HCO: Add new lane for k8s-1.32

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -1,44 +1,5 @@
 presubmits:
   kubevirt/hyperconverged-cluster-operator:
-  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.30
-    skip_branches:
-      - release-\d+\.\d+
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-    always_run: true
-    optional: false
-    decorate: true
-    decoration_config:
-      timeout: 7h
-      grace_period: 5m
-    max_concurrency: 6
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
-    spec:
-      nodeSelector:
-        type: bare-metal-external
-      containers:
-        - image: quay.io/kubevirtci/golang:v20241213-57bd934
-          command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/sh"
-            - "-c"
-            - "export TARGET=k8s-1.30 && automation/test.sh"
-          env:
-            - name: GIMME_GO_VERSION
-              value: "1.22.9"
-            - name: GINKGO_LABELS
-              value: '!OpenShift && !SINGLE_NODE_ONLY'
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: "50Gi"
   - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.31
     skip_branches:
       - release-\d+\.\d+
@@ -69,7 +30,46 @@ presubmits:
             - "export TARGET=k8s-1.31 && automation/test.sh"
           env:
             - name: GIMME_GO_VERSION
-              value: "1.22.9"
+              value: "1.22.10"
+            - name: GINKGO_LABELS
+              value: '!OpenShift && !SINGLE_NODE_ONLY'
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "50Gi"
+  - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.32
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 7h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-shared-images: "true"
+    cluster: kubevirt-prow-workloads
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20241213-57bd934
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "export TARGET=k8s-1.32 && automation/test.sh"
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.22.10"
             - name: GINKGO_LABELS
               value: '!OpenShift && !SINGLE_NODE_ONLY'
           # docker-in-docker needs privileged mode


### PR DESCRIPTION
Remove the old k8s 1.30 lane

<
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HCO: Add new lane for k8s-1.32
```
