### PR TITLE
Adds test lanes for Debian 11 and 12 preferences and containerdisks.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -695,6 +695,192 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-debian-11
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: GIMME_GO_VERSION
+              value: 1.23.7
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Debian 11"'
+          image: quay.io/kubevirtci/golang:v20250211-4e3c019
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-debian-11-arm64
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 1
+    optional: true
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "sudo dnf install binutils-gold -y && make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: GIMME_GO_VERSION
+              value: 1.23.7
+            - name: KUBEVIRT_PROVIDER
+              value: kind-1.28
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Debian 11"'
+          image: quay.io/kubevirtci/golang:v20250211-4e3c019
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            - mountPath: /var/log/audit
+              name: audit
+      volumes:
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+        - hostPath:
+            path: /var/log/audit
+            type: Directory
+          name: audit
+  - name: pull-common-instancetypes-kubevirt-debian-12
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: GIMME_GO_VERSION
+              value: 1.23.7
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Debian 12"'
+          image: quay.io/kubevirtci/golang:v20250211-4e3c019
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-debian-12-arm64
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 1
+    optional: true
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "sudo dnf install binutils-gold -y && make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: GIMME_GO_VERSION
+              value: 1.23.7
+            - name: KUBEVIRT_PROVIDER
+              value: kind-1.28
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Debian 12"'
+          image: quay.io/kubevirtci/golang:v20250211-4e3c019
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /sys/fs/cgroup
+              name: cgroup
+            - mountPath: /var/log/audit
+              name: audit
+      volumes:
+        - hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+          name: cgroup
+        - hostPath:
+            path: /var/log/audit
+            type: Directory
+          name: audit
   - name: pull-build-common-instancetypes-builder
     always_run: false
     run_if_changed: "image/.*"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -124,6 +124,41 @@ presubmits:
         securityContext:
           privileged: true
   - always_run: false
+    run_if_changed: "artifacts/debian/.*"
+    annotations:
+      testgrid-create-test-group: "false"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 11
+    name: pull-containerdisks-pipeline-debian
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -c
+            - ./pipeline.sh
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.24.1"
+            - name: FOCUS
+              value: "debian:*"
+          image: quay.io/kubevirtci/golang:v20250211-4e3c019
+          name: ""
+          resources:
+            requests:
+              memory: 12Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
     run_if_changed: "artifacts/centosstream/.*"
     annotations:
       testgrid-create-test-group: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:

Onboards test lanes for projects:
* CommonInstanceTypes: Four test lanes for Debian 11 and 12 containerdisk for each arch amd64 and arm64.
* Containerdisks: One test lane for Debian contaierdisks

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-51711](https://issues.redhat.com/browse/CNV-51711) and [CNV-51712](https://issues.redhat.com/browse/CNV-51712)

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added test lanes for Debian 11 and 12 in containerdisk and common-instancetypes projects.
```
