### PR TITLE
test-label-analyzer: add filter expressions command for Ginkgo flags

### DIFF
--- a/robots/test-label-analyzer/cmd/filter/expressions.go
+++ b/robots/test-label-analyzer/cmd/filter/expressions.go
@@ -1,0 +1,178 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package filter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type filterExpressionsOptions struct {
+	inputFilePath string
+	mode          string
+}
+
+var filterExpressionsOpts = &filterExpressionsOptions{}
+
+// expressionsCmd generates ready-to-use Ginkgo filter expressions from a matching-tests JSON file.
+//
+// It is intended to be used after `test-label-analyzer filter stats matching-tests`, taking its
+// JSON output as input and emitting filter expressions for both Ginkgo v1 text filters and
+// Ginkgo v2 label filters.
+var expressionsCmd = &cobra.Command{
+	Use:   "expressions",
+	Short: "Generates Ginkgo filter expressions from matching tests",
+	Long: `Generates expressions that can be used with Ginkgo's --filter/--skip (v1) and --label-filter (v2) flags.
+
+The command expects as input the JSON produced by 'test-label-analyzer filter stats matching-tests'.
+By default it prints a simple text representation with the expressions.
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		filterExpressionsOpts.inputFilePath = args[0]
+		return runExpressions(filterExpressionsOpts)
+	},
+}
+
+// expressionsOutput represents the combined filter expressions for Ginkgo v1 and v2.
+type expressionsOutput struct {
+	// Filter is suitable for use with Ginkgo v1 --filter
+	Filter string `json:"filter"`
+
+	// Skip is suitable for use with Ginkgo v1 --skip
+	Skip string `json:"skip"`
+
+	// LabelFilter is suitable for use with Ginkgo v2 --label-filter
+	LabelFilter string `json:"label_filter"`
+}
+
+func runExpressions(opts *filterExpressionsOptions) error {
+	fileContent, err := os.ReadFile(opts.inputFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read input file %q: %w", opts.inputFilePath, err)
+	}
+
+	var matches matchingTests
+	if err := json.Unmarshal(fileContent, &matches); err != nil {
+		return fmt.Errorf("failed to unmarshal input file %q: %w", opts.inputFilePath, err)
+	}
+
+	if len(matches) == 0 {
+		return fmt.Errorf("no matching tests found in input")
+	}
+
+	out := buildExpressions(matches)
+
+	switch strings.ToLower(opts.mode) {
+	case "", "text":
+		fmt.Printf("# Ginkgo v1\n")
+		if out.Filter != "" {
+			fmt.Printf("--filter=%s\n", out.Filter)
+		}
+		if out.Skip != "" {
+			fmt.Printf("--skip=%s\n", out.Skip)
+		}
+		fmt.Printf("\n# Ginkgo v2\n")
+		if out.LabelFilter != "" {
+			fmt.Printf("--label-filter=%s\n", out.LabelFilter)
+		}
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			return fmt.Errorf("failed to marshal expressions output: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported output mode %q, supported modes: text, json", opts.mode)
+	}
+
+	return nil
+}
+
+// buildExpressions deduplicates the matching tests and constructs simple OR-based expressions.
+func buildExpressions(matches matchingTests) expressionsOutput {
+	// For now we keep things deliberately simple:
+	// - v1 filter: OR of all test names as literal substrings
+	// - v1 skip: left empty (can be extended later)
+	// - v2 label-filter: OR of all unique reasons, treated as labels
+
+	testNameSet := map[string]struct{}{}
+	reasonSet := map[string]struct{}{}
+
+	for _, m := range matches {
+		if m.TestName != "" {
+			testNameSet[m.TestName] = struct{}{}
+		}
+		if m.Reason != "" {
+			reasonSet[m.Reason] = struct{}{}
+		}
+	}
+
+	testNames := make([]string, 0, len(testNameSet))
+	for name := range testNameSet {
+		testNames = append(testNames, name)
+	}
+	sort.Strings(testNames)
+
+	reasons := make([]string, 0, len(reasonSet))
+	for r := range reasonSet {
+		reasons = append(reasons, r)
+	}
+	sort.Strings(reasons)
+
+	var filterExpr string
+	if len(testNames) > 0 {
+		parts := make([]string, 0, len(testNames))
+		for _, name := range testNames {
+			// Escape quotes inside names to keep expression simple.
+			escaped := strings.ReplaceAll(name, `"`, `\"`)
+			escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+			parts = append(parts, fmt.Sprintf("'%s'", escaped))
+		}
+		filterExpr = strings.Join(parts, " || ")
+	}
+
+	var labelExpr string
+	if len(reasons) > 0 {
+		parts := make([]string, 0, len(reasons))
+		for _, r := range reasons {
+			escaped := strings.ReplaceAll(r, `"`, `\"`)
+			escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+			parts = append(parts, fmt.Sprintf("'%s'", escaped))
+		}
+		labelExpr = strings.Join(parts, " || ")
+	}
+
+	return expressionsOutput{
+		Filter:      filterExpr,
+		Skip:        "",
+		LabelFilter: labelExpr,
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(expressionsCmd)
+	expressionsCmd.PersistentFlags().StringVar(&filterExpressionsOpts.mode, "output-mode", "text", "output mode: text or json")
+}
+

