### PR TITLE
aaq,builder: Ensure builder image is multi-arch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
@@ -156,7 +156,8 @@ postsubmits:
     branches:
     - main
     cluster: kubevirt-prow-control-plane
-    always_run: true
+    always_run: false
+    run_if_changed: "hack/build/builder/.*"
     optional: false
     skip_report: true
     annotations:
@@ -165,6 +166,7 @@ postsubmits:
     decoration_config:
       timeout: 3h
       grace_period: 5m
+    max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -172,18 +174,17 @@ postsubmits:
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
+      nodeSelector:
+        type: bare-metal-external
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
-        env:
-        - name: DOCKER_PREFIX
-          value: quay.io/kubevirt
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
-          - "-ce"
-          - |
-            cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
-            aaq_CONTAINER_BUILDCMD=buildah make builder-push
+          - "-c"
+          - >
+            cat "$QUAY_PASSWORD" | podman login quay.io --username $(cat "$QUAY_USER") --password-stdin=true &&
+            make builder-push
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Adapt to the changes introduced by the new scripts for building the image. Ensure that the builder image is only built when needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adapt the CI lane to the changes of https://github.com/kubevirt/application-aware-quota/pull/135.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Needs to be merged before https://github.com/kubevirt/application-aware-quota/pull/135
**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
