### PR TITLE
kubevirt,releases: Update kubevirt release presubmit lanes to use new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -378,7 +378,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -416,7 +416,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -499,7 +499,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-sriov-nonroot
     decorate: true
     decoration_config:
@@ -584,7 +584,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -662,7 +662,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -721,7 +721,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -784,7 +784,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1192,7 +1192,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1227,7 +1227,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1263,7 +1263,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1298,7 +1298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1333,7 +1333,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1372,7 +1372,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1411,7 +1411,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1450,7 +1450,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1494,7 +1494,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1529,7 +1529,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1564,7 +1564,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1641,7 +1641,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1676,7 +1676,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1711,7 +1711,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1746,7 +1746,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1781,7 +1781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -397,7 +397,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -436,7 +436,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -475,7 +475,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -558,7 +558,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-sriov-nonroot
     decorate: true
     decoration_config:
@@ -643,7 +643,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -721,7 +721,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -781,7 +781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -845,7 +845,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1253,7 +1253,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1288,7 +1288,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1323,7 +1323,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1358,7 +1358,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1393,7 +1393,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1432,7 +1432,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1471,7 +1471,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1510,7 +1510,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1553,7 +1553,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1588,7 +1588,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1623,7 +1623,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1700,7 +1700,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1735,7 +1735,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1770,7 +1770,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1805,7 +1805,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1840,7 +1840,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1881,7 +1881,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.50
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -339,7 +339,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -397,7 +397,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -436,7 +436,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -475,7 +475,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -558,7 +558,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-sriov-nonroot
     decorate: true
     decoration_config:
@@ -643,7 +643,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -721,7 +721,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -781,7 +781,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -845,7 +845,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1253,7 +1253,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1288,7 +1288,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1324,7 +1324,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1359,7 +1359,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1394,7 +1394,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1433,7 +1433,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1472,7 +1472,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1511,7 +1511,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1554,7 +1554,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1589,7 +1589,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1624,7 +1624,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1701,7 +1701,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1736,7 +1736,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1771,7 +1771,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1806,7 +1806,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1841,7 +1841,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1882,7 +1882,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.51
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -396,7 +396,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -435,7 +435,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -474,7 +474,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -556,7 +556,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.19-sriov-nonroot
     decorate: true
     decoration_config:
@@ -640,7 +640,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -718,7 +718,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -777,7 +777,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -840,7 +840,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1248,7 +1248,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1283,7 +1283,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1318,7 +1318,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1353,7 +1353,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1388,7 +1388,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1427,7 +1427,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1466,7 +1466,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1505,7 +1505,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1548,7 +1548,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1583,7 +1583,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1618,7 +1618,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1695,7 +1695,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1725,7 +1725,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1760,7 +1760,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1795,7 +1795,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1830,7 +1830,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1865,7 +1865,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1906,7 +1906,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1937,7 +1937,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.52
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -298,7 +298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -337,7 +337,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -395,7 +395,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -434,7 +434,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -473,7 +473,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -556,7 +556,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -634,7 +634,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -694,7 +694,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -757,7 +757,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1165,7 +1165,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1200,7 +1200,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1235,7 +1235,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1270,7 +1270,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1305,7 +1305,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1344,7 +1344,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1383,7 +1383,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1422,7 +1422,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1465,7 +1465,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1500,7 +1500,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1535,7 +1535,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1612,7 +1612,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1642,7 +1642,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1677,7 +1677,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1712,7 +1712,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1747,7 +1747,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1782,7 +1782,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1823,7 +1823,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1854,7 +1854,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.53
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -182,7 +182,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -220,7 +220,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -259,7 +259,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -298,7 +298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -337,7 +337,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -395,7 +395,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -434,7 +434,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -472,7 +472,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -553,7 +553,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -629,7 +629,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -687,7 +687,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -748,7 +748,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1156,7 +1156,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1191,7 +1191,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1226,7 +1226,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1261,7 +1261,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1296,7 +1296,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1335,7 +1335,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1374,7 +1374,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1413,7 +1413,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1456,7 +1456,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1491,7 +1491,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1526,7 +1526,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1603,7 +1603,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1633,7 +1633,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1668,7 +1668,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1703,7 +1703,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1738,7 +1738,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1773,7 +1773,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1814,7 +1814,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1845,7 +1845,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.54
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-network
     decorate: true
     decoration_config:
