### PR TITLE
Refactor gcs cat retries into gcs_restapi.sh

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -213,30 +213,16 @@ periodics:
                 break
             else
                 echo "File $GCS_FILE_PATH not found. Checking again in $CHECK_INTERVAL seconds."
-                sleep $CHECK_INTERVAL
+                sleep "$CHECK_INTERVAL"
             fi
         done
-        # Add retry mechanism for reading file content to handle GCS eventual consistency
-        MAX_RETRIES=5
-        RETRY_COUNT=0
-        RETRY_INTERVAL=5
-        while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false")
-            if [ $? -eq 0 ] && [ -n "$KUBEVIRTCI_TAG" ]; then
-                echo "Successfully fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG"
-                break
-            else
-                RETRY_COUNT=$((RETRY_COUNT + 1))
-                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                    echo "Failed to fetch KUBEVIRTCI_TAG (attempt $RETRY_COUNT/$MAX_RETRIES). Retrying in $RETRY_INTERVAL seconds..."
-                    sleep $RETRY_INTERVAL
-                else
-                    echo "Failed to fetch KUBEVIRTCI_TAG after $MAX_RETRIES attempts"
-                    exit 1
-                fi
-            fi
-        done
+        KUBEVIRTCI_TAG=$(cat_gcs_file_with_retry kubevirt-prow "$GCS_FILE_PATH" "false")
+        if [ $? -ne 0 ]; then
+            echo "Failed to fetch KUBEVIRTCI_TAG"
+            exit 1
+        fi
         export KUBEVIRTCI_TAG &&
+        echo "Fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG" &&
         cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
         ./hack/bump-centos-version.sh &&
         export PHASES=linux; export BYPASS_PMAN_CHANGE_CHECK=true; ./publish.sh &&

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -140,30 +140,16 @@ postsubmits:
                     break
                 else
                     echo "File $GCS_FILE_PATH not found. Checking again in $CHECK_INTERVAL seconds."
-                    sleep $CHECK_INTERVAL
+                    sleep "$CHECK_INTERVAL"
                 fi
             done &&
-            # Add retry mechanism for reading file content to handle GCS eventual consistency
-            MAX_RETRIES=5
-            RETRY_COUNT=0
-            RETRY_INTERVAL=5
-            while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-                KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false")
-                if [ $? -eq 0 ] && [ -n "$KUBEVIRTCI_TAG" ]; then
-                    echo "Successfully fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG"
-                    break
-                else
-                    RETRY_COUNT=$((RETRY_COUNT + 1))
-                    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-                        echo "Failed to fetch KUBEVIRTCI_TAG (attempt $RETRY_COUNT/$MAX_RETRIES). Retrying in $RETRY_INTERVAL seconds..."
-                        sleep $RETRY_INTERVAL
-                    else
-                        echo "Failed to fetch KUBEVIRTCI_TAG after $MAX_RETRIES attempts"
-                        exit 1
-                    fi
-                fi
-            done
+            KUBEVIRTCI_TAG=$(cat_gcs_file_with_retry kubevirt-prow "$GCS_FILE_PATH" "false")
+            if [ $? -ne 0 ]; then
+                echo "Failed to fetch KUBEVIRTCI_TAG"
+                exit 1
+            fi
             export KUBEVIRTCI_TAG &&
+            echo "Fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG" &&
             ./publish.sh &&
             rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
           # docker-in-docker needs privileged mode

--- a/images/bootstrap/gcs_restapi.sh
+++ b/images/bootstrap/gcs_restapi.sh
@@ -130,6 +130,35 @@ cat_gcs_file() {
     fi
 }
 
+# Function to read GCS file content with retry mechanism
+# Usage: cat_gcs_file_with_retry <bucket_name> <gcs_file_path> <auth> [max_retries] [retry_interval]
+cat_gcs_file_with_retry() {
+    local bucket_name="$1"
+    local gcs_file_path="$2"
+    local auth="$3"
+    local max_retries="${4:-5}"
+    local retry_interval="${5:-5}"
+    local retry_count=0
+    local content
+
+    while [ "$retry_count" -lt "$max_retries" ]; do
+        content=$(cat_gcs_file "$bucket_name" "$gcs_file_path" "$auth")
+        if [ $? -eq 0 ] && [ -n "$content" ]; then
+            echo "$content"
+            return 0
+        else
+            retry_count=$((retry_count + 1))
+            if [ "$retry_count" -lt "$max_retries" ]; then
+                echo "Retry $retry_count/$max_retries in ${retry_interval}s..." >&2
+                sleep "$retry_interval"
+            else
+                echo "Failed after $max_retries attempts" >&2
+                return 1
+            fi
+        fi
+    done
+}
+
 # Function to delete a file from GCS
 rm_gcs_file() {
     local bucket_name="$1"

--- a/images/bootstrap/gcs_restapi.sh
+++ b/images/bootstrap/gcs_restapi.sh
@@ -166,16 +166,26 @@ rm_gcs_file() {
 
     auth_header=$(get_auth_header) || exit 1
 
-    delete_response=$(curl -s -X DELETE \
+    local temp_file=$(mktemp)
+    http_code=$(curl -s -w "%{http_code}" -o "$temp_file" -X DELETE \
       -H "$auth_header" \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
+    
+    delete_response=$(cat "$temp_file")
+    rm -f "$temp_file"
 
-    if [ -z "$delete_response" ]; then
-        echo "File $gcs_file_path deleted successfully."
+    if [ "$http_code" = "204" ]; then
+        echo "File $gcs_file_path deleted successfully (HTTP $http_code)."
+        return 0
+    elif [ "$http_code" = "404" ]; then
+        echo "File $gcs_file_path not found (already deleted, HTTP $http_code)."
         return 0
     else
-        echo "Failed to delete file. Response:"
-        echo "$delete_response" | jq '.'
+        echo "ERROR: Failed to delete $gcs_file_path. HTTP Status: $http_code" >&2
+        if [ -n "$delete_response" ]; then
+            echo "Response:" >&2
+            echo "$delete_response" | jq '.' 2>/dev/null || echo "$delete_response" >&2
+        fi
         return 1
     fi
 }


### PR DESCRIPTION
This avoids code duplication in prow jobs and keeps retry logic in a new wrapper function of cat operation

**What this PR does / why we need it**:
This PR refactors the GCS file reading retry logic by introducing a new cat_gcs_file_with_retry() function in [gcs_restapi.sh](vscode-webview://06qvvoscp2kpl0ghdagdrtathaiusah5fhjnqgu7jkie21pvjdt4/images/bootstrap/gcs_restapi.sh). This eliminates code duplication across Prow job configurations by centralizing the retry mechanism for handling GCS eventual consistency issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
- The retry logic behavior remains functionally equivalent to the previous implementation
- Error messages are now consistently sent to stderr while content goes to stdout

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```
