### PR TITLE
arm: Disable failing liveness check for old ARM cluster

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1108,32 +1108,6 @@ periodics:
     testgrid-dashboards: kubevirt-project-infra-periodics
     testgrid-days-of-results: "30"
     testgrid-num-failures-to-alert: "1"
-    testgrid-alert-email: kubevirt-ci-maintainers@redhat.com, dkeler@redhat.com, dollierp@redhat.com
-  cluster: kubevirt-prow-control-plane
-  decorate: true
-  decoration_config:
-    timeout: 5m
-    grace_period: 1m
-  interval: 30m
-  labels:
-  max_concurrency: 1
-  name: periodic-project-infra-prow-arm-workloads-livez
-  spec:
-    containers:
-    - image: quay.io/curl/curl:8.14.1
-      env:
-      command:
-      - "curl"
-      - "--fail"
-      - "--insecure"
-      - "https://api.upstream-ci-arm-sno-419.cnv-qe.rhood.us:6443/livez?verbose"
-      resources:
-        requests:
-          memory: "200Mi"
-- annotations:
-    testgrid-dashboards: kubevirt-project-infra-periodics
-    testgrid-days-of-results: "30"
-    testgrid-num-failures-to-alert: "1"
     testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
   cluster: kubevirt-prow-control-plane
   decorate: true


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The single node ARM cluster is no longer available - remove the liveness check.

https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/periodic-project-infra-prow-arm-workloads-livez

Updating the check with the endpoint for the new ARM cluster also failed so removing the job for now to reduce noise.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @lyarwood @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