@@ -40,7 +40,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-storage
     decorate: true
     decoration_config:
@@ -75,7 +75,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute
     decorate: true
     decoration_config:
@@ -110,7 +110,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-operator
     decorate: true
     decoration_config:
@@ -145,7 +145,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -183,7 +183,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -221,7 +221,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -260,7 +260,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -299,7 +299,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -338,7 +338,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-performance
     decorate: true
     decoration_config:
@@ -396,7 +396,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -435,7 +435,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -474,7 +474,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -555,7 +555,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -631,7 +631,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -689,7 +689,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -750,7 +750,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1158,7 +1158,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1193,7 +1193,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1228,7 +1228,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1263,7 +1263,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1298,7 +1298,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.21-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1337,7 +1337,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1376,7 +1376,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1415,7 +1415,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1458,7 +1458,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1493,7 +1493,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1528,7 +1528,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1605,7 +1605,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1635,7 +1635,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1700,7 +1700,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1735,7 +1735,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1770,7 +1770,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1805,7 +1805,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1846,7 +1846,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1877,7 +1877,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1923,7 +1923,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1959,7 +1959,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -1995,7 +1995,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -2031,7 +2031,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.55
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -44,7 +44,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -83,7 +83,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -123,7 +123,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -163,7 +163,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -203,7 +203,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
     decorate: true
     decoration_config:
@@ -242,7 +242,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
     decorate: true
     decoration_config:
@@ -301,7 +301,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -341,7 +341,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -381,7 +381,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -462,7 +462,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -538,7 +538,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -596,7 +596,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -657,7 +657,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1077,7 +1077,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1113,7 +1113,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1149,7 +1149,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1185,7 +1185,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1221,7 +1221,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1261,7 +1261,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1301,7 +1301,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1345,7 +1345,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1381,7 +1381,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1417,7 +1417,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1495,7 +1495,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1526,7 +1526,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1593,7 +1593,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1629,7 +1629,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1665,7 +1665,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1701,7 +1701,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1743,7 +1743,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1775,7 +1775,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1822,7 +1822,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1858,7 +1858,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -1894,7 +1894,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1930,7 +1930,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.56
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -43,7 +43,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -81,7 +81,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -120,7 +120,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -159,7 +159,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -198,7 +198,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
     decorate: true
     decoration_config:
@@ -235,7 +235,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
     decorate: true
     decoration_config:
@@ -293,7 +293,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -332,7 +332,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -371,7 +371,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -451,7 +451,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -528,7 +528,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -598,7 +598,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -671,7 +671,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1078,7 +1078,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1113,7 +1113,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1148,7 +1148,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1183,7 +1183,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1218,7 +1218,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1257,7 +1257,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1296,7 +1296,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1339,7 +1339,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1374,7 +1374,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1409,7 +1409,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1486,7 +1486,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1516,7 +1516,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1581,7 +1581,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1616,7 +1616,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1651,7 +1651,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1686,7 +1686,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1727,7 +1727,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1760,7 +1760,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1806,7 +1806,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1841,7 +1841,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -1876,7 +1876,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1911,7 +1911,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.57
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -43,7 +43,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -81,7 +81,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
     decorate: true
     decoration_config:
@@ -120,7 +120,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
     decorate: true
     decoration_config:
@@ -159,7 +159,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
     decorate: true
     decoration_config:
@@ -198,7 +198,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
     decorate: true
     decoration_config:
@@ -235,7 +235,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
     decorate: true
     decoration_config:
@@ -293,7 +293,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
     decorate: true
     decoration_config:
@@ -332,7 +332,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -371,7 +371,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
     decorate: true
     decoration_config:
@@ -451,7 +451,7 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
     decorate: true
     decoration_config:
@@ -528,7 +528,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
     decorate: true
     decoration_config:
