### PR TITLE
Add README documentation for phased external plugin

### DIFF
--- a/external-plugins/phased/README.md
+++ b/external-plugins/phased/README.md
@@ -7,56 +7,24 @@ still in review. The phased plugin defers these costly tests until a PR is ready
 for merging, reducing CI resource usage while still ensuring that all required
 tests pass before merge.
 
+The [referee](../referee/) external plugin detects phased comments and skips
+them when counting test request comments, to avoid skewing its retest metrics.
+
 ## Overview
 
-Phased is a Prow external plugin that automatically triggers "phase 2"
-presubmit jobs when a PR on `kubevirt/kubevirt` is ready for merging. Phase 2
-jobs are presubmits that require manual `/test` triggering.
+Phased is a Prow external plugin that:
+- Listens for GitHub pull request webhooks (`labeled` and `synchronize` events) on `kubevirt/kubevirt`
+- Triggers "phase 2" presubmit jobs when a PR targeting `main` or `master` is ready for merging
+- On `labeled`: triggers when `lgtm` + `approved` are both present, or when `skip-review` is added
+- On `synchronize`: triggers only when the `skip-review` label is present
+- Skips PRs that are draft, merged, closed, or in a merge conflict
+- Fetches Prow and presubmit job configs at runtime over HTTP from the configured `--prow-location`
+- Selects presubmit jobs that are non-optional, not always-run, and have no path-based conditions (i.e. jobs requiring manual `/test` triggering)
+- Posts a GitHub comment with `/test <job-name>` for each selected job, which Prow then picks up and runs
 
-When triggered, the plugin comments on the PR with `/test <job-name>` for each
-phase 2 job, which Prow then picks up and runs.
-
-## How it works
-
-The plugin listens for `pull_request` webhook events and triggers phase 2 jobs
-when specific conditions are met:
-
-**On `labeled` events:**
-- `lgtm` label added and `approved` label already exists, or
-- `approved` label added and `lgtm` label already exists, or
-- `skip-review` label added (regardless of other labels)
-
-**On `synchronize` events:**
-- Only if the `skip-review` label is present (`lgtm` + `approved` alone will
-  not trigger phase 2 on synchronize)
-
-**Additional conditions:**
-- PR must target `main` or `master` branch
-- PR must not be draft, merged, or closed
-- PR must be mergeable (not in conflict)
-
-## Phase 2 job selection
-
-The plugin selects presubmit jobs that match all of the following criteria:
-- Not optional (`optional: false`)
-- Not always run (`always_run: false`)
-- No `run_if_changed` condition
-- No `skip_if_only_changed` condition
-
-These are jobs that require manual `/test` triggering.
-
-## Interaction with other components
-
-- **Referee plugin**: The [referee](../referee/) external plugin detects phased
-  plugin comments and skips them when counting test request comments, to avoid
-  skewing its metrics.
-- **`kubevirt-bot`**: The `skip-review` label is restricted to `kubevirt-bot`
-  via Prow label restrictions in `plugins.yaml`. This is used for automated PRs
-  where sufficient automated checks are in place, allowing phase 2 to trigger
-  without human review labels.
-- **Job configs**: The plugin reads presubmit configurations at runtime via
-  HTTP from the configured Prow location (typically a raw Git URL) to identify
-  phase 2 jobs.
+The `skip-review` label is restricted to `kubevirt-bot` via Prow label
+restrictions in `plugins.yaml`, allowing automated PRs to trigger phase 2
+without human review labels.
 
 ## Configuration
 
@@ -71,8 +39,7 @@ Deployment manifests:
 
 ## Limitations
 
-- Hardcoded to `kubevirt/kubevirt` in the source, not just a configuration
-  choice
+- Hardcoded to `kubevirt/kubevirt` in the source, not just a configuration choice
 - Only triggers for PRs targeting `main` or `master` branches
 
 ## Development
@@ -89,7 +56,13 @@ Run tests:
 make test
 ```
 
-Push the image:
+Format, test, and push the image:
+
+```bash
+make all
+```
+
+Push the image only:
 
 ```bash
 make push

