### PR TITLE
fix,test-label-analyzer: move glue code from job into stats

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1593,21 +1593,14 @@ periodics:
   spec:
     containers:
     - args:
-      - /usr/local/bin/runner.sh
-      - /bin/bash
-      - -ce
-      - |
-        output_file_name="/tmp/index.html"
-        git_commit=$(cd ../kubevirt && git --no-pager log -1 --format=%H | tr -d '\n')
-        test-label-analyzer stats \
-          --output-html=true \
-          --config-name quarantine \
-          --test-file-path $(cd ../kubevirt && pwd)/tests \
-          --remote-url "https://github.com/kubevirt/kubevirt/tree/${git_commit}/tests" \
-            > ${output_file_name}
-          gsutil cp ${output_file_name} gs://kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/
+      - stats
+      - --output-html=true
+      - --config-name=quarantine
+      - --test-file-path=/home/prow/go/src/github.com/kubevirt/kubevirt/tests
+      - --remote-url=https://github.com/kubevirt/kubevirt/tree/%s/tests
+      - --output-gcs-url=gs://kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/index.html
       command:
-      - /bin/sh
+      - /usr/bin/test-label-analyzer
       image: quay.io/kubevirtci/test-label-analyzer:v20250219-108bcae
       name: ""
       resources: {}

--- a/robots/cmd/test-label-analyzer/cmd/root.go
+++ b/robots/cmd/test-label-analyzer/cmd/root.go
@@ -63,6 +63,9 @@ type ConfigOptions struct {
 
 	// outputHTML defines whether HTML should be generated, default is JSON
 	outputHTML bool
+
+	// outputGCSURL defines the target where to put the generated output
+	outputGCSURL string
 }
 
 // validate checks the configuration options for validity and returns an error describing the first error encountered
@@ -114,6 +117,12 @@ func (s *ConfigOptions) validate() error {
 					return err
 				}
 				s.remoteURL = fmt.Sprintf(s.remoteURL, strings.ReplaceAll(string(output), "\n", ""))
+			}
+		}
+		if s.outputGCSURL != "" {
+			gcsURLPattern := regexp.MustCompile("^gs://.*")
+			if !gcsURLPattern.MatchString(s.outputGCSURL) {
+				return fmt.Errorf("outputGCSURL must match pattern")
 			}
 		}
 	}
@@ -240,6 +249,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&rootConfigOpts.remoteURL, "remote-url", "", "remote path to tests to be analyzed")
 	RootCmd.PersistentFlags().StringVar(&rootConfigOpts.testNameLabelRE, "test-name-label-re", "", "regular expression for test names to match against")
 	RootCmd.PersistentFlags().BoolVar(&rootConfigOpts.outputHTML, "output-html", false, "defines whether HTML output should be generated, default is JSON")
+	RootCmd.PersistentFlags().StringVar(&rootConfigOpts.outputGCSURL, "output-gcs-url", "", "defines where to put the output (optional)")
 
 	RootCmd.AddCommand(filter.Command())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR fixes the quarantined test report generation, which was broken since the changes wrt prow dependencies.

Changes:
* Integrates the auto-determination of the latest commit id from the test
repository into the test repository url.
* Adds the capability to write the report directly to a gcs bucket.
* Updates the job configuration to reflect the added flags.

Successful rehearse run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-quarantined-tests-daily-report/1892152494935511040

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3925

**Special notes for your reviewer**:

/cc @brianmcarey 