### PR TITLE
kubevirtci,presubmits: Remove check-provision lanes for v1.33 k8s based providers

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -129,81 +129,6 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
-    name: check-up-kind-1.33
-    run_if_changed: cluster-up/cluster/kind(-1\.33)?
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - make cluster-up
-        env:
-        - name: KUBEVIRT_PROVIDER
-          value: kind-1.33
-        - name: KUBEVIRT_NUM_NODES
-          value: "2"
-        - name: KUBEVIRT_MEMORY_SIZE
-          value: 11264M
-        image: quay.io/kubevirtci/golang:v20260319-c8f1db8
-        name: ""
-        resources:
-          requests:
-            memory: 52Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-  - always_run: false
-    cluster: prow-arm64-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    max_concurrency: 1
-    name: check-up-kind-1.33-arm64
-    run_if_changed: cluster-up/cluster/kind(-1\.33)?
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        - make cluster-up
-        env:
-        - name: KUBEVIRT_PROVIDER
-          value: kind-1.33
-        - name: KUBEVIRT_DEPLOY_CDI
-          value: "true"
-        image: quay.io/kubevirtci/golang:v20260319-c8f1db8
-        name: ""
-        resources:
-          requests:
-            memory: 24Gi
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
-      volumes:
-      - hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
-        name: cgroup
-  - always_run: false
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
     name: check-up-kind-1.34
     optional: true
     run_if_changed: cluster-up/cluster/kind(-1\.34)?
@@ -572,36 +497,6 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  - always_run: true
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-kubevirtci-check-provision-env: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
-    name: check-provision-k8s-1.33
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.33 && ../provision.sh
-        env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
-        image: quay.io/kubevirtci/golang:v20260319-c8f1db8
-        name: ""
-        resources:
-          requests:
-            memory: 16Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
   - always_run: true
     cluster: prow-s390x-workloads
     decorate: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the release of KubeVirt v1.8 - these cluster providers are no longer needed as testing against kubernetes v1.33 is not needed for the next release.

Remove these check-provision lanes ahead of removing the cluster providers themselves

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
