### PR TITLE
feat(quarantine): add configurable warning/critical thresholds to flaky tests report

### DIFF
--- a/pkg/searchci/searchci.go
+++ b/pkg/searchci/searchci.go
@@ -159,6 +159,30 @@ func FilterImpacts(impacts []Impact, timeRange TimeRange) []Impact {
 	return FilterImpactsBy(impacts, matchingTimeRange(timeRange))
 }
 
+// WithMinPercent returns a FilterOpt that keeps impacts with at least minPercent impact.
+func WithMinPercent(minPercent float64) FilterOpt {
+	return func(i Impact) bool {
+		return i.Percent >= minPercent
+	}
+}
+
+// ScrapeImpactsWithMinPercent works like ScrapeImpacts but uses a configurable minimum percentage threshold
+// instead of the default thresholds for each time range.
+func ScrapeImpactsWithMinPercent(testNameSubstring string, timeRange TimeRange, minPercent float64) ([]Impact, error) {
+	scrapeResultURL := NewScrapeURL(testNameSubstring, timeRange)
+	logger.Debugf("scraping search.ci for test %q with URL %q", testNameSubstring, scrapeResultURL)
+	resp, err := http.Get(scrapeResultURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get search.ci results from %s: %w", scrapeResultURL, err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read search.ci result from %s: %w", scrapeResultURL, err)
+	}
+	return FilterImpactsBy(ScrapeImpact(string(body)), WithMinPercent(minPercent)), nil
+}
+
 // FilterImpactsBy filters all impacts for which all filterOpts apply, i.e. each of them returns true
 func FilterImpactsBy(impacts []Impact, filterOpts ...FilterOpt) []Impact {
 	if impacts == nil {

--- a/robots/quarantine/cmd/auto-quarantine.go
+++ b/robots/quarantine/cmd/auto-quarantine.go
@@ -149,7 +149,7 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 			continue
 		}
 
-		candidate, err := getQuarantineCandidate(topXTest, searchci.FourteenDays, 5.0)
+		candidate, err := getQuarantineCandidate(topXTest, searchci.FourteenDays, defaultFourteenDayCriticalThreshold)
 		if err != nil {
 			return nil, fmt.Errorf("could not get quarantine candidate for test %q: %w", topXTest.Name, err)
 		}

--- a/robots/quarantine/cmd/auto-quarantine.go
+++ b/robots/quarantine/cmd/auto-quarantine.go
@@ -149,7 +149,7 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 			continue
 		}
 
-		candidate, err := getQuarantineCandidate(topXTest, searchci.FourteenDays)
+		candidate, err := getQuarantineCandidate(topXTest, searchci.FourteenDays, 5.0)
 		if err != nil {
 			return nil, fmt.Errorf("could not get quarantine candidate for test %q: %w", topXTest.Name, err)
 		}

--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -69,6 +69,10 @@ func init() {
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&outputFileOpts.OverwriteOutputFile, "overwrite-output-file", false, "whether to overwrite the output file")
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.filterPeriodicJobRunResults, "filter-periodic-job-run-results", true, "whether to filter the results for periodics")
 	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.filterLaneRegex, "filter-lane-regex", filterLaneRegexDefault, "the regular expression to use to filter test lanes with")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.threeDayWarningThreshold, "three-day-warning-threshold", 10.0, "minimum 3-day failure percentage to highlight as warning")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.threeDayCriticalThreshold, "three-day-critical-threshold", 20.0, "minimum 3-day failure percentage to highlight as critical")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.fourteenDayWarningThreshold, "fourteen-day-warning-threshold", 3.0, "minimum 14-day failure percentage to highlight as warning")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.fourteenDayCriticalThreshold, "fourteen-day-critical-threshold", 5.0, "minimum 14-day failure percentage to highlight as critical")
 }
 
 var sigMatcher = regexp.MustCompile(`\[(sig-[^]]+)]`)
@@ -91,12 +95,25 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("error while aggregating data: %w", err)
 	}
