### PR TITLE
revert: set the job as optional until the s390x pipelines are stable.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -88,7 +88,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    optional: true
+    optional: false
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -159,7 +159,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    optional: true
     run_if_changed: "artifacts/centosstream/.*"
     annotations:
       testgrid-create-test-group: "false"
@@ -266,7 +265,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    optional: true
     run_if_changed: "artifacts/ubuntu/.*"
     annotations:
       testgrid-create-test-group: "false"


### PR DESCRIPTION
With the s390x pipeline now stable, we can proceed to restore the job configurations.

The root cause of the issue was the disabling of nested virtualization.

This reverts commit a7efd1940af0e1487d9bd2c75e7b2a2cad0dd7df.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
