### PR TITLE
[kubevirt/kubevirt]: make prom-rule-verify run conditional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -889,7 +889,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
@@ -901,6 +901,7 @@ presubmits:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-prom-rules-verify
+    run_if_changed: "hack/prom-rule-ci/.*"
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

**What this PR does / why we need it**:
We can save some CI resources and time.

the job should run only when hack/prom-rule-ci/* has changed this make target is related to unit tests of prometheus alerts and recording rules. The tests themselves reside in prom-rule-ci directory so there is no point to run this target unless the tests of the image were changed.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
