### PR TITLE
chore(plugins): Remove release-note plugin from enhancements repo

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -166,6 +166,7 @@ tide:
     - kubevirt/secrets
     - kubevirt/test-benchmarks
     - kubevirt/sig-release
+    - kubevirt/enhancements
     labels:
     - lgtm
     - approved
@@ -206,7 +207,6 @@ tide:
     - kubevirt/csi-driver
     - kubevirt/vm-console-proxy
     - kubevirt/kubevirt.core
-    - kubevirt/enhancements
     - kubevirt/irsa-mutation-webhook
     labels:
     - lgtm

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -173,7 +173,6 @@ plugins:
     - lgtm
     - owners-label
     - trigger
-    - release-note
 
   kubevirt/containerdisks:
     plugins:


### PR DESCRIPTION
**What this PR does / why we need it**:

/cc @vladikr 
/cc @xpivarc 

I think this was discussed a while ago but never followed through with, IMHO we don't need the release note plugin for this repo, it's already dropped from the PR template after all, so remove it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
