### PR TITLE
Docs pr needed label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -7,4 +7,13 @@
 **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
 Fixes #
 
+**Documentation update**:
+<!-- Add your Docs PR number
+1. Enter the related docs PR number in the field below. This is expected to be but not required to be in the kubevirt/user-guide repo. 
+2. If you have multiple docs PRs, just include one in this field and include the others as comments in the PR. You do not need to add the docs PR to create the PR but it will be required to merge. You can add it at a later time by editing the PR description. The docs PR does not need to be merged for this PR to merge.
+3. If a docs update is not required, just write "NONE".-->
+```docs-pr
+
+```
+
 **Special notes for your reviewer**:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ github/ci/*.retry
 testaccount.json
 .idea
 images/autoowners/autoowners
+CLAUDE.md

--- a/docs/docs-pr-template-example.md
+++ b/docs/docs-pr-template-example.md
@@ -1,0 +1,90 @@
+# Example PR Description with docs-pr Field
+
+This document shows examples of how PR descriptions should be formatted with the new `docs-pr` field.
+
+## Example 1: PR with Documentation Update
+
+```markdown
+**What this PR does / why we need it**:
+This PR adds support for new VM migration features, allowing users to migrate VMs with persistent volumes attached.
+
+**Which issue(s) this PR fixes**:
+Fixes #1234
+
+**Documentation update**:
+<!-- Add your Docs PR number
+1. Enter the related docs PR number in the field below. This is expected to be but not required to be in the kubevirt/user-guide repo. 
+2. If you have multiple docs PRs, just include one in this field and include the others as comments in the PR. You do not need to add the docs PR to create the PR but it will be required to merge. You can add it at a later time by editing the PR description. The docs PR does not need to be merged for this PR to merge.
+3. If a docs update is not required, just write "NONE".-->
+```docs-pr
+kubevirt/user-guide#567
+```
+
+**Special notes for your reviewer**:
+This change requires careful testing with different storage backends.
+```
+
+**Result**: Plugin will add `docs-pr` label and allow merge.
+
+## Example 2: PR with No Documentation Needed
+
+```markdown
+**What this PR does / why we need it**:
+This PR fixes a minor typo in error message logging.
+
+**Which issue(s) this PR fixes**:
+Fixes #5678
+
+**Documentation update**:
+<!-- Add your Docs PR number -->
+```docs-pr
+NONE
+```
+
+**Special notes for your reviewer**:
+Simple typo fix, no user-facing changes.
+```
+
+**Result**: Plugin will add `docs-pr-none` label and allow merge.
+
+## Example 3: PR Missing docs-pr Field
+
+```markdown
+**What this PR does / why we need it**:
+This PR adds new API endpoints for VM management.
+
+**Which issue(s) this PR fixes**:
+Fixes #9999
+
+**Special notes for your reviewer**:
+This introduces new APIs that need documentation.
+```
+
+**Result**: Plugin will add `do-not-merge/docs-pr-required` label and block merge.
+
+## Example 4: PR with Empty docs-pr Field
+
+```markdown
+**What this PR does / why we need it**:
+This PR changes VM behavior significantly.
+
+**Documentation update**:
+```docs-pr
+
+```
+
+**Special notes for your reviewer**:
+Major behavior change.
+```
+
+**Result**: Plugin will add `do-not-merge/docs-pr-required` label and block merge.
+
+## Using the /docs-pr Command
+
+Users can also update the docs-pr status using comments:
+
+- `/docs-pr #1234` - Set docs PR to #1234
+- `/docs-pr NONE` - Mark as not needing docs
+- `/docs-pr kubevirt/user-guide#567` - Set docs PR with full repo reference
+
+The plugin will update the PR description and labels accordingly.

--- a/external-plugins/docs-pr-checker/Makefile
+++ b/external-plugins/docs-pr-checker/Makefile
@@ -1,0 +1,22 @@
+CONTAINER_IMAGE := docs-pr-checker
+CONTAINER_REPO := quay.io/kubevirtci/$(CONTAINER_IMAGE)
+
+.PHONY: all clean format test build push
+all: format test build
+
+build:
+	go build ./...
+
+format:
+	gofmt -w .
+
+test:
+	go test ./...
+
+push:
+	cd ../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x ../../hack/update-jobs-with-latest-image.sh $(CONTAINER_REPO)
+
+clean:
+	go clean
+

--- a/external-plugins/docs-pr-checker/go.mod
+++ b/external-plugins/docs-pr-checker/go.mod
@@ -1,0 +1,10 @@
+module kubevirt.io/project-infra/external-plugins/docs-pr-checker
+
+go 1.24
+
+require (
+	github.com/sirupsen/logrus v1.9.3
+	k8s.io/test-infra v0.0.0-20250115095034-1f33b84b2d0d
+	sigs.k8s.io/prow v0.0.0-20241224162210-8e8a5cfe7516
+)
+

--- a/external-plugins/docs-pr-checker/main.go
+++ b/external-plugins/docs-pr-checker/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	prowflagutil "sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/interrupts"
+	"sigs.k8s.io/prow/pkg/pluginhelp/externalplugins"
+)
+
+type options struct {
+	port int
+
+	dryRun bool
+	github prowflagutil.GitHubOptions
+
+	webhookSecretFile string
+}
+
+func (o *options) Validate() error {
+	for idx, group := range []flagutil.OptionGroup{&o.github} {
+		if err := group.Validate(o.dryRun); err != nil {
+			return fmt.Errorf("%d: %w", idx, err)
+		}
+	}
+
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+	for _, group := range []flagutil.OptionGroup{&o.github} {
+		group.AddFlags(fs)
+	}
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.Fatalf("Invalid options: %v", err)
+	}
+
+	logrus.SetFormatter(&logrus.JSONFormatter{})
+	logrus.SetLevel(logrus.DebugLevel)
+	log := logrus.StandardLogger().WithField("plugin", pluginName)
+
+	if err := secret.Add(o.github.TokenPath, o.webhookSecretFile); err != nil {
+		logrus.WithError(err).Fatal("Error starting secrets agent.")
+	}
+
+	githubClient, err := o.github.GitHubClient(o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
+	}
+
+	botUserData, err := githubClient.BotUser()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot name.")
+	}
+
+	server := &Server{
+		tokenGenerator: secret.GetTokenGenerator(o.webhookSecretFile),
+		botName:        botUserData.Login,
+		ghc:            githubClient,
+		log:            log,
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/", server)
+	externalplugins.ServeExternalPluginHelp(mux, log, HelpProvider)
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
+	defer interrupts.WaitForGracefulShutdown()
+	interrupts.ListenAndServe(httpServer, 5*time.Second)
+}
+

--- a/external-plugins/docs-pr-checker/server.go
+++ b/external-plugins/docs-pr-checker/server.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/pluginhelp/externalplugins"
+)
+
+const pluginName = "docs-pr-checker"
+
+var (
+	// Matches a docs-pr code block, capturing everything between the opening and closing triple backticks.
+	// Handles optional whitespace/newlines and any content inside.
+	docsPRRegex = regexp.MustCompile(`(?is)```docs-pr\s*\n(.*?)\n?```)`)
+)
+
+const (
+	labelDocsPRRequired = "do-not-merge/docs-pr-required"
+	labelDocsPR         = "docs-pr"
+	labelDocsPRNone     = "docs-pr-none"
+)
+
+// HelpProvider constructs the PluginHelp for this plugin.
+func HelpProvider(config []byte) (*externalplugins.PluginHelp, error) {
+	pluginHelp := &externalplugins.PluginHelp{
+		Description: "The docs-pr-checker plugin ensures that PRs include documentation updates when required.",
+	}
+	pluginHelp.AddCommand(externalplugins.PluginCommand{
+		Usage:       "/docs-pr <PR-number|NONE>",
+		Description: "Updates the docs-pr status of a pull request.",
+		Featured:    false,
+		WhoCanUse:   "Anyone can trigger this command on a PR.",
+		Examples:    []string{"/docs-pr #123", "/docs-pr NONE"},
+	})
+	return pluginHelp, nil
+}
+
+// Server implements http.Handler. It validates incoming GitHub webhooks and
+// then dispatches them to the appropriate plugins.
+type Server struct {
+	tokenGenerator func() []byte
+	botName        string
+	ghc            github.Client
+	log            *logrus.Entry
+}
+
+// ServeHTTP validates an incoming webhook and puts it into the event channel.
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
+	if !ok {
+		return
+	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		logrus.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	l := s.log.WithFields(
+		logrus.Fields{
+			"event-type":     eventType,
+			github.EventGUID: eventGUID,
+		},
+	)
+	var handler func() error
+	switch eventType {
+	case "pull_request":
+		var pre github.PullRequestEvent
+		if err := json.Unmarshal(payload, &pre); err != nil {
+			return err
+		}
+		handler = func() error { return s.handlePullRequestEvent(l, &pre) }
+	case "issue_comment":
+		var ice github.IssueCommentEvent
+		if err := json.Unmarshal(payload, &ice); err != nil {
+			return err
+		}
+		handler = func() error { return s.handleIssueCommentEvent(l, &ice) }
+	default:
+		l.Debugf("skipping event of type %q", eventType)
+		return nil
+	}
+	go func() {
+		if err := handler(); err != nil {
+			l.WithError(err).Info("Error handling event.")
+		}
+	}()
+	return nil
+}
+
+func (s *Server) handlePullRequestEvent(l *logrus.Entry, pre *github.PullRequestEvent) error {
+	// Only process opened, edited, and synchronize events
+	if pre.Action != github.PullRequestActionOpened &&
+		pre.Action != github.PullRequestActionEdited &&
+		pre.Action != github.PullRequestActionSynchronize {
+		return nil
+	}
+
+	return s.processPR(l, pre.Repo.Owner.Login, pre.Repo.Name, &pre.PullRequest)
+}
+
+func (s *Server) handleIssueCommentEvent(l *logrus.Entry, ice *github.IssueCommentEvent) error {
+	// Only process comments on PRs
+	if !ice.Issue.IsPullRequest() {
+		return nil
+	}
+
+	// Check if comment is a docs-pr command
+	if !strings.HasPrefix(ice.Comment.Body, "/docs-pr") {
+		return nil
+	}
+
+	// Get the PR details
+	pr, err := s.ghc.GetPullRequest(ice.Repo.Owner.Login, ice.Repo.Name, ice.Issue.Number)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	// Process the command
+	return s.processDocsPRCommand(l, ice.Repo.Owner.Login, ice.Repo.Name, pr, ice.Comment.Body)
+}
+
+func (s *Server) processPR(l *logrus.Entry, org, repo string, pr *github.PullRequest) error {
+	return s.checkAndUpdateDocsPRStatus(l, org, repo, pr)
+}
+
+func (s *Server) processDocsPRCommand(l *logrus.Entry, org, repo string, pr *github.PullRequest, comment string) error {
+	// Parse the command
+	parts := strings.Fields(comment)
+	if len(parts) < 2 {
+		return nil // Invalid command, ignore
+	}
+
+	docsPRValue := strings.Join(parts[1:], " ")
+	
+	// Update PR body with the new docs-pr value
+	newBody := s.updateDocsPRInBody(pr.Body, docsPRValue)
+	
+	// Update the PR description
+	update := github.PullRequest{
+		Body: &newBody,
+	}
+	
+	if err := s.ghc.EditPullRequest(org, repo, pr.Number, &update); err != nil {
+		return fmt.Errorf("failed to update PR body: %w", err)
+	}
+
+	// Update the labels based on the new value
+	updatedPR := *pr
+	updatedPR.Body = newBody
+	
+	return s.checkAndUpdateDocsPRStatus(l, org, repo, &updatedPR)
+}
+
+func (s *Server) updateDocsPRInBody(body, newValue string) string {
+	// Remove any existing docs-pr blocks
+	cleanBody := docsPRRegex.ReplaceAllString(body, "")
+	// Trim any trailing whitespace after removal
+	cleanBody = strings.TrimSpace(cleanBody)
+	// Append a single docs-pr block at the end
+	return cleanBody + fmt.Sprintf("\n\n```docs-pr\n%s\n```", newValue)
+}
+
+func (s *Server) checkAndUpdateDocsPRStatus(l *logrus.Entry, org, repo string, pr *github.PullRequest) error {
+	current, err := s.ghc.GetIssueLabels(org, repo, pr.Number)
+	if err != nil {
+		return fmt.Errorf("failed to get current labels: %w", err)
+	}
+
+	// inline extractDocsPRValue
+	var val string
+	if m := docsPRRegex.FindStringSubmatch(pr.Body); len(m) > 1 {
+		val = strings.TrimSpace(m[1])
+	}
+
+	// compute desired state for each label
+	desired := map[string]bool{
+		labelDocsPRRequired: val == "",
+		labelDocsPRNone:     strings.EqualFold(val, "NONE"),
+		labelDocsPR:         val != "" && !strings.EqualFold(val, "NONE"),
+	}
+
+	// sync labels in one pass
+	for _, target := range []string{labelDocsPRRequired, labelDocsPR, labelDocsPRNone} {
+		present := false
+		for _, lbl := range current {
+			if lbl.Name == target {
+				present = true
+				break
+			}
+		}
+		if desired[target] && !present {
+			if err := s.ghc.AddLabel(org, repo, pr.Number, target); err != nil {
+				l.WithError(err).Warnf("failed to add label %s", target)
+			} else {
+				l.Infof("added label %s", target)
+			}
+		}
+		if !desired[target] && present {
+			if err := s.ghc.RemoveLabel(org, repo, pr.Number, target); err != nil {
+				l.WithError(err).Warnf("failed to remove label %s", target)
+			} else {
+				l.Infof("removed label %s", target)
+			}
+		}
+	}
+	return nil
+}
+
+

--- a/external-plugins/docs-pr-checker/server_test.go
+++ b/external-plugins/docs-pr-checker/server_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"testing"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+func TestExtractDocsPRValue(t *testing.T) {
+	s := &Server{}
+	
+	tests := []struct {
+		name     string
+		body     string
+		expected string
+	}{
+		{
+			name: "empty body",
+			body: "",
+			expected: "",
+		},
+		{
+			name: "body with docs-pr NONE",
+			body: "Some PR description\n\n```docs-pr\nNONE\n```",
+			expected: "NONE",
+		},
+		{
+			name: "body with docs-pr number",
+			body: "Some PR description\n\n```docs-pr\n#1234\n```",
+			expected: "#1234",
+		},
+		{
+			name: "body with empty docs-pr",
+			body: "Some PR description\n\n```docs-pr\n\n```",
+			expected: "",
+		},
+		{
+			name: "body with whitespace in docs-pr",
+			body: "Some PR description\n\n```docs-pr\n  #1234  \n```",
+			expected: "#1234",
+		},
+		{
+			name: "body without docs-pr section",
+			body: "Some PR description without docs-pr section",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.extractDocsPRValue(tt.body)
+			if result != tt.expected {
+				t.Errorf("extractDocsPRValue() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestUpdateDocsPRInBody(t *testing.T) {
+	s := &Server{}
+	
+	tests := []struct {
+		name     string
+		body     string
+		newValue string
+		expected string
+	}{
+		{
+			name:     "add docs-pr to empty body",
+			body:     "",
+			newValue: "NONE",
+			expected: "\n\n```docs-pr\nNONE\n```",
+		},
+		{
+			name:     "replace existing docs-pr",
+			body:     "Some description\n\n```docs-pr\n#1234\n```\n\nMore text",
+			newValue: "NONE",
+			expected: "Some description\n\n```docs-pr\nNONE\n```\n\nMore text",
+		},
+		{
+			name:     "add docs-pr to body without existing section",
+			body:     "Some PR description",
+			newValue: "#5678",
+			expected: "Some PR description\n\n```docs-pr\n#5678\n```",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.updateDocsPRInBody(tt.body, tt.newValue)
+			if result != tt.expected {
+				t.Errorf("updateDocsPRInBody() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasLabel(t *testing.T) {
+	s := &Server{}
+	
+	labels := []github.Label{
+		{Name: "bug"},
+		{Name: "enhancement"},
+		{Name: "docs-pr"},
+	}
+
+	tests := []struct {
+		name      string
+		labelName string
+		expected  bool
+	}{
+		{
+			name:      "label exists",
+			labelName: "docs-pr",
+			expected:  true,
+		},
+		{
+			name:      "label does not exist",
+			labelName: "do-not-merge/docs-pr-required",
+			expected:  false,
+		},
+		{
+			name:      "empty label name",
+			labelName: "",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.hasLabel(labels, tt.labelName)
+			if result != tt.expected {
+				t.Errorf("hasLabel() = %t, want %t", result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/external-plugins/docs-pr-checker/template_test.go
+++ b/external-plugins/docs-pr-checker/template_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestTemplateRegexParsing(t *testing.T) {
+	s := &Server{}
+	
+	tests := []struct {
+		name     string
+		prBody   string
+		expected string
+	}{
+		{
+			name: "template with empty docs-pr field",
+			prBody: `**What this PR does / why we need it**:
+This PR adds a new feature.
+
+**Which issue(s) this PR fixes**:
+Fixes #1234
+
+**Documentation update**:
+<!-- Add your Docs PR number -->
+` + "```docs-pr\n\n```" + `
+
+**Special notes for your reviewer**:
+Please review carefully.`,
+			expected: "",
+		},
+		{
+			name: "template with NONE in docs-pr field",
+			prBody: `**What this PR does / why we need it**:
+This PR adds a new feature.
+
+**Documentation update**:
+<!-- Add your Docs PR number -->
+` + "```docs-pr\nNONE\n```" + `
+
+**Special notes for your reviewer**:
+Please review carefully.`,
+			expected: "NONE",
+		},
+		{
+			name: "template with PR number in docs-pr field",
+			prBody: `**What this PR does / why we need it**:
+This PR adds a new feature.
+
+**Documentation update**:
+` + "```docs-pr\n#5678\n```" + `
+
+**Special notes for your reviewer**:
+Please review carefully.`,
+			expected: "#5678",
+		},
+		{
+			name: "template with multiple lines in docs-pr field should take first line",
+			prBody: `**Documentation update**:
+` + "```docs-pr\n#1234\nextra text that should be ignored\n```",
+			expected: "#1234",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.extractDocsPRValue(tt.prBody)
+			if result != tt.expected {
+				t.Errorf("extractDocsPRValue() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -173,6 +173,35 @@ postsubmits:
                 memory: "8Gi"
             securityContext:
               privileged: true
+    - name: publish-docs-pr-checker-image
+      always_run: false
+      run_if_changed: "^(external-plugins|images)/docs-pr-checker/.*"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      cluster: kubevirt-prow-control-plane
+      max_concurrency: 1
+      labels:
+        preset-bazel-cache: "true"
+        preset-kubevirtci-quay-credential: "true"
+        preset-podman-in-container-enabled: "true"
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20250701-f32dbda
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/bash"
+              - "-c"
+              - |
+                cat "$QUAY_PASSWORD" | podman login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+                make -C ./external-plugins/docs-pr-checker push
+            resources:
+              requests:
+                memory: "8Gi"
+              limits:
+                memory: "8Gi"
+            securityContext:
+              privileged: true
     - name: publish-referee-image
       always_run: false
       run_if_changed: "^(external-plugins|images)/referee/.*"

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -59,6 +59,18 @@ default:
       target: prs
       prowPlugin: release-note
       addedBy: prow
+    - color: c2e0c6
+      name: docs-pr
+      target: prs
+      description: Denotes a PR that includes a documentation update.
+      prowPlugin: docs-pr
+      addedBy: prow
+    - color: c2e0c6
+      description: Denotes a PR that doesn't require documentation updates.
+      name: docs-pr-none
+      target: prs
+      prowPlugin: docs-pr
+      addedBy: prow
     - color: e11d21
       description: Indicates that a PR should not merge because someone has issued a /hold command.
       name: do-not-merge/hold
@@ -98,6 +110,11 @@ default:
       target: prs
       prowPlugin: verify-owners
       addedBy: prow
+      description: Indicates that a PR should not merge because it's missing documentation PR reference.
+      name: do-not-merge/docs-pr-required
+      target: prs
+      addedBy: prow
+      prowPlugin: docs-pr
     - name: kind/blocker
       color: b60205
       target: both

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -553,6 +553,11 @@ external_plugins:
     endpoint: http://botreview:9900
     events:
       - pull_request
+  - name: docs-pr-checker
+    endpoint: http://docs-pr-checker:9900
+    events:
+      - pull_request
+      - issue_comment
   kubevirt/kubevirt:
   - name: phased
     endpoint: http://prow-phased:9900
@@ -566,6 +571,11 @@ external_plugins:
   - name: test-subset
     endpoint: http://test-subset:9900
     events:
+      - issue_comment
+  - name: docs-pr-checker
+    endpoint: http://docs-pr-checker:9900
+    events:
+      - pull_request
       - issue_comment
 
 approve:

--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - manifests/local/cherrypicker_deployment.yaml
   - manifests/local/cherrypicker_service.yaml
   - manifests/local/deck-ingress.yaml
+  - manifests/local/docs-pr-checker_deployment.yaml
+  - manifests/local/docs-pr-checker_service.yaml
   - manifests/local/gcsweb-deployment.yaml
   - manifests/local/gcsweb-ingress.yaml
   - manifests/local/gcsweb-service.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/docs-pr-checker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/docs-pr-checker_deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docs-pr-checker
+  labels:
+    app: docs-pr-checker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: docs-pr-checker
+  template:
+    metadata:
+      labels:
+        app: docs-pr-checker
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: docs-pr-checker
+        image: quay.io/kubevirtci/docs-pr-checker:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - --dry-run=false
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --github-token-path=/etc/github/oauth
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+        - name: plugins
+          mountPath: /etc/plugins
+          readOnly: true
+      volumes:
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: oauth
+        secret:
+          secretName: oauth-token
+      - name: plugins
+        configMap:
+          name: plugins
+

--- a/github/ci/prow-deploy/kustom/base/manifests/local/docs-pr-checker_service.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/docs-pr-checker_service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: docs-pr-checker
+spec:
+  selector:
+    app: docs-pr-checker
+  ports:
+  - port: 9900
+    targetPort: 8888
+

--- a/images/docs-pr-checker/Containerfile
+++ b/images/docs-pr-checker/Containerfile
@@ -1,0 +1,19 @@
+FROM quay.io/kubevirtci/golang:v20241213-57bd934 as builder
+ENV GOPROXY=https://proxy.golang.org,direct \
+    GOFLAGS="-mod=vendor -ldflags=-extldflags=\"-static\"" \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
+ENV GIMME_GO_VERSION=1.23.4
+RUN mkdir kubevirt && \
+    cd kubevirt && \
+    git clone https://github.com/kubevirt/project-infra.git && \
+    cd project-infra && \
+    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/docs-pr-checker ./external-plugins/docs-pr-checker" && \
+    /usr/local/bin/runner.sh /bin/sh -ce "go clean -cache -modcache" && \
+    cd .. && rm -rf ./project-infra
+
+FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
+COPY --from=builder /go/bin/docs-pr-checker /usr/bin/docs-pr-checker
+ENTRYPOINT ["/usr/bin/docs-pr-checker"]
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a docs-pr-needed plugin to the project that mimics the behaviour of the release-notes-needed plugin.
This is an attempt to ensure that our docs are always updated whenever there is a change in the code that should be documented. This plugin solves this by blocking PRs unless they include a docs pr link in the new field. They can also bypass it by writing 'NONE' as per our release note plugin.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4342

**Special notes for your reviewer**:
~99.7% of this was written by an LLM coding assistant - Claude. I have retained the commits for reviewers (will squash into 1 if this is approved). I had it review the issue, and generate a plan to resolve mimicking the already established release notes plugin.
I can't really assess the code so I apologise in advance if it's a dog's breakfast :)

Funnily enough I think the included docs template is overkill, but can't hurt.
The updated PR text is a bit verbose but it does cover the main cases.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
