### PR TITLE
feat(per-test-execution): determine k8s version for report

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -157,7 +157,7 @@ periodics:
       - |
         report_dir="/tmp/per-test-results/last-six-months"
         mkdir -p "${report_dir}"
-        go run ./robots/cmd/per-test-execution --kubernetes-version 1.31 --months 6 --output-directory "${report_dir}"
+        go run ./robots/cmd/per-test-execution --months 6 --output-directory "${report_dir}"
         gsutil cp "${report_dir}/*" "gs://kubevirt-prow/reports/per-test-results/kubevirt/kubevirt/last-six-months/"
       command:
       - /usr/local/bin/runner.sh

--- a/robots/cmd/per-test-execution/main.go
+++ b/robots/cmd/per-test-execution/main.go
@@ -96,9 +96,11 @@ func (o options) loadDefaults() error {
 		if err != nil {
 			return fmt.Errorf("failed to fetch stable k8s version: %v", err)
 		}
-		if err := resp.Body.Close(); err != nil {
-			return fmt.Errorf("failed to close response body: %v", err)
-		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Errorf("failed to close response body: %v", err)
+			}
+		}()
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Main update:
* Determines the k8s version from the stable.txt and searches for an existing sig-compute-migrations lane, using the first found as basis for the report


Fixes:
* By accident the body is closed before even an attempt to read it has been made. Using a defer to close the body on returning from the func


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
