### PR TITLE
ci: spread periodic-kubevirt-e2e-k8s-* jobs evenly across the day

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1055,7 +1055,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 40 7,15,23 * * *
+  cron: 30 7,15,23 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1179,7 +1179,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 4,12,20 * * *
+  cron: 50 4,12,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1302,7 +1302,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 3,7,15,23 * * *
+  cron: 0 0,6,12,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1432,7 +1432,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 2,18 * * *
+  cron: 30 4,16 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1478,7 +1478,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 20 3,19 * * *
+  cron: 30 10,22 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1526,7 +1526,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 6,22 * * *
+  cron: 30 7,19 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1781,7 +1781,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 0,7 * * *
+  cron: 30 1,13 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1825,7 +1825,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 50 1,6,14,22 * * *
+  cron: 25 5,11,17,23 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1871,7 +1871,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 2,7,15,23 * * *
+  cron: 25 0,6,12,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1915,7 +1915,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 3,6,14,22 * * *
+  cron: 50 0,6,12,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1959,7 +1959,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 40 1,4,9,17 * * *
+  cron: 15 1,7,13,19 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2007,7 +2007,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 50 2,5,10,18 * * *
+  cron: 40 1,7,13,19 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2051,7 +2051,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 0,3,8,16 * * *
+  cron: 5 2,8,14,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2095,7 +2095,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 40 2,7,15,23 * * *
+  cron: 30 2,8,14,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2139,7 +2139,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 50 2,6,10,18 * * *
+  cron: 55 2,8,14,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2187,7 +2187,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 3,7,11,19 * * *
+  cron: 20 3,9,15,21 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2231,7 +2231,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 20 1,7,13,19 * * *
+  cron: 45 3,9,15,21 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2275,7 +2275,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 50 3,9,15,21 * * *
+  cron: 10 4,10,16,22 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2319,7 +2319,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 3,9,15,21 * * *
+  cron: 35 4,10,16,22 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2367,7 +2367,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 4,10,16,22 * * *
+  cron: 0 5,11,17,23 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s


### PR DESCRIPTION
## Summary

- Reschedule all `periodic-kubevirt-e2e-k8s-*` jobs (22 jobs) to eliminate start-time clustering and flatten concurrent load on the `bare-metal-external` node pool
- Fix jobs with irregular hour spacing (e.g. `0,3,8,16` instead of evenly-spaced `0,6,12,18`, and 2×/day jobs with 7h/17h or 8h/16h splits instead of 12h apart)

**Before:** peak of 17 jobs running concurrently, with 9 thirty-minute windows hitting ≥12 simultaneous jobs

```mermaid
gantt
    title periodic-kubevirt-e2e-k8s-* Schedule (24h)
    dateFormat HH:mm
    axisFormat %H:%M
    tickInterval 3h
    section sig-compute
    1.33 #1 :01:40, 4h
    1.34 #1 :02:50, 4h
    1.35 #1 :03:00, 4h
    1.33 #2 :04:40, 4h
    1.34 #2 :06:50, 4h
    1.35 #2 :09:00, 4h
    1.33 #3 :09:40, 4h
    1.34 #3 :10:50, 4h
    1.35 #3 :15:00, 4h
    1.33 #4 :17:40, 4h
    1.34 #4 :18:50, 4h
    1.35 #4 :21:00, 4h
    section sig-compute-migrations
    1.35 #1 :03:10, 3h
    1.35 #2 :07:10, 3h
    1.35 #3 :15:10, 3h
    1.35 #4 :23:10, 3h
    section sig-compute-root
    1.35 #1 :03:20, 4h
    1.35 #2 :19:20, 4h
    section sig-monitoring
    1.34 #1 :00:30, 1h30m
    1.34 #2 :07:30, 1h30m
    section sig-network
    1.34 #1 :00:10, 2h30m
    1.35 #1 :01:20, 2h30m
    1.35-ipv6 #1 :01:50, 2h30m
    1.33 #1 :02:00, 2h30m
    1.34 #2 :03:10, 2h30m
    1.35-ipv6 #2 :06:50, 2h30m
    1.33 #2 :07:00, 2h30m
    1.35 #2 :07:20, 2h30m
    1.34 #3 :08:10, 2h30m
    1.35 #3 :13:20, 2h30m
    1.35-ipv6 #3 :14:50, 2h30m
    1.33 #3 :15:00, 2h30m
    1.34 #4 :16:10, 2h30m
    1.35 #4 :19:20, 2h30m
    1.35-ipv6 #4 :22:50, 2h30m
    1.33 #4 :23:00, 2h30m
    section sig-network-with-dnc
    1.35 :05:00, 2h30m
    section sig-operator
    1.33 #1 :02:50, 2h
    1.34 #1 :03:00, 2h
    1.35 #1 :04:10, 2h
    1.33 #2 :05:50, 2h
    1.34 #2 :07:00, 2h
    1.35 #2 :10:10, 2h
    1.33 #3 :10:50, 2h
    1.34 #3 :11:00, 2h
    1.35 #3 :16:10, 2h
    1.33 #4 :18:50, 2h
    1.34 #4 :19:00, 2h
    1.35 #4 :22:10, 2h
    section sig-operator-root
    1.34 #1 :06:30, 2h
    1.34 #2 :22:30, 2h
    section sig-performance
    1.34 #1 :07:40, 2h
    1.34 #2 :15:40, 2h
    1.34 #3 :23:40, 2h
    section sig-performance-kwok
    1.34 #1 :02:10, 2h
    1.34 #2 :10:10, 2h
    1.34 #3 :18:10, 2h
    section sig-performance-kwok-100
    1.34 #1 :04:10, 2h
    1.34 #2 :12:10, 2h
    1.34 #3 :20:10, 2h
    section sig-performance-realtime
    1.32 :06:00, 2h
    section sig-storage
    1.34 #1 :02:40, 3h30m
    1.33 #1 :03:30, 3h30m
    1.35 #1 :03:50, 3h30m
    1.33 #2 :06:30, 3h30m
    1.34 #2 :07:40, 3h30m
    1.35 #2 :09:50, 3h30m
    1.33 #3 :14:30, 3h30m
    1.34 #3 :15:40, 3h30m
    1.35 #3 :15:50, 3h30m
    1.35 #4 :21:50, 3h30m
    1.33 #4 :22:30, 3h30m
    1.34 #4 :23:40, 3h30m
    section sig-storage-root
    1.34 #1 :02:10, 3h30m
    1.34 #2 :18:10, 3h30m
```


