### PR TITLE
fix(flake-stats): preserve test count display when using lane filter

### DIFF
--- a/robots/pkg/flake-stats/flake-stats.gohtml
+++ b/robots/pkg/flake-stats/flake-stats.gohtml
@@ -152,8 +152,8 @@
             excludeTerms = document.getElementById("excludeByName").value.toUpperCase().split("|");
             laneTerms = document.getElementById("filterByLane").value.toUpperCase().split("|");
             reportDiv = document.getElementById("report");
-            divs = reportDiv.getElementsByTagName("div");
-
+            divs = Array.from(reportDiv.getElementsByTagName("div"))
+                .filter(d => d.id && !d.id.startsWith("total"));
             rowsShown = 0;
             for (i = 0; i < divs.length; i++) {
                 if (divs[i]) {
@@ -217,12 +217,18 @@
             updateRowsShown(rowsShown);
         }
 
+        function countTestDivs() {
+            return Array.from(document.getElementById("report").getElementsByTagName("div"))
+                .filter(d => d.id && !d.id.startsWith("total")).length;
+        }
+
         function initRowsShown() {
-            updateRowsShown(document.getElementById("report").getElementsByTagName("div").length);
+            let total = countTestDivs();
+            document.getElementById("totalRowsShown").innerText = "Showing " + total + " of " + total + " flaky tests";
         }
 
         function updateRowsShown(rowsShown) {
-            let rowsTotal = document.getElementById("report").getElementsByTagName("div").length;
+            let rowsTotal = countTestDivs();
             document.getElementById("totalRowsShown").innerText = "Showing " + rowsShown + " of " + rowsTotal + " flaky tests";
         }
     </script>


### PR DESCRIPTION
**What this PR does / why we need it**:
When the lane filter field was used, the “Showing X of Y flaky tests” counter disappeared. This PR fixes the logic so the counter updates correctly and always remains visible during filtering.

**Which issue(s) this PR fixes** 
Fixes #4536

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 preserve test count display when using lane filter
```
