### PR TITLE
chore(common-instancetypes): Adjust CentOS 7 and OpenSuse test jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
@@ -255,6 +255,84 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-tumbleweed-1.1
+    branches:
+      - release-1.1
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*OpenSUSE Tumbleweed"'
+          image: quay.io/kubevirtci/golang:v20240308-8fac017
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-leap-1.1
+    branches:
+      - release-1.1
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*OpenSUSE Leap"'
+          image: quay.io/kubevirtci/golang:v20240308-8fac017
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - name: pull-common-instancetypes-kubevirt-functest-validation-os-1.1
     branches:
       - release-1.1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
@@ -99,45 +99,6 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - name: pull-common-instancetypes-kubevirt-functest-centos-7-1.2
-    branches:
-      - release-1.2
-    always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 1
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - "/bin/sh"
-        - "-c"
-        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
-        env:
-        - name: KUBEVIRT_MEMORY_SIZE
-          value: 16G
-        - name: FUNCTEST_EXTRA_ARGS
-          value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*CentOS 7"'
-        image: quay.io/kubevirtci/golang:v20240308-8fac017
-        name: ""
-        resources:
-          requests:
-            memory: 20Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - name: pull-common-instancetypes-kubevirt-functest-stream-8-1.2
     branches:
       - release-1.2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
@@ -255,6 +255,84 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-tumbleweed-1.2
+    branches:
+      - release-1.2
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*OpenSUSE Tumbleweed"'
+          image: quay.io/kubevirtci/golang:v20240308-8fac017
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-leap-1.2
+    branches:
+      - release-1.2
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*OpenSUSE Leap"'
+          image: quay.io/kubevirtci/golang:v20240308-8fac017
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - name: pull-common-instancetypes-kubevirt-functest-validation-os-1.2
     branches:
       - release-1.2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
@@ -103,47 +103,6 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - name: pull-common-instancetypes-kubevirt-functest-centos-7-1.3
-    branches:
-      - release-1.3
-    always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 1
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - "/bin/sh"
-        - "-c"
-        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
-        env:
-        - name: GIMME_GO_VERSION
-          value: 1.22.9
-        - name: KUBEVIRT_MEMORY_SIZE
-          value: 16G
-        - name: FUNCTEST_EXTRA_ARGS
-          value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*CentOS 7"'
-        image: quay.io/kubevirtci/golang:v20250211-4e3c019
-        name: ""
-        resources:
-          requests:
-            memory: 20Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - name: pull-common-instancetypes-kubevirt-functest-centos-stream-8-1.3
     branches:
       - release-1.3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -146,47 +146,6 @@ presubmits:
             memory: 20Gi
         securityContext:
           privileged: true
-  - name: pull-common-instancetypes-kubevirt-functest-centos-7
-    branches:
-      - main
-    always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 1
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - "/bin/sh"
-        - "-c"
-        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
-        env:
-        - name: GIMME_GO_VERSION
-          value: 1.23.7
-        - name: KUBEVIRT_MEMORY_SIZE
-          value: 16G
-        - name: FUNCTEST_EXTRA_ARGS
-          value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*CentOS 7"'
-        image: quay.io/kubevirtci/golang:v20250502-3eb3b33
-        name: ""
-        resources:
-          requests:
-            memory: 20Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - name: pull-common-instancetypes-kubevirt-functest-centos-stream-8
     branches:
       - main


### PR DESCRIPTION
**What this PR does / why we need it**:

It drops the following test jobs because the preferences are no longer available:

* pull-common-instancetypes-kubevirt-functest-centos-7-1.3
* pull-common-instancetypes-kubevirt-functest-centos-7-1.2
* pull-common-instancetypes-kubevirt-functest-centos-7

It adds the following test jobs, which have preferences available but, are not currently being tested:

* pull-common-instancetypes-kubevirt-functest-leap-1.2
* pull-common-instancetypes-kubevirt-functest-tumbleweed-1.2
* pull-common-instancetypes-kubevirt-functest-leap-1.1
* pull-common-instancetypes-kubevirt-functest-tumbleweed-1.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
