### PR TITLE
lint: Remove GOLANGCI_LINT_VERSION env var from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,6 @@ flake-issue-creator := robots/cmd/flake-issue-creator
 querier := robots/cmd/release-querier
 kubevirtci := robots/cmd/kubevirtci-bumper
 
-ifndef GOLANGCI_LINT_VERSION
-	GOLANGCI_LINT_VERSION=v1.62.2
-	export GOLANGCI_LINT_VERSION
-endif
 ifndef ARTIFACTS
 	ARTIFACTS=/tmp/artifacts
 	export ARTIFACTS


### PR DESCRIPTION
**What this PR does / why we need it**:

The GOLANGCI_LINT_VERSION env var is no longer required since the removal of the install of golangci-lint binary[1]

[1] https://github.com/kubevirt/project-infra/pull/4087

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
