### PR TITLE
fix(s390x): disable reporting for most s390x presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -80,6 +80,7 @@ presubmits:
       cluster: prow-s390x-workloads
       labels:
         preset-podman-in-container-enabled: "true"
+      skip_report: true
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -119,6 +119,7 @@ presubmits:
       preset-kubevirt-s390x-icr-credential: "true"
     max_concurrency: 1
     optional: true
+    skip_report: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -99,6 +99,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
     name: pull-containerdisks-pipeline-centos-stream-9-s390x
+    skip_report: true
     spec:
       containers:
       - command:
@@ -203,6 +204,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
     name: pull-containerdisks-pipeline-centosstream-s390x
+    skip_report: true
     spec:
       containers:
       - command:
@@ -272,6 +274,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
     name: pull-containerdisks-pipeline-fedora-s390x
+    skip_report: true
     spec:
       containers:
       - command:
@@ -341,6 +344,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
     name: pull-containerdisks-pipeline-ubuntu-s390x
+    skip_report: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -45,6 +45,7 @@ presubmits:
       grace_period: 5m
     labels:
       preset-podman-in-container-enabled: "true"
+    skip_report: true
     spec:
       containers:
         - image: quay.io/kubevirtci/golang:v20250502-3eb3b33

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -123,6 +123,7 @@ presubmits:
       timeout: 2h
       grace_period: 5m
     cluster: prow-s390x-workloads
+    skip_report: true
     spec:
       containers:
         - image: quay.io/kubevirtci/golang:v20250502-3eb3b33

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -48,6 +48,7 @@ presubmits:
       decoration_config:
         grace_period: 5m0s
         timeout: 2h0m0s
+      skip_report: true
       spec:
         containers:
         - command:
@@ -76,6 +77,7 @@ presubmits:
         timeout: 2h0m0s
       labels:
         preset-podman-in-container-enabled: "true"
+      skip_report: true
       spec:
         containers:
         - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -407,6 +407,7 @@ presubmits:
     labels:
       preset-bazel-unnested: "true"
     name: pull-kubevirt-unit-test-s390x-1.4
+    skip_report: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -411,6 +411,7 @@ presubmits:
     labels:
       preset-bazel-unnested: "true"
     name: pull-kubevirt-unit-test-s390x-1.5
+    skip_report: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -434,6 +434,7 @@ presubmits:
     name: pull-kubevirt-unit-test-s390x
     skip_branches:
     - release-\d+\.\d+
+    skip_report: true
     spec:
       containers:
       - command:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since the s390x cluster is offline [1] we disable the reporting for most of the jobs.

[1]: https://prow.ci.kubevirt.io/?job=*s390x

We leave it on for kubevirtci however to not miss that fact and integrate some regression into kubevirtci.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @jschintag @cfilleke @nunnatsa 

/approve
/kind bug
/priority critical-urgent