### PR TITLE
[kubevirt/kubevirt]: disable PSA in release-1.1 job configurations

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -1099,8 +1099,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -1139,8 +1137,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
         name: ""
         resources:
@@ -1216,8 +1212,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
@@ -1301,8 +1295,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -1341,8 +1333,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -1381,8 +1371,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
         name: ""
         resources:
@@ -1419,8 +1407,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
@@ -1461,8 +1447,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-compute-realtime
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -1501,8 +1485,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -1541,8 +1523,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.28-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
@@ -1581,8 +1561,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.28-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0
         name: ""
         resources:
@@ -1619,8 +1597,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.28-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
@@ -1661,8 +1637,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.28-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230801-94954c0


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
there is a problem with pod bring up latency in release-1.1 the root cause comes from the VM based providers and the trigger is usage of custom seccomp provider in the kubevirt e2e tests.

In order to keep the lanes stable we temporarily opt out from PSA and from using seccomp.

**Special notes for your reviewer**:
We are aware that this will reduce coverage in upstream e2e, but we also must have a way to merge critical fixes.
We will keep tracking this situation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
