### PR TITLE
chore(e2e-failures): split by main and release

### DIFF
--- a/github/ci/services/grafana/deploy/base/grafana.yaml
+++ b/github/ci/services/grafana/deploy/base/grafana.yaml
@@ -83,7 +83,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboards-default
+  name: grafana-dashboards-default-0
   labels:
     dashboard-provider: default
   annotations:
@@ -2950,7 +2950,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 1,
-      "id": 5,
+      "id": 11,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -2968,7 +2968,7 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 24,
+            "w": 12,
             "x": 0,
             "y": 0
           },
@@ -3059,9 +3059,9 @@ data:
           "fillGradient": 0,
           "gridPos": {
             "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 8
+            "w": 12,
+            "x": 12,
+            "y": 0
           },
           "hiddenSeries": false,
           "id": 14,
@@ -3190,6 +3190,481 @@ data:
           "dashes": false,
           "datasource": {
             "type": "prometheus",
+            "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+          },
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 15,
+          "interval": "1h",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.1.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"${job_name}\", base_ref=\"main\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"${job_name}\", base_ref=\"main\"}[1h]))\n* 100",
+              "interval": "1h",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "lane failures % overall (main)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+          },
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 17,
+          "interval": "1h",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.1.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-compute.*\", base_ref=\"main\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-compute.*\", base_ref=\"main\"}[1h]))\n* 100",
+              "interval": "1h",
+              "legendFormat": "SIG Compute",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-network.*\", base_ref=\"main\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-network.*\", base_ref=\"main\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "SIG Network",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-storage.*\", base_ref=\"main\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-storage.*\", base_ref=\"main\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "SIG Storage",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-operator.*\", base_ref=\"main\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-operator.*\", base_ref=\"main\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "SIG Operator",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "lane failures % per SIG (main)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+          },
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 16,
+          "interval": "1h",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.1.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"${job_name}\", base_ref=~\"release-.*\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"${job_name}\", base_ref=~\"release-.*\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+              },
+              "editorMode": "builder",
+              "expr": "prowjobs{base_ref=~\"release-.*\", org=\"kubevirt\"}",
+              "hide": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "lane failures % overall (release-*)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "99254836-eba2-4667-aa63-763bfacabaf1"
+          },
+          "description": "",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 18,
+          "interval": "1h",
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.1.6",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-compute.*\", base_ref=~\"release-.*\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-compute.*\", base_ref=~\"release-.*\"}[1h]))\n* 100",
+              "interval": "1h",
+              "legendFormat": "SIG Compute",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-network.*\", base_ref=~\"release-.*\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-network.*\", base_ref=~\"release-.*\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "SIG Network",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-storage.*\", base_ref=~\"release-.*\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-storage.*\", base_ref=~\"release-.*\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "SIG Storage",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "exemplar": true,
+              "expr": "sum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"failure\", job_name=~\"pull-kubevirt-e2e.*sig-operator.*\", base_ref=~\"release-.*\"}[1h]))\n/\nsum (max_over_time(prowjobs{org=\"kubevirt\", state=~\"success|failure\", job_name=~\"pull-kubevirt-e2e.*sig-operator.*\", base_ref=~\"release-.*\"}[1h]))\n* 100",
+              "hide": false,
+              "interval": "1h",
+              "legendFormat": "SIG Operator",
+              "queryType": "randomWalk",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "lane failures % per SIG (release-*)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "max": "100",
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
             "uid": "prometheus"
           },
           "description": "",
@@ -3216,7 +3691,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "hiddenSeries": false,
           "id": 4,
@@ -3310,7 +3785,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 11,
@@ -3398,7 +3873,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 31
           },
           "hiddenSeries": false,
           "id": 6,
@@ -3590,7 +4065,7 @@ data:
       "timezone": "",
       "title": "e2e jobs overview V2",
       "uid": "efpTS3t4z",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }
   merge-queue.json: |
@@ -3611,7 +4086,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": null
+      "id": null,
       "links": [],
       "panels": [
         {
@@ -4687,6 +5162,16 @@ data:
       "uid": "qFDyvVinx",
       "version": 51
     }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-default-1
+  labels:
+    dashboard-provider: default
+  annotations:
+    grafana_folder: "monitoring"
+data:
   prow-job-load.json: |
     {
       "annotations": {
@@ -9259,7 +9744,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-0
     key: bazel-cache.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9271,7 +9756,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-0
     key: tide.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9283,7 +9768,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-0
     key: e2e-jobs-overview.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9295,7 +9780,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: e2e-jobs-failures-h.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9307,7 +9792,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-0
     key: github-cache.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9319,7 +9804,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: pod-overview.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9331,7 +9816,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: flaky-tests-kubevirt.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9343,7 +9828,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: prow-metrics-dashboard.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9366,7 +9851,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: e2e-test-metrics.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9378,7 +9863,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: referee-retests.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9390,7 +9875,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-0
     key: prow-jobs.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9402,7 +9887,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: prow-job-load.json
 ---
 apiVersion: grafana.integreatly.org/v1beta1
@@ -9414,7 +9899,7 @@ spec:
     matchLabels:
       dashboards: "grafana"
   configMapRef:
-    name: grafana-dashboards-default
+    name: grafana-dashboards-default-1
     key: e2e-lane-runtimes.json
 ---
 # FIXME the metric for the dashboard is missing, we need to reestablish it
@@ -9427,7 +9912,7 @@ spec:
 #    matchLabels:
 #      dashboards: "grafana"
 #  configMapRef:
-#    name: grafana-dashboards-default
+#    name: grafana-dashboards-default-0
 #    key: merge-queue.json
 ---
 # FIXME the metric for the dashboard is missing, we need to reestablish it
@@ -9440,5 +9925,5 @@ spec:
 #    matchLabels:
 #      dashboards: "grafana"
 #  configMapRef:
-#    name: grafana-dashboards-default
+#    name: grafana-dashboards-default-0
 #    key: ci-utilization.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The core problem on the e2e job failures graph is that it’s showing all branches - it should split failures on lanes between main and release branches.

Reason is that not all stabilization PRs and flaky test fixes are backported, so release branches are being affected more by flakes.

This change adds a couple of panels showing the numbers for the main vs. the release branches.

<img width="2348" height="1196" alt="Screenshot From 2025-09-22 11-18-20" src="https://github.com/user-attachments/assets/90684642-2d1e-472e-a744-b83f8f56db1d" />

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fossedihelm 