### PR TITLE
Allow getting the go version from the go.mod file

### DIFF
--- a/images/golang/Containerfile
+++ b/images/golang/Containerfile
@@ -3,6 +3,8 @@ FROM bootstrap-$ARCH
 
 ENV GIMME_GO_VERSION=1.24.9
 
+COPY entrypoint.sh /usr/local/bin/
+
 # Cache latest stable golang version
 RUN curl -sL -o /bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && chmod +x /bin/gimme
 RUN gimme $GIMME_GO_VERSION

--- a/images/golang/entrypoint.sh
+++ b/images/golang/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2018 The Kubernetes Authors.
+# Copyright 2021 The KubeVirt Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GO_MOD_PATH=${GO_MOD_PATH:-}
+
+if [[ -n ${GO_MOD_PATH} && -f ${GO_MOD_PATH} ]]; then
+  export GIMME_GO_VERSION="$(grep -E '^go' "${GO_MOD_PATH}" | cut -d' ' -f 2)"
+fi
+
+# actually start bootstrap and the job, under the runner (which handles dind etc.)
+/usr/local/bin/runner.sh "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:

When we want to bump the golang version in our repository, we first need to update the `GIMME_GO_VERSION` variable to the new version. This requires two PRs in two different repositories.

This PR allow setting the new `GO_MOD_PATH` variable instead of the `GIMME_GO_VERSION`, to let the golnag image to find the go version by querying the go.mod file, and then setting the `GIMME_GO_VERSION` variable internally.

After making this change in the job config file, e.g.
```
env:
- name: GO_MOD_PATH
  value: go.mod
```

we can modify the version in the project repo's go mod file without modifying the job config file in this repo.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow getting the go version from the go.mod file
```
