### PR TITLE
disable PSA in release-1.0 job configurations

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -1319,8 +1319,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-network-no-istio
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1357,8 +1355,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1395,8 +1391,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1433,8 +1427,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.26-centos9-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1471,8 +1463,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-network
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1509,8 +1499,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-storage
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1547,8 +1535,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-compute
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:
@@ -1585,8 +1571,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.27-sig-operator
-        - name: KUBEVIRT_PSA
-          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20230502-bfaa042
         name: ""
         resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
there is a problem with pod bring up latency in release-1.0 the root cause comes from the VM based providers and the trigger is usage of custom seccomp provider in the kubevirt e2e tests.

In order to keep the lanes stable we temporarily opt out from PSA and from using seccomp.

**Special notes for your reviewer**:
We are aware that this will reduce coverage in upstream e2e, but we also must have a way to merge critical fixes.
We will keep tracking this situation.

ref: https://github.com/kubevirt/project-infra/pull/4319

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```