### PR TITLE
fix(referee,test-subset): use publish_image.sh

### DIFF
--- a/external-plugins/referee/Makefile
+++ b/external-plugins/referee/Makefile
@@ -15,5 +15,5 @@ format:
 	gofmt -w .
 
 push:
-	podman build -f ../../images/$(CONTAINER_IMAGE)/Containerfile -t $(CONTAINER_REPO):$(CONTAINER_TAG) && podman push $(CONTAINER_REPO):$(CONTAINER_TAG)
-	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO) $(CONTAINER_TAG)
+	cd ../../images && ./publish_image.sh -e $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO)

--- a/external-plugins/test-subset/Makefile
+++ b/external-plugins/test-subset/Makefile
@@ -15,5 +15,5 @@ format:
 	gofmt -w .
 
 push:
-	podman build -f ../../images/$(CONTAINER_IMAGE)/Containerfile -t $(CONTAINER_REPO):$(CONTAINER_TAG) && podman push $(CONTAINER_REPO):$(CONTAINER_TAG)
-	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO) $(CONTAINER_TAG)
+	cd ../../images && ./publish_image.sh -e $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x ../../hack/update-deployments-with-latest-image.sh $(CONTAINER_REPO)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Switch to using the publish_image.sh script now, since neither environment is setup nor is the project-infra folder added.

See builds:
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-referee-image/1986782476302815232#1:build-log.txt%3A48
* https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/publish-test-subset-plugin-image/1986782545043263488

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

See #3869

**Special notes for your reviewer**:

/cc @brianmcarey