### PR TITLE
nit: consistency among s390x containerdisks jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -88,7 +88,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: true
-    optional: false
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads


### PR DESCRIPTION
One job is configured as "optional: false", while the others have this line removed. There are no functional changes involved.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
