### PR TITLE
Request 16G RAM for nmstate tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/nmstate/nmstate-presubmits.yaml
@@ -30,3 +30,6 @@ presubmits:
               - "/bin/sh"
               - "-c"
               - "automation/run-tests.sh --test-type integ_tier1 --centos-stream --k8s --artifacts-dir $ARTIFACTS"
+            env:
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G


### PR DESCRIPTION
The rust compiler for nmstate takes more than 4G RAM. Hence request 16G
RAM for its tests.