### PR TITLE
chore,image updates: fetch names from manifests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -815,7 +815,8 @@ periodics:
             -c "hack/bump-prow-job-images.sh" \
             -b prow-job-image-bump \
             -r project-infra \
-            -T main -B $'Bump Prow Job images\n@kubevirt/prow-job-taskforce\n/cc none' \
+            -T main \
+            -d "hack/describe-pr-from-updated-images-in-diff.sh 'Bump Prow Job images'" \
             -L 'skip-review'
         fi
       resources:
@@ -861,7 +862,7 @@ periodics:
             -b prow-deployment-image-bump \
             -r project-infra \
             -T main \
-            -B $'Bump Prow Deployment images\nFYI @kubevirt/prow-job-taskforce\n/cc none' \
+            -d "hack/describe-pr-from-updated-images-in-diff.sh 'Bump Prow Deployment images'" \
             -L 'skip-review'
         fi
       resources:

--- a/hack/describe-pr-from-updated-images-in-diff.sh
+++ b/hack/describe-pr-from-updated-images-in-diff.sh
@@ -15,32 +15,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright the KubeVirt Authors
+# Copyright the KubeVirt Authors.
 #
 #
 
 set -euo pipefail
-set -x
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
 
 function main() {
-    for repo_name in $(kubevirtci_images_used_in_manifests); do
-        image_name="quay.io/kubevirtci/${repo_name}"
-        if ! "$PROJECT_INFRA_ROOT/hack/update-jobs-with-latest-image.sh" "$image_name"; then
-            echo "[FAIL] prow jobs update for image $image_name"
-        else
-            echo "[OK] prow jobs update for image $image_name"
-        fi
-    done
-}
+    headline="Bump prow-deploy images"
+    if [ $# -gt 0 ]; then
+        headline="$1"
+    fi
 
-function kubevirtci_images_used_in_manifests() {
-    find "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy" -name '*.yaml' -print0 | \
-        xargs -0 grep -hoE 'quay.io/kubevirtci/[^: @]+' | \
-        sort -u | \
-        cut -d'/' -f3
+    cat << EOF
+${headline}
+
+FYI @kubevirt/prow-job-taskforce
+/cc none
+
+Images updated:
+EOF
+    for image in $(
+        git diff -- ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy | \
+            grep -E '^\+\s+- image: ' | \
+            grep -oE 'quay.io/kubevirtci/[^: @]+' | \
+            sort -u
+    ); do
+        echo "* ${image}"
+    done
 }
 
 main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently we rely on a fixed image list, which has to be modified
whenever a new image is added.

This change greps over the manifests and extracts all image names that
match `quay.io/kubevirtci` - this list is then used as input for the
update script.

Also the change expands on the PR description that is attached - changing the git-pr.sh call to replace the hard coded description with a call to al description generation script. That script retrieves a list of images from the diff being updated and returns a markdown suited to be inserted into the PR description.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3891

**Special notes for your reviewer**:
