### PR TITLE
Initial setup of kubevirt-migration-operator prow jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-presubmits.yaml
@@ -1,0 +1,95 @@
+presubmits:
+  kubevirt/kubevirt-migration-operator:
+  - name: pull-kubevirt-migration-operator-e2e
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    cluster: prow-workloads
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251022-6eb3ab1
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - export KUBEVIRT_NUM_NODES=2 && export KUBEVIRT_STORAGE=rook-ceph-default && "./hack/test-e2e.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "52Gi"
+  - name: pull-kubevirt-migration-operator-unit-test
+    cluster: kubevirt-prow-control-plane
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251022-6eb3ab1
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make test"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+  - name: pull-kubevirt-migration-operator-lint
+    cluster: kubevirt-prow-control-plane
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251022-6eb3ab1
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make lint"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -142,6 +142,7 @@ tide:
     kubevirt/irsa-mutation-webhook: squash
     kubevirt/virt-template: merge
     kubevirt/kubevirt-migration-controller: squash
+    kubevirt/kubevirt-migration-operator: squash
 
   queries:
   - repos:
@@ -214,6 +215,8 @@ tide:
     - kubevirt/irsa-mutation-webhook
     - kubevirt/virt-template
     - kubevirt/kubevirt-migration-controller
+    - kubevirt/kubevirt-migration-operator
+
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -495,6 +495,14 @@ plugins:
     - owners-label
     - release-note
     - trigger
+    
+  kubevirt/kubevirt-migration-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
 
   nmstate/kubernetes-nmstate:
     plugins:
@@ -639,6 +647,7 @@ approve:
   - kubevirt/irsa-mutation-webhook
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
+  - kubevirt/kubevirt-migration-operator
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -778,6 +787,7 @@ lgtm:
   - kubevirt/irsa-mutation-webhook
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
+  - kubevirt/kubevirt-migration-operator
   review_acts_as_lgtm: true
 
 override:
@@ -834,6 +844,7 @@ triggers:
   - kubevirt/irsa-mutation-webhook
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
+  - kubevirt/kubevirt-migration-operator
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
