### PR TITLE
kubevirt: Bump remaining v1.29 to Kubernetes v1.32

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1194,7 +1194,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.29-sig-performance-kwok
+  name: periodic-kubevirt-e2e-k8s-1.32-sig-performance-kwok
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1217,7 +1217,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make kwok-perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.29
+        value: k8s-1.32
       - name: KUBEVIRT_MEMORY_SIZE
         value: 10G
       - name: KUBEVIRT_DEPLOY_KWOK
@@ -1256,7 +1256,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.29-sig-performance-realtime
+  name: periodic-kubevirt-e2e-k8s-1.32-sig-performance-realtime
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1276,7 +1276,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make realtime-perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.29
+        value: k8s-1.32
       - name: KUBEVIRT_STORAGE
         value: rook-ceph-default
       - name: KUBEVIRT_MEMORY_SIZE
@@ -1376,7 +1376,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
+  name: periodic-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
   reporter_config:
     slack:
       job_states_to_report: []
@@ -1399,7 +1399,7 @@ periodics:
       - name: KUBEVIRT_PSA
         value: "true"
       - name: TARGET
-        value: k8s-1.29-sig-network
+        value: k8s-1.32-sig-network
       image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -914,7 +914,7 @@ presubmits:
       preset-shared-images: "true"
       rehearsal.allowed: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
+    name: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -927,7 +927,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.29-sig-network
+          value: k8s-1.32-sig-network
         - name: KUBEVIRT_WITH_MULTUS_V3
           value: "false"
         - name: KUBEVIRT_NUM_NODES
@@ -1189,7 +1189,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.29-swap-enabled
+    name: pull-kubevirt-e2e-k8s-1.32-swap-enabled
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1203,7 +1203,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.29
+          value: k8s-1.32
         - name: KUBEVIRT_E2E_FOCUS
           value: SwapTest
         - name: KUBEVIRT_SWAP_ON
@@ -1272,7 +1272,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.29-single-node
+    name: pull-kubevirt-e2e-k8s-1.32-single-node
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1285,7 +1285,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.29
+          value: k8s-1.32
         - name: KUBEVIRT_E2E_FOCUS
           value: .*
         - name: KUBEVIRT_NUM_NODES
@@ -1411,7 +1411,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
+    name: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1423,7 +1423,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.29-sig-compute-realtime
+          value: k8s-1.32-sig-compute-realtime
         - name: KUBEVIRT_PSA
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20241213-57bd934
@@ -1900,7 +1900,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
-    name: pull-kubevirt-e2e-k8s-1.29-sig-performance-kwok
+    name: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
     skip_branches:
     - release-\d+\.\d+
     optional: true
@@ -1920,7 +1920,7 @@ presubmits:
           FUNC_TEST_ARGS="--no-color --seed=42" make kwok-perftest
         env:
         - name: KUBEVIRT_PROVIDER
-          value: k8s-1.29
+          value: k8s-1.32
         - name: KUBEVIRT_MEMORY_SIZE
           value: 10G
         - name: KUBEVIRT_DEPLOY_KWOK


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrading the remaining lanes as the old provider is being removed from kubevirtci[1]

[1] https://github.com/kubevirt/kubevirtci/pull/1342

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
