### PR TITLE
Add ghprojects: declarative GitHub Projects V2 management

### DIFF
--- a/pkg/ghprojects/client/client.go
+++ b/pkg/ghprojects/client/client.go
@@ -1,0 +1,314 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
+)
+
+// Client wraps the GitHub GraphQL API for Projects V2 operations.
+type Client struct {
+	gql *githubv4.Client
+}
+
+// New creates a new Client using the provided OAuth2 token.
+func New(token string) *Client {
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	httpClient := oauth2.NewClient(context.Background(), src)
+	return &Client{gql: githubv4.NewClient(httpClient)}
+}
+
+// GetOrgID returns the node ID for a GitHub organization.
+func (c *Client) GetOrgID(ctx context.Context, login string) (string, error) {
+	var q queryOrgID
+	vars := map[string]interface{}{
+		"login": githubv4.String(login),
+	}
+	if err := c.gql.Query(ctx, &q, vars); err != nil {
+		return "", fmt.Errorf("querying org ID for %s: %w", login, err)
+	}
+	id, ok := q.Organization.ID.(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected org ID type for %s: %T", login, q.Organization.ID)
+	}
+	return id, nil
+}
+
+// ListProjects returns all Projects V2 for an organization.
+func (c *Client) ListProjects(ctx context.Context, org string) ([]ProjectV2, error) {
+	var projects []ProjectV2
+	var cursor *githubv4.String
+
+	for {
+		var q queryOrgProjects
+		vars := map[string]interface{}{
+			"login": githubv4.String(org),
+			"first": githubv4.Int(50),
+			"after": cursor,
+		}
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, fmt.Errorf("listing projects for %s: %w", org, err)
+		}
+
+		for _, n := range q.Organization.ProjectsV2.Nodes {
+			projects = append(projects, ProjectV2{
+				ID:               string(n.ID),
+				Number:           int(n.Number),
+				Title:            string(n.Title),
+				ShortDescription: string(n.ShortDescription),
+				Public:           bool(n.Public),
+			})
+		}
+
+		if !bool(q.Organization.ProjectsV2.PageInfo.HasNextPage) {
+			break
+		}
+		cursor = &q.Organization.ProjectsV2.PageInfo.EndCursor
+	}
+	return projects, nil
+}
+
+// GetProjectFields returns all fields for a project.
+func (c *Client) GetProjectFields(ctx context.Context, projectID string) ([]ProjectV2Field, error) {
+	var fields []ProjectV2Field
+	var cursor *githubv4.String
+
+	for {
+		var q queryProjectFields
+		vars := map[string]interface{}{
+			"projectID": githubv4.ID(projectID),
+			"first":     githubv4.Int(50),
+			"after":     cursor,
+		}
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, fmt.Errorf("listing fields for project %s: %w", projectID, err)
+		}
+
+		for _, n := range q.Node.ProjectV2.Fields.Nodes {
+			f := ProjectV2Field{}
+			switch n.TypeName {
+			case "ProjectV2SingleSelectField":
+				f.ID = string(n.ProjectV2SingleSelectField.ID)
+				f.Name = string(n.ProjectV2SingleSelectField.Name)
+				f.Type = string(n.ProjectV2SingleSelectField.DataType)
+				for _, o := range n.ProjectV2SingleSelectField.Options {
+					f.Options = append(f.Options, ProjectV2FieldOption{
+						ID:          string(o.ID),
+						Name:        string(o.Name),
+						Description: string(o.Description),
+						Color:       string(o.Color),
+					})
+				}
+			case "ProjectV2IterationField":
+				f.ID = string(n.ProjectV2IterationField.ID)
+				f.Name = string(n.ProjectV2IterationField.Name)
+				f.Type = string(n.ProjectV2IterationField.DataType)
+			default:
+				f.ID = string(n.ProjectV2FieldCommon.ID)
+				f.Name = string(n.ProjectV2FieldCommon.Name)
+				f.Type = string(n.ProjectV2FieldCommon.DataType)
+			}
+			fields = append(fields, f)
+		}
+
+		if !bool(q.Node.ProjectV2.Fields.PageInfo.HasNextPage) {
+			break
+		}
+		cursor = &q.Node.ProjectV2.Fields.PageInfo.EndCursor
+	}
+	return fields, nil
+}
+
+// GetProjectViews returns all views for a project.
+func (c *Client) GetProjectViews(ctx context.Context, projectID string) ([]ProjectV2View, error) {
+	var views []ProjectV2View
+	var cursor *githubv4.String
+
+	for {
+		var q queryProjectViews
+		vars := map[string]interface{}{
+			"projectID": githubv4.ID(projectID),
+			"first":     githubv4.Int(50),
+			"after":     cursor,
+		}
+		if err := c.gql.Query(ctx, &q, vars); err != nil {
+			return nil, fmt.Errorf("listing views for project %s: %w", projectID, err)
+		}
+
+		for _, n := range q.Node.ProjectV2.Views.Nodes {
+			views = append(views, ProjectV2View{
+				ID:     string(n.ID),
+				Name:   string(n.Name),
+				Layout: string(n.Layout),
+			})
+		}
+
+		if !bool(q.Node.ProjectV2.Views.PageInfo.HasNextPage) {
+			break
+		}
+		cursor = &q.Node.ProjectV2.Views.PageInfo.EndCursor
+	}
+	return views, nil
+}
+
+// CreateProject creates a new Project V2 in an organization.
+func (c *Client) CreateProject(ctx context.Context, orgID, title string) (*ProjectV2, error) {
+	var m mutationCreateProject
+	input := createProjectV2Input{
+		OwnerID: githubv4.ID(orgID),
+		Title:   githubv4.String(title),
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return nil, fmt.Errorf("creating project %q: %w", title, err)
+	}
+	return &ProjectV2{
+		ID:     string(m.CreateProjectV2.ProjectV2.ID),
+		Number: int(m.CreateProjectV2.ProjectV2.Number),
+		Title:  title,
+	}, nil
+}
+
+// UpdateProject updates a project's metadata.
+func (c *Client) UpdateProject(ctx context.Context, projectID string, title, description *string, public *bool) error {
+	var m mutationUpdateProject
+	input := updateProjectV2Input{
+		ProjectID: githubv4.ID(projectID),
+	}
+	if title != nil {
+		t := githubv4.String(*title)
+		input.Title = &t
+	}
+	if description != nil {
+		d := githubv4.String(*description)
+		input.ShortDescription = &d
+	}
+	if public != nil {
+		p := githubv4.Boolean(*public)
+		input.Public = &p
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("updating project %s: %w", projectID, err)
+	}
+	return nil
+}
+
+// DeleteProject deletes a project.
+func (c *Client) DeleteProject(ctx context.Context, projectID string) error {
+	var m mutationDeleteProject
+	input := deleteProjectV2Input{
+		ProjectID: githubv4.ID(projectID),
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("deleting project %s: %w", projectID, err)
+	}
+	return nil
+}
+
+// CreateField creates a custom field on a project.
+func (c *Client) CreateField(ctx context.Context, projectID, name, dataType string, options []ProjectV2FieldOption) (*ProjectV2Field, error) {
+	var m mutationCreateField
+	input := createProjectV2FieldInput{
+		ProjectID: githubv4.ID(projectID),
+		DataType:  githubv4.String(dataType),
+		Name:      githubv4.String(name),
+	}
+	for _, o := range options {
+		input.SingleSelectOptions = append(input.SingleSelectOptions, createProjectV2SingleSelectOption{
+			Name:        githubv4.String(o.Name),
+			Description: githubv4.String(o.Description),
+			Color:       githubv4.String(o.Color),
+		})
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return nil, fmt.Errorf("creating field %q on project %s: %w", name, projectID, err)
+	}
+	result := &ProjectV2Field{
+		Name: name,
+		Type: dataType,
+	}
+	// Extract ID from whichever fragment matched.
+	if id := string(m.CreateProjectV2Field.ProjectV2Field.ProjectV2SingleSelectField.ID); id != "" {
+		result.ID = id
+	} else {
+		result.ID = string(m.CreateProjectV2Field.ProjectV2Field.ProjectV2FieldCommon.ID)
+	}
+	return result, nil
+}
+
+// UpdateField updates a field's name.
+func (c *Client) UpdateField(ctx context.Context, fieldID, name string) error {
+	var m mutationUpdateField
+	n := githubv4.String(name)
+	input := updateProjectV2FieldInput{
+		FieldID: githubv4.ID(fieldID),
+		Name:    &n,
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("updating field %s: %w", fieldID, err)
+	}
+	return nil
+}
+
+// DeleteField deletes a custom field from a project.
+func (c *Client) DeleteField(ctx context.Context, fieldID string) error {
+	var m mutationDeleteField
+	input := deleteProjectV2FieldInput{
+		FieldID: githubv4.ID(fieldID),
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("deleting field %s: %w", fieldID, err)
+	}
+	return nil
+}
+
+// CreateView creates a view on a project.
+func (c *Client) CreateView(ctx context.Context, projectID, name, layout string) (*ProjectV2View, error) {
+	var m mutationCreateView
+	input := createProjectV2ViewInput{
+		ProjectID: githubv4.ID(projectID),
+		Name:      githubv4.String(name),
+		Layout:    githubv4.String(layout),
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return nil, fmt.Errorf("creating view %q on project %s: %w", name, projectID, err)
+	}
+	return &ProjectV2View{
+		ID:     string(m.CreateProjectV2View.ProjectV2View.ID),
+		Name:   string(m.CreateProjectV2View.ProjectV2View.Name),
+		Layout: string(m.CreateProjectV2View.ProjectV2View.Layout),
+	}, nil
+}
+
+// UpdateView updates a view's name and/or layout.
+func (c *Client) UpdateView(ctx context.Context, viewID string, name, layout *string) error {
+	var m mutationUpdateView
+	input := updateProjectV2ViewInput{
+		ViewID: githubv4.ID(viewID),
+	}
+	if name != nil {
+		n := githubv4.String(*name)
+		input.Name = &n
+	}
+	if layout != nil {
+		l := githubv4.String(*layout)
+		input.Layout = &l
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("updating view %s: %w", viewID, err)
+	}
+	return nil
+}
+
+// DeleteView deletes a view from a project.
+func (c *Client) DeleteView(ctx context.Context, viewID string) error {
+	var m mutationDeleteView
+	input := deleteProjectV2ViewInput{
+		ViewID: githubv4.ID(viewID),
+	}
+	if err := c.gql.Mutate(ctx, &m, input, nil); err != nil {
+		return fmt.Errorf("deleting view %s: %w", viewID, err)
+	}
+	return nil
+}

