### PR TITLE
kubevirt,periodic: fix cluster-up for SEV periodic lane (#4234)

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1480,8 +1480,16 @@ periodics:
           memory: 18Gi
       securityContext:
         privileged: true
+      volumeMounts:
+      - mountPath: /var/log/audit
+        name: audit
     nodeSelector:
       type: bare-metal-external
+    volumes:
+    - hostPath:
+        path: /var/log/audit
+        type: Directory
+      name: audit
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -122,7 +122,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       vgpu: "true"
     max_concurrency: 1
-    name: pull-kubevirt-e2e-kind-1.30-vgpu
+    name: pull-kubevirt-e2e-kind-1.33-vgpu
     run_before_merge: true
     skip_branches:
     - release-\d+\.\d+
@@ -146,7 +146,7 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.30-vgpu
+          value: kind-1.33-vgpu
         image: quay.io/kubevirtci/bootstrap:v20250502-3eb3b33
         name: ""
         resources:


### PR DESCRIPTION
The kind cluster is failing to start because it can't find /var/log/audit

Add this as a mount to ensure that it is present in the test pod.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
