### PR TITLE
fix: add links to own prow and own merge workflow

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -688,13 +688,15 @@ approve:
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
-  commandHelpLink: https://go.k8s.io/bot-commands
+  commandHelpLink: https://prow.ci.kubevirt.io/command-help
+  pr_process_link: https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md#example-workflow
 - repos:
   - kubevirt/secrets
   require_self_approval: false
   lgtm_acts_as_approve: true
   ignore_review_state: true
-  commandHelpLink: https://go.k8s.io/bot-commands
+  commandHelpLink: https://prow.ci.kubevirt.io/command-help
+  pr_process_link: https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md#example-workflow
 
 lgtm:
 - repos:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We are currently relying on the Kubernetes managed prow and documentation, but we want to link to our own prow instance and documentation. This change links to the merge automation doc which contains a description of the basic merge workflow.

It also links to our own prow command help page, since the installed plugins differ from the main k8s prow instance.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubevirt/community#370

**Special notes for your reviewer**:
/cc @aburdenthehand @brianmcarey 