### PR TITLE
prow: Move project-infra and kubevirtci jobs to the new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -16,7 +16,7 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-shared-images: "true"
-  cluster: kubevirt-prow-workloads
+  cluster: prow-workloads
   spec:
     containers:
       - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
@@ -86,7 +86,7 @@ periodics:
   labels:
     preset-docker-mirror: "true"
     preset-github-credentials: "true"
-  cluster: kubevirt-prow-workloads
+  cluster: prow-workloads
   spec:
     containers:
     - image: quay.io/kubevirtci/pr-creator:v20240913-6773146
@@ -118,7 +118,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-gcs-credentials: "true"
-  cluster: kubevirt-prow-workloads
+  cluster: prow-workloads
   spec:
     containers:
     - image: quay.io/kubevirtci/pr-creator:v20240913-6773146

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -20,7 +20,7 @@ postsubmits:
         preset-gcs-credentials: "true"
         preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         affinity:
           nodeAffinity:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -81,7 +81,7 @@ presubmits:
           type: Directory
         name: vfio
   - always_run: false
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -127,7 +127,7 @@ presubmits:
           type: Directory
         name: cgroup
   - always_run: false
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -174,7 +174,7 @@ presubmits:
           type: Directory
         name: audit
   - always_run: false
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -295,7 +295,7 @@ presubmits:
           type: Directory
         name: vfio
   - always_run: true
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     labels:
       preset-docker-mirror-proxy: "true"
@@ -319,7 +319,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 20m0s
@@ -390,7 +390,7 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: true
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -476,7 +476,7 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: true
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -532,7 +532,7 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: true
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s
@@ -559,7 +559,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       timeout: 3h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -619,7 +619,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  cluster: kubevirt-prow-workloads
+  cluster: prow-workloads
   spec:
     containers:
     - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -214,7 +214,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
@@ -397,7 +397,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
@@ -426,7 +426,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
@@ -458,7 +458,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -371,7 +371,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
@@ -397,7 +397,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-quay-credential: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
@@ -498,7 +498,7 @@ presubmits:
       preset-gcs-credentials: "true"
       preset-pgp-bot-key: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     extra_refs:
     - org: kubevirt
       repo: kubevirt
@@ -541,7 +541,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       containers:
         - image: quay.io/kubevirtci/golang:v20250211-4e3c019
@@ -579,7 +579,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     extra_refs:
     - org: kubevirt
       repo: kubevirt


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the prow jobs for the project-infra and kubevirtci repos to the new workloads cluster as the old cluster is affected by a data centre closure. 

This move does not include SRIOV and VGPU based kubevirtci jobs as these are not
enabled on the new cluster yet

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