**After:** peak of 11 concurrent jobs; all 48 thirty-minute windows stay in the 8–11 range — close to the unavoidable mathematical average of 9.6

```mermaid
gantt
    title periodic-kubevirt-e2e-k8s-* Schedule (24h)
    dateFormat HH:mm
    axisFormat %H:%M
    tickInterval 3h
    section sig-compute
    1.33 #1 :01:15, 4h
    1.34 #1 :02:55, 4h
    1.35 #1 :04:35, 4h
    1.33 #2 :07:15, 4h
    1.34 #2 :08:55, 4h
    1.35 #2 :10:35, 4h
    1.33 #3 :13:15, 4h
    1.34 #3 :14:55, 4h
    1.35 #3 :16:35, 4h
    1.33 #4 :19:15, 4h
    1.34 #4 :20:55, 4h
    1.35 #4 :22:35, 4h
    section sig-compute-migrations
    1.35 #1 :00:00, 3h
    1.35 #2 :06:00, 3h
    1.35 #3 :12:00, 3h
    1.35 #4 :18:00, 3h
    section sig-compute-root
    1.35 #1 :10:30, 4h
    1.35 #2 :22:30, 4h
    section sig-monitoring
    1.34 #1 :01:30, 1h30m
    1.34 #2 :13:30, 1h30m
    section sig-network
    1.33 #1 :00:25, 2h30m
    1.34 #1 :02:05, 2h30m
    1.35 #1 :03:45, 2h30m
    1.35-ipv6 #1 :05:25, 2h30m
    1.33 #2 :06:25, 2h30m
    1.34 #2 :08:05, 2h30m
    1.35 #2 :09:45, 2h30m
    1.35-ipv6 #2 :11:25, 2h30m
    1.33 #3 :12:25, 2h30m
    1.34 #3 :14:05, 2h30m
    1.35 #3 :15:45, 2h30m
    1.35-ipv6 #3 :17:25, 2h30m
    1.33 #4 :18:25, 2h30m
    1.34 #4 :20:05, 2h30m
    1.35 #4 :21:45, 2h30m
    1.35-ipv6 #4 :23:25, 2h30m
    section sig-network-with-dnc
    1.35 :05:00, 2h30m
    section sig-operator
    1.33 #1 :01:40, 2h
    1.34 #1 :03:20, 2h
    1.35 #1 :05:00, 2h
    1.33 #2 :07:40, 2h
    1.34 #2 :09:20, 2h
    1.35 #2 :11:00, 2h
    1.33 #3 :13:40, 2h
    1.34 #3 :15:20, 2h
    1.35 #3 :17:00, 2h
    1.33 #4 :19:40, 2h
    1.34 #4 :21:20, 2h
    1.35 #4 :23:00, 2h
    section sig-operator-root
    1.34 #1 :07:30, 2h
    1.34 #2 :19:30, 2h
    section sig-performance
    1.34 #1 :07:30, 2h
    1.34 #2 :15:30, 2h
    1.34 #3 :23:30, 2h
    section sig-performance-kwok
    1.34 #1 :02:10, 2h
    1.34 #2 :10:10, 2h
    1.34 #3 :18:10, 2h
    section sig-performance-kwok-100
    1.34 #1 :04:50, 2h
    1.34 #2 :12:50, 2h
    1.34 #3 :20:50, 2h
    section sig-performance-realtime
    1.32 :06:00, 2h
    section sig-storage
    1.33 #1 :00:50, 3h30m
    1.34 #1 :02:30, 3h30m
    1.35 #1 :04:10, 3h30m
    1.33 #2 :06:50, 3h30m
    1.34 #2 :08:30, 3h30m
    1.35 #2 :10:10, 3h30m
    1.33 #3 :12:50, 3h30m
    1.34 #3 :14:30, 3h30m
    1.35 #3 :16:10, 3h30m
    1.33 #4 :18:50, 3h30m
    1.34 #4 :20:30, 3h30m
    1.35 #4 :22:10, 3h30m
    section sig-storage-root
    1.34 #1 :04:30, 3h30m
    1.34 #2 :16:30, 3h30m
```


## Strategy

Stagger jobs by `period / N` minutes within each frequency group:

| Group | Jobs | Period | Slot spacing |
|---|---|---|---|
| 4×/day | 14 | 6h (360 min) | 25 min |
| 3×/day | 3 | 8h (480 min) | 160 min (2h40m) |
| 2×/day | 4 | 12h (720 min) | 180 min (3h) |

The 14 4×/day jobs are assigned to slots at 0:00, 0:25, 0:50, 1:15, 1:40, 2:05, 2:30, 2:55, 3:20, 3:45, 4:10, 4:35, 5:00, 5:25 — repeating every 6h.

## Test plan

- [x] Verify cron expressions parse correctly (`yamllint` / `prow checkconfig`)
- [ ] Confirm no two jobs in the same frequency group share an identical start time

🤖 Generated with [Claude Code](https://claude.com/claude-code)