### PR TITLE
flakefinder: highlight tests with non-deterministic outcomes

### DIFF
--- a/robots/cmd/flakefinder/report.gohtml
+++ b/robots/cmd/flakefinder/report.gohtml
@@ -51,6 +51,11 @@
             background-color: #ffbf80;
         }
 
+        .nondeterministic {
+            border: 3px solid blue !important;
+            box-shadow: 0 0 8px rgba(0,0,255,0.5);
+        }
+
         .unimportant {
         }
 
@@ -268,7 +273,14 @@
                             N/A
                         </td>
                     {{- else -}}
-                        <td class="{{ (index $.Data $test $header).Severity }} center"
+                        {{- $details := (index $.Data $test $header) -}}
+                        {{- $flakyClass := "" -}}
+
+                        {{- if $details.NonDeterministic }}
+                            {{- $flakyClass = "nondeterministic" -}}
+                        {{- end }}
+
+                        <td class="{{ $details.Severity }} {{ $flakyClass }} center"
                             title="{{ $test }}&#10;{{ $header }}">
                             <div id="r{{$row}}c{{$col}}" onClick="popup(this.id)" class="popup">
                             <span class="tests_failed"

--- a/robots/cmd/flakefinder/report_test.go
+++ b/robots/cmd/flakefinder/report_test.go
@@ -3,11 +3,12 @@ package main_test
 import (
 	"bytes"
 	"fmt"
-	"kubevirt.io/project-infra/robots/pkg/flakefinder"
-	"kubevirt.io/project-infra/robots/pkg/validation"
 	"log"
 	"os"
 	"time"
+
+	"kubevirt.io/project-infra/robots/pkg/flakefinder"
+	"kubevirt.io/project-infra/robots/pkg/validation"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,6 +44,7 @@ var _ = Describe("report.go", func() {
 		jobNameA  = "a"
 		jobNameB  = "b"
 		jobNameC  = "c"
+		commitID1 = "d66cb1c"
 	)
 
 	When("rendering report data", func() {
@@ -64,11 +66,23 @@ var _ = Describe("report.go", func() {
 				Data: map[string]map[string]*flakefinder.Details{
 					testName1: {
 						jobNameA: &flakefinder.Details{
-							Failed:    4,
-							Succeeded: 1,
-							Skipped:   2,
-							Severity:  "red",
-							Jobs:      []*flakefinder.Job{}},
+							Failed:           4,
+							Succeeded:        1,
+							Skipped:          2,
+							Severity:         "red",
+							NonDeterministic: true,
+							Jobs: []*flakefinder.Job{
+								{
+									BuildNumber: 1,
+									Severity:    "red",
+									CommitID:    commitID1,
+								},
+								{
+									BuildNumber: 2,
+									Severity:    "green",
+									CommitID:    commitID1,
+								},
+							}},
 					},
 					testName2: {
 						jobNameB: &flakefinder.Details{
@@ -141,7 +155,7 @@ var _ = Describe("report.go", func() {
 
 		It("has one filled test cell", func() {
 			prepareWithDefaultParams()
-			Expect(buffer.String()).To(ContainSubstring("<td class=\"red center\""))
+			Expect(buffer.String()).To(ContainSubstring("<td class=\"red nondeterministic center\""))
 			Expect(buffer.String()).To(MatchRegexp("(?s)4.*1.*2"))
 		})
 

--- a/robots/pkg/flakefinder/flakefinder.go
+++ b/robots/pkg/flakefinder/flakefinder.go
@@ -140,6 +140,7 @@ type JobResult struct {
 	BuildNumber int
 	PR          int
 	BatchPRs    []int
+	CommitID    string
 }
 
 type ReportBaseDataOptions struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for detecting non-deterministic test outcomes in the flakefinder report. A test is considered non-deterministic when it has both passed and failed on the same commit and same lane.
The current flakefinder report lists test failures, but it does not highlight true flaky behavior — cases where the same test behaves differently across builds for the same commit. These cases are the most important for debugging flakiness, but they are currently hard to spot.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #3910

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
flakefinder: highlight tests with non-deterministic outcomes
```
