### PR TITLE
crio,kubevirtci: automate the cri-o version bumps for the latest kubevirtci provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -385,6 +385,9 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
   cluster: kubevirt-prow-control-plane
   spec:
     securityContext:
@@ -395,6 +398,7 @@ periodics:
         args:
           - "-c"
           - git-pr.sh -c "./hack/bump-crio-mirror-versions.sh" -p ./ -r project-infra -b crio-version-bump -T main
+          - git-pr.sh -p ../kubevirtci -r kubevirtci -b crio-version-bump -s "Bump cri-o version to match provider version" -T main
         resources:
           requests:
             memory: "200Mi"

--- a/hack/bump-crio-mirror-versions.sh
+++ b/hack/bump-crio-mirror-versions.sh
@@ -11,4 +11,7 @@ if [[ $(echo "$CURRENT_VERSIONS" | grep $LATEST_VERSION) ]]; then
 else
     echo "Mirror does not include latest cri-o version $LATEST_VERSION"
     sed -i "s/${CURRENT_VERSIONS}/${CURRENT_VERSIONS},${LATEST_VERSION}/" $KUBEVIRTCI_PERIODICS
+    if [ -d "$PROJECT_INFRA_ROOT/../kubevirtci/cluster-provision/k8s/$LATEST_VERSION" ]; then
+        sed -i "s/CRIO_VERSION=1\.[0-9][0-9]/CRIO_VERSION=$LATEST_VERSION/" $PROJECT_INFRA_ROOT/../kubevirtci/cluster-provision/k8s/$LATEST_VERSION/k8s_provision.sh
+    fi
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the bump cri-o script to also update kubevirtci if its present in the environment

This should remove the need for these PRs: https://github.com/kubevirt/kubevirtci/pull/1534

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
