### PR TITLE
flake-stats: display number of PRs contributing to failures per day

### DIFF
--- a/robots/pkg/flake-stats/flake-stats.gohtml
+++ b/robots/pkg/flake-stats/flake-stats.gohtml
@@ -58,6 +58,12 @@
                 {{ .Sum }}
             </td>
         </tr>
+        {{ if gt .PrCount 0 }}
+        <tr>
+            <td>PRs merged</td>
+            <td class="failureValue">{{ .PrCount }}</td>
+        </tr>
+        {{ end }}
     </table>
 {{ end }}
 

--- a/robots/pkg/flake-stats/types.go
+++ b/robots/pkg/flake-stats/types.go
@@ -219,6 +219,7 @@ type FailureCounter struct {
 	SharePercent  float64
 	ShareCategory ShareCategory
 	URL           string
+	PrCount       int
 }
 
 func (f *FailureCounter) add(value int) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the flake-stats HTML report by displaying the number of PRs associated with each day's 24h flakefinder window. Flakefinder attributes test failures to the day on which the PR was merged, which can make a day appear to have many failures simply because many PRs were merged on that day.

By showing the count of PRs next to the daily failure totals, we can better distinguish between:
- days with genuinely high failure rates, and  
- days where the number of failures is inflated due to a high volume of merged PRs.

This helps SIG-CI more easily spot anomaly days and identify newly introduced flaky or unstable tests.

**Which issue(s) this PR fixes** 
Fixes #3630

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
flake-stats: display number of PRs contributing to failures per day
```
