### PR TITLE
flake-stats-report:sort per-lane failure summary by number of failures in descending order

### DIFF
--- a/robots/pkg/flake-stats/flake-stats.gohtml
+++ b/robots/pkg/flake-stats/flake-stats.gohtml
@@ -35,8 +35,8 @@
             </span>
         <span class="failureBlock">
             <span class="failureBlockHeader">Per Lane</span><br/>
-                {{ range $key, $value := .FailuresPerLane }}
-                    {{ template "failure" $value }}
+                {{ range .GetSortedFailuresPerLane }}
+                    {{ template "failure" . }}
                 {{ end }}
             </span>
         <hr/>

--- a/robots/pkg/flake-stats/report.go
+++ b/robots/pkg/flake-stats/report.go
@@ -23,13 +23,14 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 	"net/http"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
 )
 
 //go:embed flake-stats.gohtml

--- a/robots/pkg/flake-stats/types.go
+++ b/robots/pkg/flake-stats/types.go
@@ -21,6 +21,7 @@ package flakestats
 
 import (
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -191,6 +192,22 @@ func (t *TopXTest) CalculateShareFromTotalFailures(totalFailures int) {
 	for key := range t.FailuresPerDay {
 		t.FailuresPerDay[key].setShare(totalFailures)
 	}
+}
+
+func (t *TopXTest) GetSortedFailuresPerLane() []*FailureCounter {
+	lanes := make([]*FailureCounter, 0, len(t.FailuresPerLane))
+	for _, fc := range t.FailuresPerLane {
+		lanes = append(lanes, fc)
+	}
+
+	sort.Slice(lanes, func(i, j int) bool {
+		if lanes[i].Sum == lanes[j].Sum {
+			return lanes[i].Name < lanes[j].Name
+		}
+		return lanes[i].Sum > lanes[j].Sum
+	})
+
+	return lanes
 }
 
 type FailureCounter struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
The Per lane table in the flake stats report is currently ordered lexicographically by lane name. This makes it difficult to identify the most problematic lanes when several lanes share the same heat map color.
This PR updates flake stats to sort the per-lane summary by total number of failures (Sum) in descending order, making it easier to visually understand where failures are concentrated.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4511

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
flake-stats-report:sort per-lane failure summary by number of failures in descending order
```
