### PR TITLE
project-infra,images: Only publish images when changes are merged into the main branch

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -2,6 +2,8 @@ postsubmits:
   kubevirt/project-infra:
     - name: publish-rehearse-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "external-plugins/rehearse/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -32,6 +34,8 @@ postsubmits:
               privileged: true
     - name: publish-phased-plugin-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "external-plugins/phased/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -62,6 +66,8 @@ postsubmits:
               privileged: true
     - name: publish-test-subset-plugin-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "external-plugins/test-subset/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -92,6 +98,8 @@ postsubmits:
               privileged: true
     - name: publish-release-blocker-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "external-plugins/release-blocker/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -122,6 +130,8 @@ postsubmits:
               privileged: true
     - name: publish-release-tool-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "releng/release-tool/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -151,6 +161,8 @@ postsubmits:
               privileged: true
     - name: publish-botreview-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "external-plugins/botreview/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -181,6 +193,8 @@ postsubmits:
               privileged: true
     - name: publish-referee-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "^(external-plugins|images)/referee/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -211,6 +225,8 @@ postsubmits:
               privileged: true
     - name: publish-kubevirt-infra-bootstrap-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/kubevirt-infra-bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -241,6 +257,8 @@ postsubmits:
                 memory: "1Gi"
     - name: publish-bootstrap-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/golang/.*|images/bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -274,6 +292,8 @@ postsubmits:
                 memory: "52Gi"
     - name: publish-shared-images-controller-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/shared-images-controller/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -303,6 +323,8 @@ postsubmits:
                 memory: "4Gi"
     - name: publish-kubekins-e2e-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/kubekins-e2e/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -333,6 +355,8 @@ postsubmits:
                 memory: "1Gi"
     - name: publish-kubevirt-kubevirt.github.io-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/kubevirt-kubevirt.github.io/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -368,6 +392,8 @@ postsubmits:
                 memory: "1Gi"
     - name: publish-kubevirt-user-guide-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/kubevirt-user-guide/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -398,6 +424,8 @@ postsubmits:
                 memory: "1Gi"
     - name: publish-prow-deploy-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/prow-deploy/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -427,6 +455,8 @@ postsubmits:
                 memory: "8Gi"
     - name: publish-autoowners-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/autoowners/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -456,6 +486,8 @@ postsubmits:
                 memory: "4Gi"
     - name: publish-pr-creator-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/pr-creator/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -485,6 +517,8 @@ postsubmits:
                 memory: "52Gi"
     - name: publish-vm-image-builder-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/vm-image-builder/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -517,6 +551,8 @@ postsubmits:
                 memory: "52Gi"
     - name: publish-fedora-coreos-kubevirt-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/fedora-coreos-kubevirt/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -755,6 +791,8 @@ postsubmits:
               privileged: true
     - name: publish-test-report-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "robots/.*/test-report/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -785,6 +823,8 @@ postsubmits:
                 memory: "8Gi"
     - name: publish-test-label-analyzer-image
       always_run: false
+      branches:
+      - main
       run_if_changed: "images/test-label-analyzer/.*|robots/.*/test-label-analyzer/.*"
       annotations:
         testgrid-create-test-group: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:

These images should only be published when there are changes pushed to the main branch.

For example the github dependabot creates a branch against the project-infra repo itself and not a fork which causes the publish jobs to be triggered[1] - this good lead to bad images being published.

[1] https://github.com/kubevirt/project-infra/issues/4505

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @xpivarc 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
