### PR TITLE
SEV: disable lanes due to expired API server certificate

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -162,7 +162,8 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  # TODO: revert once the AMD workloads cluster certificate has been renewed
+  - always_run: false
     branches:
     - release-1.7
     cluster: amd-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -162,7 +162,8 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  # TODO: revert once the AMD workloads cluster certificate has been renewed
+  - always_run: false
     branches:
     - release-1.8
     cluster: amd-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -172,7 +172,8 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  # TODO: revert once the AMD workloads cluster certificate has been renewed
+  - always_run: false
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits


### PR DESCRIPTION
**What this PR does / why we need it**:

Jobs targeting the amd-workloads cluster are failing to be scheduled since 2026-04-18 afternoon:

```
> kubectl cluster-info
[...]
Get "https://165.204.53.121:30128/api?timeout=32s": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2026-04-18T23:19:45Z is after 2026-04-18T16:13:31Z
[...]

> openssl s_client -connect 165.204.53.121:30128 -showcerts </dev/null | openssl x509 -noout -dates
[...]
notBefore=Apr 18 16:08:31 2025 GMT
notAfter=Apr 18 16:13:31 2026 GMT
[...]
```
**Special notes for your reviewer**:

/cc @dhiller 