### PR TITLE
Add proper description for HCO's bump kubevirtci PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -279,7 +279,9 @@ periodics:
                 -p ../hyperconverged-cluster-operator \
                 -r hyperconverged-cluster-operator \
                 -L "release-note-none" \
-                -T main -R
+                -d "../hyperconverged-cluster-operator/hack/pr-description-for-bump-kvci.sh" \
+                -T main \
+                -R
             fi
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
The current auto generated PR description is crypt and not helpful.

This PR uses a script in HCO to generate the PR description, to make it readable and understandable.

**Release note**:
```release-note
None
```
