### PR TITLE
prow-workloads: Reduce the number of jobs that can be scheduled to each node

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.33.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.33.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.40.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.41.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.42.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.43.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.44.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.45.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.45.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.19.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.19.yaml
@@ -26,7 +26,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.26.yaml
@@ -26,7 +26,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.29.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.29.yaml
@@ -26,7 +26,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.31.yaml
@@ -26,7 +26,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
@@ -32,4 +32,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.1.yaml
@@ -92,4 +92,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.2.yaml
@@ -87,4 +87,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.3.yaml
@@ -87,4 +87,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
@@ -90,4 +90,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.6.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -148,7 +148,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -181,7 +181,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -214,7 +214,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -247,7 +247,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -280,7 +280,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -148,7 +148,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -181,7 +181,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -214,7 +214,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -247,7 +247,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -280,7 +280,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -146,7 +146,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -177,7 +177,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -208,7 +208,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -239,7 +239,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -270,7 +270,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -146,7 +146,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -177,7 +177,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -208,7 +208,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -239,7 +239,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.17"
@@ -273,7 +273,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -304,7 +304,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -115,7 +115,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -146,7 +146,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -177,7 +177,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -208,7 +208,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -239,7 +239,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -270,7 +270,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -116,7 +116,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -176,7 +176,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -207,7 +207,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -238,7 +238,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -269,7 +269,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -116,7 +116,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -176,7 +176,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -207,7 +207,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -238,7 +238,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -269,7 +269,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -300,7 +300,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -331,7 +331,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.89.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.89.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -116,7 +116,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -176,7 +176,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -207,7 +207,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -238,7 +238,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -269,7 +269,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -300,7 +300,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -331,7 +331,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.91.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.91.yaml
@@ -25,7 +25,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -55,7 +55,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -85,7 +85,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -116,7 +116,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -176,7 +176,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -207,7 +207,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -238,7 +238,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -269,7 +269,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -300,7 +300,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -331,7 +331,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.93.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.93.yaml
@@ -24,7 +24,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -112,7 +112,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -170,7 +170,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -200,7 +200,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -230,7 +230,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -260,7 +260,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -291,7 +291,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -321,7 +321,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.95.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.95.yaml
@@ -24,7 +24,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -112,7 +112,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -170,7 +170,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -200,7 +200,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -230,7 +230,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -260,7 +260,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -291,7 +291,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -321,7 +321,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.97.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.97.yaml
@@ -24,7 +24,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -112,7 +112,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -170,7 +170,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -200,7 +200,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -230,7 +230,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -260,7 +260,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -291,7 +291,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -321,7 +321,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -59,7 +59,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -91,7 +91,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -124,7 +124,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -188,7 +188,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -221,7 +221,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -254,7 +254,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -287,7 +287,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -319,7 +319,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -352,7 +352,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.34.yaml
@@ -30,7 +30,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-k8s-1.19-ceph
     branches:
       - release-v1.34
@@ -61,4 +61,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
@@ -30,7 +30,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-k8s-1.19-ceph
     branches:
       - release-v1.38
@@ -61,7 +61,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-cdi-unit-test-1.38
     context: pull-cdi-unit-test
     branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
@@ -146,7 +146,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-ceph-1.43
     context: pull-containerized-data-importer-e2e-ceph
     branches:
@@ -178,4 +178,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
@@ -146,7 +146,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-ceph-1.49
     context: pull-containerized-data-importer-e2e-ceph
     branches:
@@ -178,4 +178,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -266,7 +266,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-destructive
     skip_branches:
       - release-v\d+\.\d+
@@ -305,7 +305,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-destructive-release
     branches:
       - release-v\d+\.\d+
@@ -344,7 +344,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-istio
     skip_branches:
       - release-v\d+\.\d+
@@ -383,7 +383,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-hpp-previous
     skip_branches:
       - release-v1.28
@@ -426,7 +426,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-ceph
     skip_branches:
       - release-v1.28
@@ -469,7 +469,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-ceph-wffc
     skip_branches:
       - release-v\d+\.\d+
@@ -508,7 +508,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-upg
     skip_branches:
       - release-v\d+\.\d+
@@ -547,7 +547,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-e2e-nfs
     skip_branches:
       - release-v\d+\.\d+
@@ -586,7 +586,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-containerized-data-importer-fossa
     skip_branches:
       - release-v\d+\.\d+
