### PR TITLE
Escape auth_header value with quotes

### DIFF
--- a/images/bootstrap/gcs_restapi.sh
+++ b/images/bootstrap/gcs_restapi.sh
@@ -15,7 +15,7 @@
 
 BASE_URL="https://storage.googleapis.com"
 
-# Function to validate GOOGLE_APPLICATION_CREDENTIALS and and set access_token global variable
+# Function to validate GOOGLE_APPLICATION_CREDENTIALS and set access_token global variable
 get_access_token() {
     if [ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
         echo "GOOGLE_APPLICATION_CREDENTIALS is not set. Please set it to the path of your service account key file."
@@ -56,7 +56,7 @@ get_auth_header() {
     fi
 
     get_access_token || exit 1
-    echo "-H \"Authorization: Bearer $access_token\""
+    echo "Authorization: Bearer $access_token"
 }
 
 urlencode_path() {
@@ -75,7 +75,7 @@ upload_to_gcs() {
 
     upload_response=$(curl -X POST \
       --data-binary @"$source_file" \
-      $auth_header \
+      -H "$auth_header" \
       -H "Content-Type: $content_type" \
       "${BASE_URL}/upload/storage/v1/b/$bucket_name/o?uploadType=media&name=$destination_blob")
 
@@ -98,7 +98,7 @@ stat_gcs_file() {
     auth_header=$(get_auth_header "$auth") || exit 1
 
     stat_response=$(curl -s -X GET \
-      $auth_header \
+      ${auth_header:+-H "$auth_header"} \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
 
     if echo "$stat_response" | jq -e '.error' > /dev/null; then
@@ -117,7 +117,7 @@ cat_gcs_file() {
     auth_header=$(get_auth_header "$auth") || exit 1
 
     file_content=$(curl --silent --fail -X GET \
-      $auth_header \
+      ${auth_header:+-H "$auth_header"} \
       -H "Cache-Control: no-cache" \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path?alt=media&ignoreCache=1")
 
@@ -138,7 +138,7 @@ rm_gcs_file() {
     auth_header=$(get_auth_header) || exit 1
 
     delete_response=$(curl -s -X DELETE \
-      $auth_header \
+      -H "$auth_header" \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
 
     if [ -z "$delete_response" ]; then


### PR DESCRIPTION

**What this PR does / why we need it**:
This fixes the bug https://github.com/kubevirt/kubevirtci/issues/1405 in the file images/bootstrap/gcs_restapi.sh used by s390x image publish jobs. The auth_header was malformed, due to improper quotes. This is fixed now!

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubevirt/kubevirtci/issues/1405

**Special notes for your reviewer**:
/cc @brianmcarey 
Earlier I've tested only stat_gcs_file and cat_gcs_file functions and as for these functions I was passing public file for testing, though auth was malformed they were working. So the issue [#1405](https://github.com/kubevirt/kubevirtci/issues/1405) isn't identified. Now I've tested all functions (rm_gcs_file and upload_to_gcs) w/ and w/o auth they support and found all are working as expected (also verified URLs formed)

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
