### PR TITLE
ci: make pull-kubevirt-fossa lane optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -777,6 +777,7 @@ presubmits:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-fossa
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
## Summary

Makes the FOSSA license scanning job optional to prevent it from blocking PR merges.

## Changes

- Added `optional: true` to `pull-kubevirt-fossa` presubmit job
- Job will continue to run on all PRs (`always_run: true`)
- Failures won't block PR merges

## Rationale

The FOSSA job has been experiencing frequent timeout failures unrelated to code changes. Recent failures (PR #16659, #16670, #16632) all show the same timeout error:

```
[ERROR] An issue occurred

  *** Relevant Errors ***

      Error: Build/Issue scan was not completed on the FOSSA server, and the --timeout duration has expired
      → src/App/Fossa/API/BuildWait.hs:136:49

make: *** [Makefile:224: fossa] Error 1
```

These transient FOSSA service issues should not block PR merges when the license scanning itself is not related to the PR changes.

See [job history](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-fossa) for recent failures.

/cc @akalenyuk