--- a/robots/test-label-analyzer/cmd/filter/expressions.go
+++ b/robots/test-label-analyzer/cmd/filter/expressions.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -41,7 +42,7 @@ var filterExpressionsOpts = &filterExpressionsOptions{}
 // JSON output as input and emitting filter expressions for both Ginkgo v1 text filters and
 // Ginkgo v2 label filters.
 var expressionsCmd = &cobra.Command{
-	Use:   "expressions",
+	Use:   "expressions <matching-tests.json>",
 	Short: "Generates Ginkgo filter expressions from matching tests",
 	Long: `Generates expressions that can be used with Ginkgo's --filter/--skip (v1) and --label-filter (v2) flags.
 
@@ -145,23 +146,18 @@ func buildExpressions(matches matchingTests) expressionsOutput {
 	if len(testNames) > 0 {
 		parts := make([]string, 0, len(testNames))
 		for _, name := range testNames {
-			// Escape quotes inside names to keep expression simple.
-			escaped := strings.ReplaceAll(name, `"`, `\"`)
-			escaped = strings.ReplaceAll(escaped, `'`, `\'`)
-			parts = append(parts, fmt.Sprintf("'%s'", escaped))
+			parts = append(parts, regexp.QuoteMeta(name))
 		}
-		filterExpr = strings.Join(parts, " || ")
+		filterExpr = strings.Join(parts, "|")
 	}
 
 	var labelExpr string
 	if len(reasons) > 0 {
 		parts := make([]string, 0, len(reasons))
 		for _, r := range reasons {
-			escaped := strings.ReplaceAll(r, `"`, `\"`)
-			escaped = strings.ReplaceAll(escaped, `'`, `\'`)
-			parts = append(parts, fmt.Sprintf("'%s'", escaped))
+			parts = append(parts, r)
 		}
-		labelExpr = strings.Join(parts, " || ")
+		labelExpr = strings.Join(parts, "||")
 	}
 
 	return expressionsOutput{

--- a/robots/test-label-analyzer/cmd/filter/expressions.go
+++ b/robots/test-label-analyzer/cmd/filter/expressions.go
@@ -21,11 +21,13 @@ package filter
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
 
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +54,7 @@ By default it prints a simple text representation with the expressions.
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		filterExpressionsOpts.inputFilePath = args[0]
-		return runExpressions(filterExpressionsOpts)
+		return runExpressions(filterExpressionsOpts, cmd.OutOrStdout())
 	},
 }
 
@@ -64,11 +66,11 @@ type expressionsOutput struct {
 	// Skip is suitable for use with Ginkgo v1 --skip
 	Skip string `json:"skip"`
 
-	// LabelFilter is suitable for use with Ginkgo v2 --label-filter
+	// LabelFilter is suitable for use with Ginkgo v2 --label-filter when reasons are valid labels
 	LabelFilter string `json:"label_filter"`
 }
 
