### PR TITLE
arm64: Bump pull-kubevirt-unit-test-arm64 memory inline with amd64 job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -566,7 +566,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 8Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: true


### PR DESCRIPTION
/cc @brianmcarey 

**What this PR does / why we need it**:

$subject, I'm seeing EAGAIN errors in the job with some runs and occasional lock ups. Reviewing the job configuration I noted that the arm64 and s390x lanes are only providing `8Gi` of memory so increase this for now to see if this helps.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14967/pull-kubevirt-unit-test-arm64/1942928016044724224

```
12:52:13: FAIL: //pkg/virt-operator:go_parallel_test (see /root/.cache/bazel/_bazel_root/6f347497f91c9a385dcd9294645b76e0/execroot/kubevirt/bazel-out/aarch64-fastbuild/testlogs/pkg/virt-operator/go_parallel_test/test.log)
12:52:13: INFO: From Testing //pkg/virt-operator:go_parallel_test:
12:52:13: ==================== Test output for //pkg/virt-operator:go_parallel_test:
12:52:13: ginkgo run failed
12:52:13:   Failed to start test suite
12:52:13:   fork/exec /root/.cache/bazel/_bazel_root/6f347497f91c9a385dcd9294645b76e0/sandbox/processwrapper-sandbox/3070/execroot/kubevirt/bazel-out/aarch64-fastbuild/bin/pkg/virt-operator/go_parallel_test.runfiles/kubevirt/pkg/virt-operator/go_default_test_/go_default_test.test: resource temporarily unavailable
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