@@ -666,4 +666,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -142,7 +142,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
     - name: pull-csi-driver-split-e2e-k8s
       cluster: prow-workloads
       skip_branches:
@@ -177,7 +177,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
     - name: pull-csi-driver-split-k8s-suite-k8s
       cluster: prow-workloads
       skip_branches:
@@ -212,7 +212,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
     - name: pull-csi-driver-goveralls
       cluster: kubevirt-prow-control-plane
       skip_branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-hostpath-provisioner-e2e-k8s-ceph
     skip_branches:
       - release-\d+\.\d+
@@ -65,7 +65,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-hostpath-provisioner-sanity
     skip_branches:
       - release-\d+\.\d+
@@ -128,7 +128,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-hpp-unit-test
     cluster: kubevirt-prow-control-plane
     skip_branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
@@ -33,7 +33,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"
   - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.27
     branches:
       - release-1.10
@@ -67,4 +67,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.11.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.11.yaml
@@ -33,7 +33,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"
   - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.28
     branches:
       - release-1.11
@@ -67,4 +67,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.12.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.12.yaml
@@ -35,7 +35,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.29
     branches:
       - release-1.12
@@ -71,4 +71,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
@@ -27,7 +27,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
@@ -27,7 +27,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
@@ -30,4 +30,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.5.yaml
@@ -30,7 +30,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"
   - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.21
     branches:
     - release-1.5
@@ -61,4 +61,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.6.yaml
@@ -30,4 +30,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.7.yaml
@@ -30,4 +30,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.8.yaml
@@ -30,4 +30,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.9.yaml
@@ -30,4 +30,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
@@ -27,7 +27,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -59,7 +59,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -27,7 +27,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -58,7 +58,7 @@ presubmits:
 #        name: ""
 #        resources:
 #          requests:
-#            memory: 29Gi
+#            memory: 52Gi
 #        securityContext:
 #          privileged: true
 #      nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-periodics.yaml
@@ -34,4 +34,4 @@ periodics:
         privileged: true
       resources:
         requests:
-          memory: "29Gi"
+          memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -62,4 +62,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -196,7 +196,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
       volumeMounts:
@@ -508,7 +508,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -644,7 +644,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
       volumeMounts:
