### PR TITLE
feat(flake-stats): add md output showing lane failures

### DIFF
--- a/pkg/flake-stats/flake-stats.gomd
+++ b/pkg/flake-stats/flake-stats.gomd
@@ -1,0 +1,65 @@
+{{- /*
+
+    This file is part of the KubeVirt project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Copyright 2023 Red Hat, Inc.
+
+*/ -}}
+
+{{- /* gotype: kubevirt.io/project-infra/robots/cmd/flake-stats.TemplateData */ -}}
+
+<style>
+    <!--
+
+    .lightyellow {
+        background-color: lightgoldenrodyellow;
+    }
+
+    .yellow {
+        background-color: #ffff80;
+    }
+
+    .orange {
+        background-color: #ffbf80;
+    }
+
+    .orangered {
+        background-color: #ff9090;
+    }
+
+    .red {
+        background-color: #ff7070;
+    }
+
+    .darkred {
+        background-color: #ff5050;
+    }
+    -->
+</style>
+
+{{ define "failures" }}
+* {{ template "failure" .AllFailures }}
+{{ range .GetSortedFailuresPerLane }}
+{{ if gt .SharePercent 1.0 }}  * {{ template "failure" . }}{{ end }}{{ end }}
+{{ end }}
+
+{{ define "failure" -}}
+<span class="failureBlock {{ .ShareCategory.CSSClassName }}">{{ if .URL }}[{{ end }}{{ .Name }}{{ if .URL }}]({{ .URL }}){{ end }} <span class="failureValue">( ∑={{ .Sum }}, {{ printf "%.2f" .SharePercent }}% )</span></span>
+{{- end }}
+
+# {{$.Org}}/{{$.Repo}}
+{{ template "failures" $.OverallFailures }}
+
+Last updated: {{ $.Date }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds the md output format, that generates a summary for the lane failures overall. This is used in the lane failures summary for the weekly meetings.

```bash
go run ./robots/cmd/flake-stats --output-format md --output-file /tmp/flake-stats.md --overwrite-output-file --filter-lane-regex='.*-root$'
```

Screenshot of output:

<img width="1021" height="509" alt="image" src="https://github.com/user-attachments/assets/039e9b6c-e317-4693-96a7-f00cc6028608" />


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dollierp 