### PR TITLE
kubevirt,presubmits: Increase memory requests for presubmits on control-plane cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -324,7 +324,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -354,7 +354,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -382,7 +382,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -413,7 +413,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -500,7 +500,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -594,7 +594,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -658,7 +658,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -695,7 +695,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -731,7 +731,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -759,7 +759,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -788,7 +788,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -816,7 +816,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -845,7 +845,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1169,7 +1169,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false


### PR DESCRIPTION

**What this PR does / why we need it**:

We have seen a number of these jobs timeout over the past couple of weeks. Increase the memory request from 8GB to 12GB to reserve a bigger chunk of the node for each job to see if this reduces the timeouts.

https://search.ci.kubevirt.io/?search=Process+did+not+exit+before&maxAge=336h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
