### PR TITLE
fix(most-flaky-tests,report): filter out irrelevant

### DIFF
--- a/robots/cmd/quarantine/cmd/most-flaky-tests-report.gohtml
+++ b/robots/cmd/quarantine/cmd/most-flaky-tests-report.gohtml
@@ -63,29 +63,37 @@
     <h1>kubevirt/kubevirt: most flaky tests report</h1>
 </section>
 
-{{ range $timeRange, $mostFlakyTests := $.MostFlakyTests }}
+{{ range $timeRange := $.TimeRanges }}
+    {{ $mostFlakyTests := index $.MostFlakyTests $timeRange }}
     <section class="container">
         <div class="card-grid">
             <h2>Timerange: {{ $timeRange }}</h2>
         </div>
     </section>
-
-    <section class="container">
-        <div class="card-grid">
-            {{ range $mostFlakyTest := $mostFlakyTests }}
-                <div class="card" id="test_{{ $mostFlakyTest.Test.Name }}">
-                    <a href="#test_{{ $mostFlakyTest.Test.Name }}">#</a>
-                    <code title="{{ $mostFlakyTest.Test.Name }}">{{ $mostFlakyTest.Test.Name }}</code>
-                    <a href="{{ $mostFlakyTest.SearchCIURL }}" title="search.ci">🔎</a><br/>
-                    {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts }}
-                        <b>{{ if $mostFlakyTest.Test.NoteHasBeenQuarantined }}<span title="Test has been quarantined">Q!</span>{{ end }}
-                            💥<span title="Test has impact of {{ $relevantImpact.Percent }}%"> {{ $relevantImpact.Percent }}%</span> :</b>
-                        <a href="{{ $relevantImpact.URL }}" title="{{ $relevantImpact.URL }}">{{ $relevantImpact.URLToDisplay }}</a>
-                    {{ end }}
-                </div>
-            {{ end }}
-        </div>
-    </section>
+    {{ if $mostFlakyTests }}
+        <section class="container">
+            <div class="card-grid">
+                {{ range $mostFlakyTest := $mostFlakyTests }}
+                    <div class="card" id="test_{{ $mostFlakyTest.Test.Name }}">
+                        <a href="#test_{{ $mostFlakyTest.Test.Name }}">#</a>
+                        <code title="{{ $mostFlakyTest.Test.Name }}">{{ $mostFlakyTest.Test.Name }}</code>
+                        <a href="{{ $mostFlakyTest.SearchCIURL }}" title="search.ci">🔎</a><br/>
+                        {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts }}
+                            <b>{{ if $mostFlakyTest.Test.NoteHasBeenQuarantined }}<span title="Test has been quarantined">Q!</span>{{ end }}
+                                💥<span title="Test has impact of {{ $relevantImpact.Percent }}%"> {{ $relevantImpact.Percent }}%</span> :</b>
+                            <a href="{{ $relevantImpact.URL }}" title="{{ $relevantImpact.URL }}">{{ $relevantImpact.URLToDisplay }}</a>
+                        {{ end }}
+                    </div>
+                {{ end }}
+            </div>
+        </section>
+    {{ else }}
+        <section class="container">
+            <div class="card-grid">
+                No results! 👍
+            </div>
+        </section>
+    {{ end }}
 {{ end }}
 
 <section class="container">

--- a/robots/cmd/quarantine/cmd/types.go
+++ b/robots/cmd/quarantine/cmd/types.go
@@ -31,6 +31,8 @@ type quarantineOptions struct {
 
 	// autoQuarantine
 	daysInThePast int
+
+	filterPeriodicJobRunResults bool
 }
 
 type TestToQuarantine struct {
@@ -40,6 +42,10 @@ type TestToQuarantine struct {
 	RelevantImpacts []searchci.Impact
 }
 
+var (
+	mostFlakyTestsTimeRanges = []searchci.TimeRange{searchci.ThreeDays, searchci.FourteenDays}
+)
+
 func (t TestToQuarantine) String() string {
 	return fmt.Sprintf("TestToQuarantine{Test: %+v, SearchCIURL: %q, RelevantImpacts: %+v}", t.Test, t.SearchCIURL, t.RelevantImpacts)
 }
@@ -48,10 +54,12 @@ func NewMostFlakyTestsTemplateData(mostFlakyTests map[searchci.TimeRange][]*Test
 	return MostFlakyTestsTemplateData{
 		ReportCreation: time.Now(),
 		MostFlakyTests: mostFlakyTests,
+		TimeRanges:     mostFlakyTestsTimeRanges,
 	}
 }
 
 type MostFlakyTestsTemplateData struct {
 	ReportCreation time.Time
 	MostFlakyTests map[searchci.TimeRange][]*TestToQuarantine
+	TimeRanges     []searchci.TimeRange
 }

--- a/robots/pkg/searchci/searchci_test.go
+++ b/robots/pkg/searchci/searchci_test.go
@@ -56,7 +56,7 @@ var _ = Describe("searchci", func() {
 	})
 	DescribeTable("FilterRelevantImpacts",
 		func(impacts []Impact, timeRange TimeRange, relevantimpacts []Impact) {
-			Expect(FilterRelevantImpacts(impacts, timeRange)).To(BeEquivalentTo(relevantimpacts))
+			Expect(FilterImpacts(impacts, timeRange)).To(BeEquivalentTo(relevantimpacts))
 		},
 		Entry("filters a relevant impact for fourteen days",
 			[]Impact{
@@ -102,7 +102,7 @@ var _ = Describe("searchci", func() {
 			},
 		),
 	)
-	Context("ScrapeRelevantImpacts", func() {
+	Context("ScrapeImpacts", func() {
 		var body []byte
 		var server *httptest.Server
 		BeforeEach(func() {
@@ -119,7 +119,7 @@ var _ = Describe("searchci", func() {
 			server.Close()
 		})
 		It("scrapes", func() {
-			impacts, err := ScrapeRelevantImpacts(testName, FourteenDays)
+			impacts, err := ScrapeImpacts(testName, FourteenDays)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(impacts).ToNot(BeNil())
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Updates the report for most-flaky-tests here: https://storage.googleapis.com/kubevirt-prow/reports/most-flaky-tests/kubevirt/kubevirt/index.html

Main issue: Adjusts the filtering to only keep the relevant impacts by filtering for
matching test lanes.

Examples:
<img width="1044" height="140" alt="image" src="https://github.com/user-attachments/assets/9122bbd4-dcd7-409c-9b62-7d52a4ca821b" />
<img width="1025" height="354" alt="image" src="https://github.com/user-attachments/assets/6443bb1b-ab32-46a5-bfd4-8d8db624e74e" />

Also:
* Fixes the sort order in the report to keep three days at the top.
* Refactors some func names in searchci package for brevity.
* Adds quarantine report cli docs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