--- a/pkg/ghprojects/client/interface.go
+++ b/pkg/ghprojects/client/interface.go
@@ -1,0 +1,24 @@
+package client
+
+import "context"
+
+// ProjectsClient defines the interface for GitHub Projects V2 operations.
+// This enables mocking for tests and the reconciler.
+type ProjectsClient interface {
+	GetOrgID(ctx context.Context, login string) (string, error)
+	ListProjects(ctx context.Context, org string) ([]ProjectV2, error)
+	GetProjectFields(ctx context.Context, projectID string) ([]ProjectV2Field, error)
+	GetProjectViews(ctx context.Context, projectID string) ([]ProjectV2View, error)
+	CreateProject(ctx context.Context, orgID, title string) (*ProjectV2, error)
+	UpdateProject(ctx context.Context, projectID string, title, description *string, public *bool) error
+	DeleteProject(ctx context.Context, projectID string) error
+	CreateField(ctx context.Context, projectID, name, dataType string, options []ProjectV2FieldOption) (*ProjectV2Field, error)
+	UpdateField(ctx context.Context, fieldID, name string) error
+	DeleteField(ctx context.Context, fieldID string) error
+	CreateView(ctx context.Context, projectID, name, layout string) (*ProjectV2View, error)
+	UpdateView(ctx context.Context, viewID string, name, layout *string) error
+	DeleteView(ctx context.Context, viewID string) error
+}
+
+// Compile-time check that Client implements ProjectsClient.
+var _ ProjectsClient = (*Client)(nil)

