### PR TITLE
fix(dequarantine,check-tests-for-flakes): timeout

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -338,6 +338,8 @@ presubmits:
           value: quay.io/kubevirtci/cannier:v20250910-9d5a17d
         - name: INVOKE_FUNCTEST_ONCE
           value: "true"
+        - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+          value: "6h45m"
         image: quay.io/kubevirtci/bootstrap:v20251218-e7a7fc9
         name: ""
         resources:
@@ -387,6 +389,8 @@ presubmits:
           value: quay.io/kubevirtci/cannier:v20250910-9d5a17d
         - name: INVOKE_FUNCTEST_ONCE
           value: "true"
+        - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+          value: "35h45m"
         image: quay.io/kubevirtci/bootstrap:v20251218-e7a7fc9
         name: ""
         resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

As can be seen here [1] the internal Ginkgo timeout prohibits the lanes
running as long as the job timeout permits. This comes into play now
because `INVOKE_FUNCTEST_ONCE` only runs the process once, so the timeout
value is not valid per single test lane run but for all repetitions.

The reason for these extensive timeout values is that we are
establishing a compromise to accomodate for eventually very long test
runtimes (see kubevirt test runtimes dashboard [2] for an overview).

With the dequarantine lane we run a test that is dequarantined 500
times, to fullfill requirements described for dequarantine in [3].
Since a test might run for 10 minutes we need to compromise so that
the test can get run at least around 200 times - thus the 35h
timeout.

This change sets the env var `KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT` to a
value near the job timeout (-15 minutes less).

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/16368/pull-kubevirt-check-dequarantine-test/2001230254634438656#1:build-log.txt%3A4176
[2]: https://grafana.ci.kubevirt.io/d/gY4hNc5Iz/kubevirt-kubevirt-e2e-test-runtimes?orgId=1
[3]: https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md#getting-tests-out-of-quarantine

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
