### PR TITLE
chore(orgs): fix default branch for kubevirt-aie repo

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -322,7 +322,7 @@ orgs:
       kubevirt-aie:
         allow_rebase_merge: false
         allow_squash_merge: false
-        default_branch: main
+        default_branch: release-1.8-aie-nv
         description: A temporary KubeVirt fork aligned with the CentOS Stream Accelerated Infrastructure Enablement SIG.
         has_projects: true
         homepage: https://kubevirt.io


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR should fix the job [periodic-kubevirt-org-github-config-updater](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/periodic-kubevirt-org-github-config-updater)

```
{"message":"Validation Failed","errors":[{"message":"The branch main was not found. Please push that ref first or create it via the Git Data API.","resource":"Repository","field":"default_branch","code":"invalid"}],"status":"422"}
```

**Special notes for your reviewer**:

/cc @dhiller @lyarwood 