### PR TITLE
ci: Ubuntu s390x functest common-instacetypes job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -435,6 +435,46 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - name: pull-common-instancetypes-functest-ubuntu-s390x
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-s390x-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-kubevirt-s390x-icr-credential: "true"
+    max_concurrency: 1
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - "/bin/sh"
+        - "-c"
+        - "make cluster-up && make cluster-sync && make cluster-functest"
+        env:
+        - name: GIMME_GO_VERSION
+          value: 1.24.5
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 16G
+        - name: KUBEVIRT_ONLY_USE_TAGS
+          value: "true"
+        - name: KUBEVIRT_BUILDER_IMAGE
+          value: icr.io/kubevirt/builder:2405141107-77fe60855
+        - name: FUNCTEST_EXTRA_ARGS
+          value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Ubuntu"'
+        image: quay.io/kubevirtci/golang:v20260319-c8f1db8
+        name: ""
+        resources:
+          requests:
+            memory: 20Gi
+        securityContext:
+          privileged: true
   - name: pull-common-instancetypes-functest-opensuse-tumbleweed
     branches:
       - main

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -435,6 +435,44 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - name: pull-common-instancetypes-functest-ubuntu-s390x
+    branches:
+      - main
+    always_run: false
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    cluster: prow-s390x-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-kubevirt-s390x-icr-credential: "true"
+    max_concurrency: 1
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - "/bin/sh"
+        - "-c"
+        - "make cluster-up && make cluster-sync && make cluster-functest"
+        env:
+        - name: GO_MOD_PATH
+          value: "go.mod"
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 16G
+        - name: KUBEVIRT_BUILDER_IMAGE
+          value: icr.io/kubevirt/builder:2405141107-77fe60855
+        - name: FUNCTEST_EXTRA_ARGS
+          value: '--ginkgo.focus="VirtualMachine using a preference is able to boot a Linux guest with .*Ubuntu"'
+        image: quay.io/kubevirtci/golang:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 20Gi
+        securityContext:
+          privileged: true
   - name: pull-common-instancetypes-functest-opensuse-tumbleweed
     branches:
       - main


### PR DESCRIPTION
Add s390x architecture support for Ubuntu functional tests in the common-instancetypes project.

This PR introduces a new presubmit job pull-common-instancetypes-functest-ubuntu-s390x that enables functional testing of Ubuntu virtual machines on the s390x architecture.