### PR TITLE
kubevirt,periodics: Add job to publish json report for quarantined tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1623,6 +1623,39 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
+  cron: 45 7 * * *
+  decorate: true
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: project-infra
+    workdir: true
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-gcs-credentials: "true"
+  name: periodic-kubevirt-quarantined-tests-daily-report-json
+  spec:
+    containers:
+    - args:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -ce
+      - |
+        go run ./robots/cmd/test-label-analyzer stats --config-name=quarantine --test-file-path=/home/prow/go/src/github.com/kubevirt/kubevirt/tests --remote-url=https://github.com/kubevirt/kubevirt/%s/tests > /tmp/quarantine.json
+        gsutil cp /tmp/quarantine.json gs://kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/quarantine.json
+      command:
+      - /bin/sh
+      env:
+      - name: GIMME_GO_VERSION
+        value: 1.24.4
+      image: quay.io/kubevirtci/golang:v20250701-f32dbda
+      name: ""
+      resources: {}
+- annotations:
+    testgrid-create-test-group: "false"
+  cluster: kubevirt-prow-control-plane
   cron: 45 1 * * *
   decorate: true
   extra_refs:


### PR DESCRIPTION
**What this PR does / why we need it**:

A JSON report will be easier to consume for the quarantine metrics that are going to be introduced to ci-heath

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
