### PR TITLE
[HCO] Add K8s 1.35 lane. Drop the 1.33 lane

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -1,44 +1,5 @@
 presubmits:
   kubevirt/hyperconverged-cluster-operator:
-    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.33
-      skip_branches:
-        - release-\d+\.\d+
-      annotations:
-        fork-per-release: "true"
-        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-      always_run: true
-      optional: false
-      decorate: true
-      decoration_config:
-        timeout: 7h
-        grace_period: 5m
-      max_concurrency: 6
-      labels:
-        preset-podman-in-container-enabled: "true"
-        preset-docker-mirror-proxy: "true"
-        preset-podman-shared-images: "true"
-      cluster: prow-workloads
-      spec:
-        nodeSelector:
-          type: bare-metal-external
-        containers:
-          - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
-            command:
-              - "/usr/local/bin/runner.sh"
-              - "/bin/sh"
-              - "-c"
-              - "export TARGET=k8s-1.33 && automation/test.sh"
-            env:
-              - name: GIMME_GO_VERSION
-                value: "1.25.5"
-              - name: GINKGO_LABELS
-                value: '!OpenShift && !SINGLE_NODE_ONLY'
-            # docker-in-docker needs privileged mode
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                memory: "50Gi"
     - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.34
       skip_branches:
         - release-\d+\.\d+
@@ -69,7 +30,46 @@ presubmits:
               - "export TARGET=k8s-1.34 && automation/test.sh"
             env:
               - name: GIMME_GO_VERSION
-                value: "1.25.5"
+                value: "1.25.7"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY'
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.35
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
+      always_run: true
+      optional: false
+      decorate: true
+      decoration_config:
+        timeout: 7h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-podman-shared-images: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.35 && automation/test.sh"
+            env:
+              - name: GIMME_GO_VERSION
+                value: "1.25.7"
               - name: GINKGO_LABELS
                 value: '!OpenShift && !SINGLE_NODE_ONLY'
             # docker-in-docker needs privileged mode
@@ -97,7 +97,7 @@ presubmits:
           - image: quay.io/kubevirtci/bootstrap:v20251218-e7a7fc9
             env:
               - name: GIMME_GO_VERSION
-                value: "1.25.5"
+                value: "1.25.7"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
@@ -131,7 +131,7 @@ presubmits:
           - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
             env:
               - name: GIMME_GO_VERSION
-                value: "1.25.5"
+                value: "1.25.7"
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"


### PR DESCRIPTION
Also, bump go version to v1.25.7

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
