### PR TITLE
fix: use commenter-oauth-token for dependabot skip-review periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -192,8 +192,6 @@ periodics:
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
-  labels:
-    preset-github-credentials: "true"
   decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
@@ -218,6 +216,13 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/github
+    volumes:
+    - name: token
+      secret:
+        secretName: commenter-oauth-token
 - name: periodic-project-infra-autoowners
   interval: 24h
   annotations:


### PR DESCRIPTION
## Summary

- Switch `periodic-project-infra-dependabot-skip-review` from `preset-github-credentials` (kubevirt-bot) to `commenter-oauth-token` (kubevirt-commenter-bot)
- This fixes `/test all` not being processed on dependabot PRs (e.g. #4968)

## Why

The job posts `/test all` comments on dependabot PRs, but Prow's trigger plugin [skips commands from its own bot user](https://github.com/kubernetes-sigs/prow/blob/main/pkg/plugins/trigger/generic-comment.go#L50-L56) to prevent loops. Since `preset-github-credentials` uses the kubevirt-bot token (Prow's own bot), the `/test all` was silently ignored.

The `/label skip-review` in the same comment appeared to work because Prow's label plugin does not have this bot-user check.

The `periodic-project-infra-retester` job already uses `commenter-oauth-token` for the same reason.

## Test plan

- [ ] Verify the periodic runs successfully (check next hourly run on Prow deck)
- [ ] Verify a new dependabot PR gets `/test all` processed and tests actually trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)