### PR TITLE
feat(rehearse): collapse instructions

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -31,6 +31,9 @@ import (
 )
 
 const basicHelpCommentText = `
+<details>
+<summary>Further information on rehearsals</summary>
+
 A rehearsal can be triggered for all jobs by commenting either ` + "`/rehearse`" + ` or ` + "`/rehearse all`" + ` on this PR.
 
 A rehearsal for a specific job can be triggered by commenting ` + "`/rehearse {job-name}`" + `.
@@ -45,6 +48,7 @@ organization AND either are approvers[1] for all files in the pull request or ar
 top-level approvers[1] in the ` + "`project-infra`" + ` project.
 
 [1]: see [OWNERS](https://www.kubernetes.dev/docs/guide/owners/#owners) file definition for reference.
+</details>
 `
 
 var log *logrus.Logger


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently whenever the rehearse plugin comments on the PR the instructions section is added, however that section is quite big and that bloats the comment.

This change puts the instructions on how to trigger rehearsals into a GitHub style collapsed details section, so the comment is less chatty.

See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections for details

<img width="1236" height="365" alt="image" src="https://github.com/user-attachments/assets/6cde2e62-fbfa-4eb1-8351-e349b26af6dd" />

<img width="1241" height="763" alt="image" src="https://github.com/user-attachments/assets/3c59b65a-7ef7-4d9b-96b9-e5f7d5b78f3a" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
