### PR TITLE
kubevirt,arm64: Move arm64 lanes to optional due to issue scheduling

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -438,7 +438,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.5
-    optional: false
+    optional: true
     spec:
       containers:
       - command:
@@ -871,7 +871,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.5
-    optional: false
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -483,7 +483,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.6
-    optional: false
+    optional: true
     spec:
       containers:
       - command:
@@ -904,7 +904,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.6
-    optional: false
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -526,6 +526,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.7
+    optional: true
     spec:
       containers:
       - command:
@@ -943,6 +944,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64-1.7
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -551,6 +551,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1080,6 +1081,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

There is an issue scheduling the arm64 jobs - it appears that the arm64 workloads is not available.

Move these jobs to optional to unblock the merge queue until the issue is resolved.

<img width="2244" height="1099" alt="screenshot-2025-12-07-21:34:26" src="https://github.com/user-attachments/assets/f7cf8a5f-e35b-4b77-a962-9daa4ee7d5e0" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @dollierp 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