-	sigs, testNames, mostFlakyTestsBySig, err := aggregateMostFlakyTestsBySIG(topXTests)
+	thresholds := map[searchci.TimeRange][2]float64{
+		searchci.ThreeDays:    {quarantineOpts.threeDayWarningThreshold, quarantineOpts.threeDayCriticalThreshold},
+		searchci.FourteenDays: {quarantineOpts.fourteenDayWarningThreshold, quarantineOpts.fourteenDayCriticalThreshold},
+	}
+	sigs, testNames, mostFlakyTestsBySig, err := aggregateMostFlakyTestsBySIG(topXTests, thresholds)
 	if err != nil {
 		return err
 	}
 
-	reportTemplate, err := template.New("mostFlakyTests").Parse(mostFlakyTestsReportTemplate)
+	reportTemplate, err := template.New("mostFlakyTests").Funcs(template.FuncMap{
+		"isWarning": func(timeRange searchci.TimeRange, percent float64) bool {
+			t, ok := thresholds[timeRange]
+			return ok && percent >= t[0] && percent < t[1]
+		},
+		"isCritical": func(timeRange searchci.TimeRange, percent float64) bool {
+			t, ok := thresholds[timeRange]
+			return ok && percent >= t[1]
+		},
+	}).Parse(mostFlakyTestsReportTemplate)
 	if err != nil {
 		return fmt.Errorf("could not read template: %w", err)
 	}
@@ -114,11 +131,12 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 
 const noSIGKey = "NONE"
 
-func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string, testNames []string, mostFlakyTestsBySIG map[string]TestsPerSIG, err error) {
+func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests, thresholds map[searchci.TimeRange][2]float64) (sigs []string, testNames []string, mostFlakyTestsBySIG map[string]TestsPerSIG, err error) {
 	mostFlakyTests := make(map[string][]*TestToQuarantine)
 	for _, topXTest := range topXTests {
 		for _, timeRange := range mostFlakyTestsTimeRanges {
-			candidate, err := getQuarantineCandidate(topXTest, timeRange)
+			minPercent := thresholds[timeRange][0]
+			candidate, err := getQuarantineCandidate(topXTest, timeRange, minPercent)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("could not scrape results for Test %q: %w", topXTest.Name, err)
 			}
@@ -189,8 +207,8 @@ func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string
 	return sigs, testNames, mostFlakyTestsBySIG, nil
 }
 
-func getQuarantineCandidate(topXTest *flakestats.TopXTest, timeRange searchci.TimeRange) (*TestToQuarantine, error) {
-	impacts, err := searchci.ScrapeImpacts(topXTest.Name, timeRange)
+func getQuarantineCandidate(topXTest *flakestats.TopXTest, timeRange searchci.TimeRange, minPercent float64) (*TestToQuarantine, error) {
+	impacts, err := searchci.ScrapeImpactsWithMinPercent(topXTest.Name, timeRange, minPercent)
 	if err != nil {
 		return nil, fmt.Errorf("could not scrape results for test %q: %w", topXTest.Name, err)
 	}

--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -40,6 +40,11 @@ import (
 
 const (
 	shortReportHelp = `Creates a report of the most flaky tests`
+
+	defaultThreeDayWarningThreshold      = 10.0
+	defaultThreeDayCriticalThreshold     = 20.0
+	defaultFourteenDayWarningThreshold   = 3.0
+	defaultFourteenDayCriticalThreshold  = 5.0
 )
 
 var (
@@ -69,10 +74,10 @@ func init() {
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&outputFileOpts.OverwriteOutputFile, "overwrite-output-file", false, "whether to overwrite the output file")
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.filterPeriodicJobRunResults, "filter-periodic-job-run-results", true, "whether to filter the results for periodics")
 	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.filterLaneRegex, "filter-lane-regex", filterLaneRegexDefault, "the regular expression to use to filter test lanes with")
-	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.threeDayWarningThreshold, "three-day-warning-threshold", 10.0, "minimum 3-day failure percentage to highlight as warning")
-	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.threeDayCriticalThreshold, "three-day-critical-threshold", 20.0, "minimum 3-day failure percentage to highlight as critical")
-	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.fourteenDayWarningThreshold, "fourteen-day-warning-threshold", 3.0, "minimum 14-day failure percentage to highlight as warning")
-	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.fourteenDayCriticalThreshold, "fourteen-day-critical-threshold", 5.0, "minimum 14-day failure percentage to highlight as critical")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.threeDayWarningThreshold, "three-day-warning-threshold", defaultThreeDayWarningThreshold, "minimum 3-day failure percentage to highlight as warning")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.threeDayCriticalThreshold, "three-day-critical-threshold", defaultThreeDayCriticalThreshold, "minimum 3-day failure percentage to highlight as critical")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.fourteenDayWarningThreshold, "fourteen-day-warning-threshold", defaultFourteenDayWarningThreshold, "minimum 14-day failure percentage to highlight as warning")
+	mostFlakyTestsReportCmd.PersistentFlags().Float64Var(&quarantineOpts.fourteenDayCriticalThreshold, "fourteen-day-critical-threshold", defaultFourteenDayCriticalThreshold, "minimum 14-day failure percentage to highlight as critical")
 }
 
 var sigMatcher = regexp.MustCompile(`\[(sig-[^]]+)]`)

