### PR TITLE
fix(jobs): don't use shallow clone for presubmit jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -6,7 +6,6 @@ presubmits:
     always_run: true
     decorate: true
     cluster: kubevirt-prow-control-plane
-    clone_depth: 1
     labels:
       preset-gcs-credentials: "true"
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Using shallow clones in presubmit jobs seems to cause issues in the clonerefs init container while setting up the environment:

    fatal: refusing to merge unrelated histories


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4709

**Special notes for your reviewer**:

/cc @dhiller