--- a/pkg/ghprojects/client/types.go
+++ b/pkg/ghprojects/client/types.go
@@ -1,0 +1,268 @@
+package client
+
+import "github.com/shurcooL/githubv4"
+
+// ProjectV2 represents a GitHub Project V2 as returned by the GraphQL API.
+type ProjectV2 struct {
+	ID               string
+	Number           int
+	Title            string
+	ShortDescription string
+	Public           bool
+	Fields           []ProjectV2Field
+	Views            []ProjectV2View
+}
+
+// ProjectV2Field represents a field on a GitHub Project V2.
+type ProjectV2Field struct {
+	ID      string
+	Name    string
+	Type    string // TEXT, NUMBER, DATE, SINGLE_SELECT, ITERATION
+	Options []ProjectV2FieldOption
+}
+
+// ProjectV2FieldOption represents an option on a single-select or iteration field.
+type ProjectV2FieldOption struct {
+	ID          string
+	Name        string
+	Description string
+	Color       string
+}
+
+// ProjectV2View represents a view on a GitHub Project V2.
+type ProjectV2View struct {
+	ID     string
+	Name   string
+	Layout string // BOARD_LAYOUT, TABLE_LAYOUT, ROADMAP_LAYOUT
+}
+
+// graphQL query/mutation types for shurcooL/githubv4
+
+type queryOrgID struct {
+	Organization struct {
+		ID githubv4.ID
+	} `graphql:"organization(login: $login)"`
+}
+
+type queryOrgProjects struct {
+	Organization struct {
+		ProjectsV2 struct {
+			Nodes []struct {
+				ID               githubv4.String
+				Number           githubv4.Int
+				Title            githubv4.String
+				ShortDescription githubv4.String
+				Public           githubv4.Boolean
+			}
+			PageInfo struct {
+				HasNextPage githubv4.Boolean
+				EndCursor   githubv4.String
+			}
+		} `graphql:"projectsV2(first: $first, after: $after)"`
+	} `graphql:"organization(login: $login)"`
+}
+
+type queryProjectFields struct {
+	Node struct {
+		ProjectV2 struct {
+			Fields struct {
+				Nodes    []projectFieldNode
+				PageInfo struct {
+					HasNextPage githubv4.Boolean
+					EndCursor   githubv4.String
+				}
+			} `graphql:"fields(first: $first, after: $after)"`
+		} `graphql:"... on ProjectV2"`
+	} `graphql:"node(id: $projectID)"`
+}
+
+type projectFieldNode struct {
+	TypeName                   string `graphql:"__typename"`
+	ProjectV2FieldCommon       `graphql:"... on ProjectV2Field"`
+	ProjectV2SingleSelectField `graphql:"... on ProjectV2SingleSelectField"`
+	ProjectV2IterationField    `graphql:"... on ProjectV2IterationField"`
+}
+
+type ProjectV2FieldCommon struct {
+	ID       githubv4.String
+	Name     githubv4.String
+	DataType githubv4.String
+}
+
+type ProjectV2SingleSelectField struct {
+	ID       githubv4.String
+	Name     githubv4.String
+	DataType githubv4.String
+	Options  []struct {
+		ID          githubv4.String
+		Name        githubv4.String
+		Description githubv4.String
+		Color       githubv4.String
+	}
+}
+
+type ProjectV2IterationField struct {
+	ID       githubv4.String
+	Name     githubv4.String
+	DataType githubv4.String
+}
+
+type queryProjectViews struct {
+	Node struct {
+		ProjectV2 struct {
+			Views struct {
+				Nodes []struct {
+					ID     githubv4.String
+					Name   githubv4.String
+					Layout githubv4.String
+				}
+				PageInfo struct {
+					HasNextPage githubv4.Boolean
+					EndCursor   githubv4.String
+				}
+			} `graphql:"views(first: $first, after: $after)"`
+		} `graphql:"... on ProjectV2"`
+	} `graphql:"node(id: $projectID)"`
+}
+
+type mutationCreateProject struct {
+	CreateProjectV2 struct {
+		ProjectV2 struct {
+			ID     githubv4.String
+			Number githubv4.Int
+		}
+	} `graphql:"createProjectV2(input: $input)"`
+}
+
+type mutationUpdateProject struct {
+	UpdateProjectV2 struct {
+		ProjectV2 struct {
+			ID githubv4.String
+		}
+	} `graphql:"updateProjectV2(input: $input)"`
+}
+
+type mutationDeleteProject struct {
+	DeleteProjectV2 struct {
+		ProjectV2 struct {
+			ID githubv4.String
+		}
+	} `graphql:"deleteProjectV2(input: $input)"`
+}
+
+type mutationCreateField struct {
+	CreateProjectV2Field struct {
+		ProjectV2Field struct {
+			ProjectV2FieldCommon       `graphql:"... on ProjectV2Field"`
+			ProjectV2SingleSelectField `graphql:"... on ProjectV2SingleSelectField"`
+		}
+	} `graphql:"createProjectV2Field(input: $input)"`
+}
+
+type mutationDeleteField struct {
+	DeleteProjectV2Field struct {
+		ProjectV2Field struct {
+			ProjectV2FieldCommon `graphql:"... on ProjectV2Field"`
+		}
+	} `graphql:"deleteProjectV2Field(input: $input)"`
+}
+
+type mutationUpdateField struct {
+	UpdateProjectV2Field struct {
+		ProjectV2Field struct {
+			ProjectV2FieldCommon `graphql:"... on ProjectV2Field"`
+		}
+	} `graphql:"updateProjectV2Field(input: $input)"`
+}
+
+// Mutation input types — defined locally because the vendored githubv4
+// library predates Projects V2.
+
+type createProjectV2Input struct {
+	OwnerID          githubv4.ID      `json:"ownerId"`
+	Title            githubv4.String  `json:"title"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}
+
+type updateProjectV2Input struct {
+	ProjectID        githubv4.ID       `json:"projectId"`
+	Title            *githubv4.String  `json:"title,omitempty"`
+	ShortDescription *githubv4.String  `json:"shortDescription,omitempty"`
+	Public           *githubv4.Boolean `json:"public,omitempty"`
+	ClientMutationID *githubv4.String  `json:"clientMutationId,omitempty"`
+}
+
+type deleteProjectV2Input struct {
+	ProjectID        githubv4.ID      `json:"projectId"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}
+
+type createProjectV2FieldInput struct {
+	ProjectID           githubv4.ID                         `json:"projectId"`
+	DataType            githubv4.String                     `json:"dataType"`
+	Name                githubv4.String                     `json:"name"`
+	SingleSelectOptions []createProjectV2SingleSelectOption `json:"singleSelectOptions,omitempty"`
+	ClientMutationID    *githubv4.String                    `json:"clientMutationId,omitempty"`
+}
+
+type createProjectV2SingleSelectOption struct {
+	Name        githubv4.String `json:"name"`
+	Description githubv4.String `json:"description"`
+	Color       githubv4.String `json:"color"`
+}
+
+type updateProjectV2FieldInput struct {
+	FieldID          githubv4.ID      `json:"fieldId"`
+	Name             *githubv4.String `json:"name,omitempty"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}
+
+type deleteProjectV2FieldInput struct {
+	FieldID          githubv4.ID      `json:"fieldId"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}
+
+type mutationCreateView struct {
+	CreateProjectV2View struct {
+		ProjectV2View struct {
+			ID     githubv4.String
+			Name   githubv4.String
+			Layout githubv4.String
+		}
+	} `graphql:"createProjectV2View(input: $input)"`
+}
+
+type createProjectV2ViewInput struct {
+	ProjectID        githubv4.ID      `json:"projectId"`
+	Name             githubv4.String  `json:"name"`
+	Layout           githubv4.String  `json:"layout,omitempty"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}
+
+type mutationUpdateView struct {
+	UpdateProjectV2View struct {
+		ProjectV2View struct {
+			ID githubv4.String
+		}
+	} `graphql:"updateProjectV2View(input: $input)"`
+}
+
+type updateProjectV2ViewInput struct {
+	ViewID           githubv4.ID      `json:"viewId"`
+	Name             *githubv4.String `json:"name,omitempty"`
+	Layout           *githubv4.String `json:"layout,omitempty"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}
+
+type mutationDeleteView struct {
+	DeleteProjectV2View struct {
+		ProjectV2View struct {
+			ID githubv4.String
+		}
+	} `graphql:"deleteProjectV2View(input: $input)"`
+}
+
+type deleteProjectV2ViewInput struct {
+	ViewID           githubv4.ID      `json:"viewId"`
+	ClientMutationID *githubv4.String `json:"clientMutationId,omitempty"`
+}

