### PR TITLE
Enable prow for the new virt-template repository

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -139,6 +139,7 @@ tide:
     kubevirt/kubevirt.core: merge
     kubevirt/enhancements: squash
     kubevirt/irsa-mutation-webhook: squash
+    kubevirt/virt-template: merge
 
   queries:
   - repos:
@@ -209,6 +210,7 @@ tide:
     - kubevirt/vm-console-proxy
     - kubevirt/kubevirt.core
     - kubevirt/irsa-mutation-webhook
+    - kubevirt/virt-template
     labels:
     - lgtm
     - approved
@@ -490,6 +492,8 @@ branch-protection:
           branches:
             main:
               protect: true
+        virt-template:
+          protect: true
     k8snetworkplumbingwg:
       repos:
         kubemacpool:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -462,6 +462,15 @@ plugins:
     - owners-label
     - trigger
 
+  kubevirt/virt-template:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+    - help
+
   kubevirt/vm-console-proxy:
     plugins:
     - approve
@@ -621,6 +630,7 @@ approve:
   - kubevirt/dra-pci-driver
   - kubevirt/enhancements
   - kubevirt/irsa-mutation-webhook
+  - kubevirt/virt-template
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -758,6 +768,7 @@ lgtm:
   - kubevirt/dra-pci-driver
   - kubevirt/enhancements
   - kubevirt/irsa-mutation-webhook
+  - kubevirt/virt-template
   review_acts_as_lgtm: true
 
 override:
@@ -812,6 +823,7 @@ triggers:
   - kubevirt/application-aware-quota
   - kubevirt/enhancements
   - kubevirt/irsa-mutation-webhook
+  - kubevirt/virt-template
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This enables prow for the new virt-template repository

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
