### PR TITLE
fix(prow-deploy): remove podname modification on CI

### DIFF
--- a/github/ci/prow-deploy/hack/test.sh
+++ b/github/ci/prow-deploy/hack/test.sh
@@ -26,9 +26,6 @@ kubectl create ns kubevirt-prow && kubectl create ns kubevirt-prow-jobs
 kubectl label node node01 ci.kubevirt.io/cachenode=true ingress-ready=true
 
 POD_NAME=$KUBEVIRT_PROVIDER-node01
-if [ "${CI}" == "true" ]; then
-    POD_NAME=$JOB_NAME-node01
-fi
 
 NODE_POD_IP=$(podman inspect $POD_NAME -f '{{ .NetworkSettings.IPAddress }}')
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since the latest kubevirtci change [1] the job name is no longer part of the pod name.

[1]: https://github.com/kubevirt/kubevirtci/pull/1478/files

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Rehearse run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/4263/pull-project-infra-prow-deploy-test/1942880103373475840

/cc @brianmcarey 