### PR TITLE
Add s390 prow e2e job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -470,6 +470,79 @@ presubmits:
           resources:
             requests:
               memory: "52Gi"
+  - name: pull-containerized-data-importer-e2e-s390x
+    skip_branches:
+      - release-v\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 6h
+      grace_period: 10m
+    max_concurrency: 1
+    cluster: kubevirt-prow-control-plane
+    extra_refs:
+    - org: kubevirt
+      repo: project-infra
+      base_ref: main
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-quay-credential: "true"
+      preset-github-credentials: "true"
+      preset-pgp-bot-key: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/bootstrap:v20260306-351d3b1
+          env:
+          - name: KUBECONFIG
+            value: /kubeconfig
+          - name: TARGET
+            value: external
+          - name: BUILD_ARCH
+            value: crossbuild-s390x
+          - name: ARCHITECTURE
+            value: s390x
+          - name: PULL_POLICY
+            value: Always
+          - name: CDI_NAMESPACE
+            value: cdi
+          - name: CDI_E2E_SKIP
+            value: "Destructive|Cert rotation|cdi-apiserver tests|Importer Test Suite-prometheus"
+          - name: SNAPSHOT_SC
+            value: ocs-storagecluster-ceph-rbd
+          - name: BLOCK_SC
+            value: ocs-storagecluster-ceph-rbd
+          - name: CSICLONE_SC
+            value: ocs-storagecluster-ceph-rbd
+          - name: CDI_LABEL_FILTER
+            value: "!VDDK && !ImageIO"
+          - name: UPLOAD_PROXY_URL_OVERRIDE
+            value: "https://cdi-uploadproxy-cdi.apps.odf.cdi.ci:6005"
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - |
+              source ../project-infra/hack/manage-secrets.sh
+              decrypt_secrets
+              install -m400 "${secrets_repo_dir}"/secrets/kubeconfigs/prow-s390x-openshift /kubeconfig
+              cleanup_secrets
+
+              cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
+              echo "195.212.74.206 api.odf.cdi.ci oauth-openshift.apps.odf.cdi.ci cdi-uploadproxy-cdi.apps.odf.cdi.ci" >> /etc/hosts
+
+              kubectl delete cdi cdi --ignore-not-found --timeout=120s
+              kubectl delete ns cdi --ignore-not-found --timeout=120s
+              automation/test.sh
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "8Gi"
   - name: pull-containerized-data-importer-e2e-ceph-wffc
     skip_branches:
       - release-v\d+\.\d+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Adds `pull-containerized-data-importer-e2e-s390x`, a presubmit job that runs CDI functional e2e tests against an external s390x OpenShift cluster, similar to how kubevirt runs [periodic-kubevirt-e2e-test-S390X.](https://github.com/kubevirt/project-infra/blob/a81444c44019908fca1a1c85f59f197c93a5f759/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml#L766-L831)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Related**:
https://github.com/kubevirt/project-infra/issues/4785


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
