### PR TITLE
fix: describe-images has a non optional hyphen

### DIFF
--- a/hack/describe-pr-from-updated-images-in-diff.sh
+++ b/hack/describe-pr-from-updated-images-in-diff.sh
@@ -21,8 +21,7 @@
 
 set -euo pipefail
 
-BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-PROJECT_INFRA_ROOT=$(readlink --canonicalize ${BASEDIR}/..)
+PROJECT_INFRA_ROOT=$(readlink --canonicalize "$( dirname "${BASH_SOURCE[0]}" )/..")
 
 function main() {
     headline="Bump prow-deploy images"
@@ -39,8 +38,8 @@ FYI @kubevirt/prow-job-taskforce
 Images updated:
 EOF
     for image in $(
-        git diff -- ${PROJECT_INFRA_ROOT}/github/ci/prow-deploy | \
-            grep -E '^\+\s+- image: ' | \
+        git show -- "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy" | \
+            grep -E '^\+\s+-? image: ' | \
             grep -oE 'quay.io/kubevirtci/[^: @]+' | \
             sort -u
     ); do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The grep for the image name only worked if the image was at the top of the container configuration. This change makes the hyphen optional.

Also it simplifies the determination of the absolute path name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4033

**Special notes for your reviewer**:

/cc @enp0s3 @brianmcarey 