@@ -599,7 +599,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
     decorate: true
     decoration_config:
@@ -673,7 +673,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -1079,7 +1079,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
     decorate: true
     decoration_config:
@@ -1114,7 +1114,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1149,7 +1149,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
     decorate: true
     decoration_config:
@@ -1184,7 +1184,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
     decorate: true
     decoration_config:
@@ -1219,7 +1219,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1258,7 +1258,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1297,7 +1297,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
     decorate: true
     decoration_config:
@@ -1340,7 +1340,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
     decorate: true
     decoration_config:
@@ -1375,7 +1375,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1410,7 +1410,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
     decorate: true
     decoration_config:
@@ -1487,7 +1487,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1517,7 +1517,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
     decorate: true
     decoration_config:
@@ -1582,7 +1582,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
     decorate: true
     decoration_config:
@@ -1617,7 +1617,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
     decorate: true
     decoration_config:
@@ -1652,7 +1652,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
     decorate: true
     decoration_config:
@@ -1687,7 +1687,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
     decorate: true
     decoration_config:
@@ -1728,7 +1728,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
     decorate: true
     decoration_config:
@@ -1761,7 +1761,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
     decorate: true
     decoration_config:
@@ -1807,7 +1807,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1842,7 +1842,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -1877,7 +1877,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1912,7 +1912,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:
@@ -1947,7 +1947,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
     decorate: true
     decoration_config:
@@ -1983,7 +1983,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.58
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -44,7 +44,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -83,7 +83,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -122,7 +122,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -161,7 +161,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -200,7 +200,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -239,7 +239,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-root
     decorate: true
     decoration_config:
@@ -277,7 +277,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network-root
     decorate: true
     decoration_config:
@@ -315,7 +315,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-root
     decorate: true
     decoration_config:
@@ -353,7 +353,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-performance
     decorate: true
     decoration_config:
@@ -411,7 +411,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator-root
     decorate: true
     decoration_config:
@@ -449,7 +449,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -706,7 +706,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -739,7 +739,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-generate
     decorate: true
     decoration_config:
@@ -766,7 +766,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-verify-rpms
     decorate: true
     decoration_config:
@@ -795,7 +795,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-verify-go-mod
     decorate: true
     decoration_config:
@@ -824,7 +824,7 @@ presubmits:
       rehearsal.allowed: "true"
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-gosec
     decorate: true
     decoration_config:
@@ -880,7 +880,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -907,7 +907,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -964,7 +964,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-goveralls
     decorate: true
     decoration_config:
@@ -1003,7 +1003,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-apidocs
     decorate: true
     decoration_config:
@@ -1031,7 +1031,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-client-python
     decorate: true
     decoration_config:
@@ -1058,7 +1058,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-manifests
     decorate: true
     decoration_config:
@@ -1085,7 +1085,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-prom-rules-verify
     decorate: true
     decoration_config:
@@ -1139,7 +1139,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1175,7 +1175,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -1212,7 +1212,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-psa-sig-network
     decorate: true
     decoration_config:
@@ -1252,7 +1252,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations-root
     decorate: true
     decoration_config:
@@ -1294,7 +1294,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -1334,7 +1334,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1370,7 +1370,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime-root
     decorate: true
     decoration_config:
@@ -1459,7 +1459,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1489,7 +1489,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-code-lint
     decorate: true
     decoration_config:
@@ -1519,7 +1519,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
     decorate: true
     decoration_config:
@@ -1561,7 +1561,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
     decorate: true
     decoration_config:
@@ -1595,7 +1595,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
     decorate: true
     decoration_config:
@@ -1642,7 +1642,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
     decorate: true
     decoration_config:
@@ -1678,7 +1678,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-network
     decorate: true
     decoration_config:
@@ -1717,7 +1717,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
     decorate: true
     decoration_config:
@@ -1753,7 +1753,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
     decorate: true
     decoration_config:
@@ -1789,7 +1789,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
     decorate: true
     decoration_config:
@@ -1825,7 +1825,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-compute
     decorate: true
     decoration_config:
@@ -1864,7 +1864,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-storage
     decorate: true
     decoration_config:
