### PR TITLE
obs(e2e,arch): add arch lanes to e2e runtimes

### DIFF
--- a/github/ci/services/grafana/deploy/base/grafana.yaml
+++ b/github/ci/services/grafana/deploy/base/grafana.yaml
@@ -8885,7 +8885,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 15,
+      "id": 10,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -8948,7 +8948,7 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 26,
+            "h": 15,
             "w": 24,
             "x": 0,
             "y": 0
@@ -8983,7 +8983,104 @@ data:
               "refId": "A"
             }
           ],
-          "title": "k/kubevirt",
+          "title": "k/kubevirt - SIG lanes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 15,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+              },
+              "editorMode": "code",
+              "expr": "avg(\n  prow_job_runtime_seconds_sum{org=\"kubevirt\", repo=\"kubevirt\", state=~\"${status}\", type=~\"${jobtype}\", job_name=~\".*-kubevirt-(e2e|conformance).*(arm64|sev|s390x).*\"}\n  /\n  prow_job_runtime_seconds_count{org=\"kubevirt\", repo=\"kubevirt\", state=~\"${status}\", type=~\"${jobtype}\", job_name=~\".*-kubevirt-(e2e|conformance).*(arm64|sev|s390x).*\"}\n) by (job_name,state)\n/ 3600",
+              "legendFormat": "{{job_name}}({{state}})",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "k/kubevirt - ARCH lanes",
           "type": "timeseries"
         }
       ],
@@ -9149,7 +9246,7 @@ data:
       "timezone": "",
       "title": "e2e lane runtimes",
       "uid": "tuG1kd-Hz",
-      "version": 7,
+      "version": 6,
       "weekStart": ""
     }
 ---


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds another panel that shows the runtimes of the arch e2e test lanes to the e2e test runtimes dashboard.

<img width="1911" height="1553" alt="image" src="https://github.com/user-attachments/assets/09bf87cb-1f4a-4461-a54f-ce88e716d9cd" />

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
