### PR TITLE
Fix(coverage): Hardcode toolchain and coverage paths

### DIFF
--- a/external-plugins/coverage/plugin/handler/handler.go
+++ b/external-plugins/coverage/plugin/handler/handler.go
@@ -125,13 +125,17 @@ func (h *GitHubEventsHandler) generateCoverageJob(
 							"-ce",
 						},
 						Args: []string{
-							"go test ./... -coverprofile=${ARTIFACTS}/filtered.cov && " +
+							"go test ./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/... -coverprofile=${ARTIFACTS}/filtered.cov && " +
 								"covreport -i ${ARTIFACTS}/filtered.cov -o ${ARTIFACTS}/filtered.html",
 						},
 						Env: []corev1.EnvVar{
 							{
 								Name:  "GO_MOD_PATH",
 								Value: "go.mod",
+							},
+							{
+								Name:  "GOTOOLCHAIN",
+								Value: "local",
 							},
 						},
 					},

--- a/external-plugins/coverage/plugin/handler/handler_test.go
+++ b/external-plugins/coverage/plugin/handler/handler_test.go
@@ -155,6 +155,36 @@ var _ = Describe("generateCoverageJob", func() {
 			}
 			return ""
 		}, "go.mod"),
+		Entry("GOTOOLCHAIN env", func(j prowapi.ProwJob) string {
+			for _, env := range j.Spec.PodSpec.Containers[0].Env {
+				if env.Name == "GOTOOLCHAIN" {
+					return env.Value
+				}
+			}
+			return ""
+		}, "local"),
+	)
+
+	DescribeTable("Should include specific coverage targets",
+		func(target string) {
+			args := job.Spec.PodSpec.Containers[0].Args
+			Expect(args).To(HaveLen(1))
+			Expect(args[0]).To(ContainSubstring(target))
+		},
+		Entry("external-plugins", "./external-plugins/..."),
+		Entry("releng", "./releng/..."),
+		Entry("robots", "./robots/..."),
+		Entry("cmd", "./cmd/..."),
+		Entry("pkg", "./pkg/..."),
+	)
+
+	DescribeTable("Should not include paths with e2e tests",
+		func(target string) {
+			args := job.Spec.PodSpec.Containers[0].Args
+			Expect(args[0]).NotTo(ContainSubstring(target))
+		},
+		Entry("should not run all tests", "go test ./..."),
+		Entry("should not include github/ci/services e2e tests", "./github/ci/services/..."),
 	)
 
 	DescribeTable("Should set decoration utility images",


### PR DESCRIPTION
**What this PR does / why we need it**:
After merging the previous fix (PR #4933), the coverage plugin successfully created pods but jobs failed due to triggering e2e tests.

This PR fixes two issues: 
e2e tests failing: Running go test ./... included e2e/integration tests. The test targets now match the Makefile's COVERAGE_TARGETS (./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/...).

Go toolchain mismatch: The go.mod specifies go 1.25.0 with toolchain go 1.25.1. The entrypoint installs Go 1.25.0 via gimme, but Go then downloads 1.25.1 at runtime, causing a compile tool version mismatch. Setting GOTOOLCHAIN=local tells Go to use the installed version and ignore the toolchain directive.

**Special notes for your reviewer**:
@dhiller @dollierp 

The test targets and GOTOOLCHAIN value are hardcoded for now, these will be moved to a ConfigMap in a follow-up PR.