### PR TITLE
kubernetes-nmstate: allow force-push on ai/* branches

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -542,6 +542,8 @@ branch-protection:
       repos:
         kubernetes-nmstate:
           protect: true
+          exclude:
+          - "^ai/"
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
**What this PR does / why we need it**:

Excludes `ai/*` branches from branch protection in the `kubernetes-nmstate` repository so that `nmstate-ai` can force-push to them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

The change adds an `exclude: ["^ai/"]` regex to the `nmstate/kubernetes-nmstate` branch protection config in Prow. This leaves `ai/*` branches unprotected (no branch protection rules applied), allowing force-pushes by users with write access. All other branches remain protected with the default policy (including DCO checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)