### PR TITLE
feat(label-checker): add -M flag for checking PR

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -550,7 +550,7 @@ postsubmits:
       always_run: false
       branches:
       - main
-      run_if_changed: "images/pr-creator/.*"
+      run_if_changed: 'images/pr-creator/.*|hack/(git-pr\.sh|git-askpass\.sh)|robots/cmd/labels-checker/.*|robots/pkg/.*|go\.(mod|sum)'
       annotations:
         testgrid-create-test-group: "false"
       decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -397,7 +397,7 @@ presubmits:
               memory: "4Gi"
   - name: build-pr-creator-image
     always_run: false
-    run_if_changed: "images/pr-creator/.*"
+    run_if_changed: 'images/pr-creator/.*|hack/(git-pr\.sh|git-askpass\.sh)|robots/cmd/labels-checker/.*|robots/pkg/.*|go\.(mod|sum)'
     decorate: true
     labels:
       preset-podman-in-container-enabled: "true"

--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -40,13 +40,14 @@ repo=kubevirt
 command_path=$(pwd)
 targetbranch=master
 labels=
+missing_labels=
 description_command=
 title=
 body=
 head_branch=
 release_note_none=
 
-while getopts ":Dc:s:l:t:T:p:n:e:b:o:r:m:L:d:h:R:B:" opt; do
+while getopts ":Dc:s:l:t:T:p:n:e:b:o:r:m:L:M:d:h:R:B:" opt; do
     case "${opt}" in
         D )
             dry_run=true
@@ -90,6 +91,9 @@ while getopts ":Dc:s:l:t:T:p:n:e:b:o:r:m:L:d:h:R:B:" opt; do
         L )
             labels="${OPTARG}"
             ;;
+        M )
+            missing_labels="${OPTARG}"
+            ;;
         d )
             description_command="${OPTARG}"
             ;;
@@ -112,6 +116,19 @@ done
 if [ -z "${command}" ]; then
     usage
     exit 1
+fi
+
+if [ -n "${missing_labels}" ]; then
+    if ! labels-checker \
+        --org=kubevirt \
+        --repo="${repo}" \
+        --author="${user}" \
+        --branch-name="${branch}" \
+        --ensure-labels-missing="${missing_labels}" \
+        --github-token-path="${token}"; then
+        echo "skipping PR creation since a PR exists and has one of labels ${missing_labels}"
+        exit 0
+    fi
 fi
 
 if [ -z "${summary}" ]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds the flag `-M` with an argument of a set of comma-separated labels. If there exists a PR and has one of those, the PR creation will be aborted.

This integrates the often-found conjunction of labels-checker calls with git-pr.sh calls into the git-pr.sh script in order to avoid the boilerplate of mentioning repo, branch name etc. twice.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dollierp 

Note: will follow up with a separate pr that updates usages, since the pr-creator image update is required to be applied beforehand, so that those will work