### PR TITLE
Remove extra_ref entry from release-graph prow job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -889,11 +889,6 @@ postsubmits:
         testgrid-create-test-group: "false"
       cluster: kubevirt-prow-control-plane
       decorate: true
-      extra_refs:
-      - org: kubevirt
-        repo: project-infra
-        base_ref: main
-        workdir: true
       labels:
         preset-github-credentials: "true"
       run_if_changed: "robots/cmd/perf-report-creator/shape.yaml"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When prow job triggeres, it failed with the following error
`Init container clonerefs not ready: (state: terminated, reason: "Error", message: "{\"component\":\"clonerefs\",\"file\":\"sigs.k8s.io/prow/cmd/clonerefs/main.go:36\",\"func\":\"main.main\",\"level\":\"fatal\",\"msg\":\"Invalid options: clone ref config 1 (for kubevirt/project-infra) will be extracted to /home/prow/go/src/github.com/kubevirt/project-infra, which clone ref 0 (for kubevirt/project-infra) is also using\",\"severity\":\"fatal\",\"time\":\"2025-09-17T14:19:18Z\"}\n") Init container initupload not ready: (state: waiting, reason: "PodInitializing", message: "") Init container place-entrypoint not ready: (state: waiting, reason: "PodInitializing", message: "")`

Upon looking into the prow job yaml configuration both extra_ref and refs is pointing to the same repo.
```
spec:
  agent: kubernetes
  cluster: kubevirt-prow-control-plane
  context: post-project-infra-kubevirt-releasegraph
  decoration_config:
    gcs_configuration:
      bucket: kubevirt-prow
      path_strategy: explicit
    gcs_credentials_secret: gcs
    grace_period: 15s
    timeout: 2h0m0s
    utility_images:
      clonerefs: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250903-f49c6158b
      entrypoint: us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20250903-f49c6158b
      initupload: us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20250903-f49c6158b
      sidecar: us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20250903-f49c6158b
  extra_refs:
  - base_ref: main
    org: kubevirt
    repo: project-infra
    workdir: true
  job: post-project-infra-kubevirt-releasegraph
  namespace: kubevirt-prow-jobs
  pod_spec:
    containers:
    - args:
      - "go build -o /usr/local/bin/perf-report-creator ./robots/cmd/perf-report-creator/...\n\nRELEASE_VERSION=$(grep
        \"releaseVersion:\" robots/cmd/perf-report-creator/shape.yaml | awk '{print
        $2}' | tr -d '\"')\nBRANCH=\"add-$RELEASE_VERSION\"\nRELEASE_DIR=\"release-$RELEASE_VERSION\"\n\n(\n
        \ cd ..\n  git clone \"https://kubevirt-bot@github.com/$TARGET_GITHUB_REPO.git\"\n
        \ cd ci-performance-benchmarks\n  git checkout -b $BRANCH\n)\nCI_PERF_REPO_DIR=$(cd
        ../ci-performance-benchmarks && pwd)\n\nrobots/cmd/perf-report-creator/release-graph.sh
        \"$CI_PERF_REPO_DIR\"\n\ncd \"$CI_PERF_REPO_DIR\"\nmkdir -p \"$CI_PERF_REPO_DIR\"/$RELEASE_DIR/periodic-kubevirt-e2e-k8s-sig-performance\nmkdir
        -p \"$CI_PERF_REPO_DIR\"/$RELEASE_DIR/periodic-kubevirt-e2e-k8s-sig-performance/vmi
        \"$CI_PERF_REPO_DIR\"/$RELEASE_DIR/periodic-kubevirt-e2e-k8s-sig-performance/vm\nmv
        \"$CI_PERF_REPO_DIR\"/weekly/vmi/release-index.html \"$CI_PERF_REPO_DIR\"/$RELEASE_DIR/periodic-kubevirt-e2e-k8s-sig-performance/vmi\nmv
        \"$CI_PERF_REPO_DIR\"/weekly/vm/release-index.html \"$CI_PERF_REPO_DIR\"/$RELEASE_DIR/periodic-kubevirt-e2e-k8s-sig-performance/vm\n\ngit-pr.sh
        -c \"git clean -fd weekly && git add $RELEASE_DIR\" -T main -r ci-performance-benchmarks
        -m \"$CI_PERF_REPO_DIR\" -b $BRANCH -d \"echo 'Add release $RELEASE_VERSION
        performance benchmarks data'\" -B \"Add release $RELEASE_VERSION performance
        benchmarks data via automation\" -D true\n\necho \"PR created successfully\"\necho
        \"Process completed successfully.\" \n"
      command:
      - /usr/local/bin/runner.sh
      - /bin/sh
      - -c
      env:
      - name: GIMME_GO_VERSION
        value: 1.25.1
      - name: TARGET_GITHUB_REPO
        value: kubevirt/ci-performance-benchmarks
      - name: GITHUB_TOKEN_PATH
        value: /etc/github/oauth
      - name: GIT_ASKPASS
        value: ../project-infra/hack/git-askpass.sh
      - name: GOPROXY
        value: https://proxy.golang.org|direct
      image: quay.io/kubevirtci/pr-creator:v20240913-6773146
      name: ""
      resources:
        limits:
          memory: 200Mi
        requests:
          memory: 200Mi
      volumeMounts:
      - mountPath: /etc/github
        name: github-token
    volumes:
    - name: github-token
      secret:
        defaultMode: 256
        secretName: oauth-token
  prowjob_defaults:
    tenant_id: GlobalDefaultID
  refs:
    base_link: https://github.com/kubevirt/project-infra/compare/316ef2a1dcb0...ed9d964079a6
    base_ref: main
    base_sha: ed9d964079a6be559c42e70b23bc5fdc3b117333
    org: kubevirt
    repo: project-infra
    repo_link: https://github.com/kubevirt/project-infra
  report: true
  type: postsubmit
```
This PR will remove the duplicate reference.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
