### PR TITLE
Archiving client-python repo due to lack of maintainers

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -150,6 +150,7 @@ orgs:
       client-python:
         description: An auto-generated python SDK to interact with KubeVirt resources
         has_projects: false
+        archived: true
       cloud-image-builder:
         archived: true
         description: Scripts and playbooks for creating and testing cloud images containing Kubernetes and KubeVirt


### PR DESCRIPTION
**What this PR does / why we need it**:

/hold 
to allow for https://github.com/kubevirt/client-python/pull/61 to be merged

As per the linked PR:
We've had a few folks on the mailing list have troubles with this, since it has not been maintained in a while but is automatically updated, which gives the appearance of the repo still being supported.

We had previously put a call out for maintainers for this repo but did not receive enough volunteers. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
