### PR TITLE
prow: Move prow jobs for CDI,HCO,CNAO & hostpath-provisioner to new workloads cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
@@ -138,7 +138,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -171,7 +171,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -200,7 +200,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -233,7 +233,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -266,7 +266,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
@@ -10,7 +10,7 @@ presubmits:
       decoration_config:
         timeout: 4h
         grace_period: 10m
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
@@ -40,7 +40,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 5m
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
@@ -74,7 +74,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -100,7 +100,7 @@ presubmits:
       decoration_config:
         timeout: 3h
         grace_period: 25m
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       max_concurrency: 4
       labels:
         preset-dind-enabled: "true"
@@ -136,7 +136,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -167,7 +167,7 @@ presubmits:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -194,7 +194,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 4
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -225,7 +225,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 4
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -256,7 +256,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 4
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -101,7 +101,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -132,7 +132,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -163,7 +163,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -194,7 +194,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -225,7 +225,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -259,7 +259,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -290,7 +290,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -101,7 +101,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror: "true"
@@ -132,7 +132,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -163,7 +163,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -194,7 +194,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -225,7 +225,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -256,7 +256,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -102,7 +102,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -135,7 +135,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -162,7 +162,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -193,7 +193,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -224,7 +224,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -255,7 +255,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -102,7 +102,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -135,7 +135,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -162,7 +162,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -193,7 +193,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -224,7 +224,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -255,7 +255,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -286,7 +286,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -317,7 +317,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.89.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.89.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -102,7 +102,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -135,7 +135,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -162,7 +162,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -193,7 +193,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -224,7 +224,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -255,7 +255,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -286,7 +286,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -317,7 +317,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.91.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.91.yaml
@@ -11,7 +11,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -71,7 +71,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -102,7 +102,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -135,7 +135,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -162,7 +162,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -193,7 +193,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -224,7 +224,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -255,7 +255,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -286,7 +286,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -317,7 +317,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.93.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.93.yaml
@@ -10,7 +10,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -39,7 +39,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -68,7 +68,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -98,7 +98,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -130,7 +130,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -156,7 +156,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -186,7 +186,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -216,7 +216,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -246,7 +246,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -277,7 +277,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -307,7 +307,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.95.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.95.yaml
@@ -10,7 +10,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -39,7 +39,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -68,7 +68,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -98,7 +98,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -130,7 +130,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -156,7 +156,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -186,7 +186,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -216,7 +216,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -246,7 +246,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -277,7 +277,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -307,7 +307,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.97.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.97.yaml
@@ -10,7 +10,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -39,7 +39,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -68,7 +68,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -98,7 +98,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -130,7 +130,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -156,7 +156,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -186,7 +186,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -216,7 +216,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -246,7 +246,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -277,7 +277,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -307,7 +307,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
         timeout: 4h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -45,7 +45,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -77,7 +77,7 @@ presubmits:
         timeout: 3h
         grace_period: 5m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -110,7 +110,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -145,7 +145,7 @@ presubmits:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
         preset-shared-images: "true"
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       spec:
         nodeSelector:
           type: bare-metal-external
@@ -174,7 +174,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -207,7 +207,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -240,7 +240,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -273,7 +273,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -305,7 +305,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
@@ -338,7 +338,7 @@ presubmits:
         timeout: 3h
         grace_period: 25m
       max_concurrency: 6
-      cluster: kubevirt-prow-workloads
+      cluster: prow-workloads
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -87,7 +87,7 @@ periodics:
       repo: containerized-data-importer
       base_ref: main
       work_dir: true
-  cluster: kubevirt-prow-workloads
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.34.yaml
@@ -10,7 +10,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
@@ -10,7 +10,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -41,7 +41,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -66,7 +66,7 @@ presubmits:
     context: pull-cdi-unit-test
     branches:
       - release-v1.38
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: true
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
@@ -4,7 +4,7 @@ presubmits:
     context: pull-cdi-unit-test
     branches:
       - release-v1.43
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: true
     decorate: true
@@ -126,7 +126,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -158,7 +158,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
@@ -4,7 +4,7 @@ presubmits:
     context: pull-cdi-unit-test
     branches:
       - release-v1.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: true
     decorate: true
@@ -126,7 +126,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -158,7 +158,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
       - release-v1.38
       - release-v1.43
       - release-v1.49
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -64,7 +64,7 @@ presubmits:
     optional: true
     annotations:
       fork-per-release: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 10m0s
@@ -241,7 +241,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -280,7 +280,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -319,7 +319,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -358,7 +358,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -401,7 +401,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -444,7 +444,7 @@ presubmits:
       timeout: 6h
       grace_period: 10m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -483,7 +483,7 @@ presubmits:
       timeout: 7h
       grace_period: 10m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -522,7 +522,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -561,7 +561,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -641,7 +641,7 @@ presubmits:
       timeout: 5h
       grace_period: 5m
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-release-hostpath-provisioner-operator-images
     branches:
     - release-v\d+\.\d+
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: false
     skip_report: true
@@ -44,7 +44,7 @@ postsubmits:
   - name: push-latest-hostpath-provisioner-operator-images
     branches:
     - main
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - name: push-release-hostpath-provisioner-images
     branches:
     - release-v\d+\.\d+
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: false
     skip_report: true
@@ -45,7 +45,7 @@ postsubmits:
   - name: push-latest-hostpath-provisioner-images
     branches:
     - main
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     always_run: true
     optional: false
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -49,7 +49,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -112,7 +112,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -20,7 +20,7 @@ periodics:
       repo: hyperconverged-cluster-operator
       base_ref: main
       work_dir: true
-  cluster: kubevirt-prow-workloads
+  cluster: prow-workloads
   spec:
     nodeSelector:
       type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -48,7 +48,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.11.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.11.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -48,7 +48,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.12.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.12.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -50,7 +50,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.13.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.14.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.14.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -50,7 +50,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.5.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -45,7 +45,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.6.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.7.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.8.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.9.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.15.1
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       containers:
       - command:
@@ -45,7 +45,7 @@ presubmits:
       preset-kubevirtci-quay-credential: "true"
       preset-shared-images: "true"
     max_concurrency: 6
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     name: pull-hyperconverged-cluster-operator-e2e-ocp-4.3
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 6
     name: pull-hyperconverged-cluster-operator-e2e-k8s-1.17
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external
@@ -56,7 +56,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-shared-images: "true"
-    cluster: kubevirt-prow-workloads
+    cluster: prow-workloads
     spec:
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
