### PR TITLE
fix(arm,periodic): missing cgroup host mount

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -787,10 +787,18 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
       - mountPath: /var/log/audit
         name: audit
     volumes:
-    - emptyDir: {}
+    - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+      name: cgroup
+    - hostPath:
+        path: /var/log/audit
+        type: Directory
       name: audit
 - annotations:
     testgrid-dashboards: kubevirt-periodics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We are experiencing a lot less failures on the presubmit lane than on the periodic. A comparison of the lane configurations yielded a difference in the volume configurations - apparently the /sys/fs/cgroup hostpath mount was missing. This commit adds it.

Also the audit log mount is changed from empty dir to hostpath mount.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Example test run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirt-kind-e2e-test-ARM64/1935322933262028800