### PR TITLE
kubernetes-nmstate: gate e2e tests on unit-test success

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -36,7 +36,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
+      always_run: false
+      run_before_merge: true
       optional: false
       decorate: true
       decoration_config:
@@ -102,7 +103,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
+      always_run: false
+      run_before_merge: true
       optional: false
       decorate: true
       decoration_config:
@@ -137,7 +139,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
+      always_run: false
+      run_before_merge: true
       optional: true
       decorate: true
       decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets the handler, operator and upgrade e2e presubmits to
`always_run: false` with `run_before_merge: true`, matching the pattern
used by kubevirt/kubevirt. This defers the expensive e2e tests (52Gi
bare-metal each) to merge time, so they only run after the cheap
unit-test and docs jobs have passed.

Unit-test and docs continue to run in parallel on every PR push.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

This follows the same pattern as kubevirt/kubevirt e2e jobs (e.g.
`pull-kubevirt-e2e-k8s-1.34-sig-network`) which use
`always_run: false` + `run_before_merge: true` to defer expensive tests
until Tide is ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)