### PR TITLE
Include skip-review PRs in periodic retester job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -26,6 +26,13 @@ periodics:
           -label:needs-rebase
           repo:kubevirt/kubevirt
           repo:kubevirt/kubevirtci
+          OR (is:pr
+          is:open
+          label:skip-review
+          status:failure
+          -label:needs-rebase
+          repo:kubevirt/kubevirt
+          repo:kubevirt/kubevirtci)
       - --token=/etc/github/oauth
       - |-
         --comment=/retest-required


### PR DESCRIPTION
**What this PR does / why we need it**:
The `periodic-project-infra-retester` job currently only retries failed or flaky PRs that have both `lgtm` and `approved` labels.  
As a result, PRs labeled with `skip-review` are ignored and not picked up for automatic retesting.

This PR updates the retester query to also include PRs with the `skip-review` label, ensuring that automation or maintenance PRs (which bypass manual review) are still eligible for retest when required jobs fail or flake.

**Special notes for your reviewer**:
- Adds an OR condition in the retester query to pick up both:
  - PRs with `lgtm` and `approved`
  - PRs with `skip-review`
- Updates the retester comment message to reflect the change.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Retester bot now includes PRs with the skip-review label for automatic retries.
```
