### PR TITLE
fix(kubevirt generate): move presubmit to workloads

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -304,7 +304,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
-    cluster: kubevirt-prow-control-plane
+    cluster: prow-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Moving this job over to the workloads cluster as it is one of the heavier jobs. Also it suffers from timeouts, probably related to resouce issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4077

**Special notes for your reviewer**:

/cc @brianmcarey 