### PR TITLE
cri-o,mirror: fix cri-o repo location to match latest

### DIFF
--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -35,7 +35,7 @@ mirror_crio_repo_for_version () {
     else
         echo "Mirroring from new pkgs.k8s.io repos"
         REPOID="isv_kubernetes_addons_cri-o_stable_v$1"
-        curl -L -o $REPOID.repo https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/stable:/v$1/rpm/isv:kubernetes:addons:cri-o:stable:v$1.repo
+        curl -L -o $REPOID.repo https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v$1/rpm/isv:kubernetes:addons:cri-o:stable:v$1.repo
         reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR --repoid=$REPOID --download-metadata
     fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The location of the cri-o repos have changed[1] causing the mirror to fail[2] - update to match the latest path

[1] https://github.com/cri-o/packaging/commit/b1333931567703820da23ce2dd87954a4b95f7ef
[2] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-mirror-crio-repository-weekly/1931870219546923008


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @xpivarc @iholder101 @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
