### PR TITLE
fix(cluster-up,1.35): increase node resources

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -649,9 +649,11 @@ presubmits:
         env:
         - name: GIMME_GO_VERSION
           value: 1.24.7
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 9216M
         resources:
           requests:
-            memory: 16Gi
+            memory: 32Gi
         securityContext:
           privileged: true
       nodeSelector:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

k8s conformance tests related to pod live resizing are failing with "resize is infeasible" which is caused by lack of resources. [1]

This change updates job memory requests and increases node memory.

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirtci/1576/check-provision-k8s-1.35/1996145848941023232

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
