### PR TITLE
prow, rehearse: improvements to comment

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -31,12 +31,22 @@ import (
 	"sigs.k8s.io/prow/pkg/pjutil"
 )
 
-const basicHelpCommentText = `You can trigger rehearsal for all jobs by commenting either ` + "`/rehearse`" + ` or ` + "`/rehearse all`" + `
-on this PR.
+const basicHelpCommentText = `
+A rehearsal can be triggered for all jobs by commenting either ` + "`/rehearse`" + ` or ` + "`/rehearse all`" + ` on this PR.
 
-For a specific PR you can comment ` + "`/rehearse {job-name}`" + `.
+A rehearsal for a specific job can be triggered by commenting ` + "`/rehearse {job-name}`" + `.
 
-For a list of jobs that you can rehearse you can comment ` + "`/rehearse ?`" + `.`
+Commenting ` + "`/rehearse ?`" + ` triggers a comment with a list of jobs that can be rehearsed.
+
+A pull request can be rehearsed if either the user is authorized to rehearse or the pull
+request has the ` + "`ok-to-rehearse`" + ` label.
+
+Authorized users are the group of users that are members of the KubeVirt GitHub 
+organization AND either are approvers[1] for all files in the pull request or are
+top-level approvers[1] in the ` + "`project-infra`" + ` project.
+
+[1]: see [OWNERS](https://www.kubernetes.dev/docs/guide/owners/#owners) file definition for reference.
+`
 
 var log *logrus.Logger
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The comment currently is not entirely correct. It neglects the recent changes due to the group of people being allowed to rehearse. Also the comment around how to use the plugin should be hidden in a details section, in order to reduce the visible size of the comment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubevirt/project-infra/issues/3840

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
