### PR TITLE
cnao: Add presubmit job for release-0.99 stable branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.99.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.99.yaml
@@ -1,0 +1,329 @@
+---
+presubmits:
+  kubevirt/cluster-network-addons-operator:
+    - name: pull-e2e-cnao-lifecycle-k8s-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      decoration_config:
+        timeout: 4h
+        grace_period: 5m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-lifecycle-k8s.sh"
+    - name: pull-e2e-cnao-workflow-k8s-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-workflow-k8s.sh"
+    - name: pull-e2e-cnao-monitoring-k8s-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-monitoring-k8s.sh"
+    - name: pull-e2e-cnao-kubemacpool-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-kubemacpool-functests.sh"
+    - name: pull-cluster-network-addons-operator-unit-test-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        grace_period: 5m
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "4Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.unit-test.sh"
+    - name: pull-e2e-cnao-multus-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-multus-functests.sh"
+    - name: pull-e2e-cnao-br-marker-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-bridge-marker-functests.sh"
+    - name: pull-e2e-cnao-ovs-cni-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-ovs-cni-functests.sh"
+    - name: pull-e2e-cnao-macvtap-cni-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-macvtap-cni-functests.sh"
+    - name: pull-e2e-cnao-multus-dynamic-networks-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      optional: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-multus-dynamic-networks-controller-functests.sh"
+    - name: pull-e2e-cnao-kube-secondary-dns-functests-release-0.99
+      branches:
+        - release-0.99
+      always_run: true
+      decorate: true
+      skip_report: false
+      decoration_config:
+        timeout: 3h
+        grace_period: 25m
+      max_concurrency: 6
+      cluster: prow-workloads
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-kube-secondary-dns-functests.sh"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets presubmit job for new stable branch release-0.99

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
