### PR TITLE
fix: prowjob config reporter config explicit bool field `report` added

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/mod v0.19.0
 	golang.org/x/oauth2 v0.22.0
+	gonum.org/v1/gonum v0.12.0
 	gonum.org/v1/plot v0.12.0
 	google.golang.org/api v0.191.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/robots/pkg/kubevirt/cmd/copy/jobs_test.go
+++ b/robots/pkg/kubevirt/cmd/copy/jobs_test.go
@@ -37,6 +37,18 @@ import (
 	"kubevirt.io/project-infra/robots/pkg/querier"
 )
 
+var (
+	pTrue  *bool
+	pFalse *bool
+)
+
+func init() {
+	vTrue := true
+	pTrue = &vTrue
+	vFalse := false
+	pFalse = &vFalse
+}
+
 func Test_getSourceAndTargetRelease(t *testing.T) {
 	type args struct {
 		releases []*github.RepositoryRelease
@@ -153,87 +165,87 @@ func Test_copyPeriodicJobsForNewProvider(t *testing.T) {
 		*/
 		// TODO it seems that job_states_to_report has gotten an omitempty which effectively removes it when serializing
 		// need to see whether we can reactivate the test
-		//{
-		//	name: "reporterconfig with empty job states slice is preserved even with no job state to report",
-		//	args: args{
-		//		jobConfig: &config.JobConfig{
-		//			Periodics: []config.Periodic{
-		//				{
-		//					JobBase: config.JobBase{
-		//						Labels: map[string]string{},
-		//						ReporterConfig: &v1.ReporterConfig{
-		//							Slack: &v1.SlackReporterConfig{
-		//								JobStatesToReport: []v1.ProwJobState{},
-		//							},
-		//						},
-		//						Name: prowjobconfigs.CreatePeriodicJobName(semver("1", "21", "0"), "sig-network"),
-		//						Spec: &corev1.PodSpec{
-		//							Containers: []corev1.Container{
-		//								{
-		//									Env: []corev1.EnvVar{},
-		//								},
-		//							},
-		//						},
-		//					},
-		//					Interval: "",
-		//					Cron:     "0 1,9,17 * * *",
-		//					Tags:     nil,
-		//				},
-		//			},
-		//		},
-		//		targetProviderReleaseSemver: semver("1", "22", "0"),
-		//		sourceProviderReleaseSemver: semver("1", "21", "0"),
-		//	},
-		//	wantUpdated: true,
-		//	wantJobConfig: &config.JobConfig{
-		//		Periodics: []config.Periodic{
-		//			{
-		//				JobBase: config.JobBase{
-		//					Labels: map[string]string{},
-		//					Name:   prowjobconfigs.CreatePeriodicJobName(semver("1", "21", "0"), "sig-network"),
-		//					ReporterConfig: &v1.ReporterConfig{
-		//						Slack: &v1.SlackReporterConfig{
-		//							JobStatesToReport: []v1.ProwJobState{},
-		//						},
-		//					},
-		//					Spec: &corev1.PodSpec{
-		//						Containers: []corev1.Container{
-		//							{
-		//								Env: []corev1.EnvVar{},
-		//							},
-		//						},
-		//					},
-		//				},
-		//				Interval: "",
-		//				Cron:     "0 1,9,17 * * *",
-		//				Tags:     nil,
-		//			},
-		//			{
-		//				JobBase: config.JobBase{
-		//					Annotations: map[string]string{},
-		//					Labels:      map[string]string{},
-		//					Name:        prowjobconfigs.CreatePeriodicJobName(semver("1", "22", "0"), "sig-network"),
-		//					ReporterConfig: &v1.ReporterConfig{
-		//						Slack: &v1.SlackReporterConfig{
-		//							JobStatesToReport: []v1.ProwJobState{},
-		//						},
-		//					},
-		//					Spec: &corev1.PodSpec{
-		//						Containers: []corev1.Container{
-		//							{
-		//								Env: []corev1.EnvVar{},
-		//							},
-		//						},
-		//					},
-		//				},
-		//				Interval: "",
-		//				Cron:     "10 2,10,18 * * *",
-		//				Tags:     nil,
-		//			},
-		//		},
-		//	},
-		//	wantJobStatesToReportInSerialization: true,
-		//},
+		{
+			name: "reporterconfig with empty job states slice is preserved even with no job state to report",
+			args: args{
+				jobConfig: &config.JobConfig{
+					Periodics: []config.Periodic{
+						{
+							JobBase: config.JobBase{
+								Labels: map[string]string{},
+								ReporterConfig: &v1.ReporterConfig{
+									Slack: &v1.SlackReporterConfig{
+										Report: pFalse,
+									},
+								},
+								Name: prowjobconfigs.CreatePeriodicJobName(semver("1", "21", "0"), "sig-network"),
+								Spec: &corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Env: []corev1.EnvVar{},
+										},
+									},
+								},
+							},
+							Interval: "",
+							Cron:     "0 1,9,17 * * *",
+							Tags:     nil,
+						},
+					},
+				},
+				targetProviderReleaseSemver: semver("1", "22", "0"),
+				sourceProviderReleaseSemver: semver("1", "21", "0"),
+			},
+			wantUpdated: true,
+			wantJobConfig: &config.JobConfig{
+				Periodics: []config.Periodic{
+					{
+						JobBase: config.JobBase{
+							Labels: map[string]string{},
+							Name:   prowjobconfigs.CreatePeriodicJobName(semver("1", "21", "0"), "sig-network"),
+							ReporterConfig: &v1.ReporterConfig{
+								Slack: &v1.SlackReporterConfig{
+									Report: pFalse,
+								},
+							},
+							Spec: &corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{},
+									},
+								},
+							},
+						},
+						Interval: "",
+						Cron:     "0 1,9,17 * * *",
+						Tags:     nil,
+					},
+					{
+						JobBase: config.JobBase{
+							Annotations: map[string]string{},
+							Labels:      map[string]string{},
+							Name:        prowjobconfigs.CreatePeriodicJobName(semver("1", "22", "0"), "sig-network"),
+							ReporterConfig: &v1.ReporterConfig{
+								Slack: &v1.SlackReporterConfig{
+									Report: pFalse,
+								},
+							},
+							Spec: &corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{},
+									},
+								},
+							},
+						},
+						Interval: "",
+						Cron:     "10 2,10,18 * * *",
+						Tags:     nil,
+					},
+				},
+			},
+			wantJobStatesToReportInSerialization: false,
+		},
 		{
 			name: "extra_refs field exists for new provider job",
 			args: args{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

we need to check that the old method of cpoying the empty slice doesn't work anymore since the slice will be omitted

Luckily they've added a 'report' property to cover though

What we need to do is adjust the test to check whether it copies the state of the report property to the new configuration.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

## Summary by Sourcery

Update test configuration for prowjob reporter config to handle explicit boolean 'report' field

Bug Fixes:
- Fixed test to correctly preserve the 'report' configuration when copying job configurations between releases

Enhancements:
- Added predefined boolean pointers (pTrue and pFalse) to simplify boolean reference handling in tests

Tests:
- Modified test case for periodic jobs to include an explicit 'report' boolean field in the reporter configuration