### PR TITLE
Add CPU requests/limits and GOMAXPROCS to sig-compute periodic jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1336,11 +1336,16 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.35-sig-compute-migrations
+      - name: GOMAXPROCS
+        value: "10"
       image: quay.io/kubevirtci/bootstrap:v20260306-351d3b1
       name: ""
       resources:
         requests:
+          cpu: "8"
           memory: 52Gi
+        limits:
+          cpu: "10"
       securityContext:
         privileged: true
     nodeSelector:
@@ -1516,11 +1521,16 @@ periodics:
         value: Root
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --usb 30M --usb 40M
+      - name: GOMAXPROCS
+        value: "10"
       image: quay.io/kubevirtci/bootstrap:v20260306-351d3b1
       name: ""
       resources:
         requests:
+          cpu: "8"
           memory: 52Gi
+        limits:
+          cpu: "10"
       securityContext:
         privileged: true
     nodeSelector:
@@ -1997,11 +2007,16 @@ periodics:
         value: --usb 30M --usb 40M
       - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
         value: 4h45m
+      - name: GOMAXPROCS
+        value: "10"
       image: quay.io/kubevirtci/bootstrap:v20260306-351d3b1
       name: ""
       resources:
         requests:
+          cpu: "8"
           memory: 52Gi
+        limits:
+          cpu: "10"
       securityContext:
         privileged: true
     nodeSelector:
@@ -2177,11 +2192,16 @@ periodics:
         value: --usb 30M --usb 40M
       - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
         value: 4h45m
+      - name: GOMAXPROCS
+        value: "10"
       image: quay.io/kubevirtci/bootstrap:v20260306-351d3b1
       name: ""
       resources:
         requests:
+          cpu: "8"
           memory: 52Gi
+        limits:
+          cpu: "10"
       securityContext:
         privileged: true
     nodeSelector:
@@ -2357,11 +2377,16 @@ periodics:
         value: --usb 30M --usb 40M
       - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
         value: 4h45m
+      - name: GOMAXPROCS
+        value: "10"
       image: quay.io/kubevirtci/bootstrap:v20260306-351d3b1
       name: ""
       resources:
         requests:
+          cpu: "8"
           memory: 52Gi
+        limits:
+          cpu: "10"
       securityContext:
         privileged: true
     nodeSelector:


### PR DESCRIPTION
## Summary

Adds CPU resource governance and `GOMAXPROCS` to the 5 sig-compute periodic e2e jobs
as a targeted experiment to address soft locks caused by CPU saturation on the
prow-workloads cluster.

### Problem

The worker nodes have **72 allocatable CPUs / 503 Gi memory** each. Currently:

- **Memory requests (52Gi)** are the sole scheduling constraint (~9 pods/node)
- **CPU requests are ~1%** and **limits are effectively zero** across the cluster
- Without CPU limits or `GOMAXPROCS`, each pod's Go runtime detects all 72 host CPUs
  and sets `GOMAXPROCS=72`, spawning that many OS threads
- With ~9 pods per node, that's **~648 threads competing for 72 cores**, causing the
  soft locks we're seeing
- Actual memory usage is only 18-28% of node capacity vs 44-63% *requested*,
  meaning memory over-reservation wastes scheduling capacity without preventing
  CPU contention

### Changes

For all 5 sig-compute periodic jobs (k8s 1.33, 1.34, 1.35, 1.35-migrations, 1.35-root):

| Resource | Before | After |
|----------|--------|-------|
| CPU request | *(none)* | 8 |
| CPU limit | *(none)* | 10 |
| Memory request | 52Gi | 52Gi *(unchanged)* |
| GOMAXPROCS | *(unset -> 72)* | 10 |

### Expected impact

- **CPU limit (10 cores):** kernel CFS bandwidth throttling provides a hard ceiling,
  preventing any single pod from saturating the node
- **CPU request (8 cores):** scheduler now accounts for CPU, naturally capping
  concurrency at 71.5 / 8 = ~8 pods/node (vs current memory-only limit of ~9)
- **GOMAXPROCS=10:** Go runtime spawns 10 threads instead of 72, eliminating the
  thread stampede that causes soft locks. Even with 8 pods: 8 x 10 = 80 threads
  for 72 cores = ~1:1 ratio
- Memory request unchanged to keep this change minimal and observable

### Monitoring

Watch for:
- Soft lock recurrence (should disappear)
- CFS throttling (container_cpu_cfs_throttled_seconds_total) - if excessive,
  CPU limit can be raised
- OOMKills (not expected since memory is unchanged)
- Test timeouts (if GOMAXPROCS=10 is too low, can be raised)

This targets only periodics as a safe rollout. If results are positive, the same
changes can be applied to presubmits and other job types.

## Test plan

- [ ] Verify periodic sig-compute jobs still pass
- [ ] Monitor for soft lock occurrences on worker nodes
- [ ] Check CFS throttling metrics are within acceptable range
- [ ] Compare job duration before/after