### PR TITLE
flake-stats: add support for filtering test list by lane name

### DIFF
--- a/robots/pkg/flake-stats/flake-stats.gohtml
+++ b/robots/pkg/flake-stats/flake-stats.gohtml
@@ -143,12 +143,14 @@
         function enableFilterFields() {
             document.getElementById("filterByName").disabled = false;
             document.getElementById("excludeByName").disabled = false;
+            document.getElementById("filterByLane").disabled = false;
         }
 
         function updateFilteredRows() {
-            let filterTerms, excludeTerms, reportDiv, divs, i, testName, shouldShow, rowsShown;
+            let filterTerms, excludeTerms, laneTerms, reportDiv, divs, i, testName, shouldShow, rowsShown;
             filterTerms = document.getElementById("filterByName").value.toUpperCase().split("|");
             excludeTerms = document.getElementById("excludeByName").value.toUpperCase().split("|");
+            laneTerms = document.getElementById("filterByLane").value.toUpperCase().split("|");
             reportDiv = document.getElementById("report");
             divs = reportDiv.getElementsByTagName("div");
 
@@ -175,6 +177,33 @@
                         }
                         if (found !== true) {
                             shouldShow = false
+                        }
+                    }
+                    // Lane filtering logic
+                    if (shouldShow === true && laneTerms.length > 0 && laneTerms[0] !== "") {
+                        let failedOnMatchingLane = false;
+                        let laneBlocks = Array.from(divs[i].getElementsByClassName("failureBlock"))
+                             .find(block => block.querySelector(".failureBlockHeader")?.innerText === "Per Lane");
+                        if (laneBlocks) {
+                            let tables = laneBlocks.getElementsByTagName("table");
+
+                            for (let t = 0; t < tables.length; t++) {
+                                let laneHeader = tables[t].querySelector(".failureHeader");
+                                if (!laneHeader) continue;
+
+                                let laneName = laneHeader.innerText.toUpperCase();
+
+                                for (let k = 0; k < laneTerms.length; k++) {
+                                    if (laneName.indexOf(laneTerms[k]) !== -1) {
+                                        failedOnMatchingLane = true;
+                                        break;
+                                    }
+                                }
+                                if (failedOnMatchingLane) break;
+                            }
+                        }
+                        if (!failedOnMatchingLane) {
+                            shouldShow = false;
                         }
                     }
                     if (shouldShow === true) {
@@ -231,6 +260,15 @@
             <td class="no_border">
                 <input type="text" id="excludeByName" onkeyup="updateFilteredRows()" placeholder="term1|term2|..."
                        disabled>
+            </td>
+        </tr>
+        <tr>
+            <td class="no_border">
+                <label for="filterByLane">Show only tests that failed on lanes containing</label>
+            </td>
+            <td class="no_border">
+                <input type="text" id="filterByLane" onkeyup="updateFilteredRows()" placeholder="lane1|lane2|..."
+                    disabled>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
**What this PR does / why we need it**:
The flake-stats report currently supports filtering the list of tests only by test name. When investigating which tests contribute failures to specific lanes, it is difficult to isolate tests based on the lane they fail on. This PR adds a new filter box that allows filtering the test list by lane name, using the same user experience as the existing test-name filter.

**Which issue(s) this PR fixes** 
Fixes #4522 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
flake-stats: add support for filtering test list by lane name
```
