### PR TITLE
release-tool: fix config-forking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ ifndef COVERAGE_OUTPUT_PATH
 	COVERAGE_OUTPUT_PATH=${ARTIFACTS}/coverage.html
 	export COVERAGE_OUTPUT_PATH
 endif
+ifndef WHAT_COVERAGE
+	WHAT_COVERAGE=./external-plugins/... ./releng/... ./robots/...
+	export WHAT_COVERAGE
+endif
 
 .PHONY: all clean deps-update update-labels install-metrics-binaries lint $(limiter) $(flake-report-writer) $(querier) $(kubevirtci) $(flake-issue-creator)
 all: deps-update $(limiter) $(flake-report-writer) $(querier) $(kubevirtci) $(flake-issue-creator)
@@ -50,10 +54,6 @@ lint: install-metrics-binaries
 
 coverage:
 	if ! command -V covreport; then go install github.com/cancue/covreport@latest; fi
-	go test \
-		./external-plugins/... \
-		./releng/... \
-		./robots/... \
-		-coverprofile=/tmp/coverage.out
+	go test ${WHAT_COVERAGE} -coverprofile=/tmp/coverage.out
 	mkdir -p ${ARTIFACTS}
 	covreport  -i /tmp/coverage.out -o ${COVERAGE_OUTPUT_PATH}

--- a/images/release-tool-base/Containerfile
+++ b/images/release-tool-base/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:39
+FROM fedora:41
 
 RUN dnf install -y \
 	git \
@@ -7,7 +7,7 @@ RUN dnf install -y \
 	&& dnf clean all
 
 
-ENV GIMME_GO_VERSION=1.21.9
+ENV GIMME_GO_VERSION=1.21.13
 
 RUN mkdir -p /gimme && curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
 
@@ -19,7 +19,7 @@ RUN set -x && \
     source /etc/profile.d/gimme.sh && \
     git clone https://github.com/kubernetes/test-infra.git && \
     cd /test-infra && \
-    git checkout 1f3edddfe487b7df5714dbd9de3b2ed6e691485e && \
+    git checkout 71ea51ce37adf5ea3ab3374adc94750125208f73 && \
     cd /test-infra/robots/pr-creator && \
     go install && \
     cd /test-infra/releng/config-forker && \

--- a/images/release-tool/Containerfile
+++ b/images/release-tool/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/kubevirtci/golang:v20241213-57bd934 as builder
+FROM quay.io/kubevirtci/golang:v20250211-4e3c019 as builder
 ENV GOPROXY=https://proxy.golang.org|direct \
     GOFLAGS="-mod=vendor -ldflags=-extldflags=\"-static\"" \
     CGO_ENABLED=0 \
@@ -11,7 +11,7 @@ RUN mkdir kubevirt && \
     cd project-infra && \
     /usr/local/bin/runner.sh /bin/sh -c "env GOPROXY=off go build -tags netgo -o /go/bin/release-tool ./releng/release-tool"
 
-FROM quay.io/kubevirtci/release-tool-base:v20240528-e82f26ab92a95a70da09e78f76e241b5621b4a79
+FROM quay.io/kubevirtci/release-tool-base:v20250214-0d9df61
 COPY ./entrypoint.sh /usr/sbin/entrypoint.sh
 COPY --from=builder /go/bin/release-tool /usr/bin/release-tool
 ENTRYPOINT ["/usr/sbin/entrypoint.sh"]

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -482,7 +482,7 @@ func (r *releaseData) forkProwJobs() error {
 	return nil
 }
 
-// configureReleaseJob changes the values from the configuration requuired for jobs running against
+// configureReleaseJob changes the values from the configuration required for jobs running against
 // main branch to what is required in the config for presubmits on release branches. It
 //   - changes { run_before_merge: true; always_run: false }
 //     to { always_run: true }

--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -8,7 +8,10 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/yaml"
 	"sort"
 	"strconv"
 	"strings"
