### PR TITLE
ci: default containerdisk ci run for CentOS Stream

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -65,7 +65,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 11
-    name: pull-containerdisks-pipeline-cirros
+    name: pull-containerdisks-pipeline-centos-stream-9
     spec:
       containers:
       - command:
@@ -77,7 +77,7 @@ presubmits:
         - name: GIMME_GO_VERSION
           value: "1.22.9"
         - name: FOCUS
-          value: "cirros:*"
+          value: "centos-stream:9"
         image: quay.io/kubevirtci/golang:v20250124-4f7dce8
         name: ""
         resources:


### PR DESCRIPTION
Due to the lack of support for the s390x architecture in Cirros, we propose selecting CentOS Stream as the default container disk. CentOS Stream supports a broader range of architectures, making it a more versatile choice.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
