### PR TITLE
arm64: Move conformance to periodic and other clean ups

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -653,7 +653,7 @@ periodics:
       name: ""
       resources:
         requests:
-          memory: 24Gi
+          memory: 52Gi
       securityContext:
         privileged: true
       volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -667,6 +667,61 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+  cluster: prow-arm64-workloads
+  cron: 40 4,12,20 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-unnested: "false"
+    preset-podman-in-container-enabled: "true"
+  max_concurrency: 1
+  name: periodic-kubevirt-kind-conformance-test-ARM64
+  reporter_config:
+    slack:
+      report: false
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -ce
+      - |
+        automation/conformance.sh
+      env:
+      - name: TARGET
+        value: kind-1.33
+      - name: KUBEVIRT_PROVIDER
+        value: kind-1.33
+      - name: KUBEVIRT_NUM_NODES
+        value: "3"
+      - name: IPFAMILY
+        value: dual
+      - name: RUN_ON_ARM64_INFRA
+        value: "true"
+      image: quay.io/kubevirtci/bootstrap:v20250701-f32dbda
+      name: ""
+      resources:
+       requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /sys/fs/cgroup
+        name: cgroup
+    volumes:
+      - hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+        name: cgroup
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 30 4,12,20,00 * * *
   decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1117,7 +1117,7 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1084,7 +1084,7 @@ presubmits:
     labels:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
-    max_concurrency: 2
+    max_concurrency: 4
     name: pull-kubevirt-e2e-arm64
     optional: true
     skip_branches:


### PR DESCRIPTION
/cc @brianmcarey 
/hold

**What this PR does / why we need it**:

#4317 looks like it has helped. Assuming that remains the case now I'm wondering if we even need conformance always running as a presubmit given the e2e coverage.

This change marks conformance as optional and introduces a periodic instead. The max_concurrency for e2e is increased to take advantage of this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