--- a/pkg/ghprojects/config/dump.go
+++ b/pkg/ghprojects/config/dump.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"kubevirt.io/project-infra/pkg/ghprojects/client"
+)
+
+// Dump exports the current GitHub Projects V2 state for an organization as config.
+func Dump(ctx context.Context, c client.ProjectsClient, orgName string) (*FullConfig, error) {
+	projects, err := c.ListProjects(ctx, orgName)
+	if err != nil {
+		return nil, fmt.Errorf("listing projects: %w", err)
+	}
+
+	orgProjects := OrgProjects{
+		Projects: make([]Project, 0, len(projects)),
+	}
+
+	for _, p := range projects {
+		proj := Project{
+			Title:       p.Title,
+			Description: p.ShortDescription,
+		}
+		if p.Public {
+			proj.Visibility = "public"
+		} else {
+			proj.Visibility = "private"
+		}
+
+		fields, err := c.GetProjectFields(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("listing fields for project %q: %w", p.Title, err)
+		}
+		for _, f := range fields {
+			ft, ok := graphQLTypeToConfigType(f.Type)
+			if !ok {
+				continue
+			}
+			cf := Field{
+				Name: f.Name,
+				Type: ft,
+			}
+			for _, o := range f.Options {
+				cf.Options = append(cf.Options, FieldOption{
+					Name:        o.Name,
+					Description: o.Description,
+					Color:       o.Color,
+				})
+			}
+			proj.Fields = append(proj.Fields, cf)
+		}
+
+		views, err := c.GetProjectViews(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("listing views for project %q: %w", p.Title, err)
+		}
+		for _, v := range views {
+			vl, ok := graphQLLayoutToConfigLayout(v.Layout)
+			if !ok {
+				continue
+			}
+			proj.Views = append(proj.Views, View{
+				Name:   v.Name,
+				Layout: vl,
+			})
+		}
+
+		orgProjects.Projects = append(orgProjects.Projects, proj)
+	}
+
+	return &FullConfig{
+		Orgs: map[string]OrgProjects{
+			orgName: orgProjects,
+		},
+	}, nil
+}
+
+func graphQLTypeToConfigType(t string) (FieldType, bool) {
+	switch t {
+	case "TEXT":
+		return FieldTypeText, true
+	case "NUMBER":
+		return FieldTypeNumber, true
+	case "DATE":
+		return FieldTypeDate, true
+	case "SINGLE_SELECT":
+		return FieldTypeSingleSelect, true
+	case "ITERATION":
+		return FieldTypeIteration, true
+	default:
+		return "", false
+	}
+}
+
+func graphQLLayoutToConfigLayout(l string) (ViewLayout, bool) {
+	switch l {
+	case "BOARD_LAYOUT":
+		return ViewLayoutBoard, true
+	case "TABLE_LAYOUT":
+		return ViewLayoutTable, true
+	case "ROADMAP_LAYOUT":
+		return ViewLayoutRoadmap, true
+	default:
+		return "", false
+	}
+}

