### PR TITLE
test-label-analyzer: replace ginkgo cli call with stdout

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -32,7 +32,6 @@ presubmits:
         - "/bin/sh"
         - "-ce"
         - |
-          GOBIN=/usr/local/bin/ go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2
           go test ./robots/...
         env:
         - name: GIMME_GO_VERSION

--- a/robots/cmd/test-label-analyzer/cmd/BUILD.bazel
+++ b/robots/cmd/test-label-analyzer/cmd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//robots/pkg/git:go_default_library",
         "//robots/pkg/test-label-analyzer:go_default_library",
         "//robots/pkg/test-report:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2/ginkgo/outline:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since we can't rely on the ginkgo binary being present, we replace the call of the cli with a direct call of the Command. We capture the output of the command and replace the evaluation using the captured output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/3851/pull-project-infra-test-robots/1874869025570295808

**Special notes for your reviewer**:
