### PR TITLE
pr-creator: add workaround for cross architecture image build

### DIFF
--- a/images/pr-creator/Containerfile
+++ b/images/pr-creator/Containerfile
@@ -15,10 +15,10 @@ ENV GOPROXY=https://proxy.golang.org|direct \
 # - https://gitlab.com/qemu-project/qemu/-/issues/2738
 # - https://github.com/openshift/dpu-operator/pull/308
 ENV GOMAXPROCS=3
-ENV GIMME_GO_VERSION=1.22.6
+ENV GIMME_GO_VERSION=1.24.9
 
 RUN set -x && \
-    git clone --depth 1 --revision e4d87dae72dbf1754625cbf112afc535307c1db4 https://github.com/kubernetes/test-infra.git && \
+    git clone --depth 1 --revision 03e5768a447b55381f7517a9d27bb51831893d31 https://github.com/kubernetes/test-infra.git && \
     cd ./test-infra && \
     /usr/local/bin/runner.sh /bin/sh -cex 'go mod vendor && time go build -tags netgo -o /usr/local/bin/pr-creator ./robots/pr-creator' && \
     chmod +x /usr/local/bin/pr-creator


### PR DESCRIPTION
**What this PR does / why we need it**:

The job [build-pr-creator-image](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/build-pr-creator-image) is timing out most of the time.

The initial hypothesis was a lack of resources but it is more likely related to a bug with the combo qemu-user-static + golang and a workaround is to actually reduce the resources for the build. 

**Special notes for your reviewer**:

/cc @dhiller