### PR TITLE
fix(flakefinder): update pr_base_branch for jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -21,6 +21,7 @@ periodics:
             - --org=k8snetworkplumbingwg
             - --repo=kubemacpool
             - --skip_results_before_start_of_report=false
+            - --pr_base_branch=main
           volumeMounts:
             - name: token
               mountPath: /etc/github
@@ -56,6 +57,7 @@ periodics:
             - --org=k8snetworkplumbingwg
             - --repo=kubemacpool
             - --skip_results_before_start_of_report=false
+            - --pr_base_branch=main
           volumeMounts:
             - name: token
               mountPath: /etc/github
@@ -91,6 +93,7 @@ periodics:
             - --org=k8snetworkplumbingwg
             - --repo=kubemacpool
             - --skip_results_before_start_of_report=false
+            - --pr_base_branch=main
           volumeMounts:
             - name: token
               mountPath: /etc/github

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -20,6 +20,7 @@ periodics:
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
+      - --pr_base_branch=main
 - name: periodic-publish-cnao-flakefinder-daily-report
   cron: "15 1 * * *"
   annotations:
@@ -41,6 +42,7 @@ periodics:
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
+      - --pr_base_branch=main
 - name: periodic-publish-cnao-flakefinder-four-weekly-report
   interval: 168h
   annotations:
@@ -62,3 +64,4 @@ periodics:
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
       - --skip_results_before_start_of_report=false
+      - --pr_base_branch=main

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -21,6 +21,7 @@ periodics:
       - --org=nmstate
       - --repo=kubernetes-nmstate
       - --skip_results_before_start_of_report=false
+      - --pr_base_branch=main
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -56,6 +57,7 @@ periodics:
       - --org=nmstate
       - --repo=kubernetes-nmstate
       - --skip_results_before_start_of_report=false
+      - --pr_base_branch=main
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -91,6 +93,7 @@ periodics:
       - --org=nmstate
       - --repo=kubernetes-nmstate
       - --skip_results_before_start_of_report=false
+      - --pr_base_branch=main
       volumeMounts:
       - name: token
         mountPath: /etc/github


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

A while ago the base branch for projects

* k8snetworkplumbingwg/kubemacpool
* kubevirt/cluster-network-addons-operator
* nmstate/kubernetes-nmstate

has been moved from `master` to `main`, which caused the flakefinder to not find any PRs any more.

This change updates the base branch flag `pr_base_branch` for above projects, so PRs can be found again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey 

FYI @RamLavi 