@@ -1329,7 +1329,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1383,7 +1383,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1433,7 +1433,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1483,7 +1483,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1533,7 +1533,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1758,7 +1758,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1810,7 +1810,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1860,7 +1860,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1910,7 +1910,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -1960,7 +1960,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2012,7 +2012,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2062,7 +2062,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2112,7 +2112,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2164,7 +2164,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2214,7 +2214,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2266,7 +2266,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2316,7 +2316,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:
@@ -2366,7 +2366,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 29Gi
+          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.13.yaml
@@ -27,7 +27,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -58,7 +58,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -89,7 +89,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -120,7 +120,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -151,7 +151,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -182,7 +182,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -213,7 +213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.30.yaml
@@ -29,7 +29,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -61,7 +61,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -93,7 +93,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -124,7 +124,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -155,7 +155,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -186,7 +186,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -218,7 +218,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -250,7 +250,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -281,7 +281,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -335,7 +335,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -388,7 +388,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -435,7 +435,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -467,7 +467,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.34.yaml
@@ -29,7 +29,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -61,7 +61,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -95,7 +95,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -129,7 +129,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -160,7 +160,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -191,7 +191,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -222,7 +222,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -253,7 +253,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -285,7 +285,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -317,7 +317,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -348,7 +348,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -401,7 +401,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -455,7 +455,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -486,7 +486,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.36.yaml
@@ -28,7 +28,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -59,7 +59,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -90,7 +90,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -121,7 +121,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -152,7 +152,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -207,7 +207,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -261,7 +261,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -292,7 +292,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.37.yaml
@@ -30,7 +30,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -61,7 +61,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -92,7 +92,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -123,7 +123,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -154,7 +154,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -185,7 +185,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -238,7 +238,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -292,7 +292,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -323,7 +323,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.38.yaml
@@ -30,7 +30,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -61,7 +61,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -92,7 +92,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -123,7 +123,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -154,7 +154,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -185,7 +185,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -238,7 +238,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -292,7 +292,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -323,7 +323,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.39.yaml
@@ -31,7 +31,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -63,7 +63,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -95,7 +95,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -127,7 +127,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -159,7 +159,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -191,7 +191,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -244,7 +244,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -298,7 +298,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -330,7 +330,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.40.yaml
@@ -36,7 +36,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -74,7 +74,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -111,7 +111,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -144,7 +144,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -177,7 +177,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -213,7 +213,7 @@ presubmits:
         - automation/test.sh
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -250,7 +250,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -288,7 +288,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -320,7 +320,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -352,7 +352,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -414,7 +414,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -468,7 +468,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -500,7 +500,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -533,7 +533,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.41.yaml
@@ -36,7 +36,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -71,7 +71,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -107,7 +107,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -144,7 +144,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -183,7 +183,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -216,7 +216,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -256,7 +256,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -293,7 +293,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -328,7 +328,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -360,7 +360,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -396,7 +396,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -428,7 +428,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -460,7 +460,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -493,7 +493,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -525,7 +525,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -585,7 +585,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -665,7 +665,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -719,7 +719,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -759,7 +759,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -792,7 +792,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -824,7 +824,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.42.yaml
@@ -33,7 +33,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -69,7 +69,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -105,7 +105,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -143,7 +143,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -178,7 +178,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -213,7 +213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -249,7 +249,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -286,7 +286,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -324,7 +324,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -362,7 +362,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -400,7 +400,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -438,7 +438,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -478,7 +478,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -513,7 +513,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -548,7 +548,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -583,7 +583,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -620,7 +620,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -655,7 +655,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -715,7 +715,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -795,7 +795,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -876,7 +876,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -930,7 +930,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -970,7 +970,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1007,7 +1007,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.43.yaml
@@ -33,7 +33,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -69,7 +69,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -105,7 +105,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -143,7 +143,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -178,7 +178,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -213,7 +213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -249,7 +249,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -286,7 +286,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -324,7 +324,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -362,7 +362,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -400,7 +400,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -438,7 +438,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -478,7 +478,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -513,7 +513,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -548,7 +548,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -583,7 +583,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -620,7 +620,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -655,7 +655,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -715,7 +715,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -795,7 +795,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -849,7 +849,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -889,7 +889,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.44.yaml
@@ -33,7 +33,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -69,7 +69,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -105,7 +105,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -143,7 +143,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -178,7 +178,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -213,7 +213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -248,7 +248,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -285,7 +285,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -325,7 +325,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -362,7 +362,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -400,7 +400,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -438,7 +438,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -477,7 +477,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -512,7 +512,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -547,7 +547,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -582,7 +582,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -619,7 +619,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -655,7 +655,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -715,7 +715,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -795,7 +795,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -849,7 +849,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.45.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.45.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -139,7 +139,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -210,7 +210,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -245,7 +245,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -282,7 +282,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -322,7 +322,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -359,7 +359,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -397,7 +397,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -435,7 +435,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -474,7 +474,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -509,7 +509,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -545,7 +545,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -580,7 +580,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -617,7 +617,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -653,7 +653,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -713,7 +713,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -793,7 +793,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -905,7 +905,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.46.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.46.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -172,7 +172,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -208,7 +208,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -243,7 +243,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -278,7 +278,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -318,7 +318,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -360,7 +360,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -399,7 +399,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -439,7 +439,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -479,7 +479,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -518,7 +518,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -553,7 +553,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -589,7 +589,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -624,7 +624,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -659,7 +659,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -695,7 +695,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -758,7 +758,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -839,7 +839,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -952,7 +952,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1364,7 +1364,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1400,7 +1400,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1436,7 +1436,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1472,7 +1472,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1507,7 +1507,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.47.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.47.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -172,7 +172,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -208,7 +208,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -243,7 +243,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -278,7 +278,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -318,7 +318,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -360,7 +360,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -399,7 +399,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -439,7 +439,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -479,7 +479,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -518,7 +518,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -553,7 +553,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -589,7 +589,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -624,7 +624,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -659,7 +659,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -695,7 +695,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -756,7 +756,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -841,7 +841,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -920,7 +920,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1001,7 +1001,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1177,7 +1177,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1589,7 +1589,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1625,7 +1625,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1661,7 +1661,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1701,7 +1701,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1737,7 +1737,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1772,7 +1772,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1850,7 +1850,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.48.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.48.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -172,7 +172,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -208,7 +208,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -243,7 +243,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -278,7 +278,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -318,7 +318,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -360,7 +360,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -399,7 +399,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -439,7 +439,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -479,7 +479,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -518,7 +518,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -554,7 +554,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -615,7 +615,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -700,7 +700,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -779,7 +779,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -860,7 +860,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1036,7 +1036,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1447,7 +1447,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1482,7 +1482,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1517,7 +1517,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1557,7 +1557,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1592,7 +1592,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1627,7 +1627,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1705,7 +1705,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.49.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -212,7 +212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -251,7 +251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -291,7 +291,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -331,7 +331,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -370,7 +370,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -406,7 +406,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -467,7 +467,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -552,7 +552,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -632,7 +632,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -808,7 +808,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1219,7 +1219,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1255,7 +1255,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1290,7 +1290,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1325,7 +1325,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1364,7 +1364,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1403,7 +1403,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1442,7 +1442,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1486,7 +1486,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1521,7 +1521,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1556,7 +1556,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1633,7 +1633,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1668,7 +1668,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1703,7 +1703,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1738,7 +1738,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1773,7 +1773,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1807,6 +1807,6 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.50.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -212,7 +212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -251,7 +251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -291,7 +291,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -331,7 +331,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -428,7 +428,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -464,7 +464,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -526,7 +526,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -611,7 +611,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -691,7 +691,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -869,7 +869,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1280,7 +1280,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1315,7 +1315,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1350,7 +1350,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1385,7 +1385,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1424,7 +1424,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1463,7 +1463,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1502,7 +1502,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1545,7 +1545,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1580,7 +1580,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1615,7 +1615,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1692,7 +1692,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1727,7 +1727,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1762,7 +1762,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1797,7 +1797,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1832,7 +1832,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1873,7 +1873,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1906,6 +1906,6 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.51.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -212,7 +212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -251,7 +251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -291,7 +291,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -331,7 +331,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -428,7 +428,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -464,7 +464,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -526,7 +526,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -611,7 +611,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -691,7 +691,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -869,7 +869,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1280,7 +1280,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1316,7 +1316,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1351,7 +1351,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1386,7 +1386,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1425,7 +1425,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1464,7 +1464,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1503,7 +1503,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1546,7 +1546,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1581,7 +1581,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1616,7 +1616,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1693,7 +1693,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1728,7 +1728,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1763,7 +1763,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1798,7 +1798,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1833,7 +1833,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1874,7 +1874,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1907,6 +1907,6 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.52.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -212,7 +212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -251,7 +251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -291,7 +291,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -330,7 +330,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -427,7 +427,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -463,7 +463,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -524,7 +524,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -609,7 +609,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -688,7 +688,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -864,7 +864,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1275,7 +1275,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1310,7 +1310,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1345,7 +1345,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1380,7 +1380,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1419,7 +1419,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1458,7 +1458,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1497,7 +1497,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1540,7 +1540,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1575,7 +1575,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1610,7 +1610,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1687,7 +1687,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1719,7 +1719,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1752,7 +1752,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1787,7 +1787,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1822,7 +1822,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1857,7 +1857,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1898,7 +1898,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1931,7 +1931,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.53.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -212,7 +212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -251,7 +251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -290,7 +290,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -329,7 +329,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -426,7 +426,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -462,7 +462,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -524,7 +524,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -604,7 +604,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -781,7 +781,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1192,7 +1192,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1227,7 +1227,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1262,7 +1262,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1297,7 +1297,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1336,7 +1336,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1375,7 +1375,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1414,7 +1414,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1457,7 +1457,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1492,7 +1492,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1527,7 +1527,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1604,7 +1604,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1636,7 +1636,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1669,7 +1669,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1704,7 +1704,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1739,7 +1739,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1774,7 +1774,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1815,7 +1815,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1848,7 +1848,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.54.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -174,7 +174,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -212,7 +212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -251,7 +251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -290,7 +290,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -329,7 +329,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -426,7 +426,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -462,7 +462,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -521,7 +521,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -599,7 +599,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -772,7 +772,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1183,7 +1183,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1218,7 +1218,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1253,7 +1253,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1288,7 +1288,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1327,7 +1327,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1366,7 +1366,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1405,7 +1405,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1448,7 +1448,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1483,7 +1483,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1518,7 +1518,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1595,7 +1595,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1627,7 +1627,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1660,7 +1660,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1695,7 +1695,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1730,7 +1730,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1765,7 +1765,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1806,7 +1806,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1839,7 +1839,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.55.yaml
@@ -32,7 +32,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -67,7 +67,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -102,7 +102,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -137,7 +137,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -175,7 +175,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -213,7 +213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -252,7 +252,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -291,7 +291,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -330,7 +330,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -427,7 +427,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -463,7 +463,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -523,7 +523,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -601,7 +601,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -774,7 +774,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1185,7 +1185,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1220,7 +1220,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1255,7 +1255,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1290,7 +1290,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1329,7 +1329,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1368,7 +1368,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1407,7 +1407,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1450,7 +1450,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1485,7 +1485,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1520,7 +1520,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1597,7 +1597,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1629,7 +1629,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1662,7 +1662,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1727,7 +1727,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1762,7 +1762,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1797,7 +1797,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1838,7 +1838,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1871,7 +1871,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1951,7 +1951,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1987,7 +1987,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2023,7 +2023,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2059,7 +2059,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.56.yaml
@@ -36,7 +36,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -75,7 +75,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -115,7 +115,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -155,7 +155,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -195,7 +195,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -234,7 +234,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -333,7 +333,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -370,7 +370,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -430,7 +430,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -508,7 +508,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -681,7 +681,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1105,7 +1105,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1141,7 +1141,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1177,7 +1177,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1213,7 +1213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1253,7 +1253,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1293,7 +1293,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1337,7 +1337,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1373,7 +1373,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1409,7 +1409,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1487,7 +1487,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1520,7 +1520,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1554,7 +1554,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1621,7 +1621,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1657,7 +1657,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1693,7 +1693,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1735,7 +1735,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1769,7 +1769,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1850,7 +1850,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1886,7 +1886,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1922,7 +1922,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1958,7 +1958,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.57.yaml
@@ -35,7 +35,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -73,7 +73,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -112,7 +112,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -151,7 +151,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -190,7 +190,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -227,7 +227,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -324,7 +324,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -360,7 +360,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -419,7 +419,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -498,7 +498,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -695,7 +695,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1105,7 +1105,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1140,7 +1140,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1175,7 +1175,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1210,7 +1210,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1249,7 +1249,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1288,7 +1288,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1331,7 +1331,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1366,7 +1366,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1401,7 +1401,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1478,7 +1478,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1510,7 +1510,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1543,7 +1543,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1608,7 +1608,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1643,7 +1643,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1678,7 +1678,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1719,7 +1719,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1754,7 +1754,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1833,7 +1833,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1868,7 +1868,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1903,7 +1903,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1938,7 +1938,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -35,7 +35,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -73,7 +73,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -112,7 +112,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -151,7 +151,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -190,7 +190,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -227,7 +227,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -324,7 +324,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -360,7 +360,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -419,7 +419,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -498,7 +498,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -697,7 +697,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1106,7 +1106,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1141,7 +1141,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1176,7 +1176,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1211,7 +1211,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1250,7 +1250,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1289,7 +1289,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1332,7 +1332,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1367,7 +1367,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1402,7 +1402,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1511,7 +1511,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1544,7 +1544,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1609,7 +1609,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1644,7 +1644,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1679,7 +1679,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1720,7 +1720,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1755,7 +1755,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1834,7 +1834,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1869,7 +1869,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1904,7 +1904,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1939,7 +1939,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1975,7 +1975,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2011,7 +2011,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -36,7 +36,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -75,7 +75,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -114,7 +114,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -153,7 +153,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -192,7 +192,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -231,7 +231,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -269,7 +269,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -307,7 +307,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -345,7 +345,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -441,7 +441,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -478,7 +478,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -604,7 +604,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -731,7 +731,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1167,7 +1167,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1204,7 +1204,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1244,7 +1244,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1286,7 +1286,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1326,7 +1326,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1362,7 +1362,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1400,7 +1400,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1483,7 +1483,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1553,7 +1553,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1589,7 +1589,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1670,7 +1670,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1709,7 +1709,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1745,7 +1745,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1781,7 +1781,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1817,7 +1817,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1856,7 +1856,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1895,7 +1895,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1931,7 +1931,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1967,7 +1967,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2003,7 +2003,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2042,7 +2042,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2078,7 +2078,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2116,7 +2116,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2154,7 +2154,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2192,7 +2192,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2228,7 +2228,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2266,7 +2266,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2305,7 +2305,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -36,7 +36,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -75,7 +75,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -170,7 +170,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -296,7 +296,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -351,7 +351,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -750,7 +750,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -789,7 +789,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -829,7 +829,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -869,7 +869,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -953,7 +953,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1023,7 +1023,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1059,7 +1059,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1140,7 +1140,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1176,7 +1176,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1212,7 +1212,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1251,7 +1251,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1287,7 +1287,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1325,7 +1325,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1363,7 +1363,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1401,7 +1401,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1439,7 +1439,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1477,7 +1477,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1515,7 +1515,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1553,7 +1553,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1591,7 +1591,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -92,7 +92,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -218,7 +218,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -278,7 +278,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -670,7 +670,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -709,7 +709,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -751,7 +751,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -793,7 +793,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -876,7 +876,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -945,7 +945,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -983,7 +983,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1067,7 +1067,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1107,7 +1107,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1145,7 +1145,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1184,7 +1184,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1226,7 +1226,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1269,7 +1269,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1309,7 +1309,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1349,7 +1349,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1387,7 +1387,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1429,7 +1429,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1469,7 +1469,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1509,7 +1509,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1549,7 +1549,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1587,7 +1587,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1629,7 +1629,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1669,7 +1669,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -94,7 +94,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -220,7 +220,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -282,7 +282,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -706,7 +706,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -748,7 +748,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -790,7 +790,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -885,7 +885,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -940,7 +940,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1008,7 +1008,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1046,7 +1046,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1130,7 +1130,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1173,7 +1173,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1213,7 +1213,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1255,7 +1255,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1297,7 +1297,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1338,7 +1338,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1378,7 +1378,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1418,7 +1418,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1460,7 +1460,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1502,7 +1502,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1542,7 +1542,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1612,7 +1612,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1654,7 +1654,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1696,7 +1696,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1736,7 +1736,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -94,7 +94,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -219,7 +219,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -281,7 +281,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -707,7 +707,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -751,7 +751,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -793,7 +793,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -887,7 +887,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -942,7 +942,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1010,7 +1010,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1048,7 +1048,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1132,7 +1132,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1175,7 +1175,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1216,7 +1216,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1258,7 +1258,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1300,7 +1300,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1342,7 +1342,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1382,7 +1382,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1454,7 +1454,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1496,7 +1496,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1538,7 +1538,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1580,7 +1580,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1620,7 +1620,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1662,7 +1662,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1704,7 +1704,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1746,7 +1746,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1786,7 +1786,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -94,7 +94,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -218,7 +218,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -280,7 +280,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -762,7 +762,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -806,7 +806,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -850,7 +850,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -945,7 +945,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1000,7 +1000,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1068,7 +1068,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1106,7 +1106,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1190,7 +1190,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1233,7 +1233,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1274,7 +1274,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1346,7 +1346,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1388,7 +1388,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1430,7 +1430,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1474,7 +1474,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1514,7 +1514,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1558,7 +1558,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1602,7 +1602,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1646,7 +1646,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1688,7 +1688,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1732,7 +1732,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1776,7 +1776,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1820,7 +1820,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1862,7 +1862,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -96,7 +96,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -220,7 +220,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -284,7 +284,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -765,7 +765,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -808,7 +808,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -851,7 +851,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -945,7 +945,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1000,7 +1000,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1068,7 +1068,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1105,7 +1105,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1189,7 +1189,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1231,7 +1231,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1271,7 +1271,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1344,7 +1344,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1387,7 +1387,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1430,7 +1430,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1471,7 +1471,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1514,7 +1514,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1557,7 +1557,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1600,7 +1600,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1641,7 +1641,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1736,7 +1736,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1779,7 +1779,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1822,7 +1822,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1863,7 +1863,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1906,7 +1906,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -101,7 +101,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -231,7 +231,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -297,7 +297,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -893,7 +893,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -939,7 +939,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -985,7 +985,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1083,7 +1083,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -1141,7 +1141,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: true
@@ -1215,7 +1215,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1255,7 +1255,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
   - always_run: false
