### PR TITLE
chore(jobs): reduce memory requests close to actual use

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -519,6 +519,7 @@ postsubmits:
       always_run: false
       branches:
       - main
+      clone_depth: 1
       run_if_changed: 'images/pr-creator/.*|hack/(git-pr\.sh|git-askpass\.sh)|robots/labels-checker/.*|pkg/.*|go.mod|go.sum'
       annotations:
         testgrid-create-test-group: "false"
@@ -543,13 +544,14 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "52Gi"
+                memory: "4Gi"
               limits:
-                memory: "52Gi"
+                memory: "4Gi"
     - name: publish-vm-image-builder-image
       always_run: false
       branches:
       - main
+      clone_depth: 1
       run_if_changed: "images/vm-image-builder/.*"
       annotations:
         testgrid-create-test-group: "false"
@@ -577,9 +579,9 @@ postsubmits:
               privileged: true
             resources:
               requests:
-                memory: "52Gi"
+                memory: "4Gi"
               limits:
-                memory: "52Gi"
+                memory: "4Gi"
     - name: publish-fedora-coreos-kubevirt-image
       always_run: false
       branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -428,12 +428,12 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "52Gi"
+              memory: "4Gi"
             limits:
-              memory: "52Gi"
+              memory: "4Gi"
   - name: build-vm-image-builder-image
     always_run: false
-    run_if_changed: "images/bootstrap/.*"
+    run_if_changed: "images/vm-image-builder/.*"
     decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
@@ -776,6 +776,7 @@ presubmits:
     - org: kubevirt
       repo: kubevirt
       base_ref: main
+      clone_depth: 1
     spec:
       securityContext:
         runAsUser: 0
@@ -795,7 +796,7 @@ presubmits:
             privileged: true
           resources:
             requests:
-              memory: "52Gi"
+              memory: "2Gi"
           volumeMounts:
           - name: molecule-docker
             mountPath: /tmp/prow-deploy-molecule
@@ -846,7 +847,7 @@ presubmits:
             runAsUser: 0
   - name: pull-project-infra-grafana-deploy-test
     optional: false
-    run_if_changed: "github/ci/services/grafana/.*|github/ci/services/common/.*"
+    run_if_changed: "github/ci/services/(grafana|common)/.*"
     decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
@@ -857,6 +858,7 @@ presubmits:
     - org: kubevirt
       repo: kubevirt
       base_ref: main
+      clone_depth: 1
     spec:
       containers:
         - command:
@@ -871,7 +873,7 @@ presubmits:
               # create test cluster
               kind create cluster --image quay.io/kubevirtci/kindest-node:v1.30.0
               kubectl cluster-info --context kind-kind
-              
+
               ./github/ci/services/grafana/hack/test.sh
           env:
           - name: GIMME_GO_VERSION
@@ -879,9 +881,9 @@ presubmits:
           image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
           resources:
             requests:
-              memory: "52Gi"
+              memory: "2Gi"
             limits:
-              memory: "52Gi"
+              memory: "2Gi"
           securityContext:
             privileged: true
             runAsUser: 0


### PR DESCRIPTION
**What this PR does / why we need it**:

While the resources are not actually used, they remain reserved and the jobs spend a lot of time in the queue waiting for the resources to be released.

This PR reduce the memory requests for the following project-infra jobs:
- build-pr-creator-image
- build-vm-image-builder-image
- publish-pr-creator-image
- publish-vm-image-builder-image
- pull-project-infra-grafana-deploy-test
- pull-project-infra-prow-deploy-test

Each of them was rehearsed 10 times and no OOMKill was observed.

**Special notes for your reviewer**:

/cc @dhiller