### PR TITLE
skip-review: enable for k/cdi uploader prs

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -8,6 +8,7 @@
 - [Labels that apply to all repos, for both issues and PRs](#labels-that-apply-to-all-repos-for-both-issues-and-prs)
 - [Labels that apply to all repos, only for issues](#labels-that-apply-to-all-repos-only-for-issues)
 - [Labels that apply to all repos, only for PRs](#labels-that-apply-to-all-repos-only-for-prs)
+- [Labels that apply to kubevirt/containerized-data-importer, only for PRs](#labels-that-apply-to-kubevirtcontainerized-data-importer-only-for-prs)
 - [Labels that apply to kubevirt/hyperconverged-cluster-operator, only for PRs](#labels-that-apply-to-kubevirthyperconverged-cluster-operator-only-for-prs)
 - [Labels that apply to kubevirt/kubevirt, for both issues and PRs](#labels-that-apply-to-kubevirtkubevirt-for-both-issues-and-prs)
 - [Labels that apply to kubevirt/kubevirt, only for issues](#labels-that-apply-to-kubevirtkubevirt-only-for-issues)
@@ -122,6 +123,12 @@ larger set of contributors to apply/remove them.
 | <a id="release-note" href="#release-note">`release-note`</a> | Denotes a PR that will be considered when it comes time to generate release notes.| prow |  [release-note](https://prow.ci.kubevirt.io/command-help#release-note) |
 | <a id="release-note-action-required" href="#release-note-action-required">`release-note-action-required`</a> | Denotes a PR that introduces potentially breaking changes that require user action.| prow |  [releasenote](https://prow.ci.kubevirt.io/command-help#releasenote) |
 | <a id="release-note-none" href="#release-note-none">`release-note-none`</a> | Denotes a PR that doesn't merit a release note.| prow |  [release-note](https://prow.ci.kubevirt.io/command-help#release-note) |
+
+## Labels that apply to kubevirt/containerized-data-importer, only for PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="skip-review" href="#skip-review">`skip-review`</a> | Indicates a PR is trusted, used by tide for auto-merging PRs.| kubevirt-bot | |
 
 ## Labels that apply to kubevirt/hyperconverged-cluster-operator, only for PRs
 

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -282,7 +282,7 @@ periodics:
         args:
         - |
           git-pr.sh -c "go run ./robots/cmd/uploader -workspace ${PWD}/../kubevirt/WORKSPACE -dry-run=false" -p ../kubevirt -r kubevirt -L lgtm,approved,release-note-none -T main
-          git-pr.sh -c "go run ./robots/cmd/uploader -workspace ${PWD}/../containerized-data-importer/WORKSPACE -dry-run=false" -p ../containerized-data-importer -r containerized-data-importer -T main -L lgtm,approved,release-note-none
+          git-pr.sh -c "go run ./robots/cmd/uploader -workspace ${PWD}/../containerized-data-importer/WORKSPACE -dry-run=false" -p ../containerized-data-importer -r containerized-data-importer -T main -L skip-review,release-note-none
         resources:
           requests:
             memory: "200Mi"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -224,6 +224,7 @@ tide:
     repos:
     - kubevirt/project-infra
     - kubevirt/kubevirtci
+    - kubevirt/containerized-data-importer
     labels:
     - skip-review
     missingLabels:

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -396,6 +396,13 @@ default:
       prowPlugin: label 
       target: both
 repos:
+  kubevirt/containerized-data-importer:
+    labels:
+      - addedBy: kubevirt-bot
+        color: 0ffa16
+        description: Indicates a PR is trusted, used by tide for auto-merging PRs.
+        name: skip-review
+        target: prs
   kubevirt/kubevirt:
     labels:
       - name: needs/documentation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We repeatedly had the issue for k/kubevirt, that binaries mirrored to the gcs to avoid losing them were not reachable any more, as the mirroring PR was not merged ahead of branching the release.

This change enables `skip-review` label, which will make tide merge PRs that have all lanes succeeded and no forbidden labels, i.e. `do-not-merge/hold`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @akalenyu @brianmcarey @mhenriks