-func runExpressions(opts *filterExpressionsOptions) error {
+func runExpressions(opts *filterExpressionsOptions, outWriter io.Writer) error {
 	fileContent, err := os.ReadFile(opts.inputFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read input file %q: %w", opts.inputFilePath, err)
@@ -83,23 +85,26 @@ func runExpressions(opts *filterExpressionsOptions) error {
 		return fmt.Errorf("no matching tests found in input")
 	}
 
-	out := buildExpressions(matches)
+	out, err := buildExpressions(matches)
+	if err != nil {
+		return err
+	}
 
 	switch strings.ToLower(opts.mode) {
 	case "", "text":
-		fmt.Printf("# Ginkgo v1\n")
+		fmt.Fprintf(outWriter, "# Ginkgo v1\n")
 		if out.Filter != "" {
-			fmt.Printf("--filter=%s\n", out.Filter)
+			fmt.Fprintf(outWriter, "--filter=%s\n", out.Filter)
 		}
 		if out.Skip != "" {
-			fmt.Printf("--skip=%s\n", out.Skip)
+			fmt.Fprintf(outWriter, "--skip=%s\n", out.Skip)
 		}
-		fmt.Printf("\n# Ginkgo v2\n")
+		fmt.Fprintf(outWriter, "\n# Ginkgo v2\n")
 		if out.LabelFilter != "" {
-			fmt.Printf("--label-filter=%s\n", out.LabelFilter)
+			fmt.Fprintf(outWriter, "--label-filter=%s\n", out.LabelFilter)
 		}
 	case "json":
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(outWriter)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(out); err != nil {
 			return fmt.Errorf("failed to marshal expressions output: %w", err)
@@ -112,11 +117,11 @@ func runExpressions(opts *filterExpressionsOptions) error {
 }
 
 // buildExpressions deduplicates the matching tests and constructs simple OR-based expressions.
-func buildExpressions(matches matchingTests) expressionsOutput {
+func buildExpressions(matches matchingTests) (expressionsOutput, error) {
 	// For now we keep things deliberately simple:
 	// - v1 filter: OR of all test names as literal substrings
 	// - v1 skip: left empty (can be extended later)
-	// - v2 label-filter: OR of all unique reasons, treated as labels
+	// - v2 label-filter: OR of all unique reasons, if they are already valid Ginkgo labels
 
 	testNameSet := map[string]struct{}{}
 	reasonSet := map[string]struct{}{}
@@ -155,7 +160,11 @@ func buildExpressions(matches matchingTests) expressionsOutput {
 	if len(reasons) > 0 {
 		parts := make([]string, 0, len(reasons))
 		for _, r := range reasons {
-			parts = append(parts, r)
+			cleaned, err := ginkgotypes.ValidateAndCleanupLabel(r, ginkgotypes.CodeLocation{})
+			if err != nil {
+				return expressionsOutput{}, fmt.Errorf("cannot generate --label-filter from reason %q: %w", r, err)
+			}
+			parts = append(parts, cleaned)
 		}
 		labelExpr = strings.Join(parts, "||")
 	}
@@ -164,11 +173,10 @@ func buildExpressions(matches matchingTests) expressionsOutput {
 		Filter:      filterExpr,
 		Skip:        "",
 		LabelFilter: labelExpr,
-	}
+	}, nil
 }
 
 func init() {
 	rootCmd.AddCommand(expressionsCmd)
 	expressionsCmd.PersistentFlags().StringVar(&filterExpressionsOpts.mode, "output-mode", "text", "output mode: text or json")
 }
-

--- a/robots/test-label-analyzer/cmd/filter/expressions_test.go
+++ b/robots/test-label-analyzer/cmd/filter/expressions_test.go
@@ -19,8 +19,6 @@
 package filter
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -38,13 +36,13 @@ var _ = Describe("expressions", func() {
 			matches := matchingTests{
 				{
 					Id:       "id-1",
-					Reason:   "Quarantine",
+					Reason:   "sig-network",
 					Version:  "",
 					TestName: "test A",
 				},
 				{
 					Id:       "id-2",
-					Reason:   "Quarantine",
+					Reason:   "sig-storage",
 					Version:  "",
 					TestName: "test B",
 				},
@@ -53,13 +51,8 @@ var _ = Describe("expressions", func() {
 			out := buildExpressions(matches)
 
 			Expect(out.Skip).To(BeEmpty())
-
-			// Filter should mention both test names
-			Expect(out.Filter).To(ContainSubstring("test A"))
-			Expect(out.Filter).To(ContainSubstring("test B"))
-
-			// LabelFilter should mention the reason once
-			Expect(strings.Count(out.LabelFilter, "Quarantine")).To(Equal(1))
+			Expect(out.Filter).To(Equal("test A|test B"))
+			Expect(out.LabelFilter).To(Equal("sig-network||sig-storage"))
 		})
 	})
 })

--- a/robots/test-label-analyzer/cmd/filter/expressions_test.go
+++ b/robots/test-label-analyzer/cmd/filter/expressions_test.go
@@ -19,6 +19,11 @@
 package filter
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -26,34 +31,91 @@ import (
 var _ = Describe("expressions", func() {
 	Context("buildExpressions", func() {
 		It("returns empty expressions for empty input", func() {
-			out := buildExpressions(nil)
+			out, err := buildExpressions(nil)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(out.Filter).To(BeEmpty())
 			Expect(out.Skip).To(BeEmpty())
 			Expect(out.LabelFilter).To(BeEmpty())
 		})
 
-		It("builds expressions from matching tests", func() {
+		It("deduplicates matches and escapes regex metacharacters", func() {
 			matches := matchingTests{
 				{
 					Id:       "id-1",
 					Reason:   "sig-network",
 					Version:  "",
-					TestName: "test A",
+					TestName: "test [1]",
 				},
 				{
 					Id:       "id-2",
 					Reason:   "sig-storage",
 					Version:  "",
-					TestName: "test B",
+					TestName: "test .2",
+				},
+				{
+					Id:       "id-3",
+					Reason:   "sig-network",
+					Version:  "",
+					TestName: "test [1]",
 				},
 			}
 
-			out := buildExpressions(matches)
+			out, err := buildExpressions(matches)
+			Expect(err).ToNot(HaveOccurred())
 
 			Expect(out.Skip).To(BeEmpty())
-			Expect(out.Filter).To(Equal("test A|test B"))
+			Expect(out.Filter).To(Equal(`test \.2|test \[1\]`))
 			Expect(out.LabelFilter).To(Equal("sig-network||sig-storage"))
+		})
+
+		It("returns an error when a reason is not a valid Ginkgo label", func() {
+			_, err := buildExpressions(matchingTests{
+				{
+					Id:       "id-1",
+					Reason:   "flaky test - Tracked in https://github.com/kubevirt/kubevirt/issues/37",
+					Version:  "",
+					TestName: "test A",
+				},
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot generate --label-filter"))
+		})
+	})
+
+	Context("runExpressions", func() {
+		It("writes text output to the provided writer", func() {
+			tempDir, err := os.MkdirTemp("", "expressions")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tempDir)
+
+			inputPath := filepath.Join(tempDir, "matching-tests.json")
+			matches := matchingTests{
+				{
+					Id:       "id-1",
+					Reason:   "sig-network",
+					Version:  "",
+					TestName: "test [1]",
+				},
+				{
+					Id:       "id-2",
+					Reason:   "sig-storage",
+					Version:  "",
+					TestName: "test .2",
+				},
+			}
+
+			payload, err := json.Marshal(matches)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(os.WriteFile(inputPath, payload, 0600)).To(Succeed())
+
+			var out bytes.Buffer
+			err = runExpressions(&filterExpressionsOptions{
+				inputFilePath: inputPath,
+				mode:          "text",
+			}, &out)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out.String()).To(Equal("# Ginkgo v1\n--filter=test \\.2|test \\[1\\]\n\n# Ginkgo v2\n--label-filter=sig-network||sig-storage\n"))
 		})
 	})
 })
-

--- a/robots/test-label-analyzer/cmd/filter/expressions_test.go
+++ b/robots/test-label-analyzer/cmd/filter/expressions_test.go
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ */
+
+package filter
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("expressions", func() {
+	Context("buildExpressions", func() {
+		It("returns empty expressions for empty input", func() {
+			out := buildExpressions(nil)
+			Expect(out.Filter).To(BeEmpty())
+			Expect(out.Skip).To(BeEmpty())
+			Expect(out.LabelFilter).To(BeEmpty())
+		})
+
+		It("builds expressions from matching tests", func() {
+			matches := matchingTests{
+				{
+					Id:       "id-1",
+					Reason:   "Quarantine",
+					Version:  "",
+					TestName: "test A",
+				},
+				{
+					Id:       "id-2",
+					Reason:   "Quarantine",
+					Version:  "",
+					TestName: "test B",
+				},
+			}
+
+			out := buildExpressions(matches)
+
+			Expect(out.Skip).To(BeEmpty())
+
+			// Filter should mention both test names
+			Expect(out.Filter).To(ContainSubstring("test A"))
+			Expect(out.Filter).To(ContainSubstring("test B"))
+
+			// LabelFilter should mention the reason once
+			Expect(strings.Count(out.LabelFilter, "Quarantine")).To(Equal(1))
+		})
+	})
+})
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Implements the “generate strings for Ginkgo flags” use case from the test-label-analyzer design:

- **New subcommand**: `test-label-analyzer filter expressions <matching-tests.json>`
- **Input**: JSON produced by `test-label-analyzer filter stats matching-tests` (same format as existing `matching-tests` output).
- **Output** (default text): Lines suitable for `--filter`, `--skip`, and `--label-filter` (Ginkgo v1 text filters and v2 label filter).
- **Flag**: `--output-mode=text|json` (default `text`).

Typical flow: run `stats` → `filter stats matching-tests` → `filter expressions` to get strings to pass to `ginkgo --filter` / `ginkgo --label-filter` for the same set of tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2679 (partial — filter string generation)

**Special notes for your reviewer**:

- New files: `robots/test-label-analyzer/cmd/filter/expressions.go` and `expressions_test.go`. No changes to existing commands.
- Deduplicates test names (for v1 filter) and category reasons (for v2 label-filter). Output format is intentionally simple (OR of literals).

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
test-label-analyzer: add `filter expressions` subcommand to generate Ginkgo --filter/--skip and --label-filter strings from matching-tests JSON.
```