### PR TITLE
chore(docs): update Prow links using its new home

### DIFF
--- a/docs/how-to-add-a-prow-cluster.md
+++ b/docs/how-to-add-a-prow-cluster.md
@@ -174,7 +174,7 @@ The encrypted file will be available in `my-kubeconfig.gpg` in the current
 directory.
 
 
-[this Prow document]: https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#Run-test-pods-in-different-clusters
+[this Prow document]: https://docs.prow.k8s.io/docs/getting-started-deploy/#run-test-pods-in-different-clusters
 [issue on project-infra]: https://github.com/kubevirt/project-infra/issues/new
 [kubeconfig encrypted as described here]: #encrypt
 [an example of a job configured with KubeVirtCI external provider]: https://github.com/kubevirt/project-infra/blob/bab947fa42f89f78238160d487bf047f4dea5c9f/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml#L650

--- a/docs/how-to-onboard-a-repository.md
+++ b/docs/how-to-onboard-a-repository.md
@@ -28,7 +28,7 @@ If you do not want the webhook to be managed by Prow, here's how you setup the w
 * Go to the settings page of your repository or org, select webhooks on the left, and click on "Add webhook"
 * Enter the values as described in the screenshot
   * payload url is `https://prow.ci.kubevirt.io/hook`
-  * how and what to add as a secret is [documented here](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-github-secrets)
+  * how and what to add as a secret is [documented here](https://docs.prow.k8s.io/docs/getting-started-deploy/#create-the-github-secrets)
 
 ![Prow Webhook Configuration](prow_webhook_configuration.png)
 
@@ -39,7 +39,7 @@ Further resources
   * [Prow Deployment overview](https://github.com/kubevirt/project-infra/tree/main/github/ci/prow-deploy#kubevirt-prow-deployment)
   * [Prow configuration repository](https://github.com/kubevirt/project-infra/)
   * [Deck - the prow ui](https://prow.ci.kubevirt.io/)
-* kubernetes/test-infra
-  * [Prow docs](https://github.com/kubernetes/test-infra/blob/master/prow/)
-  * [Life Of A Prow Job](https://github.com/kubernetes/test-infra/blob/master/prow/life_of_a_prow_job.md)
-  * [How To Configure New Jobs](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#how-to-configure-new-jobs)
+* sigs.k8s.io/prow
+  * [Prow docs](https://docs.prow.k8s.io/docs/)
+  * [Life Of A Prow Job](https://docs.prow.k8s.io/docs/life-of-a-prow-job/)
+  * [How To Configure New Jobs](https://docs.prow.k8s.io/docs/jobs/#how-to-configure-new-jobs)

--- a/docs/infrastructure-components.md
+++ b/docs/infrastructure-components.md
@@ -143,12 +143,12 @@ Used to run ARM test jobs.
 
 Runs [performance-related jobs](performance-cluster.md).
 
-[Prow]: https://github.com/kubernetes/test-infra/tree/master/prow#readme
-["Life of a Prow Job"]: https://github.com/kubernetes/test-infra/blob/master/prow/life_of_a_prow_job.md
-[sequence diagram]: https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/docs/pr-interactions-sequence.svg?sanitize=true
+[Prow]: https://github.com/kubernetes-sigs/prow#readme
+["Life of a Prow Job"]: https://docs.prow.k8s.io/docs/life-of-a-prow-job/
+[sequence diagram]: https://docs.prow.k8s.io/images/pr-interactions-sequence.svg
 [ci-search]: https://github.com/openshift/ci-search
 [docker proxy]: https://github.com/rpardini/docker-registry-proxy
 [cert-manager]: https://cert-manager.io/docs/
-[greenhouse]: https://github.com/kubernetes/test-infra/tree/master/greenhouse
+[greenhouse]: https://github.com/kubernetes/test-infra/tree/1b4b11a/greenhouse
 [automation secrets]: https://github.com/kubevirt/secrets/blob/master/secrets.tar.asc
 [build clusters configuration here]: ./how-to-add-a-prow-cluster.md

--- a/docs/performance-cluster.md
+++ b/docs/performance-cluster.md
@@ -12,7 +12,7 @@ Correctness tests run as unit and functional tests for each PR, and performance 
 ## Prow cluster
 The CI/CD system for performance testing is based on [Prow], a Kubernetes CI system, using the same control plane system as the Correctness tests. Therefore, all test statuses can be viewed in the same testgrid.
 
-However, unlike Correctness tests, Performance testing jobs do not use KubeVirtCI, which creates a Kubernetes cluster in a virtual machine. Instead, a pre-built cluster on top of baremetal nodes is used due to performance reasons. Most speacilly because we want to avoid the performance implications of nested virtualization. Moreover, unlike Correctness tests, only one Performance test job can run at a time to avoid performance interference from workload collocation.
+However, unlike Correctness tests, Performance testing jobs do not use KubeVirtCI, which creates a Kubernetes cluster in a virtual machine. Instead, a pre-built cluster on top of baremetal nodes is used due to performance reasons. Most specially because we want to avoid the performance implications of nested virtualization. Moreover, unlike Correctness tests, only one Performance test job can run at a time to avoid performance interference from workload collocation.
 
 
 
@@ -85,11 +85,10 @@ Regarding the hardware configuration, all nodes are homogeneous, with 2 Intel(R)
 
 ## Contact
 
-Please join our community and help us build the future of KubeVirt! There are many ways to participate. If you’re particularly interested in perfoamcne and scalability, you’ll be interested in: 
+Please join our community and help us build the future of KubeVirt! There are many ways to participate. If you’re particularly interested in performance and scalability, you’ll be interested in:
 
 * Joining the scalability “Special Interest Group”, which meets every Thursday at 7 AM Pacific Time at [Zoom meeting](https://zoom.us/j/96406344036). Calendar information [here](https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io&ctz=GMT).
 * Chat with us on Slack via [#virtualization](https://kubernetes.slack.com/?redir=%2Farchives%2FC8ED7RKFE) or [#kubevirt-dev](https://kubernetes.slack.com/archives/C0163DT0R8X) @ kubernetes.slack.com
 * Discuss with us on the [kubevirt-dev Google Group](https://groups.google.com/forum/#!forum/kubevirt-dev)
 
-[Prow]: https://github.com/kubernetes/test-infra/tree/master/prow#readme
-[docker proxy]: https://github.com/rpardini/docker-registry-proxy
+[Prow]: https://github.com/kubernetes-sigs/prow#readme


### PR DESCRIPTION
**What this PR does / why we need it**:

Prow has moved to a new standalone repository since 2024-04-09 and is also using a new website, making obsolete the links to its documentation referenced in this repository.

This PR fixes those dead links.

**Special notes for your reviewer**:

/cc @dhiller