@@ -1903,7 +1903,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-network
     decorate: true
     decoration_config:
@@ -1939,7 +1939,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage
     decorate: true
     decoration_config:
@@ -1975,7 +1975,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute
     decorate: true
     decoration_config:
@@ -2011,7 +2011,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
     decorate: true
     decoration_config:
@@ -2050,7 +2050,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-operator
     decorate: true
     decoration_config:
@@ -2086,7 +2086,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
     decorate: true
     decoration_config:
@@ -2124,7 +2124,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
     decorate: true
     decoration_config:
@@ -2162,7 +2162,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
     decorate: true
     decoration_config:
@@ -2200,7 +2200,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator-upgrade
     decorate: true
     decoration_config:
@@ -2236,7 +2236,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator-configuration
     decorate: true
     decoration_config:
@@ -2274,7 +2274,7 @@ presubmits:
   - always_run: false
     branches:
     - release-0.59
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-psa-sig-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-cgroupsv2
     decorate: true
     decoration_config:
@@ -44,7 +44,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage-cgroupsv2
     decorate: true
     decoration_config:
@@ -83,7 +83,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-performance
     decorate: true
     decoration_config:
@@ -141,7 +141,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -326,7 +326,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -500,7 +500,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -527,7 +527,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -720,7 +720,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -758,7 +758,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -797,7 +797,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
     decorate: true
     decoration_config:
@@ -837,7 +837,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -929,7 +929,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -989,7 +989,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
     decorate: true
     decoration_config:
@@ -1031,7 +1031,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
     decorate: true
     decoration_config:
@@ -1065,7 +1065,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
     decorate: true
     decoration_config:
@@ -1112,7 +1112,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-network
     decorate: true
     decoration_config:
@@ -1148,7 +1148,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage
     decorate: true
     decoration_config:
@@ -1184,7 +1184,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute
     decorate: true
     decoration_config:
@@ -1220,7 +1220,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
     decorate: true
     decoration_config:
@@ -1259,7 +1259,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-operator
     decorate: true
     decoration_config:
@@ -1295,7 +1295,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
     decorate: true
     decoration_config:
@@ -1333,7 +1333,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
     decorate: true
     decoration_config:
@@ -1371,7 +1371,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
     decorate: true
     decoration_config:
@@ -1409,7 +1409,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator
     decorate: true
     decoration_config:
@@ -1447,7 +1447,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-network
     decorate: true
     decoration_config:
@@ -1485,7 +1485,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-storage
     decorate: true
     decoration_config:
@@ -1523,7 +1523,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute
     decorate: true
     decoration_config:
@@ -1561,7 +1561,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-performance
     decorate: true
     decoration_config:
@@ -63,7 +63,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -248,7 +248,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -423,7 +423,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -450,7 +450,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -638,7 +638,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -678,7 +678,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -717,7 +717,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
     decorate: true
     decoration_config:
@@ -759,7 +759,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -852,7 +852,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -911,7 +911,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
     decorate: true
     decoration_config:
@@ -953,7 +953,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
     decorate: true
     decoration_config:
@@ -989,7 +989,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
     decorate: true
     decoration_config:
@@ -1036,7 +1036,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
     decorate: true
     decoration_config:
@@ -1075,7 +1075,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
     decorate: true
     decoration_config:
@@ -1115,7 +1115,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
     decorate: true
     decoration_config:
@@ -1153,7 +1153,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage-root
     decorate: true
     decoration_config:
@@ -1192,7 +1192,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
     decorate: true
     decoration_config:
@@ -1234,7 +1234,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute-root
     decorate: true
     decoration_config:
@@ -1277,7 +1277,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator
     decorate: true
     decoration_config:
@@ -1317,7 +1317,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-network
     decorate: true
     decoration_config:
@@ -1357,7 +1357,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-storage
     decorate: true
     decoration_config:
@@ -1395,7 +1395,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute
     decorate: true
     decoration_config:
@@ -1437,7 +1437,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1477,7 +1477,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-operator
     decorate: true
     decoration_config:
