### PR TITLE
enhancements repo: drop admin and enable tide

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -138,6 +138,7 @@ tide:
     kubevirt/vm-console-proxy: merge
     kubevirt/sig-release: merge
     kubevirt/kubevirt.core: merge
+    kubevirt/enhancements: squash
 
   queries:
   - repos:
@@ -204,6 +205,7 @@ tide:
     - kubevirt/csi-driver
     - kubevirt/vm-console-proxy
     - kubevirt/kubevirt.core
+    - kubevirt/enhancements
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -596,7 +596,7 @@ orgs:
           - xpivarc
           - vladikr
         repos:
-          enhancements: admin
+          enhancements: write
       maintainers:
         description: ""
         maintainers:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -167,6 +167,14 @@ plugins:
     - owners-label
     - trigger
 
+  kubevirt/enhancements:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - trigger
+    - release-note
+
   kubevirt/containerdisks:
     plugins:
     - approve
@@ -610,6 +618,7 @@ triggers:
   - kubevirt/kubevirt.core
   - kubevirt/managed-tenant-quota
   - kubevirt/application-aware-quota
+  - kubevirt/enhancements
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks
@@ -671,6 +680,7 @@ approve:
   - kubevirt/managed-tenant-quota
   - kubevirt/application-aware-quota
   - kubevirt/dra-pci-driver
+  - kubevirt/enhancements
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -733,6 +743,7 @@ lgtm:
   - kubevirt/managed-tenant-quota
   - kubevirt/application-aware-quota
   - kubevirt/dra-pci-driver
+  - kubevirt/enhancements
   review_acts_as_lgtm: true
 
 override:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR drops the admin privileges and enables tide for the kubevirt/enhancements repo

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
