### PR TITLE
push-test-metrics: derive job names from prow config instead of hard-coding

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -238,7 +238,8 @@ periodics:
     - args:
       - |
         go run robots/push-test-metrics/main.go \
-          --pushgateway-url=http://pushgateway.kubevirt-prow
+          --pushgateway-url=http://pushgateway.kubevirt-prow \
+          --job-config-path=github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
       command:
       - /usr/local/bin/runner.sh
       - /bin/bash

--- a/robots/push-test-metrics/main.go
+++ b/robots/push-test-metrics/main.go
@@ -26,7 +26,9 @@ import (
 	"fmt"
 	"io"
 	"path"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"cloud.google.com/go/storage"
@@ -34,32 +36,83 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
+	"sigs.k8s.io/prow/pkg/config"
 
 	"github.com/prometheus/client_golang/prometheus/push"
 )
 
 type jobNames []string
 
-func (j jobNames) String() string {
-	return strings.Join(j, ",")
+func (j *jobNames) String() string {
+	return strings.Join(*j, ",")
 }
-func (j jobNames) Set(string) error {
+func (j *jobNames) Set(value string) error {
+	*j = append(*j, value)
 	return nil
+}
+
+var mainSigJobNameRegexp = regexp.MustCompile(
+	`^periodic-kubevirt-e2e-k8s-(\d+)\.(\d+)-sig-(compute|storage|network|operator)$`,
+)
+
+func readJobNamesFromConfig(jobConfigPath string) (jobNames, error) {
+	jobConfig, err := config.ReadJobConfig(jobConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read job config %s: %v", jobConfigPath, err)
+	}
+
+	type versionedJob struct {
+		major, minor int
+		name         string
+	}
+	latestBySig := map[string]versionedJob{}
+
+	for _, periodic := range jobConfig.Periodics {
+		matches := mainSigJobNameRegexp.FindStringSubmatch(periodic.Name)
+		if matches == nil {
+			continue
+		}
+		major, _ := strconv.Atoi(matches[1])
+		minor, _ := strconv.Atoi(matches[2])
+		sig := matches[3]
+
+		if current, exists := latestBySig[sig]; !exists ||
+			major > current.major ||
+			(major == current.major && minor > current.minor) {
+			latestBySig[sig] = versionedJob{major: major, minor: minor, name: periodic.Name}
+		}
+	}
+
+	if len(latestBySig) == 0 {
+		return nil, fmt.Errorf("no matching periodic e2e sig jobs found in %s", jobConfigPath)
+	}
+
+	var names jobNames
+	for _, vj := range latestBySig {
+		names = append(names, vj.name)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func main() {
 	var pushgatewayURL string
+	var jobConfigPath string
 	var jobNamesToScan jobNames
 	flag.StringVar(&pushgatewayURL, "pushgateway-url", "http://localhost:8080/", "pushgateway url to push values to")
-	flag.Var(jobNamesToScan, "job-name", "periodic job names to scan for values")
+	flag.StringVar(&jobConfigPath, "job-config-path", "", "path to the prow periodics job config yaml to derive job names from")
+	flag.Var(&jobNamesToScan, "job-name", "periodic job names to scan for values (can be specified multiple times)")
 	flag.Parse()
 	if len(jobNamesToScan) == 0 {
-		jobNamesToScan = jobNames{
-			"periodic-kubevirt-e2e-k8s-1.29-sig-compute",
-			"periodic-kubevirt-e2e-k8s-1.29-sig-storage",
-			"periodic-kubevirt-e2e-k8s-1.29-sig-network",
-			"periodic-kubevirt-e2e-k8s-1.29-sig-operator",
+		if jobConfigPath == "" {
+			log.Fatalf("either --job-name or --job-config-path must be specified")
 		}
+		var err error
+		jobNamesToScan, err = readJobNamesFromConfig(jobConfigPath)
+		if err != nil {
+			log.Fatalf("error reading job names from config: %v", err)
+		}
+		log.Infof("derived job names from config: %s", jobNamesToScan.String())
 	}
 
 	ctx := context.Background()

--- a/robots/push-test-metrics/main_test.go
+++ b/robots/push-test-metrics/main_test.go
@@ -1,0 +1,205 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadJobNamesFromConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		yamlContent    string
+		expectedNames  []string
+		expectError    bool
+	}{
+		{
+			name: "selects latest k8s version per sig",
+			yamlContent: `periodics:
+- name: periodic-kubevirt-e2e-k8s-1.33-sig-compute
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-compute
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.34-sig-storage
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-storage
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-network
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-operator
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+`,
+			expectedNames: []string{
+				"periodic-kubevirt-e2e-k8s-1.35-sig-compute",
+				"periodic-kubevirt-e2e-k8s-1.35-sig-network",
+				"periodic-kubevirt-e2e-k8s-1.35-sig-operator",
+				"periodic-kubevirt-e2e-k8s-1.35-sig-storage",
+			},
+		},
+		{
+			name: "ignores non-main-sig jobs",
+			yamlContent: `periodics:
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-compute
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-compute-migrations
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-compute-root
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-performance
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-push-test-metrics
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-ipv6-sig-network
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+`,
+			expectedNames: []string{
+				"periodic-kubevirt-e2e-k8s-1.35-sig-compute",
+			},
+		},
+		{
+			name: "error on no matching jobs",
+			yamlContent: `periodics:
+- name: periodic-kubevirt-push-test-metrics
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+`,
+			expectError: true,
+		},
+		{
+			name: "handles multiple k8s versions correctly",
+			yamlContent: `periodics:
+- name: periodic-kubevirt-e2e-k8s-1.33-sig-network
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.34-sig-network
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+- name: periodic-kubevirt-e2e-k8s-1.35-sig-network
+  cron: "0 0 * * *"
+  spec:
+    containers:
+    - image: test
+`,
+			expectedNames: []string{
+				"periodic-kubevirt-e2e-k8s-1.35-sig-network",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configFile := filepath.Join(tmpDir, "periodics.yaml")
+			if err := os.WriteFile(configFile, []byte(tc.yamlContent), 0644); err != nil {
+				t.Fatalf("failed to write temp config: %v", err)
+			}
+
+			names, err := readJobNamesFromConfig(configFile)
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(names) != len(tc.expectedNames) {
+				t.Fatalf("expected %d job names, got %d: %v", len(tc.expectedNames), len(names), names)
+			}
+			for i, expected := range tc.expectedNames {
+				if names[i] != expected {
+					t.Errorf("job name[%d]: expected %q, got %q", i, expected, names[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReadJobNamesFromConfig_invalidPath(t *testing.T) {
+	_, err := readJobNamesFromConfig("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Fatal("expected error for nonexistent config path")
+	}
+}
+
+func TestJobNamesFlag(t *testing.T) {
+	var names jobNames
+	if err := names.Set("job-a"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := names.Set("job-b"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d", len(names))
+	}
+	if names[0] != "job-a" || names[1] != "job-b" {
+		t.Errorf("unexpected names: %v", names)
+	}
+	if names.String() != "job-a,job-b" {
+		t.Errorf("unexpected String() output: %q", names.String())
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `push-test-metrics` robot has a hard coded list of periodic job names stuck at k8s 1.29. Since those lanes no longer exist, the robot scans stale GCS paths and pushes incorrect metrics to the Grafana dashboard.

This PR replaces the hard-coded default with dynamic discovery from the prow periodics job config YAML using `config.ReadJobConfig`. It selects the latest k8s version for each of the four main SIG lanes (compute, storage, network, operator) automatically.

Additionally fixes the `jobNames.Set()` method which was silently discarding values, making the existing `--job-name` flag non-functional.

**Which issue(s) this PR fixes** 
Fixes #4802

**Special notes for your reviewer**:

- The regex intentionally matches only the four main SIG lanes (`sig-compute`, `sig-storage`, `sig-network`, `sig-operator`) and excludes variant lanes like `-migrations`, `-root`, `-performance`, `ipv6-` to preserve the original dashboard scope.
- The three copies of `kubevirt-periodics.yaml` (`config/`, `jobs/`, `github/ci/prow-deploy/files/`) are hardlinked to the same inode, so the single file edit covers all three.
- `--job-name` flags still work as a manual override if specified.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test

**Release note**:
```release-note
NONE
```