### PR TITLE
kubevirt: Run jobs nested to use a consistent builder image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -660,7 +660,6 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
-    preset-bazel-unnested: "false"
     preset-podman-in-container-enabled: "true"
   max_concurrency: 5
   name: periodic-kubevirt-kind-e2e-test-ARM64
@@ -909,7 +908,6 @@ periodics:
     repo: project-infra
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-pgp-bot-key: "true"
@@ -986,7 +984,6 @@ periodics:
     repo: project-infra
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-pgp-bot-key: "true"
@@ -1072,7 +1069,6 @@ periodics:
   labels:
     ci.kubevirt.io/prometheus: ""
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1136,7 +1132,6 @@ periodics:
   labels:
     ci.kubevirt.io/prometheus: ""
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
@@ -1195,7 +1190,6 @@ periodics:
   labels:
     ci.kubevirt.io/prometheus: ""
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
@@ -1256,7 +1250,6 @@ periodics:
   labels:
     ci.kubevirt.io/prometheus: ""
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
@@ -1319,7 +1312,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1363,7 +1355,6 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
-    preset-bazel-unnested: "true"
     preset-podman-in-container-enabled: "true"
   name: periodic-kubevirt-e2e-kind-1.33-sev
   spec:
@@ -1408,7 +1399,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1456,7 +1446,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1503,7 +1492,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1552,7 +1540,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1808,7 +1795,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1853,7 +1839,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1898,7 +1883,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1945,7 +1929,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -1990,7 +1973,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2039,7 +2021,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2084,7 +2065,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2129,7 +2109,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2174,7 +2153,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2223,7 +2201,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2268,7 +2245,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2313,7 +2289,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2358,7 +2333,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"
@@ -2407,7 +2381,6 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-bazel-unnested: "true"
     preset-docker-mirror-proxy: "true"
     preset-kubevirtci-etcd-in-mem: "true"
     preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -11,7 +11,6 @@ presubmits:
       timeout: 2h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -75,7 +74,6 @@ presubmits:
       timeout: 2h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-kubevirtci-etcd-in-mem: "true"
@@ -117,7 +115,6 @@ presubmits:
       grace_period: 30m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       vgpu: "true"
@@ -181,7 +178,6 @@ presubmits:
       grace_period: 30m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-unnested: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 5
     name: pull-kubevirt-e2e-kind-1.33-sev
@@ -235,7 +231,6 @@ presubmits:
       grace_period: 30m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-shared-images: "true"
@@ -552,7 +547,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
-      preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
     optional: true
@@ -676,8 +670,8 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test
     skip_branches:
     - release-\d+\.\d+
@@ -706,8 +700,8 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-fuzz
     optional: true
     skip_branches:
@@ -928,8 +922,8 @@ presubmits:
       timeout: 1h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-check-unassigned-tests
     skip_branches:
     - release-\d+\.\d+
@@ -958,7 +952,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1001,7 +994,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1045,7 +1037,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1084,7 +1075,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.33-sig-compute-arm64
@@ -1180,7 +1170,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     name: build-kubevirt-builder
@@ -1243,7 +1232,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
@@ -1324,7 +1312,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
@@ -1374,7 +1361,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
@@ -1416,7 +1402,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1461,7 +1446,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1534,7 +1518,6 @@ presubmits:
       timeout: 2h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1576,7 +1559,6 @@ presubmits:
     labels:
       ci.kubevirt.io/prometheus: ""
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
@@ -1630,7 +1612,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1671,7 +1652,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1712,7 +1692,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1755,7 +1734,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1796,7 +1774,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1837,7 +1814,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1878,7 +1854,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1921,7 +1896,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -1962,7 +1936,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -2002,7 +1975,6 @@ presubmits:
       timeout: 4h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -2042,7 +2014,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -2084,7 +2055,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"
@@ -2124,7 +2094,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
-      preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-kubevirtci-etcd-in-mem: "true"
       preset-podman-in-container-enabled: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:

While trying to upgrade to go v1.24.7 - issues were hit due to inconsistencies between the builder and the bootstrap.

https://github.com/kubevirt/kubevirt/pull/15784#issuecomment-3351889264

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
