### PR TITLE
feat: show detailed report output file path

### DIFF
--- a/hack/contributions.sh
+++ b/hack/contributions.sh
@@ -61,6 +61,7 @@ podman run \
     quay.io/kubevirtci/contributions:v20250417-cd6921f \
     --github-token "/etc/github/$(basename "${oauth_token}")" \
     --orgs-file-path "/project-infra/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml" \
-    "$@"
+    "$@" 2>&1 | tee "${temp_dir}/output.txt"
+report_file=$(grep -oE '[^/]*\.yaml' "${temp_dir}/output.txt" | head -n1)
 
-ls -la "${temp_dir}"
+echo "Detailed user activity report: ${temp_dir}/${report_file}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Improves the contributions script to emit the path of the detailed contributions report, as that is hidden in a temp file path and one would need to actually guess where it is.

Example:
```bash
$ ./hack/contributions.sh /home/dhiller/.tokens/github/kubevirt-bot/oauth --username dhiller
{"level":"info","msg":"creating report for user \"dhiller\"","time":"2025-05-07T10:03:19Z"}
activity log:
    user:          dhiller
...
{"level":"debug","msg":"user activity log: \"/tmp/user-activity-dhiller-kubevirt-3277565534.yaml\"","time":"2025-05-07T10:03:27Z"}
Stored user activity report in /tmp/contributions-sm4oBV/user-activity-dhiller-kubevirt-3277565534.yaml
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 
