### PR TITLE
orgs: Add vdpa-network-binding-plugin-admins maintainers group

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -914,6 +914,13 @@ orgs:
           - alicefr
         repos:
           test-benchmarks: admin
+      vdpa-network-binding-plugin-maintainers:
+        description: "Maintainers of vdpa-network-binding-plugin repository"
+        maintainers:
+          - bgartzi
+        privacy: closed
+        repos:
+          vdpa-network-binding-plugin: admin
       vm-console-proxy-maintainers:
         description: "Maintainers of vm-console-proxy repository"
         privacy: closed


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a maintainer group to the repository `vdpa-network-binding-plugin` to the KubeVirt organization.
I am setting myself as the admin of that repository.

The repository is being added in another PR, see https://github.com/kubevirt/project-infra/pull/4944

**Why this repository is needed**:
Network binding plugins are thought to be able to implement support for new network interfaces outside of the core KubeVirt source code.

`vdpa-network-binding-plugin` implements the vdpa network binding plugin, which brings vhost-vdpa support to KubeVirt VMs, and needs someone who takes the maintenance responsibility.

**Which licensing model the repository is using or planning to use**:
Apache-2.0

**Maintainers who sponsor this repository**:
- @vladikr 

**New GitHub team[^1] within KubeVirt org for new repository**:
GitHub team:
- vdpa-network-binding-plugin-maintainers

Repo maintainers:

- @bgartzi

Repo users:

- @

[^1]: See [GitHub teams docs](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams)

**CI support is planned for**:

- [ ] tide [^2]
- [ ] prow jobs [^3]


**Note: Using [GitHub actions](https://docs.github.com/en/actions) might be an option if prow support is not available. However¸ KubeVirt CI maintainers will only support GitHub actions to the extent possible.**

[^2]:
See [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md)
[^3]:
See [How to onboard a repository to Prow](https://github.com/kubevirt/project-infra/blob/main/docs/how-to-onboard-a-repository.md)

CI maintainer sponsoring:

<!--
    A CI maintainer from [CI maintainers](../../OWNERS_ALIASES) is required to sponsor the repository PR if CI support is required.
-->

- @

**KubeVirt mailing list announcement**:
- https://groups.google.com/g/kubevirt-dev/c/psaJGONf-ts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close
the issue(s) when PR gets merged)*:
Fixes #

### Special notes for your reviewer
- Current repository and source code: https://github.com/bgartzi/vdpa-network-binding-plugin
- Repository creation PR: https://github.com/kubevirt/project-infra/pull/4944