### PR TITLE
Add the `release-note-none` label to the HCO kvci bump job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -278,6 +278,7 @@ periodics:
                 -b bump-kubevirtci \
                 -p ../hyperconverged-cluster-operator \
                 -r hyperconverged-cluster-operator \
+                -L "release-note-none" \
                 -T main -R
             fi
         securityContext:


### PR DESCRIPTION
**Release note**:
```release-note
None
```
