### PR TITLE
fix(deps): bump bootstrap image for release-0.59 vgpu lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -522,7 +522,7 @@ presubmits:
         env:
         - name: TARGET
           value: kind-1.23-vgpu
-        image: quay.io/kubevirtci/bootstrap:v20221222-8f66e7e
+        image: quay.io/kubevirtci/bootstrap:v20241121-ac63e76
         name: ""
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:

This brings a podman update which is required to fix the following error with newer kernels.

    Error: OCI runtime error: crun: chmod `run/shm`: Operation not supported

See https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-kind-1.23-vgpu-0.59

**Special notes for your reviewer**:

/cc @dhiller 