### PR TITLE
feat: enable INVOKE_FUNCTEST_ONCE for flake checks

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -329,7 +329,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - TARGET_COMMIT_RANGE=$PULL_BASE_SHA.. automation/repeated_test.sh
+        - automation/repeated_test.sh
         env:
         - name: KUBEVIRT_E2E_PARALLEL
           value: "true"
@@ -378,7 +378,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - /bin/sh
         - -c
-        - TARGET_COMMIT_RANGE=$PULL_BASE_SHA.. automation/repeated_test.sh
+        - automation/repeated_test.sh
         env:
         - name: KUBEVIRT_MEMORY_SIZE
           value: 9216M

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -341,6 +341,8 @@ presubmits:
           value: 1G
         - name: CANNIER_IMAGE
           value: quay.io/kubevirtci/cannier:v20250910-9d5a17d
+        - name: INVOKE_FUNCTEST_ONCE
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20250701-f32dbda
         name: ""
         resources:
@@ -388,6 +390,8 @@ presubmits:
           value: 1G
         - name: CANNIER_IMAGE
           value: quay.io/kubevirtci/cannier:v20250910-9d5a17d
+        - name: INVOKE_FUNCTEST_ONCE
+          value: "true"
         image: quay.io/kubevirtci/bootstrap:v20250701-f32dbda
         name: ""
         resources:


### PR DESCRIPTION
Adds the INVOKE_FUNCTEST_ONCE environment variable to the
check-tests-for-flakes and dequarantine-test presubmit jobs.

This enables the new ginkgo --repeat functionality for faster test reruns.