### PR TITLE
fix(robots,push): align paths after directory structure change

### DIFF
--- a/robots/flake-report-creator/Makefile
+++ b/robots/flake-report-creator/Makefile
@@ -14,9 +14,9 @@ verify:
 	../build-verify.sh
 
 push:
-	cd ../../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
-	bash -x "../../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
-	bash -x "../../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
+	cd ../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x "../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
+	bash -x "../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
 
 clean:
 	go clean -cache -modcache

--- a/robots/flakefinder/Makefile
+++ b/robots/flakefinder/Makefile
@@ -14,9 +14,9 @@ verify:
 	../build-verify.sh
 
 push:
-	cd ../../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
-	bash -x "../../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
-	bash -x "../../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
+	cd ../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x "../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
+	bash -x "../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
 
 clean:
 	go clean -cache -modcache

--- a/robots/indexpagecreator/Makefile
+++ b/robots/indexpagecreator/Makefile
@@ -14,9 +14,9 @@ verify:
 	../build-verify.sh
 
 push:
-	cd ../../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
-	bash -x "../../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
-	bash -x "../../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
+	cd ../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x "../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
+	bash -x "../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
 
 clean:
 	go clean -cache -modcache

--- a/robots/kubevirt/Makefile
+++ b/robots/kubevirt/Makefile
@@ -12,4 +12,4 @@ format:
 	goimports -w -local kubevirt.io/project-infra . ../../pkg/kubevirt
 
 validate: format
-	../../../hack/check-workspace-dirty.sh
+	../../hack/check-workspace-dirty.sh

--- a/robots/test-report/Makefile
+++ b/robots/test-report/Makefile
@@ -14,9 +14,9 @@ verify:
 	../build-verify.sh
 
 push:
-	cd ../../../images && ./publish_image.sh -e $(CONTAINER_IMAGE) quay.io kubevirtci
-	bash -x "../../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
-	bash -x "../../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
+	cd ../../images && ./publish_image.sh -e $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x "../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
+	bash -x "../../hack/update-scripts-with-latest-image.sh" "$(CONTAINER_REPO)"
 
 clean:
 	go clean -cache -modcache


### PR DESCRIPTION
**What this PR does / why we need it**:

Align paths in robots Makefile push target according to the recent directory change.

This fixes publish-* jobs.

**Special notes for your reviewer**:

/cc @dhiller