### PR TITLE
fix: release-tool image push

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -113,6 +113,8 @@ postsubmits:
                 memory: "8Gi"
               limits:
                 memory: "8Gi"
+            securityContext:
+              privileged: true
     - name: publish-botreview-image
       always_run: false
       run_if_changed: "external-plugins/botreview/.*"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

release-tool image push job has to run privileged [1]. Rehearse run [2]

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-release-tool-image/1900115653214343168
[2]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-release-
tool-image/1900118963895930880

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey 
