### PR TITLE
fix(fossa,goveralls): increase job resources

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -159,7 +159,7 @@ postsubmits:
             privileged: true
           resources:
             requests:
-              memory: "12Gi"
+              memory: "16Gi"
           volumeMounts:
             - name: kubevirtci-coveralls
               mountPath: /root/.docker/secrets/coveralls
@@ -198,7 +198,7 @@ postsubmits:
             privileged: true
           resources:
             requests:
-              memory: "12Gi"
+              memory: "16Gi"
           volumeMounts:
             - name: kubevirtci-fossa
               mountPath: /root/.docker/secrets/fossa

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -755,7 +755,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 12Gi
+            memory: 16Gi
         securityContext:
           privileged: true
         volumeMounts:
@@ -792,7 +792,7 @@ presubmits:
         name: ""
         resources:
           requests:
-            memory: 12Gi
+            memory: 16Gi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We are seeing frequent 1h timeouts in the push-kubevirt-goveralls [1] and push-kubevirt-fossa [2] jobs. Since these are still running on the control-plane cluster, they are likely failing due to resource constraints.

A CI search [3] shows that also the pull jobs are failing, not in the same frequency as the postsubmits, but still we think increasing memory will stabilize them.

[1]: https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/push-kubevirt-goveralls
[2]: https://prow.ci.kubevirt.io/job-history/kubevirt-prow/logs/push-kubevirt-fossa
[3]: https://search.ci.kubevirt.io/?search=Process+did+not+finish+before+1h0m0s+timeout&maxAge=336h&context=1&type=build-log&name=%28push%7Cpull%29-kubevirt-%28fossa%7Cgoveralls%29&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @brianmcarey 