### PR TITLE
kubevirt,kind: Remove audit log hostPath as no londer needed

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -610,8 +610,6 @@ periodics:
         name: cgroup
       - mountPath: /dev/vfio/
         name: vfio
-      - mountPath: /var/log/audit
-        name: audit
     nodeSelector:
       hardwareSupport: gpu
     priorityClassName: vgpu
@@ -624,10 +622,6 @@ periodics:
         path: /dev/vfio
         type: Directory
       name: vfio
-    - hostPath:
-        path: /var/log/audit
-        type: Directory
-      name: audit
 - annotations:
     k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     testgrid-dashboards: kubevirt-periodics
@@ -687,8 +681,6 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - mountPath: /var/log/audit
-        name: audit
       - mountPath: /sys/fs/cgroup
         name: cgroup
       - mountPath: /dev/vfio/
@@ -697,10 +689,6 @@ periodics:
       hardwareSupport: sriov-nic
     priorityClassName: sriov
     volumes:
-    - hostPath:
-        path: /var/log/audit
-        type: Directory
-      name: audit
     - hostPath:
         path: /sys/fs/cgroup
         type: Directory
@@ -789,17 +777,11 @@ periodics:
       volumeMounts:
       - mountPath: /sys/fs/cgroup
         name: cgroup
-      - mountPath: /var/log/audit
-        name: audit
     volumes:
     - hostPath:
         path: /sys/fs/cgroup
         type: Directory
       name: cgroup
-    - hostPath:
-        path: /var/log/audit
-        type: Directory
-      name: audit
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1480,14 +1462,6 @@ periodics:
           memory: 18Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /var/log/audit
-        name: audit
-    volumes:
-    - hostPath:
-        path: /var/log/audit
-        type: Directory
-      name: audit
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -159,8 +159,6 @@ presubmits:
           name: cgroup
         - mountPath: /dev/vfio/
           name: vfio
-        - mountPath: /var/log/audit
-          name: audit
       nodeSelector:
         hardwareSupport: gpu
       priorityClassName: vgpu
@@ -173,10 +171,6 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
   - always_run: false
     annotations:
       fork-per-release: "true"
@@ -1067,17 +1061,11 @@ presubmits:
         volumeMounts:
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /var/log/audit
-          name: audit
       volumes:
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
   - always_run: false
     annotations:
       fork-per-release: "true"
@@ -1128,8 +1116,6 @@ presubmits:
           readOnly: true
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /var/log/audit
-          name: audit
       dnsConfig:
         nameservers:
         - 8.8.8.8
@@ -1143,10 +1129,6 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
   - always_run: false
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -113,15 +113,9 @@ presubmits:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /var/log/audit
-          name: audit
         - mountPath: /sys/fs/cgroup
           name: cgroup
       volumes:
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
@@ -162,17 +156,11 @@ presubmits:
         volumeMounts:
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /var/log/audit
-          name: audit
       volumes:
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
   - always_run: false
     cluster: prow-workloads
     decorate: true
@@ -209,17 +197,11 @@ presubmits:
         volumeMounts:
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /var/log/audit
-          name: audit
       volumes:
       - hostPath:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
   - always_run: true
     cluster: prow-workloads
     decorate: true
@@ -274,8 +256,6 @@ presubmits:
         volumeMounts:
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /var/log/audit
-          name: audit
         - mountPath: /dev/vfio/
           name: vfio
       nodeSelector:
@@ -286,10 +266,6 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
       - hostPath:
           path: /dev/vfio/
           type: Directory
@@ -348,8 +324,6 @@ presubmits:
         volumeMounts:
         - mountPath: /sys/fs/cgroup
           name: cgroup
-        - mountPath: /var/log/audit
-          name: audit
         - mountPath: /dev/vfio/
           name: vfio
       nodeSelector:
@@ -360,10 +334,6 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-      - hostPath:
-          path: /var/log/audit
-          type: Directory
-        name: audit
       - hostPath:
           path: /dev/vfio/
           type: Directory


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The kind provider requires the "/var/log/audit" path to exist in the test pod but this is now added in the bootstrap[1] so the hostPath mount is no longer required.

[1] https://github.com/kubevirt/project-infra/pull/4245

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
