### PR TITLE
fix,shared-images: Registry image is not being pulled due to wrong image name

### DIFF
--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -99,7 +99,7 @@ func pullRequiredImages(ctx context.Context, tag string) error {
 	}
 
 	registryTarget := "quay.io/libpod/registry:2.8.2"
-	_, err = images.Pull(ctx, gocliTarget, nil)
+	_, err = images.Pull(ctx, registryTarget, nil)
 	if err != nil {
 		log.WithError(err).Errorf("Failed to pull image '%s'", registryTarget)
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

gocli is available locally to the test pod however the registry image is still pulled by the test pod.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/13670/pull-kubevirt-e2e-k8s-1.32-sig-network/1884223087730233344#1:build-log.txt%3A475

The wrong target is being pulled for the registr step.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
