### PR TITLE
skip-review: enable for k/kubevirt uploader prs

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -180,6 +180,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="kind/build-change" href="#kind/build-change">`kind/build-change`</a> | Categorizes PRs as related to changing build files of virt-* components| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
+| <a id="skip-review" href="#skip-review">`skip-review`</a> | Indicates a PR is trusted, used by tide for auto-merging PRs.| kubevirt-bot | |
 
 ## Labels that apply to kubevirt/kubevirt-tutorial, only for PRs
 

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -281,7 +281,7 @@ periodics:
         - -ce
         args:
         - |
-          git-pr.sh -c "go run ./robots/cmd/uploader -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt -L lgtm,approved,release-note-none -T main
+          git-pr.sh -c "go run ./robots/cmd/uploader -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt -L skip-review,release-note-none -T main
           git-pr.sh -c "go run ./robots/cmd/uploader -workspace ${PWD}/../containerized-data-importer/WORKSPACE -dry-run=false" -p ../containerized-data-importer -r containerized-data-importer -T main -L skip-review,release-note-none
         resources:
           requests:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -225,6 +225,7 @@ tide:
     - kubevirt/project-infra
     - kubevirt/kubevirtci
     - kubevirt/containerized-data-importer
+    - kubevirt/kubevirt
     labels:
     - skip-review
     missingLabels:

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -507,6 +507,11 @@ repos:
         target: both
         prowPlugin: release-blocker
         addedBy: prow
+      - addedBy: kubevirt-bot
+        color: 0ffa16
+        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+        name: skip-review
+        target: prs
   kubevirt/kubevirtci:
     labels:
     - addedBy: kubevirt-bot


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We repeatedly had the issue that binaries mirrored to the gcs to avoid losing them were not reachable any more, as the mirroring PR was not merged ahead of branching the release.

This change enables skip-review label, which will make tide merge PRs that have all lanes succeeded and no forbidden labels, i.e. `do-not-merge/hold`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey @xpivarc @jean-edouard @stu-gott 
