### PR TITLE
feat: align goveralls and fossa postsubmit resources

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -159,7 +159,7 @@ postsubmits:
             privileged: true
           resources:
             requests:
-              memory: "8Gi"
+              memory: "12Gi"
           volumeMounts:
             - name: kubevirtci-coveralls
               mountPath: /root/.docker/secrets/coveralls
@@ -198,7 +198,7 @@ postsubmits:
             privileged: true
           resources:
             requests:
-              memory: "4Gi"
+              memory: "12Gi"
           volumeMounts:
             - name: kubevirtci-fossa
               mountPath: /root/.docker/secrets/fossa


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Postsubmit jobs are failing due to resource constraints: https://cloud-native.slack.com/archives/C02GACK29RV/p1759176553392959

Align the configurations regarding resources for the postsubmit jobs push-kubevirt-goveralls and push-kubevirt-fossa to their counterparting presubmits.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
