### PR TITLE
Update Makefile - Add pkg to build and test. Chnaged WHAT_COVERAGE TO COVERAGE_TARGETS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,9 @@ ifndef COVERAGE_OUTPUT_PATH
 	COVERAGE_OUTPUT_PATH=${ARTIFACTS}/coverage.html
 	export COVERAGE_OUTPUT_PATH
 endif
-ifndef WHAT_COVERAGE
-	WHAT_COVERAGE=./external-plugins/... ./releng/... ./robots/... ./pkg/...
-	export WHAT_COVERAGE
+ifndef COVERAGE_TARGETS
+	COVERAGE_TARGETS=./external-plugins/... ./releng/... ./robots/... ./pkg/...
+	export COVERAGE_TARGETS
 endif
 
 .PHONY: all clean deps-update update-labels install-metrics-binaries lint $(limiter) $(flake-report-writer) $(querier) $(kubevirtci) $(flake-issue-creator)
@@ -49,6 +49,6 @@ lint:
 
 coverage:
 	if ! command -V covreport; then go install github.com/cancue/covreport@latest; fi
-	go test ${WHAT_COVERAGE} -coverprofile=/tmp/coverage.out
+	go test ${COVERAGE_TARGETS} -coverprofile=/tmp/coverage.out
 	mkdir -p ${ARTIFACTS}
 	covreport  -i /tmp/coverage.out -o ${COVERAGE_OUTPUT_PATH}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Added ./pkg/... to the build and test targets in Makefile. Renamed WHAT_COVERAGE to COVERAGE_TARGETS for clarity. 
Previously PKG was not included in builds or tests so coverage was not being tracked. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
-->
```release-note
NONE
```
