### PR TITLE
Fix the periodic-kubevirtci-bump-hco job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -263,6 +263,7 @@ periodics:
     preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
+    rehearsal.allowed: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -272,7 +273,12 @@ periodics:
           - |
             set -e
             if labels-checker --org=kubevirt --repo=hyperconverged-cluster-operator --author=kubevirt-bot --branch-name=bump-kubevirtci --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
-              git-pr.sh -c "cd ../hyperconverged-cluster-operator && make bump-kubevirtci" -b bump-kubevirtci -p ../hyperconverged-cluster-operator -T main -R
+              git-pr.sh \
+                -c "cd ../hyperconverged-cluster-operator && make bump-kubevirtci" \
+                -b bump-kubevirtci \
+                -p ../hyperconverged-cluster-operator \
+                -r hyperconverged-cluster-operator \
+                -T main -R
             fi
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This job is trying to push PRs to the kubevirt repository, instead of to the hyperconverged-cluster-operator repository. see here for example: https://github.com/kubevirt/kubevirt/pull/14659


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the periodic-kubevirtci-bump-hco job
```
