### PR TITLE
Bump Go version to 1.26.0 for containerdisks CI jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -26,7 +26,7 @@ periodics:
       - ./pipeline-periodic.sh
       env:
       - name: GIMME_GO_VERSION
-        value: "1.24.1"
+        value: "1.26.0"
       - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
         value: "true"
       - name: PROMOTE_DRY_RUN
@@ -70,7 +70,7 @@ periodics:
         ./pipeline-periodic.sh
       env:
       - name: GIMME_GO_VERSION
-        value: "1.24.1"
+        value: "1.26.0"
       image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
       name: ""
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
         - make test
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
         name: ""
         resources:
@@ -46,7 +46,7 @@ presubmits:
         - make medius
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
         name: ""
         resources:
@@ -75,7 +75,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "centos-stream:9"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
@@ -108,7 +108,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "centos-stream:9"
         - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
@@ -143,7 +143,7 @@ presubmits:
             - ./pipeline.sh
           env:
             - name: GIMME_GO_VERSION
-              value: "1.24.1"
+              value: "1.26.0"
             - name: FOCUS
               value: "debian:*"
           image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
@@ -178,7 +178,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "centos-stream:*"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
@@ -212,7 +212,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "centos-stream:*"
         - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
@@ -247,7 +247,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "fedora:*"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
@@ -281,7 +281,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "fedora:*"
         - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
@@ -316,7 +316,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "ubuntu:*"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
@@ -350,7 +350,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "ubuntu:*"
         - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
@@ -385,7 +385,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "opensuse-tumbleweed:*"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
@@ -419,7 +419,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "opensuse-tumbleweed:*"
         - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
@@ -454,7 +454,7 @@ presubmits:
         - ./pipeline.sh
         env:
         - name: GIMME_GO_VERSION
-          value: "1.24.1"
+          value: "1.26.0"
         - name: FOCUS
           value: "opensuse-leap:*"
         image: quay.io/kubevirtci/golang:v20251218-e7a7fc9


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps the Go version used in containerdisks CI jobs from 1.24.1 to 1.26.0. All presubmit and periodic jobs for `kubevirt/containerdisks` now use `GIMME_GO_VERSION=1.26.0`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes GO version 

**Special notes for your reviewer**:
Only Prow job config changes: `containerdisks-periodics.yaml` and `containerdisks-presubmits.yaml`. No code changes in containerdisks repo.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
NONE