### PR TITLE
HCO: run test o  k8s 1.33

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -1,44 +1,5 @@
 presubmits:
   kubevirt/hyperconverged-cluster-operator:
-    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.31
-      skip_branches:
-        - release-\d+\.\d+
-      annotations:
-        fork-per-release: "true"
-        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-      always_run: true
-      optional: false
-      decorate: true
-      decoration_config:
-        timeout: 7h
-        grace_period: 5m
-      max_concurrency: 6
-      labels:
-        preset-podman-in-container-enabled: "true"
-        preset-docker-mirror-proxy: "true"
-        preset-podman-shared-images: "true"
-      cluster: prow-workloads
-      spec:
-        nodeSelector:
-          type: bare-metal-external
-        containers:
-          - image: quay.io/kubevirtci/golang:v20250502-3eb3b33
-            command:
-              - "/usr/local/bin/runner.sh"
-              - "/bin/sh"
-              - "-c"
-              - "export TARGET=k8s-1.31 && automation/test.sh"
-            env:
-              - name: GIMME_GO_VERSION
-                value: "1.24.3"
-              - name: GINKGO_LABELS
-                value: '!OpenShift && !SINGLE_NODE_ONLY'
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                memory: "50Gi"
     - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.32
       skip_branches:
         - release-\d+\.\d+
@@ -67,6 +28,45 @@ presubmits:
               - "/bin/sh"
               - "-c"
               - "export TARGET=k8s-1.32 && automation/test.sh"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.24.3"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY'
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.33
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
+      always_run: true
+      optional: false
+      decorate: true
+      decoration_config:
+        timeout: 7h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-podman-shared-images: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/golang:v20250502-3eb3b33
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.33 && automation/test.sh"
             env:
               - name: GIMME_GO_VERSION
                 value: "1.24.3"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HCO: run tests on k8s 1.33
```
