### PR TITLE
tempfix: make cluster-up for s390x common instancetypes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -125,9 +125,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - |
-          cat $ICR_PASSWORD | podman login icr.io --username $(cat $ICR_USER) --password-stdin=true
-          make kubevirt-up && make kubevirt-sync && make kubevirt-functest
+        - "make cluster-up && make cluster-sync && make cluster-functest"
         env:
         - name: GIMME_GO_VERSION
           value: 1.24.5


### PR DESCRIPTION
Building natively for s390x is not feasable with the latest Bazel update. To ensure test coverage for the s390x common instancetypes, this commit replaces the use of "make kubevirt" with "make cluster".

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
