### PR TITLE
chore(cleanup): remove obsolete bm9 node (anti) affinity

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -22,15 +22,6 @@ postsubmits:
         preset-kubevirtci-quay-credential: "true"
       cluster: prow-workloads
       spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - key: kubernetes.io/hostname
-                  operator: NotIn
-                  values:
-                  - bare-metal-9
         nodeSelector:
           type: bare-metal-external
         volumes:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -447,15 +447,6 @@ presubmits:
     name: check-provision-alpine-with-test-tooling
     optional: true
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/hostname
-                operator: NotIn
-                values:
-                - bare-metal-9
       containers:
       - command:
         - /usr/local/bin/runner.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

This rule doesn't have any effect anymore since the new workloads cluster has no node named bare-metal-9.

This reverts commit ff69a25a0b4a88fa0bc9dd2a14d15e1dc7e9c971.

**Special notes for your reviewer**:

/cc @dhiller