### PR TITLE
ci-search: fix post deploy go call

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -591,10 +591,13 @@ postsubmits:
           runAsUser: 0
         containers:
         - image: quay.io/kubevirtci/golang:v20241213-57bd934
+          env:
+          - name: GIMME_GO_VERSION
+            value: "1.21.6"
           command:
-            - "/usr/local/bin/runner.sh"
-            - "/bin/bash"
-            - "-c"
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -c
             - |
               # install yq
               curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

After changing to kustomize the post deploy job couldn't find go binary.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-ci-search-deployment/1874781272862101504

This changes the job by adding the gimme go version and using sh instead.

Successful run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/post-project-infra-ci-search-deployment/1874792004890660864

/kind bug
/priority critical-urgent 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
