### PR TITLE
feat(buildlog): add TIMEOUT as keyword

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -35,13 +35,12 @@ deck:
         name: buildlog
         config:
           highlight_regexes:
-          # default patterns, see https://github.com/kubernetes/test-infra/blob/e7ccf79861d3c53dfaa6c784c0c8537922c4c0cc/prow/spyglass/lenses/buildlog/lens.go#L95
+          # see default patterns https://github.com/kubernetes-sigs/prow/blob/269d4b273f64d1a4371bc6c0bebc4d452320a649/pkg/spyglass/lenses/buildlog/lens.go#L98
           - ^E\d{4} \d\d:\d\d:\d\d\.\d+
           - "(Error|ERROR|error)s?:"
           - (FAIL|Failure \[)\b
-          - "timed out"
+          - "(timed out|TIMEOUT)"
           - panic\b
-          # own patterns
           - \[FAILED\]
           - "fatal: "
       required_files:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Currently lines like

```
//pkg/virt-controller/watch:go_default_test                             TIMEOUT in 301.9s
```
([source](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/15756/pull-kubevirt-unit-test-1.3/1972998538749022208#1:build-log.txt%3A589))

are not shown by default.

This change adds `TIMEOUT` as keyword.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey @jean-edouard 