### PR TITLE
IRSA mutation webhook for injecting virtiofs container to virt-launcher pod

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -139,6 +139,7 @@ tide:
     kubevirt/sig-release: merge
     kubevirt/kubevirt.core: merge
     kubevirt/enhancements: squash
+    kubevirt/irsa-mutation-webhook: squash
 
   queries:
   - repos:
@@ -206,6 +207,7 @@ tide:
     - kubevirt/vm-console-proxy
     - kubevirt/kubevirt.core
     - kubevirt/enhancements
+    - kubevirt/irsa-mutation-webhook
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -237,6 +237,10 @@ orgs:
         allow_rebase_merge: false
         description: Operator pattern for managing multi-operator products
         has_projects: true
+      irsa-mutation-webhook:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        description: Webhook to mutate virt-launcher pods by injecting a virtiofs container for IRSA token sharing
       k8s-seccomp-generator:
         allow_rebase_merge: false
         allow_squash_merge: false
@@ -626,6 +630,12 @@ orgs:
           - vladikr
         repos:
           enhancements: write
+      irsa-mutation-webhook-maintainers:
+        maintainers:
+          - aqilbeig
+          - aerosouund
+        repos:
+          irsa-mutation-webhook: write
       maintainers:
         description: ""
         maintainers:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -254,6 +254,14 @@ plugins:
     - release-note
     - trigger
 
+  kubevirt/irsa-mutation-webhook:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
   kubevirt/katacoda-scenarios:
     plugins:
     - approve
@@ -623,6 +631,7 @@ triggers:
   - kubevirt/managed-tenant-quota
   - kubevirt/application-aware-quota
   - kubevirt/enhancements
+  - kubevirt/irsa-mutation-webhook
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks
@@ -685,6 +694,7 @@ approve:
   - kubevirt/application-aware-quota
   - kubevirt/dra-pci-driver
   - kubevirt/enhancements
+  - kubevirt/irsa-mutation-webhook
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -750,6 +760,7 @@ lgtm:
   - kubevirt/application-aware-quota
   - kubevirt/dra-pci-driver
   - kubevirt/enhancements
+  - kubevirt/irsa-mutation-webhook
   review_acts_as_lgtm: true
 
 override:


### PR DESCRIPTION
…ontainer

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This is related to https://groups.google.com/g/kubevirt-dev/c/gZCZQkcuKCU. This is in reference to feedback received from @dhiller https://github.com/kubevirt/project-infra/pull/4063#pullrequestreview-2804758188

```
Currently, KubeVirt VMs do not support IAM roles for service accounts when running on EKS clusters.

If you are using a service account as a filesystem with a KubeVirt VM, and that service account has the annotation [eks.amazonaws.com/role-arn](http://eks.amazonaws.com/role-arn), the IRSA mutates the virt-launcher pod of the VM with the following volume:

volumes:
  - name: aws-iam-token
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          audience: [sts.amazonaws.com](http://sts.amazonaws.com/)
          expirationSeconds: 86400
          path: token

and also mounts the aws-iam-token to each container of the virt-launcher pod, along with the service account token:

volumeMounts:
  - mountPath: /var/run/secrets/[kubernetes.io/serviceaccount](http://kubernetes.io/serviceaccount)
    name: kube-api-access-gbzpp
    readOnly: true
  - mountPath: /var/run/secrets/[eks.amazonaws.com/serviceaccount](http://eks.amazonaws.com/serviceaccount)
    name: aws-iam-token
    readOnly: true

However, the aws-iam-token is not available inside the VM because KubeVirt only adds the virtio-fs container to share the service account token at a specific path. It does not add a virtio-fs container to share the aws-iam-token, nor does it include the filesystem for it in the domain XML.

To address this, we plan to leverage a hook sidecar to modify the domain XML and add the filesystem for the aws-iam-token, similar to how KubeVirt adds the service account token. The configuration would look like this:


<filesystem type='mount' accessmode='passthrough'>
  <driver type='virtiofs' queue='1024'/>
  <source dir='' socket='/var/run/kubevirt/virtiofs-containers/aws-iam-token.sock'/>
  <target dir='aws-iam-token'/>
</filesystem>

However, we still need a webhook that modifies the virt-launcher pod to add the virtio-fs container. This container will share the token mounted in the pod with the VM using virtiofsd, similar to what is done for the service account token:
  - args:
    - --socket-path=/var/run/kubevirt/virtiofs-containers/aws-iam-token.sock
    - --shared-dir=/var/run/secrets/[eks.amazonaws.com/serviceaccount](http://eks.amazonaws.com/serviceaccount)
    - --sandbox=none
    - --cache=auto
    - --migration-on-error=guest-error
    - --migration-mode=find-paths
    command:
    - /usr/libexec/virtiofsd

We have already created a pull [PR#14568](https://github.com/kubevirt/kubevirt/pull/14568/files) for the hook sidecar implementation.

Additionally, we would like to introduce this repo in KubeVirt for managing this webhook.
```

ref: https://github.com/kubevirt/kubevirt/pull/14568

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Webhook to mutate virt-launcher pods by injecting a virtiofs container for IRSA token sharing
```
