### PR TITLE
add maintainers for charts

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -790,6 +790,7 @@ orgs:
           sig-release: write
           project-infra: write
           kubevirt: write
+          charts: write
       rerun-jobs-hco:
         description: can rerun failed job in the hyperconverged-cluster-operator repository
         maintainers:
@@ -969,3 +970,11 @@ orgs:
           - lyarwood
         repos:
           containerdisks: admin
+      charts-maintainers:
+        description: Maintainers of helm charts
+        privacy: closed
+        maintainers:
+          - dhiller
+          - lerrigatto
+        repos:
+          charts: admin

--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -977,4 +977,4 @@ orgs:
           - dhiller
           - lerrigatto
         repos:
-          charts: admin
+          charts: write


### PR DESCRIPTION
**What this PR does / why we need it**:

We need (preliminary) maintainers for the charts repo.
My plan is to add the bare minimum to the repo (readme, codeowners) and start opening issues to discuss the implementation of the charts design doc: https://github.com/kubevirt/community/pull/224
And, obviously, to write the charts :)

The charts repo have been created recently: https://github.com/kubevirt/project-infra/pull/4093

I have added a new group for charts maintainers, I added @dhiller and myself but it doesn't need to be. Please let me know who should be in that list instead.
I added the repo to the release team, as for sure it's going to be related to them.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
