### PR TITLE
Update Prow document link for getting started

### DIFF
--- a/docs/how-to-add-a-prow-cluster.md
+++ b/docs/how-to-add-a-prow-cluster.md
@@ -174,7 +174,7 @@ The encrypted file will be available in `my-kubeconfig.gpg` in the current
 directory.
 
 
-[this Prow document]: https://github.com//kubernetes-sigs/prow/blob/main/site/content/en/docs/getting-started-deploy.md#run-test-pods-in-different-clusters
+[this Prow document]: https://github.com/kubernetes-sigs/prow/blob/main/site/content/en/docs/getting-started-deploy.md#run-test-pods-in-different-clusters
 [issue on project-infra]: https://github.com/kubevirt/project-infra/issues/new
 [kubeconfig encrypted as described here]: #encrypt
 [an example of a job configured with KubeVirtCI external provider]: https://github.com/kubevirt/project-infra/blob/bab947fa42f89f78238160d487bf047f4dea5c9f/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml#L650


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
prow had moved, so the link to the prow documentation needed to be updated.  


**Special notes for your reviewer**:

This is an update to a link in the documentation, so people don't get a 404 when they try to learn how to add a new cluster to the virt test infrastructure. 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
this is a documentation update.
```
