### PR TITLE
fix: repair broken regexp for PermaLinks

### DIFF
--- a/robots/cmd/test-label-analyzer/cmd/stats.go
+++ b/robots/cmd/test-label-analyzer/cmd/stats.go
@@ -101,7 +101,7 @@ func (t *TestHTMLData) initElementsMatchingConfig() {
 	}
 }
 
-var replaceToPermaLinkMatcher = regexp.MustCompile(`https://github.com/[\\w]+/[\\w]+/((tree|blob)/[\\w]+)/.*`)
+var replaceToPermaLinkMatcher = regexp.MustCompile(`https://github.com/[\w]+/[\w]+/((tree|blob)/[\w]+)/.*`)
 
 // initPermalinks initializes Permalinks with the permanent links to the GitBlameLines
 func (t *TestHTMLData) initPermalinks() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In a previous change the regexp was changed to using multiline string - this supports basically less verbose expressions since backslashes don't need to get escaped. However it was forgotten to remove the duplicate backslashes, thus the matching expression didn't work any more.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4126

**Special notes for your reviewer**:
/cc @brianmcarey @anishbista60 