### PR TITLE
Add triage/no-action label for kubevirt org

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -91,6 +91,7 @@ larger set of contributors to apply/remove them.
 | <a id="triage/duplicate" href="#triage/duplicate">`triage/duplicate`</a> | Indicates an issue is a duplicate of other open issue.| anyone | |
 | <a id="triage/infra-issue" href="#triage/infra-issue">`triage/infra-issue`</a> | Indicates an issue was caused by failures in the infrastructure.| anyone | |
 | <a id="triage/needs-information" href="#triage/needs-information">`triage/needs-information`</a> | Indicates an issue needs more information in order to work on it.| anyone | |
+| <a id="triage/no-action" href="#triage/no-action">`triage/no-action`</a> | Indicates an issue or PR is accepted but requires no action from the triage team.| org members |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="triage/not-reproducible" href="#triage/not-reproducible">`triage/not-reproducible`</a> | Indicates an issue can not be reproduced as described.| anyone | |
 | <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not or will not be resolved.| anyone | |
 | <a id="wg/arch-arm" href="#wg/arch-arm">`wg/arch-arm`</a> | Denotes an issue or PR that relates to the ARM architecture working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -41,6 +41,12 @@ default:
       name: triage/infra-issue
       target: both
       addedBy: anyone
+    - color: d455d0
+      description: Indicates an issue or PR is accepted but requires no action from the triage team.
+      name: triage/no-action
+      target: both
+      prowPlugin: label
+      addedBy: org members
     - color: c2e0c6
       name: release-note
       target: prs


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new `triage/no-action` label to the org-wide label configuration. This label is for issues and PRs that have been triaged and accepted but require no further action from the triage team — the author(s) and reviewers can handle them independently.

- Added to `default.labels` in `labels.yaml` so it applies to all kubevirt org repos
- Targets both issues and PRs (`target: both`)
- Managed by the `label` Prow plugin (apply via `/label triage/no-action`)
- Can be added by org members
- Updated `docs/labels.md` accordingly

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

🤖 Generated with [Claude Code](https://claude.com/claude-code)