### PR TITLE
CDI periodic: build and publish multi-arch images and manifest

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -65,49 +65,10 @@ periodics:
       - --pr_base_branch=main
       - --repo=containerized-data-importer
       - --skip_results_before_start_of_report=false
-- name: periodic-containerized-data-importer-push-nightly-ARM64
-  cron: "2 3 * * *"
-  decorate: true
-  annotations:
-    testgrid-create-test-group: "false"
-  decoration_config:
-    timeout: 1h
-    grace_period: 5m
-  max_concurrency: 1
-  labels:
-    preset-dind-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-gcs-credentials: "true"
-    preset-kubevirtci-quay-credential: "true"
-  extra_refs:
-    - org: kubevirt
-      repo: containerized-data-importer
-      base_ref: main
-      work_dir: true
-  cluster: kubevirt-prow-workloads
-  spec:
-    nodeSelector:
-      type: bare-metal-external
-    containers:
-    - image: quay.io/kubevirtci/bootstrap-legacy:v20240523-1a2c9b8
-      env:
-      - name: DOCKER_PREFIX
-        value: quay.io/kubevirt
-      - name: BUILD_ARCH
-        value: crossbuild-aarch64
-      command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - |
-          ./automation/prow_periodic_push.sh
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "8Gi"
-- name: periodic-containerized-data-importer-push-nightly-s390x
+
+# This task would build images for amd64, arm64 and s390x, and push
+# multi-arch manifest
+- name: periodic-containerized-data-importer-push-nightly
   cron: "2 3 * * *"
   decorate: true
   annotations:
@@ -135,8 +96,6 @@ periodics:
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
-      - name: BUILD_ARCH
-        value: crossbuild-s390x
       command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -148,46 +107,4 @@ periodics:
         privileged: true
       resources:
         requests:
-          memory: "8Gi"
-- name: periodic-containerized-data-importer-push-nightly-AMD64
-  cron: "2 3 * * *"
-  decorate: true
-  annotations:
-    testgrid-create-test-group: "false"
-  decoration_config:
-    timeout: 1h
-    grace_period: 5m
-  max_concurrency: 1
-  labels:
-    preset-podman-in-container-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-gcs-credentials: "true"
-    preset-kubevirtci-quay-credential: "true"
-  extra_refs:
-    - org: kubevirt
-      repo: containerized-data-importer
-      base_ref: main
-      work_dir: true
-  cluster: kubevirt-prow-workloads
-  spec:
-    nodeSelector:
-      type: bare-metal-external
-    containers:
-    - image: quay.io/kubevirtci/golang:v20250124-4f7dce8
-      env:
-      - name: DOCKER_PREFIX
-        value: quay.io/kubevirt
-      - name: BUILD_ARCH
-        value: x86_64
-      command:
-        - "/usr/local/bin/runner.sh"
-        - "/bin/sh"
-        - "-c"
-        - |
-          ./automation/prow_periodic_push.sh
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "8Gi"
+          memory: "16Gi"


### PR DESCRIPTION
**What this PR does / why we need it**:
As the PR for build and publish multi-arch manifest has merged https://github.com/kubevirt/containerized-data-importer/pull/3586
We can start to release multi-arch manifest

**Release note**:
```release-note
NONE
```
