### PR TITLE
Add presubmit and postsubmit jobs for kubevirt-aie-webhook

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-postsubmits.yaml
@@ -1,0 +1,37 @@
+postsubmits:
+  kubevirt/kubevirt-aie-webhook:
+  - name: push-tagged-kubevirt-aie-webhook
+    branches:
+    # branches also handle tags
+    - ^v\d+\.\d+\.\d+$
+    cluster: prow-workloads
+    always_run: true
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20251218-e7a7fc9
+        command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/sh"
+          - "-c"
+          - |
+            cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+            DOCKER_TAG=$(git describe --tags --exact-match) make image-build image-push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-presubmits.yaml
@@ -1,0 +1,153 @@
+presubmits:
+  kubevirt/kubevirt-aie-webhook:
+  - name: pull-kubevirt-aie-webhook-unit-tests
+    branches:
+      - main
+    annotations:
+      fork-per-release: "true"
+      testgrid-create-test-group: "false"
+    always_run: true
+    optional: false
+    skip_report: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 10m
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make test"
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.24.11"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "10Gi"
+  - name: pull-kubevirt-aie-webhook-lint
+    branches:
+      - main
+    annotations:
+      fork-per-release: "true"
+      testgrid-create-test-group: "false"
+    always_run: true
+    optional: false
+    skip_report: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 10m
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make lint"
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.24.11"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "10Gi"
+  - name: pull-kubevirt-aie-webhook-image-build
+    branches:
+      - main
+    annotations:
+      fork-per-release: "true"
+      testgrid-create-test-group: "false"
+    always_run: true
+    optional: false
+    skip_report: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 10m
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make image-build"
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.24.11"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "10Gi"
+  - name: pull-kubevirt-aie-webhook-functest
+    branches:
+      - main
+    annotations:
+      fork-per-release: "true"
+      testgrid-create-test-group: "false"
+    always_run: true
+    optional: false
+    skip_report: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    max_concurrency: 11
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20251218-e7a7fc9
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make cluster-up cluster-sync functest"
+          env:
+            - name: GIMME_GO_VERSION
+              value: "1.24.11"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "16Gi"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add unit-tests, lint, image-build and functest presubmit jobs and a tag-triggered postsubmit job for the kubevirt-aie-webhook repository.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
