### PR TITLE
kubernetes-nmstate: Use latest networkmanager on reporter

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -107,7 +107,7 @@ periodics:
     - name: gcs
       secret:
         secretName: gcs
-- name: periodic-knmstate-e2e-handler-k8s-future
+- name: periodic-knmstate-e2e-handler-k8s-latest
   cron: "0 2 * * *"
   annotations:
     testgrid-create-test-group: "false"
@@ -137,8 +137,10 @@ periodics:
           requests:
             memory: "52Gi"
         env:
-          - name: NMSTATE_PIN
-            value: "future"
+          - name: NMSTATE_VERSION
+            value: "latest"
+          - name: NM_VERSION
+            value: "latest"
         command:
           - "/usr/local/bin/runner.sh"
           - "/bin/sh"


### PR DESCRIPTION
**What this PR does / why we need it**:
kubernetes-nmstate: Use latest networkmanager on reporter

**Special notes for your reviewer**:
Depends-on:
- https://github.com/nmstate/kubernetes-nmstate/pull/1385

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
