### PR TITLE
bug,ginkgo: fix handling no ginkgo import

### DIFF
--- a/robots/cmd/test-label-analyzer/cmd/stats_test.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats_test.go
@@ -37,6 +37,17 @@ var _ = Describe("stats", func() {
 			Expect(outline).ToNot(BeNil())
 		})
 
+		It("does not panic but just returns nil on outline from file missing import", func() {
+			outline, err := getGinkgoOutlineFromFile("testdata/simple-basic_test.go")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(outline).To(BeNil())
+		})
+
+		It("does not panic on outline from non existing file", func() {
+			_, err := getGinkgoOutlineFromFile("testdata/nonexistent_test.go")
+			Expect(err).To(HaveOccurred())
+		})
+
 	})
 
 	Context("NewStatsHTMLData", func() {

--- a/robots/cmd/test-label-analyzer/cmd/testdata/simple-basic_test.go
+++ b/robots/cmd/test-label-analyzer/cmd/testdata/simple-basic_test.go
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package testdata
+
+import "testing"
+
+func TestName(t *testing.T) {
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

After the changes around using the ginkgo command instead of the osexec for ginkgo binary handling the case of ginkgo outline failing due to missing import did not work any more. This commit fixes the issue by recovering from the panic that is caused in the case, also returning the error in all other cases by setting the named return argument.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes failing job periodic-kubevirt-quarantined-tests-daily-report https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-quarantined-tests-daily-report/1882318824603127808

**Special notes for your reviewer**:
/cc @brianmcarey 