### PR TITLE
bazel: update bootstrap and jobs to use bazel v6.5.0

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -617,7 +617,7 @@ presets:
     preset-bazel-cache: "true"
   env:
     - name: BAZEL_VERSION
-      value: "5.4.1"
+      value: "6.5.0"
     - name: CACHE_HOST
       value: bazel-cache.kubevirt-prow
     - name: CACHE_PORT

--- a/images/bootstrap/Containerfile
+++ b/images/bootstrap/Containerfile
@@ -87,8 +87,8 @@ RUN if test "${ARCH}" != s390x; then \
 
         # Cache the most commonly used bazel versions inside the image
         # and remove resulting cache directories to save a few hundred MB
-        USE_BAZEL_VERSION=5.3.1 bazel version && \
         USE_BAZEL_VERSION=5.4.1 bazel version && \
+        USE_BAZEL_VERSION=6.5.0 bazel version && \
         rm -rf /root/.cache/bazel; \
     fi
 


### PR DESCRIPTION
KubeVirt has been updated to use bazel v6.5.0
https://github.com/kubevirt/kubevirt/blob/e92685b259cec20ced8a4e7df71168702f44aaa7/.bazelversion#L1

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
