### PR TITLE
virt-template: Add periodic update of virt-template

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
@@ -31,3 +31,77 @@ periodics:
       resources:
         requests:
           memory: 200Mi
+- name: periodic-update-virt-template-kubevirt-main
+  cron: 0 2 * * *
+  cluster: kubevirt-prow-control-plane
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt
+    base_ref: main
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260126-f00ab24
+      env:
+      - name: VIRT_TEMPLATE_BRANCH
+        value: release-0.1
+      - name: KUBEVIRT_BRANCH
+        value: main
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -c
+      - |
+        export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+        latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
+        description="Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+
+        git-pr.sh -c "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH}" -p ../kubevirt -d "echo -e \"${description}\"" -r kubevirt -b update-virt-template-main -T ${KUBEVIRT_BRANCH} -M lgtm,approved,do-not-merge/hold
+      resources:
+        requests:
+          memory: "200Mi"
+- name: periodic-update-virt-template-kubevirt-release-1.8
+  cron: 0 2 * * *
+  cluster: kubevirt-prow-control-plane
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt
+    base_ref: release-1.8
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260126-f00ab24
+      env:
+      - name: VIRT_TEMPLATE_BRANCH
+        value: release-0.1
+      - name: KUBEVIRT_BRANCH
+        value: release-1.8
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -c
+      - |
+        export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+        latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
+        description="Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+
+        git-pr.sh -c "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH}" -p ../kubevirt -d "echo -e \"${description}\"" -r kubevirt -b update-virt-template-release-1.8 -T ${KUBEVIRT_BRANCH} -M lgtm,approved,do-not-merge/hold
+      resources:
+        requests:
+          memory: "200Mi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add periodic update of the virt-template installer bundle in kubevirt/kubevirt and the virt-template version in kubevirt/hyperconverged-cluster-operator.

See https://github.com/kubevirt/enhancements/issues/76

/hold

This requires https://github.com/kubevirt/kubevirt/pull/16670 and https://github.com/kubevirt/hyperconverged-cluster-operator/pull/3987 first


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
