### PR TITLE
Add Scott Seago (sseago) to kubevirt maintainers

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -89,6 +89,7 @@ orgs:
       - shubham-pampattiwar
       - sradco
       - Sreeja1725
+      - sseago
       - stu-gott
       - TheRealSibasishBehera
       - tiraboschi


### PR DESCRIPTION
# GitHub Username
@sseago
 
## Requirements
 * [x]  I have reviewed the community code of conduct (https://github.com/kubevirt/kubevirt/blob/master/CODE_OF_CONDUCT.md)
 * [x]  I have enabled 2FA on my GitHub account (https://github.com/settings/security)
 * [x]  I have subscribed to the kubevirt-dev e-mail list (https://groups.google.com/forum/#!forum/kubevirt-dev)
 * [x]  I am actively contributing to KubeVirt
 * [x]  I have two sponsors that meet the sponsor requirements listed in the community membership guidelines
 * [x]  I have spoken to my sponsors ahead of this application and they have agreed to sponsor my application
 * [x]  I have publicly introduced myself to the community through one of the community communication channels
 
## Sponsors
 * @mhenriks
 * @ShellyKa13
 
 ## List of contributions to the KubeVirt project
 * PRs reviewed and/or authored
 * [Bump github.com/vmware-tanzu/velero from 1.14.0 to 1.16.0](https://github.com/kubevirt/kubevirt-velero-plugin/pull/355 )
* [Fix backup of CloudInit secrets](https://github.com/kubevirt/kubevirt-velero-plugin/pull/359)
* [Include VMI's datavolume type in restore graph](https://github.com/kubevirt/kubevirt-velero-plugin/pull/328)