### PR TITLE
test-subset: Fix focus

### DIFF
--- a/external-plugins/test-subset/plugin/handler/handler.go
+++ b/external-plugins/test-subset/plugin/handler/handler.go
@@ -232,7 +232,7 @@ func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, event *g
 		envName string
 	}{
 		{params.filter, "KUBEVIRT_LABEL_FILTER"},
-		{params.focus, "KUBEVIRT_LABEL_FOCUS"},
+		{params.focus, "KUBEVIRT_E2E_FOCUS"},
 		{params.verbosity, "KUBEVIRT_VERBOSITY"},
 	}
 

--- a/external-plugins/test-subset/plugin/testsubset_test.go
+++ b/external-plugins/test-subset/plugin/testsubset_test.go
@@ -148,10 +148,10 @@ var _ = Describe("Test-subset", func() {
 				})
 			})
 
-			It("Should set KUBEVIRT_LABEL_FOCUS for --focus parameter", func() {
+			It("Should set KUBEVIRT_E2E_FOCUS for --focus parameter", func() {
 				handleTestSubsetCommand(eventsHandler, `/test-subset job1 --focus "FocusString"`)
 				validateJobEnvironmentVars(prowc, map[string]string{
-					"KUBEVIRT_LABEL_FOCUS": "FocusString",
+					"KUBEVIRT_E2E_FOCUS": "FocusString",
 				})
 			})
 
@@ -166,7 +166,7 @@ var _ = Describe("Test-subset", func() {
 				handleTestSubsetCommand(eventsHandler, `/test-subset job1 --filter "(USB)" --focus "FocusString" --verbosity=virtLauncher:2`)
 				validateJobEnvironmentVars(prowc, map[string]string{
 					"KUBEVIRT_LABEL_FILTER": "(USB)",
-					"KUBEVIRT_LABEL_FOCUS":  "FocusString",
+					"KUBEVIRT_E2E_FOCUS":    "FocusString",
 					"KUBEVIRT_VERBOSITY":    "virtLauncher:2",
 				})
 			})
@@ -182,7 +182,7 @@ var _ = Describe("Test-subset", func() {
 				handleTestSubsetCommand(eventsHandler, `/test-subset job1 --filter='(USB)' --verbosity="virtLauncher:2" --focus "Focus String"`)
 				validateJobEnvironmentVars(prowc, map[string]string{
 					"KUBEVIRT_LABEL_FILTER": "(USB)",
-					"KUBEVIRT_LABEL_FOCUS":  "Focus String",
+					"KUBEVIRT_E2E_FOCUS":    "Focus String",
 					"KUBEVIRT_VERBOSITY":    "virtLauncher:2",
 				})
 			})
@@ -296,7 +296,7 @@ func validateJobEnvironmentVars(prowc *fake.FakeProwV1, expectedEnvVars map[stri
 	}
 
 	// Ensure no unexpected environment variables are set
-	expectedNames := []string{"KUBEVIRT_LABEL_FILTER", "KUBEVIRT_LABEL_FOCUS", "KUBEVIRT_VERBOSITY"}
+	expectedNames := []string{"KUBEVIRT_LABEL_FILTER", "KUBEVIRT_E2E_FOCUS", "KUBEVIRT_VERBOSITY"}
 	for _, env := range envVars {
 		for _, expectedName := range expectedNames {
 			if env.Name == expectedName {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Kubevirt variable name was wrong.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
