### PR TITLE
fix(s390x): remove unknown presets

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -15,8 +15,6 @@ periodics:
     workdir: true
   labels:
     preset-podman-in-container-enabled: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-kubevirtci-quay-credential: "true"
   max_concurrency: 1
   name: periodic-containerdisks-s390x-verify-nightly
   spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since the mounts pointed at by the presets
preset-docker-mirror-proxy and preset-kubevirtci-quay-credential aren't available on the s390x cluster, jobs using these fail to schedule.

This change removes the presets for the job.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4640

**Special notes for your reviewer**:

/cc @dollierp 

FYI @nestoracunablanco 