### PR TITLE
fix(retester): use kubevirt-commenter-bot credentials

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -4,8 +4,6 @@ periodics:
   decorate: true
   annotations:
     testgrid-create-test-group: "false"
-  labels:
-    preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   extra_refs:
   - org: kubevirt
@@ -27,6 +25,13 @@ periodics:
       env:
       - name: GIMME_GO_VERSION
         value: "1.25.1"
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github
+    volumes:
+    - name: token
+      secret:
+        secretName:  commenter-oauth-token
 - name: periodic-project-infra-close
   interval: 1h
   annotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

kubevirt-bot will be ignored by the trigger plugin, so we need to use kubevirt-commenter-bot credentials so that the retest comments are not ignored.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4532

**Special notes for your reviewer**:
/cc @brianmcarey @xpivarc @fossedihelm @victortoso 