### PR TITLE
feat(amd): add livez probe on cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1130,3 +1130,29 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- annotations:
+    testgrid-dashboards: kubevirt-project-infra-periodics
+    testgrid-days-of-results: "30"
+    testgrid-num-failures-to-alert: "1"
+    testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
+  cluster: kubevirt-prow-control-plane
+  decorate: true
+  decoration_config:
+    timeout: 5m
+    grace_period: 1m
+  interval: 30m
+  labels:
+  max_concurrency: 1
+  name: periodic-project-infra-prow-amd-workloads-livez
+  spec:
+    containers:
+    - image: quay.io/curl/curl:8.14.1
+      env:
+      command:
+      - "curl"
+      - "--fail"
+      - "--insecure"
+      - "https://165.204.53.121:30128/livez?verbose"
+      resources:
+        requests:
+          memory: "200Mi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds a liveness probe for the amd workloads cluster.

Successful example run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-project-infra-prow-amd-workloads-livez/1935311747820818432

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey 