### PR TITLE
ci: s390x CentOS Stream 9 containerdisks always_run job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -87,6 +87,42 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    optional: false
+    annotations:
+      testgrid-create-test-group: "false"
+    cluster: prow-s390x-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: pull-containerdisks-pipeline-centos-stream-9-s390x
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - ./pipeline.sh
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.22.9"
+        - name: FOCUS
+          value: "centos-stream:9"
+        - name: KUBEVIRTCI_TAG
+          value: "2501140834-56eb34e6"
+        - name: KUBEVIRT_SLIM
+          value: "true"
+        image: quay.io/kubevirtci/golang:v20250124-4f7dce8
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
   - always_run: false
     run_if_changed: "artifacts/centosstream/.*"
     annotations:


### PR DESCRIPTION
This job tests the CentOS Stream 9 in the container disks on the s390x cluster for every pull request.

The containerdisks tooling publishes containerdisks to quay.io, making early detection essential from the s390x perspective. For example, an error in the tooling may produce correct images for the amd64 architecture while generating incorrect ones for s390x. Without this check, along with others, incorrectly generated s390x images could also be published.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
