### PR TITLE
ci: copy SIG test lanes for k8s 1.36 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1099,7 +1099,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 7,15,23 * * *
+  cron: 0 0,8,16 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1166,7 +1166,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 2,10,18 * * *
+  cron: 40 2,10,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1228,7 +1228,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 50 4,12,20 * * *
+  cron: 20 5,13,21 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1292,7 +1292,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 6 * * *
+  cron: 0 0 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1355,7 +1355,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 0,6,12,18 * * *
+  cron: 30 2,8,14,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1445,7 +1445,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 5 * * 0
+  cron: 0 12 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1495,7 +1495,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 4,16 * * *
+  cron: 0 6,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1544,7 +1544,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 10,22 * * *
+  cron: 0 9,21 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1595,7 +1595,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 7,19 * * *
+  cron: 0 3,15 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1859,7 +1859,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 1,13 * * *
+  cron: 0 0,12 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1906,7 +1906,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 25 5,11,17,23 * * *
+  cron: 40 1,7,13,19 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -1955,7 +1955,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 5 2,8,14,20 * * *
+  cron: 25 0,6,12,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2002,7 +2002,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 30 2,8,14,20 * * *
+  cron: 15 1,7,13,19 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2049,7 +2049,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 55 2,8,14,20 * * *
+  cron: 0 0,6,12,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2100,7 +2100,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 20 3,9,15,21 * * *
+  cron: 50 0,6,12,18 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2147,7 +2147,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 45 3,9,15,21 * * *
+  cron: 55 2,8,14,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2194,7 +2194,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 4,10,16,22 * * *
+  cron: 45 3,9,15,21 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2241,7 +2241,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 35 4,10,16,22 * * *
+  cron: 5 2,8,14,20 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2292,7 +2292,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 5,11,17,23 * * *
+  cron: 20 3,9,15,21 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2460,7 +2460,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 55 4,10,16,22 * * *
+  cron: 35 4,10,16,22 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2507,7 +2507,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 20 5,11,17,23 * * *
+  cron: 25 5,11,17,23 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2554,7 +2554,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 45 5,11,17,23 * * *
+  cron: 10 4,10,16,22 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -2605,7 +2605,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 0,6,12,18 * * *
+  cron: 0 5,11,17,23 * * *
   decorate: true
   decoration_config:
     grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2456,3 +2456,195 @@ periodics:
       resources: {}
     nodeSelector:
       type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 55 4,10,16,22 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-network
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.36-sig-network
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+      name: ""
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 20 5,11,17,23 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-storage
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.36-sig-storage
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+      name: ""
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 45 5,11,17,23 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-compute
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.36-sig-compute
+      - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+        value: --usb 30M --usb 40M
+      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+        value: 4h45m
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+      name: ""
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 10 0,6,12,18 * * *
+  decorate: true
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-operator
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.36-sig-operator
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+      name: ""
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2210,3 +2210,177 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.36-sig-network
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.36-sig-network
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.36-sig-storage
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.36-sig-storage
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.36-sig-compute
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.36-sig-compute
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.36-sig-operator
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.36-sig-operator
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external


### PR DESCRIPTION
## Summary

- Add presubmit and periodic e2e job definitions for k8s 1.36 (copied from k8s 1.35)
- New presubmits: `always_run: false`, `optional: true`
- Spread periodic job cron schedules to minimize concurrent execution

## Periodic Job Schedule

