### PR TITLE
prowjob,env: add script to extract env vars from job

### DIFF
--- a/hack/export-job-env-vars.sh
+++ b/hack/export-job-env-vars.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+#
+
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
+
+function main() {
+    if [ "$#" -eq 0 ]; then
+        usage
+        exit 1
+    fi
+
+    if [[ "$1" =~ -h ]]; then
+        usage
+        exit 0
+    fi
+
+    echo "$(extract_env_vars_to_export "$1" "$2")"
+}
+
+function extract_env_vars_to_export() {
+    if [ -z "$1" ]; then
+        usage
+        exit 1
+    fi
+
+    job_type="${2:-periodics}"
+
+    rg -l "$1" "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy/files/jobs" | \
+        xargs yq -r '.'"${job_type}"'[] | select(.name=="'"$1"'") | .spec.containers[0].env[] | "export "+.name+"="+.value+ " &&"' | \
+        tr '\n' ' ' | \
+        sed 's/\s&&\s*$//'
+}
+
+function usage() {
+    cat << EOF
+usage:
+    $0 -h|--help
+    $0 <job_name> [job-type(default: periodics)]
+
+    Transforms the env var section of a prow job into a set of export commands and prints them out.
+
+    Can then be used as input for eval like this:
+
+    eval "\$(./hack/export-job-env-vars.sh periodic-kubevirt-e2e-k8s-1.31-sig-storage-root)"
+
+    for presubmits
+
+    ./hack/export-job-env-vars.sh pull-kubevirt-e2e-k8s-1.31-sig-compute 'presubmits."kubevirt/kubevirt"'
+
+    Note: Requires ripgrep/rg to work.
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds a script that extract the environment variables from a job and converts them into a set of `export` commands.

Example:
```
$ ./hack/export-job-env-vars.sh periodic-kubevirt-e2e-k8s-1.31-sig-storage-root
export KUBEVIRT_E2E_RUN_ALL_SUITES=true && export KUBEVIRT_QUARANTINE=true && export TARGET=k8s-1.31-sig-storage && export FEATURE_GATES=Root
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
