### PR TITLE
prow,workloads: Increase resource requests/limits for image proxy and bazel cache

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/prow-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-workloads/kustomization.yaml
@@ -15,6 +15,20 @@ resources:
 components:
   - ../../components/docker-mirror-proxy/hostpath
 
+patches:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: docker-mirror-proxy
+    path: patches/JsonRFC6902/docker_mirror_deployment.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: greenhouse
+    path: patches/JsonRFC6902/greenhouse_deployment.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 

--- a/github/ci/prow-deploy/kustom/overlays/prow-workloads/patches/JsonRFC6902/docker_mirror_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-workloads/patches/JsonRFC6902/docker_mirror_deployment.yaml
@@ -1,0 +1,10 @@
+# sets resources
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    requests:
+      cpu: 4
+      memory: 8Gi
+    limits:
+      cpu: 4
+      memory: 8Gi

--- a/github/ci/prow-deploy/kustom/overlays/prow-workloads/patches/JsonRFC6902/greenhouse_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-workloads/patches/JsonRFC6902/greenhouse_deployment.yaml
@@ -1,0 +1,10 @@
+# sets resources
+- op: replace
+  path: /spec/template/spec/containers/0/resources
+  value:
+    requests:
+      cpu: 4
+      memory: 8Gi
+    limits:
+      cpu: 4
+      memory: 8Gi


### PR DESCRIPTION
**What this PR does / why we need it**:

These services run on a dedicated cache node in the workloads cluster - it doesn't make sense to limit there resources so much.

It has also been seen that there are performance issues with the docker image cache when a large number of jobs are run and the jobs begin to fail to pull the images[1]. When these issues occur, the docker-mirror-proxy pod hits it's CPU limits and starts to throttle the CPU usage.

![screenshot-2025-03-27-08:02:00](https://github.com/user-attachments/assets/0865afb6-28cb-4744-8bd1-915096c1f681)

Increase the resource requests & limits for both the docker-mirror-proxy and greenhouse (bazel cache).

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14352/pull-kubevirt-e2e-k8s-1.30-sig-storage-1.3/1905156088500588544#1:build-log.txt%3A385

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
