### PR TITLE
lint: increase timeout

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 run:
   modules-download-mode: readonly
+  timeout: 5m
 output:
   show-stats: true
 linters:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

golangci-lint job seems to frequently exceed it's timeout value [1], so we increase it to 5m.

[1]: https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-project-infra-lint

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
