### PR TITLE
arm64, e2e: revert bootstrap-legacy image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1079,7 +1079,7 @@ presubmits:
           value: dual
         - name: RUN_ON_ARM64_INFRA
           value: "true"
-        image: quay.io/kubevirtci/bootstrap-legacy:v20240523-1a2c9b8
+        image: quay.io/kubevirtci/bootstrap-legacy:v20230829-f2e4ded
         name: ""
         resources:
           requests:


### PR DESCRIPTION
The image kubevirtci/bootstrap-legacy:v20240523-1a2c9b8 does not contain Arm64 arch image. Revert to v20230829-f2e4ded.

**What this PR does / why we need it**:
make the conformance test line works on Arm64

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubevirt/kubevirt/issues/13673

**Release note**:
```release-note
NONE
```
