### PR TITLE
chore(restricted_labels,gh teams): reorg & simplify

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -889,61 +889,38 @@ orgs:
           - ksimon1
         repos:
           common-instancetypes: admin
+      restricted-labels-kubevirt:
+        description: "Users who can manage restricted labels inside the KubeVirt org"
+        members:
+        - 0xFelix
+        - aburdenthehand
+        - alicefr
+        - davidvossel
+        - dhiller
+        - EdDev
+        - enp0s3
+        - fabiand
+        - fossedihelm
+        - iholder101
+        - jean-edouard
+        - lyarwood
+        - mhenriks
+        - rthallisey
+        - stu-gott
+        - vladikr
+        - xpivarc
       kubevirtorg-label:
-        description: "Users who can apply restricted labels to any issue inside the KubeVirt org"
+        description: "[DEPRECATED]Users who can apply restricted labels to any issue inside the KubeVirt org"
         members:
-         - davidvossel
-         - vladikr
-         - rmohr
-         - fabiand
-         - stu-gott
-         - vasiliy-ul
-         - rthallisey
-         - aburdenthehand
       needs-approver-review-label:
-        description: "Users who can manage needs-approver-review label to any PR inside the KubeVirt org"
+        description: "[DEPRECATED]Users who can manage needs-approver-review label to any PR inside the KubeVirt org"
         members:
-         - 0xFelix
-         - aburdenthehand
-         - alicefr
-         - davidvossel
-         - dhiller
-         - EdDev
-         - enp0s3
-         - fabiand
-         - fossedihelm
-         - iholder101
-         - jean-edouard
-         - lyarwood
-         - mhenriks
-         - stu-gott
-         - vladikr
-         - xpivarc
       kubevirtkubevirt-label:
-        description: "Users who can apply restricted labels to any issue inside the kubevirt/kubevirt repo"
+        description: "[DEPRECATED]Users who can apply restricted labels to any issue inside the kubevirt/kubevirt repo"
         members:
-         - 0xFelix
-         - iholder101
-         - davidvossel
-         - vladikr
-         - rmohr
-         - stu-gott
-         - fabiand
-         - AlonaKaplan
-         - dhiller
-         - jean-edouard
-         - mhenriks
-         - enp0s3
-         - xpivarc
-         - vasiliy-ul
-         - alicefr
       kubevirtproject-infra-label:
-        description: "Users who can apply restricted labels to any issue inside the kubevirt/project-infra repo"
+        description: "[DEPRECATED]Users who can apply restricted labels to any issue inside the kubevirt/project-infra repo"
         members:
-         - dhiller
-         - brianmcarey
-         - enp0s3
-         - xpivarc
       sig-buildsystem:
         description: "Users who are responsible for when things go wrong wrt CI."
         members:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -785,26 +785,16 @@ label:
     - allowed_users:
       - kubevirt-bot
       allowed_teams:
-      - needs-approver-review-label
+      - restricted-labels-kubevirt
       label: needs-approver-review
 
     - allowed_teams:
-      - kubevirtorg-label
+      - restricted-labels-kubevirt
       label: good-first-issue
 
     - allowed_teams:
-      - needs-approver-review-label
+      - restricted-labels-kubevirt
       label: approved-vep
-
-    'kubevirt/kubevirt':
-    - allowed_teams:
-      - kubevirtkubevirt-label
-      label: good-first-issue
-
-    'kubevirt/project-infra':
-    - allowed_teams:
-      - kubevirtproject-infra-label
-      label: good-first-issue
 
 help:
   help_guidelines_url: "https://www.github.com/kubevirt/community/tree/main/contributors/help-wanted.md"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

There was quite a mess related to GitHub teams that were allowed to manage different restricted labels via the Prow `label` plugin. Since those teams largely overlap it makes sense to merge them into one.

The result is now one team called `restricted-labels-kubevirt` that holds all the members of the previous teams.

Also some team members who have decided to step down from reviewer obligations have not been included in the new team, since it's unlikely that they will need to use those labels.

> [!NOTE]
> **After merging this PR will cause a short period of around 2 hours of friction, since the Prow config will very likely get into effect before the GitHub team changes are applied.**


In a later step the old teams will be removed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @vladikr @alicefr @fossedihelm @xpivarc @aburdenthehand 