### PR TITLE
Fix the periodic-kubevirtci-bump-kubevirt job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -232,7 +232,7 @@ periodics:
           - |
             set -e
             if labels-checker --org=kubevirt --repo=hyperconverged-cluster-operator --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
-              git-pr.sh -c "cd ../hyperconverged-cluster-operator && make bump-kubevirtci" -d "./hack/whatchanged.sh" -b bump-kubevirtci -p ../hyperconverged-cluster-operator -T main
+              git-pr.sh -c "cd ../hyperconverged-cluster-operator && make bump-kubevirtci" -b bump-kubevirtci -p ../hyperconverged-cluster-operator -T main -R
             fi
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
The current configuration is trying to call git-pr.sh with `-d`, pointing to not existing script. That causes failing of the job.

Fixing by removing the `-d` parameter and adding the `-R` to add release-notes of None in the PR description.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the periodic-kubevirtci-bump-kubevirt job
```