@@ -1517,7 +1517,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-network
     decorate: true
     decoration_config:
@@ -1557,7 +1557,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-storage
     decorate: true
     decoration_config:
@@ -1595,7 +1595,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute
     decorate: true
     decoration_config:
@@ -1637,7 +1637,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-performance
     decorate: true
     decoration_config:
@@ -63,7 +63,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -250,7 +250,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -427,7 +427,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -454,7 +454,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -484,7 +484,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-s390x
     decorate: true
     decoration_config:
@@ -674,7 +674,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -714,7 +714,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
     decorate: true
     decoration_config:
@@ -756,7 +756,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -916,7 +916,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -975,7 +975,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-swap-enabled
     decorate: true
     decoration_config:
@@ -1016,7 +1016,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
     decorate: true
     decoration_config:
@@ -1052,7 +1052,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-single-node
     decorate: true
     decoration_config:
@@ -1099,7 +1099,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
     decorate: true
     decoration_config:
@@ -1138,7 +1138,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
     decorate: true
     decoration_config:
@@ -1181,7 +1181,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-network
     decorate: true
     decoration_config:
@@ -1221,7 +1221,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-storage
     decorate: true
     decoration_config:
@@ -1263,7 +1263,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute
     decorate: true
     decoration_config:
@@ -1305,7 +1305,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1346,7 +1346,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-operator
     decorate: true
     decoration_config:
@@ -1386,7 +1386,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-network
     decorate: true
     decoration_config:
@@ -1426,7 +1426,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-storage
     decorate: true
     decoration_config:
@@ -1468,7 +1468,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute
     decorate: true
     decoration_config:
@@ -1510,7 +1510,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-operator
     decorate: true
     decoration_config:
@@ -1580,7 +1580,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network
     decorate: true
     decoration_config:
@@ -1620,7 +1620,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage
     decorate: true
     decoration_config:
@@ -1662,7 +1662,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute
     decorate: true
     decoration_config:
@@ -1704,7 +1704,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-performance
     decorate: true
     decoration_config:
@@ -63,7 +63,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -249,7 +249,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -426,7 +426,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -453,7 +453,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -483,7 +483,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-s390x
     decorate: true
     decoration_config:
@@ -673,7 +673,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -715,7 +715,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
     decorate: true
     decoration_config:
@@ -759,7 +759,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -918,7 +918,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -976,7 +976,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-swap-enabled
     decorate: true
     decoration_config:
@@ -1018,7 +1018,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
     decorate: true
     decoration_config:
@@ -1054,7 +1054,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-single-node
     decorate: true
     decoration_config:
@@ -1101,7 +1101,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
     decorate: true
     decoration_config:
@@ -1140,7 +1140,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
     decorate: true
     decoration_config:
@@ -1183,7 +1183,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1224,7 +1224,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-network
     decorate: true
     decoration_config:
@@ -1266,7 +1266,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-storage
     decorate: true
     decoration_config:
@@ -1308,7 +1308,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute
     decorate: true
     decoration_config:
@@ -1350,7 +1350,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-operator
     decorate: true
     decoration_config:
@@ -1420,7 +1420,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network
     decorate: true
     decoration_config:
@@ -1462,7 +1462,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage
     decorate: true
     decoration_config:
@@ -1504,7 +1504,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute
     decorate: true
     decoration_config:
@@ -1546,7 +1546,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute-serial
     decorate: true
     decoration_config:
@@ -1588,7 +1588,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-operator
     decorate: true
     decoration_config:
@@ -1628,7 +1628,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
     decorate: true
     decoration_config:
@@ -1670,7 +1670,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
     decorate: true
     decoration_config:
@@ -1712,7 +1712,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
     decorate: true
     decoration_config:
@@ -1754,7 +1754,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-performance
     decorate: true
     decoration_config:
@@ -63,7 +63,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -248,7 +248,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -452,7 +452,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -479,7 +479,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -509,7 +509,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-s390x
     decorate: true
     decoration_config:
@@ -566,7 +566,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-fuzz
     decorate: true
     decoration_config:
