### PR TITLE
In s390x publish centos9 and kubevirtci jobs, do GCS calls without auth where possible

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -176,7 +176,7 @@ periodics:
         CHECK_INTERVAL=30 &&
         source /usr/local/bin/gcs_restapi.sh &&
         while true; do
-            if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH"; then
+            if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false"; then
                 echo "File $GCS_FILE_PATH is now available."
                 break
             else
@@ -184,7 +184,7 @@ periodics:
                 sleep $CHECK_INTERVAL
             fi
         done
-        KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH")
+        KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false")
         if [ $? -ne 0 ]; then
             echo "Failed to fetch KUBEVIRTCI_TAG"
             exit 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -104,7 +104,7 @@ postsubmits:
             source /usr/local/bin/gcs_restapi.sh &&
             CHECK_INTERVAL=30 &&
             while true; do
-                if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH"; then
+                if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false"; then
                     echo "File $GCS_FILE_PATH is now available."
                     break
                 else
@@ -112,7 +112,7 @@ postsubmits:
                     sleep $CHECK_INTERVAL
                 fi
             done &&
-            KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH")
+            KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false")
             if [ $? -ne 0 ]; then
                 echo "Failed to fetch KUBEVIRTCI_TAG"
                 exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:
In s390x publish centos9 and kubevirtci jobs, do GCS calls to check for existence and contents of the publicly available files under kubevirt-prow/release/kubevirt/kubevirtci/ without authentication

As there are limits to number of refresh tokens that are issued per client-user combination in GCS, and beyond limits it may make old token to stop working, so we are reducing the token usage with this fix.
Ref: https://developers.google.com/identity/protocols/oauth2#5.-refresh-the-access-token,-if-necessary.
https://github.com/kubevirt/project-infra/pull/3812

This PR is adds to the previous PR [3812](https://github.com/kubevirt/project-infra/pull/3812) to fix the issue

This should address prow job failures like:
[periodic-kubevirtci-bump-centos-base-s390x/1871405677058985984](https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirtci-bump-centos-base-s390x/1871405677058985984/build-log.txt)
[publish-kubevirtci-s390x/1886882224930820096](https://storage.googleapis.com/kubevirt-prow/logs/publish-kubevirtci-s390x/1886882224930820096/build-log.txt)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
@brianmcarey As you suggested earlier, I'm using the curl without auth for publicly available URLs. Apologies for implementing it late. Please review.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
