### PR TITLE
prow,automation: Update automations to point to new cluster

### DIFF
--- a/hack/update-deployments-with-latest-image.sh
+++ b/hack/update-deployments-with-latest-image.sh
@@ -12,7 +12,7 @@ if [ $# -gt 1 ]; then
     image_tag="$2"
 fi
 
-declare -a deployment_dirs=('/../github/ci/prow-deploy/kustom/base/manifests/local' '/../github/ci/prow-deploy/kustom/overlays/kubevirt-prow-workloads/resources')
+declare -a deployment_dirs=('/../github/ci/prow-deploy/kustom/base/manifests/local' '/../github/ci/prow-deploy/kustom/overlays/prow-workloads/resources')
 
 for i in "${deployment_dirs[@]}";
 do

--- a/robots/cmd/kubevirtci-presubmit-creator/main.go
+++ b/robots/cmd/kubevirtci-presubmit-creator/main.go
@@ -180,7 +180,7 @@ func AddNewPresubmitIfNotExists(jobConfig config.JobConfig, latestReleaseSemver 
 func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 	yes := true
 	golangImage := "quay.io/kubevirtci/golang:v20230801-94954c0"
-	cluster := "kubevirt-prow-workloads"
+	cluster := "prow-workloads"
 	res := config.Presubmit{
 		AlwaysRun: false,
 		Optional:  true,


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
