### PR TITLE
Fix metrics linter job to the right path

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1492,7 +1492,7 @@ presubmits:
     max_concurrency: 11
     name: pull-kubevirt-metrics-lint
     optional: true
-    run_if_changed: docs/metrics.md
+    run_if_changed: docs/observability/metrics.md
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
The metrics.md file path changed need to also update the job to the correct path

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