--- a/pkg/ghprojects/config/load.go
+++ b/pkg/ghprojects/config/load.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Load reads and parses a projects configuration file.
+func Load(path string) (*FullConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config %s: %w", path, err)
+	}
+	var cfg FullConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config %s: %w", path, err)
+	}
+	if err := validate(&cfg); err != nil {
+		return nil, fmt.Errorf("validating config %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+func validate(cfg *FullConfig) error {
+	for orgName, org := range cfg.Orgs {
+		for i, proj := range org.Projects {
+			if proj.Title == "" {
+				return fmt.Errorf("org %q project[%d]: title is required", orgName, i)
+			}
+			if proj.Visibility != "" && proj.Visibility != "public" && proj.Visibility != "private" {
+				return fmt.Errorf("org %q project %q: visibility must be \"public\" or \"private\", got %q", orgName, proj.Title, proj.Visibility)
+			}
+			for j, f := range proj.Fields {
+				if f.Name == "" {
+					return fmt.Errorf("org %q project %q field[%d]: name is required", orgName, proj.Title, j)
+				}
+				switch f.Type {
+				case FieldTypeText, FieldTypeNumber, FieldTypeDate, FieldTypeSingleSelect, FieldTypeIteration:
+				default:
+					return fmt.Errorf("org %q project %q field %q: unknown type %q", orgName, proj.Title, f.Name, f.Type)
+				}
+			}
+			for j, v := range proj.Views {
+				if v.Name == "" {
+					return fmt.Errorf("org %q project %q view[%d]: name is required", orgName, proj.Title, j)
+				}
+				switch v.Layout {
+				case ViewLayoutBoard, ViewLayoutTable, ViewLayoutRoadmap:
+				default:
+					return fmt.Errorf("org %q project %q view %q: unknown layout %q", orgName, proj.Title, v.Name, v.Layout)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/ghprojects/config/load_test.go
+++ b/pkg/ghprojects/config/load_test.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	content := `
+orgs:
+  kubevirt:
+    projects:
+      - title: "CI Board"
+        description: "Tracking CI improvements"
+        visibility: public
+        fields:
+          - name: Status
+            type: single_select
+            options:
+              - name: Todo
+                color: GRAY
+              - name: In Progress
+                color: YELLOW
+              - name: Done
+                color: GREEN
+          - name: Priority
+            type: single_select
+            options:
+              - name: P0
+                color: RED
+              - name: P1
+                color: ORANGE
+        views:
+          - name: Board
+            layout: board
+            group_by: Status
+          - name: Table
+            layout: table
+            fields: [Title, Status, Priority]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "projects.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	org, ok := cfg.Orgs["kubevirt"]
+	if !ok {
+		t.Fatal("expected org kubevirt")
+	}
+	if len(org.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(org.Projects))
+	}
+	proj := org.Projects[0]
+	if proj.Title != "CI Board" {
+		t.Errorf("expected title 'CI Board', got %q", proj.Title)
+	}
+	if len(proj.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(proj.Fields))
+	}
+	if len(proj.Views) != 2 {
+		t.Errorf("expected 2 views, got %d", len(proj.Views))
+	}
+}
+
+func TestLoad_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name: "missing title",
+			content: `
+orgs:
+  test:
+    projects:
+      - description: "no title"
+`,
+		},
+		{
+			name: "invalid visibility",
+			content: `
+orgs:
+  test:
+    projects:
+      - title: "test"
+        visibility: "internal"
+`,
+		},
+		{
+			name: "invalid field type",
+			content: `
+orgs:
+  test:
+    projects:
+      - title: "test"
+        fields:
+          - name: F1
+            type: unknown
+`,
+		},
+		{
+			name: "invalid view layout",
+			content: `
+orgs:
+  test:
+    projects:
+      - title: "test"
+        views:
+          - name: V1
+            layout: kanban
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "projects.yaml")
+			if err := os.WriteFile(path, []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(path)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}

--- a/pkg/ghprojects/config/types.go
+++ b/pkg/ghprojects/config/types.go
@@ -1,0 +1,64 @@
+package config
+
+// FullConfig is the top-level configuration mapping org names to their projects.
+type FullConfig struct {
+	Orgs map[string]OrgProjects `yaml:"orgs"`
+}
+
+// OrgProjects holds all project definitions for a single GitHub organization.
+type OrgProjects struct {
+	Projects []Project `yaml:"projects"`
+}
+
+// Project defines the desired state of a single GitHub Project V2.
+type Project struct {
+	Title       string  `yaml:"title"`
+	Description string  `yaml:"description,omitempty"`
+	Visibility  string  `yaml:"visibility,omitempty"` // "public" or "private"
+	Fields      []Field `yaml:"fields,omitempty"`
+	Views       []View  `yaml:"views,omitempty"`
+}
+
+// Field defines a custom field on a project.
+type Field struct {
+	Name    string        `yaml:"name"`
+	Type    FieldType     `yaml:"type"`
+	Options []FieldOption `yaml:"options,omitempty"` // For single_select and iteration fields
+}
+
+// FieldType represents the type of a project field.
+type FieldType string
+
+const (
+	FieldTypeText         FieldType = "text"
+	FieldTypeNumber       FieldType = "number"
+	FieldTypeDate         FieldType = "date"
+	FieldTypeSingleSelect FieldType = "single_select"
+	FieldTypeIteration    FieldType = "iteration"
+)
+
+// FieldOption defines an option for a single_select or iteration field.
+type FieldOption struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description,omitempty"`
+	Color       string `yaml:"color,omitempty"`
+}
+
+// View defines a project view (board or table layout).
+type View struct {
+	Name    string     `yaml:"name"`
+	Layout  ViewLayout `yaml:"layout"`
+	GroupBy string     `yaml:"group_by,omitempty"` // Field name to group by (for board views)
+	SortBy  string     `yaml:"sort_by,omitempty"`  // Field name to sort by
+	Filter  string     `yaml:"filter,omitempty"`   // Filter expression
+	Fields  []string   `yaml:"fields,omitempty"`   // Field names to display (for table views)
+}
+
+// ViewLayout represents the layout type of a project view.
+type ViewLayout string
+
+const (
+	ViewLayoutBoard   ViewLayout = "board"
+	ViewLayoutTable   ViewLayout = "table"
+	ViewLayoutRoadmap ViewLayout = "roadmap"
+)

--- a/pkg/ghprojects/reconcile/reconcile.go
+++ b/pkg/ghprojects/reconcile/reconcile.go
@@ -1,0 +1,269 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"kubevirt.io/project-infra/pkg/ghprojects/client"
+	"kubevirt.io/project-infra/pkg/ghprojects/config"
+)
+
+// Options controls reconciliation behavior.
+type Options struct {
+	Confirm     bool // If false, dry-run only (log what would happen).
+	FixProjects bool // Create/update projects.
+	FixFields   bool // Create missing custom fields.
+	FixViews    bool // Create/update views.
+}
+
+// Reconcile compares the desired config against the actual GitHub state
+// and makes changes to converge them.
+func Reconcile(ctx context.Context, c client.ProjectsClient, cfg *config.FullConfig, opts Options) error {
+	for orgName, org := range cfg.Orgs {
+		if err := reconcileOrg(ctx, c, orgName, org, opts); err != nil {
+			return fmt.Errorf("org %s: %w", orgName, err)
+		}
+	}
+	return nil
+}
+
+func reconcileOrg(ctx context.Context, c client.ProjectsClient, orgName string, org config.OrgProjects, opts Options) error {
+	orgID, err := c.GetOrgID(ctx, orgName)
+	if err != nil {
+		return err
+	}
+
+	existing, err := c.ListProjects(ctx, orgName)
+	if err != nil {
+		return err
+	}
+
+	existingByTitle := make(map[string]*client.ProjectV2, len(existing))
+	for i := range existing {
+		existingByTitle[existing[i].Title] = &existing[i]
+	}
+
+	for _, desired := range org.Projects {
+		actual, found := existingByTitle[desired.Title]
+		if !found {
+			if err := createProject(ctx, c, orgID, desired, opts); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if err := updateProject(ctx, c, actual, desired, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createProject(ctx context.Context, c client.ProjectsClient, orgID string, desired config.Project, opts Options) error {
+	logrus.Infof("project %q: would create", desired.Title)
+
+	if !opts.Confirm || !opts.FixProjects {
+		return nil
+	}
+
+	proj, err := c.CreateProject(ctx, orgID, desired.Title)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("project %q: created with ID %s", desired.Title, proj.ID)
+
+	// Set description and visibility if specified.
+	if desired.Description != "" || desired.Visibility != "" {
+		var desc *string
+		if desired.Description != "" {
+			desc = &desired.Description
+		}
+		public := visibilityToPublic(desired.Visibility)
+		if err := c.UpdateProject(ctx, proj.ID, nil, desc, public); err != nil {
+			return fmt.Errorf("setting metadata for new project %q: %w", desired.Title, err)
+		}
+	}
+
+	if opts.FixFields {
+		if err := reconcileFields(ctx, c, proj.ID, desired.Title, nil, desired.Fields, opts); err != nil {
+			return err
+		}
+	}
+	if opts.FixViews {
+		if err := reconcileViews(ctx, c, proj.ID, desired.Title, nil, desired.Views, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func updateProject(ctx context.Context, c client.ProjectsClient, actual *client.ProjectV2, desired config.Project, opts Options) error {
+	var needsUpdate bool
+	var title, desc *string
+	var public *bool
+
+	if actual.Title != desired.Title {
+		needsUpdate = true
+		title = &desired.Title
+	}
+	if desired.Description != "" && actual.ShortDescription != desired.Description {
+		needsUpdate = true
+		desc = &desired.Description
+	}
+	if p := visibilityToPublic(desired.Visibility); p != nil && *p != actual.Public {
+		needsUpdate = true
+		public = p
+	}
+
+	if needsUpdate {
+		logrus.Infof("project %q: would update metadata", desired.Title)
+		if opts.Confirm && opts.FixProjects {
+			if err := c.UpdateProject(ctx, actual.ID, title, desc, public); err != nil {
+				return err
+			}
+			logrus.Infof("project %q: updated metadata", desired.Title)
+		}
+	}
+
+	if opts.FixFields {
+		fields, err := c.GetProjectFields(ctx, actual.ID)
+		if err != nil {
+			return err
+		}
+		if err := reconcileFields(ctx, c, actual.ID, desired.Title, fields, desired.Fields, opts); err != nil {
+			return err
+		}
+	}
+
+	if opts.FixViews {
+		views, err := c.GetProjectViews(ctx, actual.ID)
+		if err != nil {
+			return err
+		}
+		if err := reconcileViews(ctx, c, actual.ID, desired.Title, views, desired.Views, opts); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func reconcileFields(ctx context.Context, c client.ProjectsClient, projectID, key string, existing []client.ProjectV2Field, desired []config.Field, opts Options) error {
+	existingByName := make(map[string]*client.ProjectV2Field, len(existing))
+	for i := range existing {
+		existingByName[existing[i].Name] = &existing[i]
+	}
+
+	for _, df := range desired {
+		actual, found := existingByName[df.Name]
+		if !found {
+			logrus.Infof("project %s: would create field %q (type=%s)", key, df.Name, df.Type)
+			if opts.Confirm {
+				var fieldOpts []client.ProjectV2FieldOption
+				for _, o := range df.Options {
+					fieldOpts = append(fieldOpts, client.ProjectV2FieldOption{
+						Name:        o.Name,
+						Description: o.Description,
+						Color:       o.Color,
+					})
+				}
+				if _, err := c.CreateField(ctx, projectID, df.Name, configTypeToGraphQL(df.Type), fieldOpts); err != nil {
+					return err
+				}
+				logrus.Infof("project %s: created field %q", key, df.Name)
+			}
+			continue
+		}
+
+		// Check if the field type matches — if not, we need to recreate it
+		// since GitHub doesn't allow changing field types.
+		if actual.Type != configTypeToGraphQL(df.Type) {
+			logrus.Warnf("project %s: field %q type mismatch (have=%s, want=%s) — field type cannot be changed in place, skipping", key, df.Name, actual.Type, df.Type)
+		}
+	}
+
+	return nil
+}
+
+func reconcileViews(ctx context.Context, c client.ProjectsClient, projectID, key string, existing []client.ProjectV2View, desired []config.View, opts Options) error {
+	existingByName := make(map[string]*client.ProjectV2View, len(existing))
+	for i := range existing {
+		existingByName[existing[i].Name] = &existing[i]
+	}
+
+	for _, dv := range desired {
+		actual, found := existingByName[dv.Name]
+		ghLayout := configLayoutToGraphQL(dv.Layout)
+
+		if !found {
+			logrus.Infof("project %s: would create view %q (layout=%s)", key, dv.Name, dv.Layout)
+			if opts.Confirm {
+				if _, err := c.CreateView(ctx, projectID, dv.Name, ghLayout); err != nil {
+					return err
+				}
+				logrus.Infof("project %s: created view %q", key, dv.Name)
+			}
+			continue
+		}
+
+		if actual.Layout != ghLayout {
+			logrus.Infof("project %s: would update view %q layout (%s -> %s)", key, dv.Name, actual.Layout, ghLayout)
+			if opts.Confirm {
+				layout := ghLayout
+				if err := c.UpdateView(ctx, actual.ID, nil, &layout); err != nil {
+					return err
+				}
+				logrus.Infof("project %s: updated view %q", key, dv.Name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func configTypeToGraphQL(t config.FieldType) string {
+	switch t {
+	case config.FieldTypeText:
+		return "TEXT"
+	case config.FieldTypeNumber:
+		return "NUMBER"
+	case config.FieldTypeDate:
+		return "DATE"
+	case config.FieldTypeSingleSelect:
+		return "SINGLE_SELECT"
+	case config.FieldTypeIteration:
+		return "ITERATION"
+	default:
+		return string(t)
+	}
+}
+
+func configLayoutToGraphQL(l config.ViewLayout) string {
+	switch l {
+	case config.ViewLayoutBoard:
+		return "BOARD_LAYOUT"
+	case config.ViewLayoutTable:
+		return "TABLE_LAYOUT"
+	case config.ViewLayoutRoadmap:
+		return "ROADMAP_LAYOUT"
+	default:
+		return string(l)
+	}
+}
+
+func visibilityToPublic(v string) *bool {
+	switch v {
+	case "public":
+		b := true
+		return &b
+	case "private":
+		b := false
+		return &b
+	default:
+		return nil
+	}
+}

--- a/pkg/ghprojects/reconcile/reconcile_test.go
+++ b/pkg/ghprojects/reconcile/reconcile_test.go
@@ -1,0 +1,340 @@
+package reconcile
+
+import (
+	"context"
+	"testing"
+
+	"kubevirt.io/project-infra/pkg/ghprojects/client"
+	"kubevirt.io/project-infra/pkg/ghprojects/config"
+)
+
+type fakeClient struct {
+	orgID    string
+	projects []client.ProjectV2
+	fields   []client.ProjectV2Field
+	views    []client.ProjectV2View
+
+	createdProjects []string
+	updatedProjects []string
+	createdFields   []string
+	updatedFields   []string
+	deletedFields   []string
+	createdViews    []string
+	updatedViews    []string
+	updatedLayouts  []string
+	deletedViews    []string
+}
+
+func (f *fakeClient) GetOrgID(_ context.Context, _ string) (string, error) {
+	return f.orgID, nil
+}
+
+func (f *fakeClient) ListProjects(_ context.Context, _ string) ([]client.ProjectV2, error) {
+	return f.projects, nil
+}
+
+func (f *fakeClient) GetProjectFields(_ context.Context, _ string) ([]client.ProjectV2Field, error) {
+	return f.fields, nil
+}
+
+func (f *fakeClient) GetProjectViews(_ context.Context, _ string) ([]client.ProjectV2View, error) {
+	return f.views, nil
+}
+
+func (f *fakeClient) CreateProject(_ context.Context, _, title string) (*client.ProjectV2, error) {
+	f.createdProjects = append(f.createdProjects, title)
+	return &client.ProjectV2{ID: "new-id", Number: 1, Title: title}, nil
+}
+
+func (f *fakeClient) UpdateProject(_ context.Context, projectID string, title, _ *string, _ *bool) error {
+	t := projectID
+	if title != nil {
+		t = *title
+	}
+	f.updatedProjects = append(f.updatedProjects, t)
+	return nil
+}
+
+func (f *fakeClient) DeleteProject(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeClient) CreateField(_ context.Context, _, name, dataType string, _ []client.ProjectV2FieldOption) (*client.ProjectV2Field, error) {
+	f.createdFields = append(f.createdFields, name)
+	return &client.ProjectV2Field{ID: "field-new", Name: name, Type: dataType}, nil
+}
+
+func (f *fakeClient) UpdateField(_ context.Context, fieldID, name string) error {
+	f.updatedFields = append(f.updatedFields, name)
+	return nil
+}
+
+func (f *fakeClient) DeleteField(_ context.Context, fieldID string) error {
+	f.deletedFields = append(f.deletedFields, fieldID)
+	return nil
+}
+
+func (f *fakeClient) CreateView(_ context.Context, _, name, layout string) (*client.ProjectV2View, error) {
+	f.createdViews = append(f.createdViews, name)
+	return &client.ProjectV2View{ID: "view-new", Name: name, Layout: layout}, nil
+}
+
+func (f *fakeClient) UpdateView(_ context.Context, viewID string, name, layout *string) error {
+	n := viewID
+	if name != nil {
+		n = *name
+	}
+	f.updatedViews = append(f.updatedViews, n)
+	if layout != nil {
+		f.updatedLayouts = append(f.updatedLayouts, *layout)
+	}
+	return nil
+}
+
+func (f *fakeClient) DeleteView(_ context.Context, viewID string) error {
+	f.deletedViews = append(f.deletedViews, viewID)
+	return nil
+}
+
+func TestReconcile_DryRun(t *testing.T) {
+	fc := &fakeClient{orgID: "org-123"}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{Title: "My Board", Visibility: "public"},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: false, FixProjects: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdProjects) != 0 {
+		t.Error("expected no projects created in dry-run mode")
+	}
+}
+
+func TestReconcile_CreateProject(t *testing.T) {
+	fc := &fakeClient{orgID: "org-123"}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{Title: "My Board", Visibility: "public"},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdProjects) != 1 || fc.createdProjects[0] != "My Board" {
+		t.Errorf("expected 1 project created with title 'My Board', got %v", fc.createdProjects)
+	}
+}
+
+func TestReconcile_UpdateProject(t *testing.T) {
+	fc := &fakeClient{
+		orgID: "org-123",
+		projects: []client.ProjectV2{
+			{ID: "proj-1", Title: "My Board", ShortDescription: "old", Public: false},
+		},
+	}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{Title: "My Board", Description: "new desc", Visibility: "public"},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdProjects) != 0 {
+		t.Error("expected no projects created")
+	}
+	if len(fc.updatedProjects) != 1 {
+		t.Errorf("expected 1 project updated, got %d", len(fc.updatedProjects))
+	}
+}
+
+func TestReconcile_NoOpWhenInSync(t *testing.T) {
+	fc := &fakeClient{
+		orgID: "org-123",
+		projects: []client.ProjectV2{
+			{ID: "proj-1", Title: "My Board", ShortDescription: "desc", Public: true},
+		},
+	}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{Title: "My Board", Description: "desc", Visibility: "public"},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdProjects) != 0 {
+		t.Error("expected no projects created")
+	}
+	if len(fc.updatedProjects) != 0 {
+		t.Error("expected no projects updated")
+	}
+}
+
+func TestReconcile_CreateField(t *testing.T) {
+	fc := &fakeClient{
+		orgID: "org-123",
+		projects: []client.ProjectV2{
+			{ID: "proj-1", Title: "My Board", Public: true},
+		},
+	}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{
+						Title:      "My Board",
+						Visibility: "public",
+						Fields: []config.Field{
+							{Name: "Status", Type: config.FieldTypeSingleSelect, Options: []config.FieldOption{
+								{Name: "Todo", Color: "GRAY"},
+								{Name: "Done", Color: "GREEN"},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true, FixFields: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdFields) != 1 || fc.createdFields[0] != "Status" {
+		t.Errorf("expected field 'Status' created, got %v", fc.createdFields)
+	}
+}
+
+func TestReconcile_FieldAlreadyExists(t *testing.T) {
+	fc := &fakeClient{
+		orgID: "org-123",
+		projects: []client.ProjectV2{
+			{ID: "proj-1", Title: "My Board", Public: true},
+		},
+		fields: []client.ProjectV2Field{
+			{ID: "f-1", Name: "Status", Type: "SINGLE_SELECT"},
+		},
+	}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{
+						Title:      "My Board",
+						Visibility: "public",
+						Fields: []config.Field{
+							{Name: "Status", Type: config.FieldTypeSingleSelect},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true, FixFields: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdFields) != 0 {
+		t.Error("expected no fields created when field already exists")
+	}
+}
+
+func TestReconcile_CreateView(t *testing.T) {
+	fc := &fakeClient{
+		orgID: "org-123",
+		projects: []client.ProjectV2{
+			{ID: "proj-1", Title: "My Board", Public: true},
+		},
+	}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{
+						Title:      "My Board",
+						Visibility: "public",
+						Views: []config.View{
+							{Name: "Kanban", Layout: config.ViewLayoutBoard},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true, FixViews: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdViews) != 1 || fc.createdViews[0] != "Kanban" {
+		t.Errorf("expected view 'Kanban' created, got %v", fc.createdViews)
+	}
+}
+
+func TestReconcile_UpdateViewLayout(t *testing.T) {
+	fc := &fakeClient{
+		orgID: "org-123",
+		projects: []client.ProjectV2{
+			{ID: "proj-1", Title: "My Board", Public: true},
+		},
+		views: []client.ProjectV2View{
+			{ID: "v-1", Name: "Kanban", Layout: "TABLE_LAYOUT"},
+		},
+	}
+	cfg := &config.FullConfig{
+		Orgs: map[string]config.OrgProjects{
+			"test-org": {
+				Projects: []config.Project{
+					{
+						Title:      "My Board",
+						Visibility: "public",
+						Views: []config.View{
+							{Name: "Kanban", Layout: config.ViewLayoutBoard},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	opts := Options{Confirm: true, FixProjects: true, FixViews: true}
+	if err := Reconcile(context.Background(), fc, cfg, opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fc.createdViews) != 0 {
+		t.Error("expected no views created")
+	}
+	if len(fc.updatedViews) != 1 {
+		t.Errorf("expected 1 view updated, got %d", len(fc.updatedViews))
+	}
+	if len(fc.updatedLayouts) != 1 || fc.updatedLayouts[0] != "BOARD_LAYOUT" {
+		t.Errorf("expected layout update to BOARD_LAYOUT, got %v", fc.updatedLayouts)
+	}
+}

--- a/robots/ghprojects/main.go
+++ b/robots/ghprojects/main.go
@@ -1,0 +1,176 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"kubevirt.io/project-infra/pkg/ghprojects/client"
+	"kubevirt.io/project-infra/pkg/ghprojects/config"
+	"kubevirt.io/project-infra/pkg/ghprojects/reconcile"
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "ghprojects",
+		Short: "Manage GitHub Projects V2 declaratively from YAML configuration",
+	}
+
+	rootCmd.AddCommand(syncCmd())
+	rootCmd.AddCommand(dumpCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func syncCmd() *cobra.Command {
+	var (
+		configPath  string
+		tokenPath   string
+		confirm     bool
+		fixAll      bool
+		fixProjects bool
+		fixFields   bool
+		fixViews    bool
+		debug       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Synchronize GitHub Projects V2 to match the YAML configuration",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+
+			token, err := readToken(tokenPath)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return err
+			}
+
+			c := client.New(token)
+
+			opts := reconcile.Options{
+				Confirm:     confirm,
+				FixProjects: fixAll || fixProjects,
+				FixFields:   fixAll || fixFields,
+				FixViews:    fixAll || fixViews,
+			}
+
+			if !opts.FixProjects && !opts.FixFields && !opts.FixViews {
+				opts.FixProjects = true
+				opts.FixFields = true
+				opts.FixViews = true
+			}
+
+			if !confirm {
+				logrus.Info("running in dry-run mode, use --confirm to apply changes")
+			}
+
+			return reconcile.Reconcile(context.Background(), c, cfg, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config-path", "", "Path to the projects YAML configuration file (required)")
+	cmd.Flags().StringVar(&tokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Apply changes (default is dry-run)")
+	cmd.Flags().BoolVar(&fixAll, "fix-all", false, "Fix all resource types (projects, fields, views)")
+	cmd.Flags().BoolVar(&fixProjects, "fix-projects", false, "Create/update projects")
+	cmd.Flags().BoolVar(&fixFields, "fix-fields", false, "Create/update custom fields")
+	cmd.Flags().BoolVar(&fixViews, "fix-views", false, "Create/update views")
+	cmd.Flags().BoolVar(&debug, "v", false, "Enable debug logging")
+	if err := cmd.MarkFlagRequired("config-path"); err != nil {
+		logrus.WithError(err).Fatal("failed to mark config-path flag as required")
+	}
+
+	return cmd
+}
+
+func dumpCmd() *cobra.Command {
+	var (
+		tokenPath string
+		org       string
+		debug     bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "dump",
+		Short: "Export the current GitHub Projects V2 state as YAML",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if debug {
+				logrus.SetLevel(logrus.DebugLevel)
+			}
+
+			token, err := readToken(tokenPath)
+			if err != nil {
+				return err
+			}
+
+			c := client.New(token)
+
+			cfg, err := config.Dump(context.Background(), c, org)
+			if err != nil {
+				return err
+			}
+
+			out, err := yaml.Marshal(cfg)
+			if err != nil {
+				return fmt.Errorf("marshaling config: %w", err)
+			}
+
+			fmt.Print(string(out))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&tokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth token")
+	cmd.Flags().StringVar(&org, "org", "", "GitHub organization to dump projects from (required)")
+	cmd.Flags().BoolVar(&debug, "v", false, "Enable debug logging")
+	if err := cmd.MarkFlagRequired("org"); err != nil {
+		logrus.WithError(err).Fatal("failed to mark org flag as required")
+	}
+
+	return cmd
+}
+
+func readToken(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading token from %s: %w", path, err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("token file %s is empty", path)
+	}
+	return token, nil
+}


### PR DESCRIPTION
## Summary

- Scaffolds a new `pkg/ghprojects` package and `robots/ghprojects` CLI for managing GitHub Projects V2 boards declaratively from YAML configuration
- Follows the same desired-state reconciliation pattern as peribolos: dry-run by default, `--confirm` to apply, granular `--fix-projects`/`--fix-fields`/`--fix-views` flags
- Uses the `shurcooL/githubv4` GraphQL library already vendored in this repo
- Includes a `dump` subcommand to export live project state back to YAML

Closes #4814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a CLI tool for managing GitHub Projects V2 configuration
  * Added configuration-driven synchronization to keep projects, custom fields, and views in sync with desired state
  * Support for YAML configuration import and export capabilities
  * Dry-run mode for previewing changes before applying them
  * Selective control over what gets updated (projects, fields, views)

* **Tests**
  * Added test coverage for configuration validation and synchronization scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->