### PR TITLE
feat(arm64): re-add arm lanes for new cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -749,7 +749,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-arm64-workloads-2
+  cluster: prow-arm64-workloads
   cron: 40 4 1,5,9,13,17,19 * *
   decorate: true
   decoration_config:
@@ -776,7 +776,7 @@ periodics:
       - automation/test.sh
       env:
       - name: TARGET
-        value: kind-1.28-wg-arm64
+        value: kind-1.31-wg-arm64
       - name: KUBEVIRT_NUM_NODES
         value: "1"
       image: quay.io/kubevirtci/bootstrap:v20250320-f6c439c
@@ -885,7 +885,7 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
-  cluster: prow-arm64-workloads-2
+  cluster: prow-arm64-workloads
   cron: 40 4 * * *
   decorate: true
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -749,6 +749,52 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+  cluster: prow-arm64-workloads-2
+  cron: 40 4 1,5,9,13,17,19 * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-unnested: "false"
+    preset-podman-in-container-enabled: "true"
+  max_concurrency: 5
+  name: periodic-kubevirt-kind-e2e-test-ARM64
+  reporter_config:
+    slack:
+      report: false
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -ce
+      - automation/test.sh
+      env:
+      - name: TARGET
+        value: kind-1.28-wg-arm64
+      - name: KUBEVIRT_NUM_NODES
+        value: "1"
+      image: quay.io/kubevirtci/bootstrap:v20250320-f6c439c
+      name: ""
+      resources:
+        requests:
+          memory: 16Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /var/log/audit
+        name: audit
+    volumes:
+    - emptyDir: {}
+      name: audit
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 30 4,12,20,00 * * *
   decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -853,7 +853,7 @@ presubmits:
   - always_run: true
     branches:
     - release-0.59
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -473,7 +473,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.0
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -874,6 +874,58 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.0
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64-1.0
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.23
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: arm64
+        image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     branches:
     - release-1.0

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -396,7 +396,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.1
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -798,6 +798,57 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.1
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64-1.1
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.27
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: arm64
+        image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     branches:
     - release-1.1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -400,7 +400,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:
@@ -849,7 +849,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -795,6 +795,124 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.2
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64-1.2
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: arm64
+        image: quay.io/kubevirtci/bootstrap:v20240118-315742b
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: true
+    branches:
+    - release-1.2
+    cluster: prow-arm64-workloads-2
+    context: pull-kubevirt-conformance-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-dind-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-conformance-arm64-1.2
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap-legacy:v20230829-f2e4ded
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+      dnsPolicy: None
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     branches:
     - release-1.2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -399,7 +399,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:
@@ -852,7 +852,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -798,6 +798,123 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.3
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64-1.3
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: arm64
+        image: quay.io/kubevirtci/bootstrap:v20240607-febc467
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: true
+    branches:
+    - release-1.3
+    cluster: prow-arm64-workloads-2
+    context: pull-kubevirt-conformance-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-dind-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-conformance-arm64-1.3
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap-legacy:v20230829-f2e4ded
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+      dnsPolicy: None
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     branches:
     - release-1.3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -424,7 +424,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:
@@ -909,7 +909,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.4
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -855,6 +855,124 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.4
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64-1.4
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: KUBEVIRT_E2E_FOCUS
+          value: arm64
+        image: quay.io/kubevirtci/bootstrap:v20241014-80f340c
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: true
+    branches:
+    - release-1.4
+    cluster: prow-arm64-workloads-2
+    context: pull-kubevirt-conformance-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-dind-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-conformance-arm64-1.4
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap-legacy:v20230829-f2e4ded
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+      dnsPolicy: None
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     branches:
     - release-1.4

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -856,6 +856,123 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    branches:
+    - release-1.5
+    cluster: prow-arm64-workloads
+    context: pull-kubevirt-e2e-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64-1.5
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.28-wg-arm64
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        image: quay.io/kubevirtci/bootstrap:v20250211-4e3c019
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: true
+    branches:
+    - release-1.5
+    cluster: prow-arm64-workloads-2
+    context: pull-kubevirt-conformance-arm64
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-dind-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-conformance-arm64-1.5
+    optional: true
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap-legacy:v20240523-1a2c9b8
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+      dnsPolicy: None
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     branches:
     - release-1.5

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -428,7 +428,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
     decorate: true
     decoration_config:
@@ -909,7 +909,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.5
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -452,7 +452,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1007,7 +1007,7 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.28-wg-arm64
+          value: kind-1.31-wg-arm64
         - name: KUBEVIRT_NUM_NODES
           value: "1"
         image: quay.io/kubevirtci/bootstrap:v20250320-f6c439c
@@ -1035,7 +1035,7 @@ presubmits:
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-arm64-workloads-2
+    cluster: prow-arm64-workloads
     decorate: true
     decoration_config:
       grace_period: 5m0s
@@ -1059,9 +1059,9 @@ presubmits:
           automation/conformance.sh
         env:
         - name: TARGET
-          value: kind-1.28
+          value: kind-1.31
         - name: KUBEVIRT_PROVIDER
-          value: kind-1.28
+          value: kind-1.31
         - name: KUBEVIRT_NUM_NODES
           value: "3"
         - name: IPFAMILY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -979,6 +979,127 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 5
+    name: pull-kubevirt-e2e-arm64
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.28-wg-arm64
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        image: quay.io/kubevirtci/bootstrap:v20250320-f6c439c
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-arm64-workloads-2
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-unnested: "false"
+      preset-dind-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-conformance-arm64
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    skip_report: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.28
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.28
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        image: quay.io/kubevirtci/bootstrap-legacy:v20230829-f2e4ded
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: modules
+          readOnly: true
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /var/log/audit
+          name: audit
+      dnsConfig:
+        nameservers:
+        - 8.8.8.8
+      dnsPolicy: None
+      volumes:
+      - hostPath:
+          path: /lib/modules
+          type: Directory
+        name: modules
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /var/log/audit
+          type: Directory
+        name: audit
   - always_run: false
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/.gitignore
+++ b/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/.gitignore
@@ -1,0 +1,2 @@
+secrets/*
+configs/*

--- a/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/kustomization.yaml
@@ -1,0 +1,13 @@
+# Requires kustomize v3
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: gcs
+    namespace: kubevirt-prow-jobs
+    files:
+      - secrets/service-account.json
+    type: Opaque


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

* add kustomize for secret for prow-arm64-workloads cluster
* revert commit that removed the arm lanes
* adjust cluster names to replace `...-2` with the current cluster name

Example runs:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-kind-e2e-test-ARM64/1934632652430643200
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14746/pull-kubevirt-e2e-arm64/1934638712851795968

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @brianmcarey 