### PR TITLE
removed outdated job config for kubevirt versions 0.3x.xx

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -55,41 +55,6 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
-  - name: push-update-testing-manifests-on-kubevirt-tag
-    branches:
-    - ^v0\.3[46]\.[0-9]+$
-    cluster: kubevirt-prow-control-plane
-    always_run: true
-    annotations:
-      testgrid-create-test-group: "false"
-    decorate: true
-    decoration_config:
-      timeout: 1h
-      grace_period: 5m
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-gcs-credentials: "true"
-    spec:
-      containers:
-      - image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
-        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
-        args:
-        - |
-          set -xe
-          DOCKER_TAG="$(git tag --points-at HEAD | head -1)"
-          if [ -z "$DOCKER_TAG" ]; then
-            echo "commit $(git show -s --format=%h) doesn't have a tag, exiting..."
-            exit 0
-          fi
-          make manifests
-          gsutil -m rm -r "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG" || true
-          gsutil cp -r "_out/manifests/testing" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG/manifests/"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            memory: "8Gi"
   - name: push-kubevirt-main
     branches:
     - main


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
There's a job config [3](https://github.com/kubevirt/project-infra/blob/22b13988c9b751a829caced2625a40f267d7f10b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml#L58C11-L58C56) that is outdated (it is configured to work on 0.34 and 0.36 branches only [2](https://github.com/kubevirt/project-infra/blob/main/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml#L60)) and hasn't been run in tree years [1](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/push-update-testing-manifests-on-kubevirt-tag)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubevirt/project-infra/issues/3768

**Special notes for your reviewer**:
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
