### PR TITLE
Revert "aaq,builder: Ensure builder image is built multi-arch (#4110)"

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
@@ -155,9 +155,8 @@ postsubmits:
   - name: push-aaq-builder
     branches:
     - main
-    cluster: prow-workloads
-    always_run: false
-    run_if_changed: "hack/build/builder/.*"
+    cluster: kubevirt-prow-control-plane
+    always_run: true
     optional: false
     skip_report: true
     annotations:
@@ -166,7 +165,6 @@ postsubmits:
     decoration_config:
       timeout: 3h
       grace_period: 5m
-    max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -174,17 +172,18 @@ postsubmits:
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
     spec:
-      nodeSelector:
-        type: bare-metal-external
       containers:
       - image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"
-          - "-c"
-          - >
-            cat "$QUAY_PASSWORD" | podman login quay.io --username $(cat "$QUAY_USER") --password-stdin=true &&
-            make builder-push
+          - "-ce"
+          - |
+            cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+            aaq_CONTAINER_BUILDCMD=buildah make builder-push
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This reverts commit efdadf06fd6af11025cece381f917747321f18da.
This reverts commit 926bf396df71c3cee7aad63dad4138400f48bbd5.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Revert the changes made for building the multiarch builder image, as the ci pipeline job hangs with them.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