--- a/external-plugins/phased/README.md
+++ b/external-plugins/phased/README.md
@@ -1,0 +1,96 @@
+# phased - external plugin for Prow
+
+## Motivation
+
+Running expensive e2e tests on every PR update is wasteful when most PRs are
+still in review. The phased plugin defers these costly tests until a PR is ready
+for merging, reducing CI resource usage while still ensuring that all required
+tests pass before merge.
+
+## Overview
+
+Phased is a Prow external plugin that automatically triggers "phase 2"
+presubmit jobs when a PR on `kubevirt/kubevirt` is ready for merging. Phase 2
+jobs are presubmits that require manual `/test` triggering.
+
+When triggered, the plugin comments on the PR with `/test <job-name>` for each
+phase 2 job, which Prow then picks up and runs.
+
+## How it works
+
+The plugin listens for `pull_request` webhook events and triggers phase 2 jobs
+when specific conditions are met:
+
+**On `labeled` events:**
+- `lgtm` label added and `approved` label already exists, or
+- `approved` label added and `lgtm` label already exists, or
+- `skip-review` label added (regardless of other labels)
+
+**On `synchronize` events:**
+- Only if the `skip-review` label is present (`lgtm` + `approved` alone will
+  not trigger phase 2 on synchronize)
+
+**Additional conditions:**
+- PR must target `main` or `master` branch
+- PR must not be draft, merged, or closed
+- PR must be mergeable (not in conflict)
+
+## Phase 2 job selection
+
+The plugin selects presubmit jobs that match all of the following criteria:
+- Not optional (`optional: false`)
+- Not always run (`always_run: false`)
+- No `run_if_changed` condition
+- No `skip_if_only_changed` condition
+
+These are jobs that require manual `/test` triggering.
+
+## Interaction with other components
+
+- **Referee plugin**: The [referee](../referee/) external plugin detects phased
+  plugin comments and skips them when counting test request comments, to avoid
+  skewing its metrics.
+- **`kubevirt-bot`**: The `skip-review` label is restricted to `kubevirt-bot`
+  via Prow label restrictions in `plugins.yaml`. This is used for automated PRs
+  where sufficient automated checks are in place, allowing phase 2 to trigger
+  without human review labels.
+- **Job configs**: The plugin reads presubmit configurations at runtime via
+  HTTP from the configured Prow location (typically a raw Git URL) to identify
+  phase 2 jobs.
+
+## Configuration
+
+The plugin is registered in:
+- `github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml`
+
+Currently enabled for `kubevirt/kubevirt` only.
+
+Deployment manifests:
+- `github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml`
+- `github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-service.yaml`
+
+## Limitations
+
+- Hardcoded to `kubevirt/kubevirt` in the source, not just a configuration
+  choice
+- Only triggers for PRs targeting `main` or `master` branches
+
+## Development
+
+Build the binary:
+
+```bash
+make build
+```
+
+Run tests:
+
+```bash
+make test
+```
+
+Push the image:
+
+```bash
+make push
+```

--- a/external-plugins/phased/README.md
+++ b/external-plugins/phased/README.md
@@ -22,9 +22,9 @@ Phased is a Prow external plugin that:
 - Selects presubmit jobs that are non-optional, not always-run, and have no path-based conditions (i.e. jobs requiring manual `/test` triggering)
 - Posts a GitHub comment with `/test <job-name>` for each selected job, which Prow then picks up and runs
 
-The `skip-review` label is restricted to `kubevirt-bot` via Prow label
-restrictions in `plugins.yaml`, allowing automated PRs to trigger phase 2
-without human review labels.
+The `skip-review` label is restricted to `kubevirt-bot` and
+`kubevirt-commenter-bot` via Prow label restrictions in `plugins.yaml`,
+allowing automated PRs to trigger phase 2 without human review labels.
 
 ## Configuration
 
@@ -41,6 +41,7 @@ Deployment manifests:
 
 - Hardcoded to `kubevirt/kubevirt` in the source, not just a configuration choice
 - Only triggers for PRs targeting `main` or `master` branches
+- Does not handle `opened` events, PRs created with `skip-review` already applied will not trigger phase 2 until a subsequent `synchronize` event
 
 ## Development
 


### PR DESCRIPTION
What this PR does / why we need it:
Adds a README to the phased external plugin which previously had no documentation. The README covers the plugin's motivation, how it works, usage commands, authorization rules, limitations and configuration/deployment references.

Special notes for your reviewer:
@dollierp @dhiller
