### PR TITLE
chore(grafana): improve e2e job failures/h

### DIFF
--- a/github/ci/services/grafana/deploy/base/grafana.yaml
+++ b/github/ci/services/grafana/deploy/base/grafana.yaml
@@ -9123,7 +9123,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 21,
+      "id": 12,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -9162,7 +9162,7 @@ data:
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "none"
+                  "mode": "normal"
                 },
                 "thresholdsStyle": {
                   "mode": "line+area"
@@ -9210,10 +9210,14 @@ data:
           "id": 2,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
               "mode": "single",
@@ -9239,7 +9243,7 @@ data:
               },
               "editorMode": "code",
               "expr": "sum(increase(prowjobs{org=\"kubevirt\", state=\"failure\"}[1h]))",
-              "hide": false,
+              "hide": true,
               "legendFormat": "total: failed/h",
               "range": true,
               "refId": "B"
@@ -9283,7 +9287,7 @@ data:
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "none"
+                  "mode": "normal"
                 },
                 "thresholdsStyle": {
                   "mode": "line+area"
@@ -9331,10 +9335,14 @@ data:
           "id": 3,
           "options": {
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": false
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "sortBy": "Last *",
+              "sortDesc": true
             },
             "tooltip": {
               "mode": "single",
@@ -9360,7 +9368,7 @@ data:
               },
               "editorMode": "code",
               "expr": "sum(increase(prowjobs{org=\"kubevirt\", state=\"aborted\"}[1h]))",
-              "hide": false,
+              "hide": true,
               "legendFormat": "total: aborted/h",
               "range": true,
               "refId": "B"
@@ -9370,7 +9378,7 @@ data:
           "type": "timeseries"
         }
       ],
-      "refresh": "15m",
+      "refresh": false,
       "schemaVersion": 37,
       "style": "dark",
       "tags": [],
@@ -9378,14 +9386,14 @@ data:
         "list": []
       },
       "time": {
-        "from": "now-2d",
+        "from": "now-6h",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "e2e job failures / h",
       "uid": "_6XBEfyIk",
-      "version": 8,
+      "version": 2,
       "weekStart": ""
     }
   e2e-lane-runtimes.json: |


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

ATM the e2e job failures per hour pane (top on [1]) is showing the lanes where failures happened, additionally it shows a sum of all failures/h. This makes the failures on the lanes very had to distinguish. Same goes for job abortions panel below.

<img width="1903" height="1290" alt="Screenshot From 2025-12-31 12-10-54" src="https://github.com/user-attachments/assets/5b506d3e-c904-4725-ad2c-d46766468ac9" />

This change updates the dashboard graphs in three ways - it removes the sum graph, changes the display to stacking mode, which improves overall usability of the graphs by showing each lane better, and finally it adds a legend with last value property sorted descending.

<img width="2094" height="1293" alt="Screenshot From 2025-12-31 10-19-32" src="https://github.com/user-attachments/assets/41a15d7e-42d0-4ab1-a6f0-c3d2eb907c77" />


[1]: https://grafana.ci.kubevirt.io/d/_6XBEfyIk/e2e-job-failures-h?orgId=1&from=now-6h&to=now&refresh=15m

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dollierp @enp0s3 