### PR TITLE
kubevirtci,periodic: fix job to automatically bump fedora image in kubevirtci

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -98,12 +98,12 @@ periodics:
         set -e
         if labels-checker \
               --org=kubevirt \
-              --repo=kubevirt \
+              --repo=kubevirtci \
               --author=kubevirt-bot \
               --branch-name=bump-fedora-provision \
               --ensure-labels-missing=lgtm,approved,do-not-merge/hold \
               --github-token-path=/etc/github/oauth; then
-          git-pr.sh -c "./hack/bump-fedora-images-version.sh ../kubevirtci/cluster-provision/centos9/Dockerfile" -d "Bump fedora provisioning base to latest version" -b bump-fedora-provision -p ../kubevirtci -T main
+          git-pr.sh -c "./hack/bump-fedora-images-version.sh ../kubevirtci/cluster-provision/centos9/Dockerfile" -d "echo 'Bump fedora provisioning base to latest version'" -b bump-fedora-provision -p ../kubevirtci -r kubevirtci -T main
         fi
       securityContext:
         privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This job has been failing for some time - fix job so that the correct repo is targeted.

https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-fedora-provision-image

example run with these changes:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kubevirtci-bump-fedora-provision-image/1996863511434629120

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