@@ -1345,7 +1345,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1390,7 +1390,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1433,7 +1433,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1512,7 +1512,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1559,7 +1559,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1606,7 +1606,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1651,7 +1651,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1698,7 +1698,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1745,7 +1745,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1790,7 +1790,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1837,7 +1837,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1882,7 +1882,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -1983,7 +1983,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2029,7 +2029,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2075,7 +2075,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2119,7 +2119,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2165,7 +2165,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -143,7 +143,7 @@ periodics:
         privileged: true
       resources:
         requests:
-          memory: "29Gi"
+          memory: "52Gi"
 - name: periodic-kubevirtci-bump-centos-base-s390x
   cron: "0 4 * * 2" #Triggered at same time as x86 job so that both will run on same commit
   annotations:
@@ -202,4 +202,4 @@ periodics:
         privileged: true
       resources:
         requests:
-          memory: "29Gi"
+          memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -65,7 +65,7 @@ postsubmits:
             name: devices
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
     - name: publish-kubevirtci-s390x
       branches:
       - main
@@ -132,4 +132,4 @@ postsubmits:
             name: devices
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -156,7 +156,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -203,7 +203,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -268,7 +268,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 29Gi
+            memory: 52Gi
         securityContext:
           privileged: true
         volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -54,7 +54,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
             - name: OCI_BIN
               value: podman

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
@@ -91,4 +91,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.2.yaml
@@ -91,4 +91,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
@@ -94,4 +94,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.10.yaml
@@ -32,7 +32,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"
   - name: pull-node-maintenance-operator-check
     cluster: kubevirt-prow-control-plane
     branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
