### PR TITLE
Revert "kubevirt,arm64: Move arm64 lanes to optional due to issue sch…

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -438,7 +438,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.5
-    optional: true
+    optional: false
     spec:
       containers:
       - command:
@@ -871,7 +871,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.5
-    optional: true
+    optional: false
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -483,7 +483,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.6
-    optional: true
+    optional: false
     spec:
       containers:
       - command:
@@ -904,7 +904,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.6
-    optional: true
+    optional: false
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -526,7 +526,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.7
-    optional: true
     spec:
       containers:
       - command:
@@ -944,7 +943,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64-1.7
-    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -551,7 +551,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1081,7 +1080,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

…eduling (#4570)"

Cluster config has been updated, jobs are scheduled successfully again: https://prow.ci.kubevirt.io/?job=*-arm64

This reverts commit f7d65436a3dab40f09ed6573ebaebb3962add456.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dollierp @xpivarc 