### PR TITLE
Add Ronilerr to KubeVirt org members

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -92,6 +92,7 @@ orgs:
       - rabin-io
       - RamLavi
       - RoniKishner
+      - Ronilerr
       - Ruclo
       - rthallisey
       - salawhaaat


### PR DESCRIPTION
# GitHub Username
@Ronilerr 

## Requirements

- [x] I have reviewed the community code of conduct (https://github.com/kubevirt/kubevirt/blob/master/CODE_OF_CONDUCT.md)<br>
- [x] I have enabled 2FA on my GitHub account (https://github.com/settings/security)<br>
- [x] I have subscribed to the kubevirt-dev e-mail list (https://groups.google.com/forum/#!forum/kubevirt-dev)<br>
- [x] I am actively contributing to KubeVirt<br>
- [x] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines<br>
- [x] I have spoken to my sponsors ahead of this application and they have agreed to sponsor my application<br>
- [x] I have publicly introduced myself to the community through one of the community communication channels<br>

(https://github.com/kubevirt/community#socializing)

## Sponsors
@avlitman 
@nunnatsa 

## List of contributions to the KubeVirt project

* PRs reviewed and/or authored

https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3916
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3842
https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3867

**Note to reviewer:**
Member list was ordered alphabetically.