### PR TITLE
fix: use /test all instead of /retest-required for dependabot PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -214,7 +214,7 @@ periodics:
         once all required presubmit tests pass.
 
         /label skip-review
-        /retest-required
+        /test all
       - --template
       - --ceiling=10
       - --confirm


### PR DESCRIPTION
## Summary

- Replace `/retest-required` with `/test all` in the dependabot commenter periodic

`/retest-required` only retests required jobs that have **already failed**. Since `dependabot[bot]` is an untrusted user and `ignore_ok_to_test: true` is set for this repo, presubmit tests are never auto-triggered on PR creation — so there are zero failed jobs to retest and `/retest-required` is a no-op.

`/test all` triggers all matching presubmit jobs regardless of prior run state. Since the commenter runs as `kubevirt-bot` (a trusted collaborator), the trigger plugin authorizes the command even though the PR author is untrusted.

Observed on https://github.com/kubevirt/project-infra/pull/4924 where tests were only triggered after a human manually approved, not by the commenter periodic.

## Test plan

- [ ] Verify next dependabot PR gets tests triggered by the commenter periodic without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)