### PR TITLE
shared-images: Add gocli and registry images to shared-images 

### DIFF
--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -81,11 +81,6 @@ func pullRequiredImages(ctx context.Context, tag string) error {
 		log.Infoln("Kubevirt Provider version: ", version)
 
 		name := fmt.Sprintf("%sk8s-%s:%s", kubevirtci_repo, version, tag)
-		// k8s-1.26 kubevirtci provider was renamed to k8s-1.26-centos9
-		// to track the change to CentOS Stream 9
-		if version == "1.26" {
-			name = fmt.Sprintf("%sk8s-%s-centos9:%s", kubevirtci_repo, version, tag)
-		}
 		if _, exists := imageNames[name]; exists {
 			log.Infoln("Image already present:", name)
 			continue

--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -91,6 +91,19 @@ func pullRequiredImages(ctx context.Context, tag string) error {
 			log.WithError(err).Errorf("Failed to pull image '%s'", name)
 		}
 	}
+
+	gocliTarget := fmt.Sprintf("%sgocli:%s", kubevirtci_repo, tag)
+	_, err = images.Pull(ctx, gocliTarget, nil)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to pull image '%s'", gocliTarget)
+	}
+
+	registryTarget := "quay.io/libpod/registry:2.8.2"
+	_, err = images.Pull(ctx, gocliTarget, nil)
+	if err != nil {
+		log.WithError(err).Errorf("Failed to pull image '%s'", registryTarget)
+	}
+
 	return nil
 }
 
@@ -104,6 +117,10 @@ func cleanOldImages(ctx context.Context, tag string) error {
 	for _, i := range imageList {
 		for _, repoTag := range i.RepoTags {
 			if strings.Contains(repoTag, tag) {
+				log.Infof("%s is a required image", repoTag)
+				continue
+			}
+			if strings.Contains(repoTag, "2.8.2") {
 				log.Infof("%s is a required image", repoTag)
 				continue
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This should reduce cluster-up failures due to issues pulling the gocli
image or registry image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
