### PR TITLE
ci: make pull-kubevirt-fossa lane non-optional again

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -777,7 +777,6 @@ presubmits:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
     name: pull-kubevirt-fossa
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The outage is now resolved [1] and the job is passing [2]

[1]: https://status.fossa.com/incidents/073f8y6bnfb4
[2]: https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/pull-kubevirt-fossa

This reverts commit b746e7d4dad0ace4f48bc9284c3bff36562f149e.

**Special notes for your reviewer**:

/cc @dhiller