### PR TITLE
test-label-analyzer: support Ginkgo v2 first-class labels in traversal

### DIFF
--- a/pkg/test-label-analyzer/stats.go
+++ b/pkg/test-label-analyzer/stats.go
@@ -83,14 +83,36 @@ func traverseNodesRecursively(stats *TestStats, config *Config, gingkoOutline []
 		var parentsWithNode []*GinkgoNode
 		parentsWithNode = append(parentsWithNode, parents...)
 		parentsWithNode = append(parentsWithNode, node)
+
 		if node.Spec {
 			stats.SpecsTotal++
+
+			// compute testName once per spec and reuse across categories
+			var testName string
+			for _, nodeFromPath := range parentsWithNode {
+				testName = strings.Join([]string{testName, nodeFromPath.Text}, " ")
+			}
+
+			// accumulate labels from parents + spec to mimic Ginkgo v2 label inheritance semantics
+			inheritedLabels := make([]string, 0, len(parentsWithNode))
+			for _, parentNode := range parentsWithNode {
+				inheritedLabels = append(inheritedLabels, parentNode.Labels...)
+			}
+
 			for _, category := range config.Categories {
-				var testName string
-				for _, nodeFromPath := range parentsWithNode {
-					testName = strings.Join([]string{testName, nodeFromPath.Text}, " ")
+				matchesTestName := category.TestNameLabelRE != nil && category.TestNameLabelRE.MatchString(testName)
+
+				matchesGinkgoLabel := false
+				if !matchesTestName && category.GinkgoLabelRE != nil {
+					for _, label := range inheritedLabels {
+						if category.GinkgoLabelRE.MatchString(label) {
+							matchesGinkgoLabel = true
+							break
+						}
+					}
 				}
-				if category.TestNameLabelRE.MatchString(testName) {
+
+				if matchesTestName || matchesGinkgoLabel {
 					var path []*GinkgoNode
 					for _, pathNode := range parentsWithNode {
 						path = append(path, pathNode.CloneWithoutNodes())

--- a/pkg/test-label-analyzer/stats_test.go
+++ b/pkg/test-label-analyzer/stats_test.go
@@ -223,6 +223,114 @@ var _ = Describe("GetStatsFromGinkgoOutline", func() {
 					}}))
 		})
 
+		It("matches when a parent node has a matching Ginkgo label", func() {
+			quarantineLabelCategory.Hits = 1
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text:   "parent",
+						Labels: []string{"Quarantine"},
+						Nodes: []*GinkgoNode{
+							{
+								Text: "child",
+								Spec: true,
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal: 1,
+					MatchingSpecPaths: []*PathStats{
+						{
+							Path: []*GinkgoNode{
+								{
+									Text:   "parent",
+									Labels: []string{"Quarantine"},
+								},
+								{
+									Text: "child",
+									Spec: true,
+								},
+							},
+							MatchingCategory: quarantineLabelCategory,
+						},
+					},
+				}))
+		})
+
+		It("matches when the spec node itself has a matching Ginkgo label", func() {
+			quarantineLabelCategory.Hits = 1
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "parent",
+						Nodes: []*GinkgoNode{
+							{
+								Text:   "child",
+								Spec:   true,
+								Labels: []string{"Quarantine"},
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal: 1,
+					MatchingSpecPaths: []*PathStats{
+						{
+							Path: []*GinkgoNode{
+								{
+									Text: "parent",
+								},
+								{
+									Text:   "child",
+									Spec:   true,
+									Labels: []string{"Quarantine"},
+								},
+							},
+							MatchingCategory: quarantineLabelCategory,
+						},
+					},
+				}))
+		})
+
+		It("matches only once when both test name and Ginkgo label match the same category", func() {
+			quarantineLabelCategory.Hits = 1
+			Expect(GetStatsFromGinkgoOutline(
+				NewQuarantineDefaultConfig(),
+				[]*GinkgoNode{
+					{
+						Text: "parent [QUARANTINE]",
+						Nodes: []*GinkgoNode{
+							{
+								Text:   "child",
+								Spec:   true,
+								Labels: []string{"Quarantine"},
+							},
+						},
+					},
+				})).To(BeEquivalentTo(
+				&TestStats{
+					SpecsTotal: 1,
+					MatchingSpecPaths: []*PathStats{
+						{
+							Path: []*GinkgoNode{
+								{
+									Text: "parent [QUARANTINE]",
+								},
+								{
+									Text:   "child",
+									Spec:   true,
+									Labels: []string{"Quarantine"},
+								},
+							},
+							MatchingCategory: quarantineLabelCategory,
+						},
+					},
+				}))
+		})
+
 		It("doesnt collect the test names twice if parent and child contain the matching label", func() {
 			quarantineLabelCategory.Hits = 1
 			Expect(GetStatsFromGinkgoOutline(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Extends `test-label-analyzer` so category matching uses both:
- **Textual labels** in the spec path (existing behavior), and
- **First-class Ginkgo v2 labels** on the spec or any parent node (inherited, same as Ginkgo v2).

Traversal now accumulates labels from the full path (all parents + spec) and treats a spec as matching a category if either `TestNameLabelRE` matches the concatenated spec text or `GinkgoLabelRE` matches any of those labels. This supports migration from v1-style text tags (e.g. `[QUARANTINE]`) to v2 `Label("Quarantine")` without losing existing configs that already define `GinkgoLabelRE` (e.g. quarantine).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2679 (partial — core label matching)

**Special notes for your reviewer**:

- No change to config or CLI surface; only `pkg/test-label-analyzer` traversal and tests.
- New tests: parent node has matching Ginkgo label; spec node has matching Ginkgo label.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
test-label-analyzer: stats now match specs by Ginkgo v2 first-class labels (inherited from spec or parents) in addition to textual labels in the spec name.
```