@@ -726,7 +726,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -770,7 +770,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
     decorate: true
     decoration_config:
@@ -814,7 +814,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -976,7 +976,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1034,7 +1034,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-swap-enabled
     decorate: true
     decoration_config:
@@ -1076,7 +1076,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
     decorate: true
     decoration_config:
@@ -1112,7 +1112,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-single-node
     decorate: true
     decoration_config:
@@ -1159,7 +1159,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
     decorate: true
     decoration_config:
@@ -1198,7 +1198,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
     decorate: true
     decoration_config:
@@ -1241,7 +1241,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1312,7 +1312,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network
     decorate: true
     decoration_config:
@@ -1354,7 +1354,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage
     decorate: true
     decoration_config:
@@ -1396,7 +1396,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute
     decorate: true
     decoration_config:
@@ -1438,7 +1438,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-serial
     decorate: true
     decoration_config:
@@ -1482,7 +1482,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-operator
     decorate: true
     decoration_config:
@@ -1522,7 +1522,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
     decorate: true
     decoration_config:
@@ -1566,7 +1566,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
     decorate: true
     decoration_config:
@@ -1610,7 +1610,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
     decorate: true
     decoration_config:
@@ -1654,7 +1654,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
     decorate: true
     decoration_config:
@@ -1696,7 +1696,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-network
     decorate: true
     decoration_config:
@@ -1740,7 +1740,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage
     decorate: true
     decoration_config:
@@ -1784,7 +1784,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute
     decorate: true
     decoration_config:
@@ -1828,7 +1828,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-operator
     decorate: true
     decoration_config:
@@ -1870,7 +1870,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.4
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-performance-kwok
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -5,7 +5,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-performance
     decorate: true
     decoration_config:
@@ -67,7 +67,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
     decorate: true
     decoration_config:
@@ -251,7 +251,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
     decorate: true
     decoration_config:
@@ -462,7 +462,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build
     decorate: true
     decoration_config:
@@ -490,7 +490,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-arm64
     decorate: true
     decoration_config:
@@ -521,7 +521,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-build-s390x
     decorate: true
     decoration_config:
@@ -580,7 +580,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-fuzz
     decorate: true
     decoration_config:
@@ -746,7 +746,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-ipv6-sig-network
     decorate: true
     decoration_config:
@@ -790,7 +790,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
     decorate: true
     decoration_config:
@@ -834,7 +834,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations
     decorate: true
     decoration_config:
@@ -995,7 +995,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: build-kubevirt-builder
     decorate: true
     decoration_config:
@@ -1055,7 +1055,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-swap-enabled
     decorate: true
     decoration_config:
@@ -1098,7 +1098,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-monitoring
     decorate: true
     decoration_config:
@@ -1134,7 +1134,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-single-node
     decorate: true
     decoration_config:
@@ -1182,7 +1182,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
     decorate: true
     decoration_config:
@@ -1222,7 +1222,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
     decorate: true
     decoration_config:
@@ -1265,7 +1265,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
     decorate: true
     decoration_config:
@@ -1337,7 +1337,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
     decorate: true
     decoration_config:
@@ -1381,7 +1381,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
     decorate: true
     decoration_config:
@@ -1425,7 +1425,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
     decorate: true
     decoration_config:
@@ -1469,7 +1469,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
     decorate: true
     decoration_config:
@@ -1511,7 +1511,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-network
     decorate: true
     decoration_config:
@@ -1555,7 +1555,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage
     decorate: true
     decoration_config:
@@ -1599,7 +1599,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute
     decorate: true
     decoration_config:
@@ -1643,7 +1643,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-operator
     decorate: true
     decoration_config:
@@ -1685,7 +1685,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
     decorate: true
     decoration_config:
@@ -1738,7 +1738,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network
     decorate: true
     decoration_config:
@@ -1782,7 +1782,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-storage
     decorate: true
     decoration_config:
@@ -1826,7 +1826,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute
     decorate: true
     decoration_config:
@@ -1870,7 +1870,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-operator
     decorate: true
     decoration_config:
@@ -1912,7 +1912,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-serial
     decorate: true
     decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
