### PR TITLE
fix: correct test-subset external-plugin compile source path

### DIFF
--- a/external-plugins/test-subset/Containerfile
+++ b/external-plugins/test-subset/Containerfile
@@ -9,7 +9,7 @@ RUN mkdir kubevirt && \
     cd kubevirt && \
     git clone https://github.com/kubevirt/project-infra.git && \
     cd project-infra && \
-    /usr/local/bin/runner.sh /bin/sh -c "env GOPROXY=off go build -tags netgo -o /go/bin/test-subset ./external-plugins/test-subset/main.go"
+    /usr/local/bin/runner.sh /bin/sh -c "env GOPROXY=off go build -tags netgo -o /go/bin/test-subset ./external-plugins/test-subset/plugin/main.go"
 
 FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
 COPY --from=builder /go/bin/test-subset /usr/bin/test-subset

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -488,6 +488,30 @@ presubmits:
               memory: "1Gi"
             limits:
               memory: "1Gi"
+  - name: build-test-subset-image
+    always_run: false
+    run_if_changed: "images/test-subset/.*|external-plugins/test-subset/.*"
+    decorate: true
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    cluster: kubevirt-prow-control-plane
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/bash"
+            - "-ce"
+            - "cd images && ./publish_image.sh -b test-subset quay.io kubevirtci"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "1Gi"
+            limits:
+              memory: "1Gi"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
     run_if_changed: "github/ci/prow-deploy/.*"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: test-subset
-          image: quay.io/kubevirtci/test-subset:v20240108-87253b59
+          image: quay.io/kubevirtci/test-subset:v20250319-03c04fe
           imagePullPolicy: IfNotPresent
           args:
             - --github-token-path=/etc/github/oauth


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Changes
* fixes the compile path for the test-subset external-plugin.
* adds a presubmit that checks whether the image for test-subset is buildable
* updates the image for test-subset to latest in deployment

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey @oshoval 