```mermaid
gantt
    title periodic-kubevirt-e2e-k8s-* Schedule (24h)
    dateFormat HH:mm
    axisFormat %H:%M
    tickInterval 3h
    section sig-compute
    1.34 #1 :00:00, 5h30m
    1.35 #1 :02:05, 5h30m
    1.36 #1 :04:10, 5h30m
    1.34 #2 :06:00, 5h30m
    1.35 #2 :08:05, 5h30m
    1.36 #2 :10:10, 5h30m
    1.34 #3 :12:00, 5h30m
    1.35 #3 :14:05, 5h30m
    1.36 #3 :16:10, 5h30m
    1.34 #4 :18:00, 5h30m
    1.35 #4 :20:05, 5h30m
    1.36 #4 :22:10, 5h30m
    section sig-compute-migrations
    1.35 #1 :02:30, 2h30m
    1.35 #2 :08:30, 2h30m
    1.35 #3 :14:30, 2h30m
    1.35 #4 :20:30, 2h30m
    section sig-compute-root
    1.35 #1 :09:00, 4h
    1.35 #2 :21:00, 4h
    section sig-monitoring
    1.34 #1 :00:00, 2h30m
    1.34 #2 :12:00, 2h30m
    section sig-network
    1.34 #1 :00:25, 2h30m
    1.35-ipv6 #1 :01:40, 2h30m
    1.35 #1 :02:55, 2h30m
    1.36 #1 :04:35, 2h30m
    1.34 #2 :06:25, 2h30m
    1.35-ipv6 #2 :07:40, 2h30m
    1.35 #2 :08:55, 2h30m
    1.36 #2 :10:35, 2h30m
    1.34 #3 :12:25, 2h30m
    1.35-ipv6 #3 :13:40, 2h30m
    1.35 #3 :14:55, 2h30m
    1.36 #3 :16:35, 2h30m
    1.34 #4 :18:25, 2h30m
    1.35-ipv6 #4 :19:40, 2h30m
    1.35 #4 :20:55, 2h30m
    1.36 #4 :22:35, 2h30m
    section sig-network-with-dnc
    1.35 :12:00, 2h30m
    section sig-operator
    1.34 #1 :00:50, 2h30m
    1.35 #1 :03:20, 2h30m
    1.36 #1 :05:00, 2h30m
    1.34 #2 :06:50, 2h30m
    1.35 #2 :09:20, 2h30m
    1.36 #2 :11:00, 2h30m
    1.34 #3 :12:50, 2h30m
    1.35 #3 :15:20, 2h30m
    1.36 #3 :17:00, 2h30m
    1.34 #4 :18:50, 2h30m
    1.35 #4 :21:20, 2h30m
    1.36 #4 :23:00, 2h30m
    section sig-operator-root
    1.34 #1 :03:00, 2h
    1.34 #2 :15:00, 2h
    section sig-performance
    1.34 #1 :00:00, 1h
    1.34 #2 :08:00, 1h
    1.34 #3 :16:00, 1h
    section sig-performance-kwok
    1.34 #1 :02:40, 3h30m
    1.34 #2 :10:40, 3h30m
    1.34 #3 :18:40, 3h30m
    section sig-performance-kwok-100
    1.34 #1 :05:20, 0h30m
    1.34 #2 :13:20, 0h30m
    1.34 #3 :21:20, 0h30m
    section sig-performance-realtime
    1.32 :00:00, 1h
    section sig-storage
    1.34 #1 :01:15, 4h
    1.35 #1 :03:45, 4h
    1.36 #1 :05:25, 4h
    1.34 #2 :07:15, 4h
    1.35 #2 :09:45, 4h
    1.36 #2 :11:25, 4h
    1.34 #3 :13:15, 4h
    1.35 #3 :15:45, 4h
    1.36 #3 :17:25, 4h
    1.34 #4 :19:15, 4h
    1.35 #4 :21:45, 4h
    1.36 #4 :23:25, 4h
    section sig-storage-root
    1.34 #1 :06:00, 8h30m
    1.34 #2 :18:00, 8h30m
```

## Lane Migration Reminders

- Promote presubmits later with `kubevirt require presubmits` once the provider is integrated
- When merging: `/hold` the PR, scale down `statusreconciler`, then `/unhold`
- After merge: use `migratestatus` to retire old job statuses if removing old lanes

See `docs/lane-migration-process.md` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)