--- a/robots/quarantine/cmd/most-flaky-tests-report.gohtml
+++ b/robots/quarantine/cmd/most-flaky-tests-report.gohtml
@@ -55,6 +55,20 @@
             transition: transform var(--transition-speed);
         }
 
+        .impact-warning {
+            background-color: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: 4px 8px;
+            margin: 2px 0;
+        }
+
+        .impact-critical {
+            background-color: #f8d7da;
+            border-left: 4px solid #dc3545;
+            padding: 4px 8px;
+            margin: 2px 0;
+        }
+
     </style>
 </head>
 <body>
@@ -90,9 +104,10 @@
                             <code title="{{ $testName }}">{{ $testName }}</code><br/>
                             {{ range $mostFlakyTest := $mostFlakyTests }}
                                 {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts -}}
-                                    <div class="impact-entry" data-lane="{{ $relevantImpact.URLToDisplay }}">
+                                    <div class="impact-entry{{ if isCritical $mostFlakyTest.TimeRange $relevantImpact.Percent }} impact-critical{{ else if isWarning $mostFlakyTest.TimeRange $relevantImpact.Percent }} impact-warning{{ end }}" data-lane="{{ $relevantImpact.URLToDisplay }}">
                                     <span style="white-space: nowrap;">
                                         <a href="{{ $mostFlakyTest.SearchCIURL }}" title="execute query on search.ci">🔎</a>
+                                        {{ if isCritical $mostFlakyTest.TimeRange $relevantImpact.Percent }}🔴{{ else if isWarning $mostFlakyTest.TimeRange $relevantImpact.Percent }}🟡{{ end -}}
                                         💥<span title="Test has impact of {{ $relevantImpact.Percent }}%"> <b>{{ $relevantImpact.Percent }}%</b> over <b>{{ $mostFlakyTest.TimeRange }}</b></span> on<br/>
                                         <a href="{{ $relevantImpact.URL }}">{{ $relevantImpact.URLToDisplay }}</a>:</span> <span
                                             style="white-space: nowrap;">Failures: {{ range $buildURL := $relevantImpact.BuildURLs -}}

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -51,6 +51,11 @@ type quarantineOptions struct {
 	filterPeriodicJobRunResults bool
 	filterLaneRegex             string
 
+	threeDayWarningThreshold      float64
+	threeDayCriticalThreshold     float64
+	fourteenDayWarningThreshold   float64
+	fourteenDayCriticalThreshold  float64
+
 	testName string
 
 	autoQuarantineOptions


### PR DESCRIPTION
## Summary
- Adds visual highlighting (warning/critical) for flaky test impacts in the most-flaky-tests report
- Configurable thresholds via CLI flags for both 3-day and 14-day time ranges
- Warning (yellow/🟡) and critical (red/🔴) styling based on failure percentage relative to quarantine criteria

## Flags
| Flag | Default | Description |
|------|---------|-------------|
| `--three-day-warning-threshold` | 10% | Minimum 3-day failure % for warning |
| `--three-day-critical-threshold` | 20% | Minimum 3-day failure % for critical |
| `--fourteen-day-warning-threshold` | 3% | Minimum 14-day failure % for warning |
| `--fourteen-day-critical-threshold` | 5% | Minimum 14-day failure % for critical |

Critical thresholds align with [quarantine criteria](https://github.com/kubevirt/kubevirt/blob/main/docs/quarantine.md).

Fixes #4906

🤖 Generated with [Claude Code](https://claude.com/claude-code)