### PR TITLE
Add kubevirt-csi-driver release job to prow.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -1,45 +1,79 @@
 postsubmits:
   kubevirt/csi-driver:
-    - name: publish-csi-driver
+    - name: push-release-csi-driver-images
       branches:
-        - main
-      decorate: true
-      max_concurrency: 1
-      extra_refs:
-        - org: kubevirt
-          repo: project-infra
-          base_ref: main
-      labels:
-        preset-podman-in-container-enabled: "true"
-        preset-docker-mirror: "true"
-        preset-gcs-credentials: "true"
-        preset-github-credentials: "true"
-        preset-kubevirtci-quay-credential: "true"
+        - release-v\d+\.\d+
+      cluster: prow-workloads
+      always_run: true
+      skip_report: true
       annotations:
         testgrid-create-test-group: "false"
-        rehearsal.allowed: "true"
-      cluster: prow-workloads
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 15m
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "false"
+        preset-kubevirtci-quay-credential: "true"
       spec:
         nodeSelector:
           type: bare-metal-external
         containers:
           - image: quay.io/kubevirtci/golang:v20260319-c8f1db8
             env:
-              - name: REPO
+              - name: REGISTRY
                 value: quay.io/kubevirt
-              - name: TARGET_NAME
-                value: csi-driver
-              - name: TAG
-                value: latest
             command:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
               - >
                 cat $QUAY_PASSWORD | docker login quay.io --username $(cat $QUAY_USER) --password-stdin=true &&
-                make image-push
+                [ -z "$(git tag --points-at HEAD | head -1)" ] ||
+                TAG="$(git tag --points-at HEAD | head -1)" make image-push
             securityContext:
               privileged: true
             resources:
               requests:
                 memory: "8Gi"
+    - name: push-release-csi-driver-gh
+      branches:
+      - release-v\d+\.\d+
+      cluster: kubevirt-prow-control-plane
+      always_run: true
+      skip_report: true
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "false"
+        preset-github-credentials: "true"
+        preset-kubevirtci-quay-credential: "false"
+      spec:
+        containers:
+        - image: quay.io/kubevirtci/bootstrap:v20260319-c8f1db8
+          env:
+          - name: DOCKER_REPO
+            value: quay.io/kubevirt
+          - name: GH_CLI_VERSION
+            value: "1.5.0"
+          - name: GITHUB_TOKEN_PATH
+            value: /etc/github/oauth
+          - name: GITHUB_REPOSITORY
+            value: kubevirt/csi-driver
+          - name: GIT_USER_NAME
+            value: kubevirt-bot
+          command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+          args:
+          - ./hack/release.sh
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "8Gi"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Together with the release.sh script this will allow us to make releases of the CSI driver.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
