### PR TITLE
fix(prow-bump): improve prow changelog generation

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -667,7 +667,7 @@ periodics:
       args:
       - "-ce"
       - |
-        hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main -d "./hack/prow-updates.sh"
+        hack/git-pr.sh -c "hack/bump-prow.sh" -b prow-autobump -r project-infra -T main -d "./hack/prow-changelog.sh"
       securityContext:
         privileged: true
       resources:

--- a/hack/describe-pr-from-updated-images-in-diff.sh
+++ b/hack/describe-pr-from-updated-images-in-diff.sh
@@ -38,7 +38,7 @@ FYI @kubevirt/prow-job-taskforce
 Images updated:
 EOF
     for image in $(
-        git show -- "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy" | \
+        git diff -- "${PROJECT_INFRA_ROOT}/github/ci/prow-deploy" | \
             grep -E '^\+\s+-? image: ' | \
             grep -oE 'quay.io/kubevirtci/[^: @]+' | \
             sort -u

--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -139,7 +139,12 @@ cd "${command_path}"
 eval "${command}"
 
 cd "${repo_path}"
-echo "git config user.name=${git_name} user.email=${git_email}..." >&2
+
+if [ -z "$(git status --porcelain)" ]; then
+    echo "Nothing changed" >&2
+    exit 0
+fi
+
 git config user.name "${git_name}"
 git config user.email "${git_email}"
 
@@ -166,10 +171,6 @@ if [ -z "${head_branch}" ]; then
 fi
 
 git add -A
-if git diff --name-only --exit-code HEAD; then
-    echo "Nothing changed" >&2
-    exit 0
-fi
 
 if [ -n "$release_note_none" ]; then
     summary+='\n\n```release-note\nNONE\n```'

--- a/hack/prow-changelog.sh
+++ b/hack/prow-changelog.sh
@@ -31,14 +31,14 @@ set -u
 set -o pipefail
 
 commit_range=$(
-    git show "$(git log -1 --format=%H -- hack/bump-prow.sh)" -- hack/bump-prow.sh | \
+    git diff -- hack/bump-prow.sh | \
         grep -E '^[+-]\s.*v[0-9]+-([a-f0-9]+).*$' |\
         sed -E 's#^[+-]\s.*v[0-9]+-([a-f0-9]+).*$#\1#g'
 )
 changes=$(
     (
         cd ../../kubernetes-sigs/prow
-        git log --format=oneline "${commit_range/$'\n'/..}"
+        git log --format=oneline --abbrev-commit "${commit_range/$'\n'/..}"
     ) | sed -E 's#^([a-f0-9]+)#* \[\1\]\(https://github.com/kubernetes-sigs/prow/commit/\1\)#g' \
       | sed -E 's/ (#[0-9]+) / kubernetes-sigs\/prow\1 /g'
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

When the script generating prow changelog is invoked, the changes from the autobumper are not committed yet, hence, we need to use `git diff` instead of `git show` to parse them.

If `git show` is used, the changelog is generated for the previous PR which modified the file.

**Special notes for your reviewer**:

/cc @dhiller