### PR TITLE
chore(common-instancetypes): Add test job for Debian 13

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -518,6 +518,47 @@ presubmits:
             privileged: true
       nodeSelector:
         type: bare-metal-external
+  - name: pull-common-instancetypes-kubevirt-functest-debian-13
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-bazel-unnested: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - "/bin/sh"
+            - "-c"
+            - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
+          env:
+            - name: GIMME_GO_VERSION
+              value: 1.24.5
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: FUNCTEST_EXTRA_ARGS
+              value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Debian 13"'
+          image: quay.io/kubevirtci/golang:v20250701-f32dbda
+          name: ""
+          resources:
+            requests:
+              memory: 20Gi
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - name: pull-build-common-instancetypes-builder
     always_run: false
     run_if_changed: "image/.*"


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a new test job for Debian 13.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [CNV-68033](https://issues.redhat.com/browse/CNV-68033)

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None.
```
