### PR TITLE
fix: let phased plugin run tests for skip-review PRs

### DIFF
--- a/external-plugins/phased/plugin/handler/handler.go
+++ b/external-plugins/phased/plugin/handler/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	pi_github "kubevirt.io/project-infra/robots/pkg/github"
+	kubeVirtLabels "kubevirt.io/project-infra/robots/pkg/github/labels"
 	"net/http"
 	"os"
 	"os/exec"
@@ -190,7 +191,8 @@ func (h *GitHubEventsHandler) shouldRunPhase2(org, repo, eventLabel string, prNu
 	}
 
 	return (eventLabel == labels.LGTM && github.HasLabel(labels.Approved, l)) ||
-		(eventLabel == labels.Approved && github.HasLabel(labels.LGTM, l)), nil
+		(eventLabel == labels.Approved && github.HasLabel(labels.LGTM, l)) ||
+		(eventLabel == kubeVirtLabels.SkipReview), nil
 }
 
 func catFile(log *logrus.Logger, gitDir, file, refspec string) ([]byte, int) {

--- a/external-plugins/phased/plugin/phased_test.go
+++ b/external-plugins/phased/plugin/phased_test.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/prow/pkg/labels"
 
 	"kubevirt.io/project-infra/external-plugins/phased/plugin/handler"
+	kubeVirtLabels "kubevirt.io/project-infra/robots/pkg/github/labels"
 )
 
 const (
@@ -193,6 +194,12 @@ var _ = Describe("Phased", func() {
 					AddedLabel:      labels.Approved,
 					LGTMLabelExists: false,
 					ExpectComment:   false}),
+			Entry("Skip Review is added, LGTM and Approve dont exist",
+				TestCase{
+					AddedLabel:         kubeVirtLabels.SkipReview,
+					ApproveLabelExists: false,
+					LGTMLabelExists:    false,
+					ExpectComment:      true}),
 		)
 
 	})

--- a/robots/pkg/github/labels/labels.go
+++ b/robots/pkg/github/labels/labels.go
@@ -1,0 +1,24 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package labels
+
+const (
+	SkipReview = "skip-review"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We noticed that the automated tests aren't being run if a PR with `skip-review` label is added and the phased plugin is active for a repository. I.e. this hinders auto bump PRs in k/kubevirt to get merged. Example: https://github.com/kubevirt/kubevirt/pull/14211

This change adds `skip-review` support to the phased plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @oshoval @brianmcarey @iholder101

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
