### PR TITLE
chore: remove ginkgo install

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -143,12 +143,15 @@ presubmits:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
         - "-ce"
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.23.4"
         image: quay.io/kubevirtci/golang:v20250124-4f7dce8
         resources:
           requests:
-            memory: "1Gi"
+            memory: "4Gi"
           limits:
-            memory: "1Gi"
+            memory: "4Gi"
   - name: build-kubevirt-infra-bootstrap-image
     always_run: false
     run_if_changed: "images/kubevirt-infra-bootstrap/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -138,7 +138,6 @@ presubmits:
       containers:
       - args:
         - |
-          GOBIN=/usr/local/bin/ go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2
           make coverage
         command:
         - "/usr/local/bin/runner.sh"

--- a/images/test-label-analyzer/Containerfile
+++ b/images/test-label-analyzer/Containerfile
@@ -1,13 +1,16 @@
-FROM quay.io/kubevirtci/golang:v20230801-94954c0
+FROM quay.io/kubevirtci/golang:v20241213-57bd934 as builder
+ENV GOPROXY=https://proxy.golang.org|direct \
+    GOFLAGS="-mod=vendor -ldflags=-extldflags=\"-static\"" \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+ENV GIMME_GO_VERSION=1.23.4
+RUN mkdir kubevirt && \
+    cd kubevirt && \
+    git clone https://github.com/kubevirt/project-infra.git && \
+    cd project-infra && \
+    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/test-label-analyzer ./robots/cmd/test-label-analyzer"
 
-ENV GIMME_GO_VERSION=1.19
-
-RUN set -x && \
-    git clone https://github.com/kubevirt/project-infra && \
-    cd ./project-infra && \
-    /usr/local/bin/runner.sh /bin/sh -ce 'go install ./robots/cmd/test-label-analyzer' && \
-    mv /root/go/bin/test-label-analyzer /usr/local/bin/ && \
-    /usr/local/bin/runner.sh /bin/sh -ce 'go clean -cache -modcache' && \
-    cd .. && rm -rf ./project-infra
-
-ENTRYPOINT ["/usr/local/bin/test-label-analyzer"]
+FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
+COPY --from=builder /go/bin/test-label-analyzer /usr/bin/test-label-analyzer
+ENTRYPOINT ["/usr/bin/test-label-analyzer"]

--- a/images/test-label-analyzer/Containerfile
+++ b/images/test-label-analyzer/Containerfile
@@ -3,10 +3,6 @@ FROM quay.io/kubevirtci/golang:v20230801-94954c0
 ENV GIMME_GO_VERSION=1.19
 
 RUN set -x && \
-    /usr/local/bin/runner.sh /bin/sh -ce 'go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2' && \
-    mv /root/go/bin/ginkgo /usr/local/bin/
-
-RUN set -x && \
     git clone https://github.com/kubevirt/project-infra && \
     cd ./project-infra && \
     /usr/local/bin/runner.sh /bin/sh -ce 'go install ./robots/cmd/test-label-analyzer' && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

install of ginkgo binary is removed as the dependency is used directly now.

Also memory requests and limits are increased since it seems the job suffers from starvation sometimes: https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-project-infra-coverage

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
