### PR TITLE
Convert SIG report from periodic to postsubmit

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-postsubmits.yaml
@@ -1,0 +1,36 @@
+postsubmits:
+  kubevirt/ci-health:
+  - name: ci-health-sig-report-publish
+    always_run: false
+    run_if_changed: "output/kubevirt/kubevirt/results.json"
+    branches:
+    - main
+    max_concurrency: 1
+    annotations:
+      testgrid-create-test-group: "false"
+    labels:
+      preset-gcs-credentials: "true"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    cluster: kubevirt-prow-control-plane
+    spec:
+      securityContext:
+        runAsUser: 0
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260319-c8f1db8
+          command:
+          - /usr/local/bin/runner.sh
+          - /bin/bash
+          - -ce
+          args:
+            - |
+              SIGS_TO_REPORT=("compute" "network" "storage" "operator" "monitoring")
+              for SIG in "${SIGS_TO_REPORT[@]}"; do
+                go run ./cmd/html-report --sig $SIG --results-path ./output/kubevirt/kubevirt/results.json --path /tmp/
+              done
+              gsutil cp /tmp/sig*.html gs://kubevirt-prow/reports/sig-failure-reports/
+          resources:
+            requests:
+              memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -374,42 +374,6 @@ periodics:
         resources:
           requests:
             memory: "200Mi"
-- name: periodic-ci-health-sig-report-publish
-  interval: 6h
-  max_concurrency: 1
-  annotations:
-    testgrid-create-test-group: "false"
-  labels:
-    preset-gcs-credentials: "true"
-  decorate: true
-  decoration_config:
-    timeout: 1h
-    grace_period: 5m
-  extra_refs:
-  - org: kubevirt
-    repo: ci-health
-    base_ref: main
-    workdir: true
-  cluster: kubevirt-prow-control-plane
-  spec:
-    securityContext:
-      runAsUser: 0
-    containers:
-      - image: quay.io/kubevirtci/golang:v20260417-7427ea2
-        command:
-        - /usr/local/bin/runner.sh
-        - /bin/bash
-        - -ce
-        args:
-          - |
-            SIGS_TO_REPORT=("compute" "network" "storage" "operator" "monitoring")
-            for SIG in "${SIGS_TO_REPORT[@]}"; do
-              go run ./cmd/html-report --sig $SIG --results-path ./output/kubevirt/kubevirt/results.json --path /tmp/
-            done
-            gsutil cp /tmp/sig*.html gs://kubevirt-prow/reports/sig-failure-reports/
-        resources:
-          requests:
-            memory: "200Mi"
 - name: periodic-kubevirtci-cluster-minorversion-updater
   interval: 24h
   max_concurrency: 1

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -147,7 +147,7 @@ tide:
     kubevirt/iommufd-device-plugin: merge
     kubevirt/kubevirt-aie: merge
     kubevirt/kubevirt-aie-webhook: merge
-
+    kubevirt/ci-health: merge
   queries:
   - repos:
     - kubevirt/dra-pci-driver
@@ -223,6 +223,7 @@ tide:
     - kubevirt/iommufd-device-plugin
     - kubevirt/kubevirt-aie
     - kubevirt/kubevirt-aie-webhook
+    - kubevirt/ci-health
     labels:
     - lgtm
     - approved
@@ -374,6 +375,10 @@ branch-protection:
               protect: true
               allow_force_pushes: true
         project-infra:
+          branches:
+            main:
+              protect: true
+        ci-health:
           branches:
             main:
               protect: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -79,11 +79,13 @@ plugins:
     - release-note
     - trigger
 
-  kubevirt/ci-health:
+  kubevirt/charts:
     plugins:
+    - approve
+    - lgtm
     - trigger
 
-  kubevirt/charts:
+  kubevirt/ci-health:
     plugins:
     - approve
     - lgtm
@@ -680,6 +682,7 @@ approve:
   - kubevirt/iommufd-device-plugin
   - kubevirt/kubevirt-aie
   - kubevirt/kubevirt-aie-webhook
+  - kubevirt/ci-health
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -820,6 +823,7 @@ lgtm:
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
   - kubevirt/kubevirt-migration-operator
+  - kubevirt/ci-health
   review_acts_as_lgtm: true
 
 override:
@@ -877,6 +881,7 @@ triggers:
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
   - kubevirt/kubevirt-migration-operator
+  - kubevirt/ci-health
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -89,6 +89,7 @@ plugins:
     plugins:
     - approve
     - lgtm
+    - release-note
     - trigger
 
   kubevirt/cloud-image-builder:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -79,6 +79,10 @@ plugins:
     - release-note
     - trigger
 
+  kubevirt/ci-health:
+    plugins:
+    - trigger
+
   kubevirt/charts:
     plugins:
     - approve


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr converts `periodic-ci-health-sig-report-publish` periodic job into a postsubmit that gets triggered by changes to `results.json`. The reason for this is, the perodic ran every 6 hours while `results.json` updates every 3 hours by `badges-updates.yaml` in ci-health, causing a mismatch in badge values. 

On boarding https://github.com/kubevirt/ci-health with prow plugins, as well as adding branch protection on main.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubevirt/ci-health#116
**Special notes for your reviewer**:
/cc @dhiller 