### PR TITLE
Add wg/aie label for the AIE working group

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -94,6 +94,7 @@ larger set of contributors to apply/remove them.
 | <a id="triage/no-action" href="#triage/no-action">`triage/no-action`</a> | Indicates an issue or PR is accepted but requires no action from the triage team.| org members |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="triage/not-reproducible" href="#triage/not-reproducible">`triage/not-reproducible`</a> | Indicates an issue can not be reproduced as described.| anyone | |
 | <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not or will not be resolved.| anyone | |
+| <a id="wg/aie" href="#wg/aie">`wg/aie`</a> | Denotes an issue or PR that relates to the AIE working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="wg/arch-arm" href="#wg/arch-arm">`wg/arch-arm`</a> | Denotes an issue or PR that relates to the ARM architecture working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="wg/arch-s390x" href="#wg/arch-s390x">`wg/arch-s390x`</a> | Denotes an issue or PR that relates to the s390x architecture working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="wg/code-quality" href="#wg/code-quality">`wg/code-quality`</a> | Denotes an issue or PR that relates to the code-quality working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -348,6 +348,12 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - name: wg/aie
+      color: E3F582
+      description: Denotes an issue or PR that relates to the AIE working group.
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - color: e11d21
       description: Indicates the PR's author has not DCO signed all their commits.
       name: "dco-signoff: no"


### PR DESCRIPTION
**What this PR does / why we need it**:

The working group was introduced by https://github.com/kubevirt/community/pull/430

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