@@ -32,4 +32,4 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -32,7 +32,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"
   - name: pull-node-maintenance-operator-check
     cluster: kubevirt-prow-control-plane
     branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
@@ -32,7 +32,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            memory: "29Gi"
+            memory: "52Gi"
   - name: pull-node-maintenance-operator-check
     cluster: kubevirt-prow-control-plane
     branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -231,9 +231,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
               limits:
-                memory: "29Gi"
+                memory: "52Gi"
     - name: publish-shared-images-controller-image
       always_run: false
       run_if_changed: "images/shared-images-controller/.*"
@@ -442,9 +442,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
               limits:
-                memory: "29Gi"
+                memory: "52Gi"
     - name: publish-vm-image-builder-image
       always_run: false
       run_if_changed: "images/vm-image-builder/.*"
@@ -474,9 +474,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
               limits:
-                memory: "29Gi"
+                memory: "52Gi"
     - name: publish-fedora-coreos-kubevirt-image
       always_run: false
       run_if_changed: "images/fedora-coreos-kubevirt/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -412,9 +412,9 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
             limits:
-              memory: "29Gi"
+              memory: "52Gi"
   - name: build-vm-image-builder-image
     always_run: false
     run_if_changed: "images/bootstrap/.*"
@@ -522,7 +522,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
           volumeMounts:
           - name: molecule-docker
             mountPath: /tmp/prow-deploy-molecule