@@ -415,10 +418,22 @@ func (r *releaseData) forkProwJobs() error {
 	// create new prow configs if they don't already exist
 	if _, err := os.Stat(fullOutputConfig); err != nil && os.IsNotExist(err) {
 		log.Printf("Creating new prow yaml at path %s", fullOutputConfig)
-		cmd := exec.Command("/usr/bin/config-forker", "--job-config", fullJobConfig, "--version", version, "--output", fullOutputConfig)
+		temp, err := os.MkdirTemp("", "presubmits")
+		if err != nil {
+			log.Printf("ERROR: temp dir creation failed: %s", err)
+			return err
+		}
+		tempPresubmitsConfigPath := filepath.Join(temp, "presubmits.yaml")
+		cmd := exec.Command("/usr/bin/config-forker", "--job-config", fullJobConfig, "--version", version, "--output", tempPresubmitsConfigPath)
 		bytes, err := cmd.CombinedOutput()
 		if err != nil {
 			log.Printf("ERROR: config-forker command output: %s : %s ", string(bytes), err)
+			return err
+		}
+
+		err = configureReleaseJob(tempPresubmitsConfigPath, fullOutputConfig)
+		if err != nil {
+			log.Printf("ERROR: configuring release job failed: %s", err)
 			return err
 		}
 
@@ -464,6 +479,48 @@ func (r *releaseData) forkProwJobs() error {
 		}
 	}
 
+	return nil
+}
+
+// configureReleaseJob changes the values from the configuration requuired for jobs running against
+// main branch to what is required in the config for presubmits on release branches. It
+//   - changes { run_before_merge: true; always_run: false }
+//     to { always_run: true }
+//   - deletes { labels.preset_bazel_cache: true }
+func configureReleaseJob(configPath string, outputPath string) error {
+	if outputPath == configPath {
+		return fmt.Errorf("output-path and config-path must not be the same")
+	}
+	jobConfig, err := config.ReadJobConfig(configPath)
+	if err != nil {
+		return err
+	}
+	for key, presubmits := range jobConfig.PresubmitsStatic {
+		var newPresubmits []config.Presubmit
+		for _, presubmit := range presubmits {
+			if presubmit.RunBeforeMerge {
+				presubmit.AlwaysRun = true
+				presubmit.RunBeforeMerge = false
+			}
+			if _, hasLabel := presubmit.Labels["preset-bazel-cache"]; hasLabel {
+				delete(presubmit.Labels, "preset-bazel-cache")
+			}
+			newPresubmits = append(newPresubmits, presubmit)
+		}
+		jobConfig.PresubmitsStatic[key] = newPresubmits
+	}
+	marshalled, err := yaml.Marshal(&jobConfig)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stat(outputPath)
+	if err == nil || !os.IsNotExist(err) {
+		return fmt.Errorf("unexpected error on output file %s: %v", outputPath, err)
+	}
+	err = os.WriteFile(outputPath, marshalled, os.ModePerm)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/releng/release-tool/testdata/jobconfig/kubevirt-presubmits-1.6.yaml
+++ b/releng/release-tool/testdata/jobconfig/kubevirt-presubmits-1.6.yaml
@@ -1,0 +1,1966 @@
+periodics: null
+postsubmits: {}
+presubmits:
+  kubevirt/kubevirt:
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-performance
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-e2e-k8s-1.31-sig-performance
+    run_if_changed: ^cmd/.*|^rpm/.*|^tests/performance/.*|^hack/perftests.sh|^tools/perfscale-audit/.*|^bazel/.*|^third_party/.*|^staging/src/.*|^api/.*|^pkg/virt-.*|^pkg/controlller/.*|^pkg/monitoring/.*
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          # Build the perfscale-audit binary
+          make bazel-build
+
+          # Create k8s cluster
+          make cluster-up
+
+          # Push and deploy kubevirt
+          make cluster-sync
+
+          FUNC_TEST_ARGS="--no-color --seed=42" make perftest
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.31
+        - name: KUBEVIRT_STORAGE
+          value: hpp
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 16G
+        - name: KUBEVIRT_NUM_NODES
+          value: "4"
+        - name: KUBEVIRT_DEPLOY_PROMETHEUS
+          value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --prometheus-port 30007
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            cpu: "12"
+            memory: 73Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-windows2016
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 2h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    name: pull-kubevirt-e2e-windows2016
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: windows2016
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+      priorityClassName: windows
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-kind-1.30-vgpu
+    decorate: true
+    decoration_config:
+      grace_period: 30m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      vgpu: "true"
+    max_concurrency: 1
+    name: pull-kubevirt-e2e-kind-1.30-vgpu
+    run_before_merge: true
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: vgpu
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.30-vgpu
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 18Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
+        - mountPath: /var/log/audit
+          name: audit
+      nodeSelector:
+        hardwareSupport: gpu
+      priorityClassName: vgpu
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: false
+    annotations:
+      k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-kind-sriov
+    decorate: true
+    decoration_config:
+      grace_period: 30m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-shared-images: "true"
+      rehearsal.allowed: "true"
+      sriov-pod: "true"
+    max_concurrency: 10
+    name: pull-kubevirt-e2e-kind-sriov
+    run_before_merge: true
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: sriov-pod-multi
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-sriov
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/log/audit
+          name: audit
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
+      nodeSelector:
+        hardwareSupport: sriov-nic
+      priorityClassName: sriov
+      volumes:
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-check-tests-for-flakes
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-check-tests-for-flakes
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - TARGET_COMMIT=$PULL_BASE_SHA automation/repeated_test.sh
+        env:
+        - name: KUBEVIRT_E2E_PARALLEL
+          value: "true"
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 9216M
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-generate
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-generate
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make generate-verify
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-verify-rpms
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-verify-rpms
+    optional: true
+    run_if_changed: WORKSPACE
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make verify-rpm-deps
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-verify-go-mod
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-verify-go-mod
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make deps-sync && hack/verify-generate.sh
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    annotations:
+      rehearsal.allowed: "true"
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-gosec
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-gosec
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make gosec
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: prow-s390x-workloads
+    context: pull-kubevirt-unit-test-s390x
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 2h0m0s
+    labels:
+      preset-bazel-unnested: "true"
+    name: pull-kubevirt-unit-test-s390x
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make go-test
+        image: quay.io/kubevirtci/golang:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: prow-arm64-workloads-2
+    context: pull-kubevirt-unit-test-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 2h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+    name: pull-kubevirt-unit-test-arm64
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make test
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-build
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-build
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-build-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-build-arm64
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+        env:
+        - name: BUILD_ARCH
+          value: crossbuild-aarch64
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-build-s390x
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-build-s390x
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+        env:
+        - name: BUILD_ARCH
+          value: crossbuild-s390x
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-unit-test
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-unit-test
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make test
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-fuzz
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-fuzz
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make fuzz
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-apidocs
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-apidocs
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make apidocs
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-client-python
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-client-python
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make client-python
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-manifests
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-manifests
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make manifests DOCKER_PREFIX="docker.io/kubevirt" && make olm-verify
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-prom-rules-verify
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-prom-rules-verify
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make prom-rules-verify
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-check-unassigned-tests
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+    name: pull-kubevirt-check-unassigned-tests
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - hack/check-unassigned-tests.sh
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-ipv6-sig-network
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-ipv6-sig-network
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-network
+        - name: KUBEVIRT_SINGLE_STACK
+          value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+      rehearsal.allowed: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-network
+        - name: KUBEVIRT_WITH_MULTUS_V3
+          value: "false"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-compute-migrations
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: KUBEVIRT_STORAGE
+          value: rook-ceph-default
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.28-wg-arm64
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: prow-arm64-workloads-2
+    context: pull-kubevirt-conformance-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-dind-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-conformance-arm64
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap-legacy:v20240523-1a2c9b8
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+      dnsPolicy: None
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: build-kubevirt-builder
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: build-kubevirt-builder
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          make builder-build
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-code-lint
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-code-lint
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - |
+          make lint
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-swap-enabled
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-swap-enabled
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32
+        - name: KUBEVIRT_E2E_FOCUS
+          value: SwapTest
+        - name: KUBEVIRT_SWAP_ON
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-monitoring
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 2h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+    name: pull-kubevirt-e2e-k8s-1.31-sig-monitoring
+    run_if_changed: ^pkg/monitoring/.*|^tests/monitoring/.*|^tests/libmonitoring/.*|^vendor/github.com/machadovilaca/operator-observability/.*
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-monitoring
+        - name: KUBEVIRT_NUM_NODES
+          value: "2"
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-single-node
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-single-node
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32
+        - name: KUBEVIRT_E2E_FOCUS
+          value: .*
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: KUBEVIRT_INFRA_REPLICAS
+          value: "1"
+        - name: KUBEVIRT_WITH_CNAO
+          value: "true"
+        - name: KUBEVIRT_STORAGE
+          value: rook-ceph-default
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 15Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-storage
+        - name: FEATURE_GATES
+          value: Root
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-compute
+        - name: FEATURE_GATES
+          value: Root
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-compute-realtime
+        - name: KUBEVIRT_PSA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-control-plane
+    context: pull-kubevirt-metrics-lint
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-metrics-lint
+    optional: true
+    run_if_changed: docs/metrics.md
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - |
+          make lint-metrics
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 4Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.30-sig-network
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.30-sig-network
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.30-sig-network
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.30-sig-storage
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.30-sig-storage
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.30-sig-storage
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.30-sig-compute
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.30-sig-compute
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.30-sig-compute-parallel
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.30-sig-operator
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.30-sig-operator
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.30-sig-operator
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-network
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-network
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-network
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-storage
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-storage
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-storage
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-compute
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-compute
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-compute-parallel
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.31-sig-operator
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.31-sig-operator
+    run_before_merge: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.31-sig-operator
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      ci.kubevirt.io/prometheus: ""
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+    name: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - |
+          # Build the perfscale-audit binary
+          make bazel-build
+          # Create k8s cluster
+          make cluster-up
+          # Push and deploy kubevirt
+          make cluster-sync
+          FUNC_TEST_ARGS="--no-color --seed=42" make kwok-perftest
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: k8s-1.32
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 10G
+        - name: KUBEVIRT_DEPLOY_KWOK
+          value: "true"
+        - name: KUBEVIRT_DEPLOY_PROMETHEUS
+          value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --prometheus-port 30007
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            cpu: "12"
+            memory: 73Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-network
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-network
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-network
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-storage
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-storage
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-storage
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-compute
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-compute
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-compute-parallel
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-operator
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-operator
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-operator
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.6
+    cluster: kubevirt-prow-workloads
+    context: pull-kubevirt-e2e-k8s-1.32-sig-compute-serial
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-etcd-in-mem: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.32-sig-compute-serial
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.32-sig-compute-serial
+        - name: KUBEVIRT_PSA
+          value: "true"
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        - name: FEATURE_GATES
+          value: NodeRestriction
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 29Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

config-forking was broken in a couple of ways:
* it used an old version of the config-forker from test-infra which didn't retain the value for `run_before_merge`
* it didn't update the forked config, since for release branches the phase plugin didn't work in the same way, therefore the values had to be converted from `run_before_merge` to `always_run`

This PR fixes the issues.

We also now use this opportunity to remove the bazel cache label since
we need to do that every time anyways: https://github.com/kubevirt/project-infra/pull/3961

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3478

**Special notes for your reviewer**:
/cc @xpivarc @enp0s3 
