### PR TITLE
chore(verify-owners): enable for hostpath-provisioner

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -221,6 +221,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    - verify-owners
 
   kubevirt/hostpath-provisioner-operator:
     plugins:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We were bitten by an invalid OWNERS_ALIASES, which made `/approve` not work: https://github.com/kubevirt/hostpath-provisioner-operator/pull/620#issuecomment-3275931850 

This was fixed by: https://github.com/kubevirt/hostpath-provisioner-operator/pull/624

Therefore this change enabled verify-owners plugin for kubevirt#hostpath-provisioner

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
