### PR TITLE
bump-prow-job-images: avoid bumping bootstrap-legacy

### DIFF
--- a/hack/_include_image_funcs.sh
+++ b/hack/_include_image_funcs.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 #
 # This file is part of the KubeVirt project
 #
@@ -15,31 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Copyright the KubeVirt Authors
+# Copyright the KubeVirt Authors.
 #
 #
 
-set -euo pipefail
-set -x
+# _include_image_funcs.sh contains bash functions that are being used in multiple
+# places
 
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
 
-source "${BASEDIR}/_include_image_funcs.sh"
-
-function main() {
-    for repo_name in $(kubevirtci_images_used_in_manifests); do
-        # avoid bumping bootstrap-legacy images automatically
-        if [[ "${repo_name}" == "bootstrap-legacy" ]]; then
-            continue
-        fi
-        image_name="quay.io/kubevirtci/${repo_name}"
-        if ! "$PROJECT_INFRA_ROOT/hack/update-jobs-with-latest-image.sh" "$image_name"; then
-            echo "[FAIL] prow jobs update for image $image_name"
-        else
-            echo "[OK] prow jobs update for image $image_name"
-        fi
-    done
+function kubevirtci_images_used_in_manifests() {
+    find "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy" -name '*.yaml' -print0 | \
+        xargs -0 grep -hoE 'quay.io/kubevirtci/[^: @]+' | \
+        sort -u | \
+        cut -d'/' -f3
 }
-
-main "$@"

--- a/hack/bump-prow-deployment-images.sh
+++ b/hack/bump-prow-deployment-images.sh
@@ -25,6 +25,8 @@ set -x
 BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
 
+source "${BASEDIR}/_include_image_funcs.sh"
+
 function main() {
     for repo_name in $(kubevirtci_images_used_in_manifests); do
         image_name="quay.io/kubevirtci/${repo_name}"
@@ -34,13 +36,6 @@ function main() {
             echo "[OK] prow deployment update for image $image_name"
         fi
     done
-}
-
-function kubevirtci_images_used_in_manifests() {
-    find "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy" -name '*.yaml' -print0 | \
-        xargs -0 grep -hoE 'quay.io/kubevirtci/[^: @]+' | \
-        sort -u | \
-        cut -d'/' -f3
 }
 
 main "$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We don't want to bump the bootstrap-legacy image, it's there for legacy reasons. Any change there should be done by intention. This PR avoids bumping in in the automation script. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 
