### PR TITLE
fix(sig-compute,periodics): bump timeout values

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1827,7 +1827,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 5m0s
-    timeout: 4h0m0s
+    timeout: 5h0m0s
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -1860,6 +1860,8 @@ periodics:
         value: k8s-1.30-sig-compute
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --usb 30M --usb 40M
+      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+        value: 4h45m
       image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
       name: ""
       resources:
@@ -2021,7 +2023,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 5m0s
-    timeout: 4h0m0s
+    timeout: 5h0m0s
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -2054,6 +2056,8 @@ periodics:
         value: k8s-1.31-sig-compute
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --usb 30M --usb 40M
+      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+        value: 4h45m
       image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
       name: ""
       resources:
@@ -2313,7 +2317,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 5m0s
-    timeout: 4h0m0s
+    timeout: 5h0m0s
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -2346,6 +2350,8 @@ periodics:
         value: k8s-1.32-sig-compute
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --usb 30M --usb 40M
+      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+        value: 4h45m
       image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
       name: ""
       resources:
@@ -2507,7 +2513,7 @@ periodics:
   decorate: true
   decoration_config:
     grace_period: 5m0s
-    timeout: 4h0m0s
+    timeout: 5h0m0s
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -2540,6 +2546,8 @@ periodics:
         value: k8s-1.33-sig-compute
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --usb 30M --usb 40M
+      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+        value: 4h45m
       image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
       name: ""
       resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As the sig-compute are on the brink of the timeout since a while now, let's increase the lane timeout value to give the jobs a bit nore time to finish.

We know that a failing test will likely increase the lane runtime by around 5 minutes, so it makes sense to give the failing lanes a bit more of headroom to finish writing their artifacts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
