### PR TITLE
Introduce presubmit phase env var for jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -92,6 +92,8 @@ presubmits:
         env:
         - name: TARGET
           value: windows2016
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -143,6 +145,8 @@ presubmits:
         env:
         - name: TARGET
           value: kind-1.35-vgpu
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
         resources:
           requests:
@@ -1070,6 +1074,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-network
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1158,6 +1164,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-emulated-igb
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -1800,6 +1808,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.34-sig-network
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -1841,6 +1851,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.34-sig-storage
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -1882,6 +1894,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.34-sig-compute-parallel
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1925,6 +1939,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.34-sig-operator
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -1966,6 +1982,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.35-sig-network
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2007,6 +2025,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.35-sig-storage
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2048,6 +2068,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.35-sig-compute-parallel
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -2091,6 +2113,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.35-sig-operator
+        - name: RUN_BEFORE_MERGE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -53,7 +53,7 @@ presubmits:
           limits:
             memory: "4Gi"
   - name: pull-project-infra-check-presubmits
-    run_if_changed: "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml"
+    run_if_changed: "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml|hack/check-run-before-merge-env.sh"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -63,6 +63,7 @@ presubmits:
         - "/bin/sh"
         - "-ce"
         - |
+          hack/check-run-before-merge-env.sh github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
           go run ./robots/kubevirt check presubmits \
            --job-config-path-kubevirt-presubmits=github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml \
            --github-token-path='' \

--- a/hack/check-run-before-merge-env.sh
+++ b/hack/check-run-before-merge-env.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <presubmits-config-file>" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+config_file="$1"
+
+had_error=0
+
+if ! jobs="$(yq -o=json '.presubmits[].[]' "$config_file" | jq -c '.')"; then
+  echo "error: failed to parse $config_file" >&2
+  exit 1
+fi
+
+if [[ -n "$jobs" ]]; then
+  while IFS= read -r job; do
+    name=$(echo "$job" | jq -r '.name')
+    run_before_merge=$(echo "$job" | jq -r '.run_before_merge // false')
+    env_count=$(echo "$job" | jq -r '[.spec.containers[].env[]? | select(.name == "RUN_BEFORE_MERGE")] | length')
+    env_val=$(echo "$job" | jq -r '.spec.containers[].env[]? | select(.name == "RUN_BEFORE_MERGE") | .value' | head -n1)
+
+    if (( env_count > 1 )); then
+      echo "Job '$name': has duplicate RUN_BEFORE_MERGE env vars" >&2
+      had_error=1
+    fi
+
+    if [[ "$run_before_merge" == "true" ]]; then
+      if [[ "$env_val" != "true" ]]; then
+        echo "Job '$name': run_before_merge is true but env var is not true" >&2
+        had_error=1
+      fi
+    else
+      if [[ "$env_val" == "true" ]]; then
+        echo "Job '$name': run_before_merge is false/missing but env var is true" >&2
+        had_error=1
+      fi
+    fi
+  done <<< "$jobs"
+fi
+
+exit "$had_error"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Introduce a method which allows skipping phase 2 tests that already ran on phase 1.
Periodics won't have this var, so periodic will simply run all tests as now.

Add a mechanism to distinguish phase 1 from phase 2 presubmits based
on `run_before_merge`, and add a check that this mapping stays coherent
in `kubevirt-presubmits.yaml`.

This allows jobs to decide whether to skip or run phase-specific tests,
such as skipping conformance in phase 2 latest k8s, since it already ran in phase 1.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Alternative to this as a whole, we can just add env var manually to sig-network lane where we want to skip conformance, and make sure we update it manually when new lane becomes gating.
Reason is we are using it now only for sig-network, one lane.

We can add sanity check, that the smoke lane version equal the lane where we add this skip.
Checking if we can make it as part of the `check presubmits` test suite.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Presubmit validation now checks that merge-related settings are consistent across job configurations.
  * Pull requests changing relevant CI configuration automatically run this validation.
  * Detects duplicate or conflicting merge-environment settings before changes are accepted.

* **Chores**
  * Updated applicable Windows and KubeVirt presubmit jobs to include the required merge execution setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->