@@ -606,9 +606,9 @@ presubmits:
           image: quay.io/kubevirtci/golang:v20250211-4e3c019
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"
             limits:
-              memory: "29Gi"
+              memory: "52Gi"
           securityContext:
             privileged: true
             runAsUser: 0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -28,4 +28,4 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "29Gi"
+              memory: "52Gi"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -114,7 +114,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -113,7 +113,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -141,7 +141,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.43.yaml
@@ -49,7 +49,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -78,7 +78,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -107,7 +107,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.47.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.47.yaml
@@ -49,7 +49,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -78,7 +78,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
@@ -51,7 +51,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
@@ -82,7 +82,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
@@ -53,7 +53,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.17"
@@ -87,7 +87,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.17"

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -57,7 +57,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.18"
@@ -93,7 +93,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.18"
@@ -161,7 +161,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.16"
@@ -196,7 +196,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.16"

--- a/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
               privileged: true
             resources:
               requests:
-                memory: "29Gi"
+                memory: "52Gi"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"


### PR DESCRIPTION
**What this PR does / why we need it**:


Memory per node was doubled when the new prow workloads was created. As we split up node resources by memory requests, this means that a larger number of jobs are scheduled to each node. We have seen that this increased workload has caused stability issues with the in cluster container image cache[1][2] and has also significantly increased lane runtimes when the cluster is loaded.

Increase the standard memory request from 29Gi to 52Gi to reduce the number of jobs that can be scheduled to each node.

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14128/pull-kubevirt-e2e-k8s-1.32-sig-compute-serial/1897341187082162176
[2] https://search.ci.kubevirt.io/?search=net%2Fhttp%3A+TLS+handshake+timeout&maxAge=168h&context=1&type=build-log&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
