### PR TITLE
kubernetes-nmstate: Add repo to periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -121,6 +121,11 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
   cluster: prow-workloads
+  extra_refs:
+  - base_ref: main
+    org: nmstate
+    repo: kubernetes-nmstate
+    workdir: true
   spec:
     nodeSelector:
       type: bare-metal-external


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix failures like https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-knmstate-e2e-handler-k8s-future/1983715634990551040

**Release note**:
```release-note
NONE
```
