### PR TITLE
Cloud-Provider: fix golang version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
             - "make test"
           env:
             - name: GIMME_GO_VERSION
-              value: "1.24"
+              value: "1.24.11"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -69,7 +69,7 @@ presubmits:
             - "make lint"
           env:
             - name: GIMME_GO_VERSION
-              value: "1.24"
+              value: "1.24.11"
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
@@ -106,6 +106,6 @@ presubmits:
           privileged: true
         env:
           - name: GIMME_GO_VERSION
-            value: "1.24"
+            value: "1.24.11"
       nodeSelector:
         type: bare-metal-external


### PR DESCRIPTION
Gimme rejected the current setting of `1.24`. Changed to `1.24.11`, to satisfy Gimme.


