### PR TITLE
Enabled govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,7 @@ linters:
 #  - staticcheck
   - unused
 #  - ineffassign
-#  - govet
+  - govet
   - gosimple
 #  - errcheck
 #linters-settings:

--- a/robots/cmd/per-test-execution/main.go
+++ b/robots/cmd/per-test-execution/main.go
@@ -93,7 +93,9 @@ func (o options) loadDefaults() error {
 	if opts.K8sVersion == "" {
 		log.Info("loading default stable k8s version")
 		resp, err := http.Get("https://dl.k8s.io/release/stable.txt")
-		defer resp.Body.Close()
+		if err := resp.Body.Close(); err != nil {
+			return fmt.Errorf("failed to close response body: %v", err)
+		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err

--- a/robots/cmd/perf-report-creator/main.go
+++ b/robots/cmd/perf-report-creator/main.go
@@ -137,7 +137,6 @@ func runResults(r resultOpts) error {
 	}
 	if err != nil {
 		return fmt.Errorf("Failed to create new storage client: %v.\n", err)
-		return err
 	}
 
 	jobsDirs, err := listAllRunsForJob(ctx, storageClient, r.performanceJobName)

--- a/robots/pkg/kubevirt/release/release_test.go
+++ b/robots/pkg/kubevirt/release/release_test.go
@@ -41,29 +41,29 @@ func Test_getLatestMinorReleases(t *testing.T) {
 			name: "two elements, same minor",
 			args: args{
 				releases: []*querier.SemVer{
-					{"1", "17", "42"},
-					{"1", "17", "37"},
+					{Major: "1", Minor: "17", Patch: "42"},
+					{Major: "1", Minor: "17", Patch: "37"},
 				},
 			},
 			wantLatestMinorReleases: []*querier.SemVer{
-				{"1", "17", "42"},
+				{Major: "1", Minor: "17", Patch: "42"},
 			},
 		},
 		{
 			name: "five elements, three minors",
 			args: args{
 				releases: []*querier.SemVer{
-					{"1", "17", "42"},
-					{"1", "17", "37"},
-					{"1", "16", "4"},
-					{"1", "16", "3"},
-					{"1", "15", "1"},
+					{Major: "1", Minor: "17", Patch: "42"},
+					{Major: "1", Minor: "17", Patch: "37"},
+					{Major: "1", Minor: "16", Patch: "4"},
+					{Major: "1", Minor: "16", Patch: "3"},
+					{Major: "1", Minor: "15", Patch: "1"},
 				},
 			},
 			wantLatestMinorReleases: []*querier.SemVer{
-				{"1", "17", "42"},
-				{"1", "16", "4"},
-				{"1", "15", "1"},
+				{Major: "1", Minor: "17", Patch: "42"},
+				{Major: "1", Minor: "16", Patch: "4"},
+				{Major: "1", Minor: "15", Patch: "1"},
 			},
 		},
 	}

--- a/robots/pkg/kubevirtci/kubevirtci_test.go
+++ b/robots/pkg/kubevirtci/kubevirtci_test.go
@@ -330,7 +330,7 @@ func release(tagName string, released bool) *github.RepositoryRelease {
 		TagName: &tagName,
 	}
 	if released {
-		release.PublishedAt = &github.Timestamp{time.Now()}
+		release.PublishedAt = &github.Timestamp{Time: time.Now()}
 	}
 	return release
 }

--- a/robots/pkg/querier/queries_test.go
+++ b/robots/pkg/querier/queries_test.go
@@ -248,7 +248,7 @@ func release(tagName string, released bool) *github.RepositoryRelease {
 		TagName: &tagName,
 	}
 	if released {
-		release.PublishedAt = &github.Timestamp{time.Now()}
+		release.PublishedAt = &github.Timestamp{Time: time.Now()}
 	}
 	return release
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
- Enabled govet linter

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #3837 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
