### PR TITLE
Updating the user-guide image to Fedora 43

### DIFF
--- a/images/kubevirt-user-guide/Dockerfile
+++ b/images/kubevirt-user-guide/Dockerfile
@@ -1,5 +1,5 @@
 # BASE
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:43
 
 ENV LC_ALL=en_US.UTF-8
 
@@ -12,13 +12,13 @@ RUN mkdir -p /src && cd /src && \
       nodejs npm python3-pip ruby ruby-devel rubygems rubygems-devel \
       rubygem-bundler rubygem-json rubygem-nenv rubygem-rake && \
     alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    npm install -g markdownlint-cli casperjs phantomjs-prebuilt yaspeller && \
+    npm install -g markdownlint-cli@latest yaspeller@latest && \
     cd /src && bundle install && bundle update && cd && \
     pip install --upgrade pip && \
     pip install mkdocs mkdocs-material mkdocs-awesome-pages-plugin mkdocs-htmlproofer-plugin && \
     gem list && \
     rpm -e --nodeps libX11 libX11-common libXrender libXft && \
-    dnf erase -y @development-tools gcc qt5-srpm-macros \
+    dnf remove -y @development-tools gcc qt5-srpm-macros \
       xkeyboard-config qrencode-libs memstrack \
       openssl-devel ruby-devel rubygems-devel \
       nodejs-docs rubygem-rdoc glibc-all-langpacks vim-minimal tar \


### PR DESCRIPTION
**What this PR does / why we need it**:
Fedora 37 is deprecated and local build was not building for me. Updating image to F43.
This meant also updating the 'dnf erase' command to 'dnf remove'. 
The build log showed various npm deprecation warnings. Claude suggested the changes made on L21: Dropping deprecated libraries (casperjs, phantomjs-prebuilt) and tagging others @latest.

Local build succeeds with updated Dockerfile. 

**Special notes for your reviewer**:
Changes to npm (L21) suggested by Claude. 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Updating user-guide-image to Fedora 43; includes updated commands for dnf and npm
```
