### PR TITLE
feat: shorten PR lifecycle to 45/14/7, keep issues at 90/30/30

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
     - name: token
       secret:
         secretName:  commenter-oauth-token
-- name: periodic-project-infra-close
+- name: periodic-project-infra-close-issues
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
@@ -47,6 +47,7 @@ periodics:
       args:
       - |-
         --query=org:kubevirt
+          is:issue
           -label:lifecycle/frozen
           label:lifecycle/rotten
       - --updated=720h
@@ -60,7 +61,7 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
-- name: periodic-project-infra-rotten
+- name: periodic-project-infra-close-prs
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
@@ -76,6 +77,104 @@ periodics:
       args:
       - |-
         --query=org:kubevirt
+          is:pr
+          -label:lifecycle/frozen
+          label:lifecycle/rotten
+      - --updated=168h
+      - --token=/etc/github/oauth
+      - |-
+        --comment=Rotten PRs close after 7d of inactivity.
+        Reopen the PR with `/reopen`.
+        Mark the PR as fresh with `/remove-lifecycle rotten`.
+
+        /close
+      - --template
+      - --ceiling=10
+      - --confirm
+- name: periodic-project-infra-rotten-prs
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:pr
+          -label:lifecycle/frozen
+          label:lifecycle/stale
+          -label:lifecycle/rotten
+      - --updated=336h
+      - --token=/etc/github/oauth
+      - |-
+        --comment=Stale PRs rot after 14d of inactivity.
+        Mark the PR as fresh with `/remove-lifecycle rotten`.
+        Rotten PRs close after an additional 7d of inactivity.
+
+        If this PR is safe to close now please do so with `/close`.
+
+        /lifecycle rotten
+      - --template
+      - --ceiling=10
+      - --confirm
+- name: periodic-project-infra-stale-prs
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:pr
+          -label:lifecycle/frozen
+          -label:lifecycle/stale
+          -label:lifecycle/rotten
+          is:public
+      - --updated=1080h
+      - --token=/etc/github/oauth
+      - |-
+        --comment=PRs go stale after 45d of inactivity.
+        Mark the PR as fresh with `/remove-lifecycle stale`.
+        Stale PRs rot after an additional 14d of inactivity and eventually close.
+
+        If this PR is safe to close now please do so with `/close`.
+
+        /lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+- name: periodic-project-infra-rotten-issues
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:issue
           -label:lifecycle/frozen
           label:lifecycle/stale
           -label:lifecycle/rotten
@@ -92,7 +191,7 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
-- name: periodic-project-infra-stale
+- name: periodic-project-infra-stale-issues
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
@@ -108,6 +207,7 @@ periodics:
       args:
       - |-
         --query=org:kubevirt
+          is:issue
           -label:lifecycle/frozen
           -label:lifecycle/stale
           -label:lifecycle/rotten

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -31,7 +31,7 @@ periodics:
     - name: token
       secret:
         secretName:  commenter-oauth-token
-- name: periodic-project-infra-close-issues
+- name: periodic-project-infra-stale-issues
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
@@ -49,110 +49,17 @@ periodics:
         --query=org:kubevirt
           is:issue
           -label:lifecycle/frozen
-          label:lifecycle/rotten
-      - --updated=720h
-      - --token=/etc/github/oauth
-      - |-
-        --comment=Rotten issues close after 30d of inactivity.
-        Reopen the issue with `/reopen`.
-        Mark the issue as fresh with `/remove-lifecycle rotten`.
-
-        /close
-      - --template
-      - --ceiling=10
-      - --confirm
-- name: periodic-project-infra-close-prs
-  interval: 1h
-  annotations:
-    testgrid-create-test-group: "false"
-  labels:
-    preset-github-credentials: "true"
-  decorate: true
-  cluster: kubevirt-prow-control-plane
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
-      command:
-      - /ko-app/commenter
-      args:
-      - |-
-        --query=org:kubevirt
-          is:pr
-          -label:lifecycle/frozen
-          label:lifecycle/rotten
-      - --updated=168h
-      - --token=/etc/github/oauth
-      - |-
-        --comment=Rotten PRs close after 7d of inactivity.
-        Reopen the PR with `/reopen`.
-        Mark the PR as fresh with `/remove-lifecycle rotten`.
-
-        /close
-      - --template
-      - --ceiling=10
-      - --confirm
-- name: periodic-project-infra-rotten-prs
-  interval: 1h
-  annotations:
-    testgrid-create-test-group: "false"
-  labels:
-    preset-github-credentials: "true"
-  decorate: true
-  cluster: kubevirt-prow-control-plane
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
-      command:
-      - /ko-app/commenter
-      args:
-      - |-
-        --query=org:kubevirt
-          is:pr
-          -label:lifecycle/frozen
-          label:lifecycle/stale
-          -label:lifecycle/rotten
-      - --updated=336h
-      - --token=/etc/github/oauth
-      - |-
-        --comment=Stale PRs rot after 14d of inactivity.
-        Mark the PR as fresh with `/remove-lifecycle rotten`.
-        Rotten PRs close after an additional 7d of inactivity.
-
-        If this PR is safe to close now please do so with `/close`.
-
-        /lifecycle rotten
-      - --template
-      - --ceiling=10
-      - --confirm
-- name: periodic-project-infra-stale-prs
-  interval: 1h
-  annotations:
-    testgrid-create-test-group: "false"
-  labels:
-    preset-github-credentials: "true"
-  decorate: true
-  cluster: kubevirt-prow-control-plane
-  spec:
-    containers:
-    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
-      command:
-      - /ko-app/commenter
-      args:
-      - |-
-        --query=org:kubevirt
-          is:pr
-          -label:lifecycle/frozen
           -label:lifecycle/stale
           -label:lifecycle/rotten
           is:public
-      - --updated=1080h
+      - --updated=2160h
       - --token=/etc/github/oauth
       - |-
-        --comment=PRs go stale after 45d of inactivity.
-        Mark the PR as fresh with `/remove-lifecycle stale`.
-        Stale PRs rot after an additional 14d of inactivity and eventually close.
+        --comment=Issues go stale after 90d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle stale`.
+        Stale issues rot after an additional 30d of inactivity and eventually close.
 
-        If this PR is safe to close now please do so with `/close`.
+        If this issue is safe to close now please do so with `/close`.
 
         /lifecycle stale
       - --template
@@ -191,7 +98,7 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
-- name: periodic-project-infra-stale-issues
+- name: periodic-project-infra-close-issues
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
@@ -209,19 +116,112 @@ periodics:
         --query=org:kubevirt
           is:issue
           -label:lifecycle/frozen
+          label:lifecycle/rotten
+      - --updated=720h
+      - --token=/etc/github/oauth
+      - |-
+        --comment=Rotten issues close after 30d of inactivity.
+        Reopen the issue with `/reopen`.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+        /close
+      - --template
+      - --ceiling=10
+      - --confirm
+- name: periodic-project-infra-stale-prs
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:pr
+          -label:lifecycle/frozen
           -label:lifecycle/stale
           -label:lifecycle/rotten
           is:public
-      - --updated=2160h
+      - --updated=1080h
       - --token=/etc/github/oauth
       - |-
-        --comment=Issues go stale after 90d of inactivity.
-        Mark the issue as fresh with `/remove-lifecycle stale`.
-        Stale issues rot after an additional 30d of inactivity and eventually close.
+        --comment=PRs go stale after 45d of inactivity.
+        Mark the PR as fresh with `/remove-lifecycle stale`.
+        Stale PRs rot after an additional 14d of inactivity and eventually close.
 
-        If this issue is safe to close now please do so with `/close`.
+        If this PR is safe to close now please do so with `/close`.
 
         /lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+- name: periodic-project-infra-rotten-prs
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:pr
+          -label:lifecycle/frozen
+          label:lifecycle/stale
+          -label:lifecycle/rotten
+      - --updated=336h
+      - --token=/etc/github/oauth
+      - |-
+        --comment=Stale PRs rot after 14d of inactivity.
+        Mark the PR as fresh with `/remove-lifecycle rotten`.
+        Rotten PRs close after an additional 7d of inactivity.
+
+        If this PR is safe to close now please do so with `/close`.
+
+        /lifecycle rotten
+      - --template
+      - --ceiling=10
+      - --confirm
+- name: periodic-project-infra-close-prs
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  decorate: true
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20240801-a5d9345e59
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:pr
+          -label:lifecycle/frozen
+          label:lifecycle/rotten
+      - --updated=168h
+      - --token=/etc/github/oauth
+      - |-
+        --comment=Rotten PRs close after 7d of inactivity.
+        Reopen the PR with `/reopen`.
+        Mark the PR as fresh with `/remove-lifecycle rotten`.
+
+        /close
       - --template
       - --ceiling=10
       - --confirm

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -152,11 +152,16 @@ periodics:
       - --updated=1080h
       - --token=/etc/github/oauth
       - |-
-        --comment=PRs go stale after 45d of inactivity.
-        Mark the PR as fresh with `/remove-lifecycle stale`.
-        Stale PRs rot after an additional 14d of inactivity and eventually close.
+        --comment=There has been no activity on this PR for 45 days.
+        To protect limited CI resources, it has been automatically labelled 'stale'.
+        This PR will automatically rot after an additional 14 days of inactivity, and will be closed shortly after that.
 
-        If this PR is safe to close now please do so with `/close`.
+        What you can do:
+
+        * If the PR is waiting on you to respond to a question or feedback and/or update the PR, please do so.
+        * You can mark the PR as fresh and remove the label with the following command: `/remove-lifecycle stale`
+        * If this PR is safe to close now, please help the project by closing it with: `/close`
+        * If you need attention on this PR from a reviewer, you can raise it on the agenda of the relevant [SIG meeting or KubeVirt Community meeting](https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io), or ping the [kubevirt-dev slack](https://kubernetes.slack.com/messages/kubevirt-dev) channel.
 
         /lifecycle stale
       - --template
@@ -185,11 +190,15 @@ periodics:
       - --updated=336h
       - --token=/etc/github/oauth
       - |-
-        --comment=Stale PRs rot after 14d of inactivity.
-        Mark the PR as fresh with `/remove-lifecycle rotten`.
-        Rotten PRs close after an additional 7d of inactivity.
+        --comment=There has been no activity on this PR for 59 days and it has been stale for 14 days.
+        To protect limited CI resources, it has been automatically labelled 'rotten' and will be closed in 7 days.
 
-        If this PR is safe to close now please do so with `/close`.
+        What you can do:
+
+        * If the PR is waiting on you to respond to a question or feedback and/or update the PR, please do so.
+        * You can mark the PR as fresh and remove the label with the following command: `/remove-lifecycle rotten`
+        * If this PR is safe to close now, please help the project by closing it with: `/close`
+        * If you need attention on this PR from a reviewer, you can raise it on the agenda of the relevant [SIG meeting or KubeVirt Community meeting](https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io), or ping the [kubevirt-dev slack](https://kubernetes.slack.com/messages/kubevirt-dev) channel.
 
         /lifecycle rotten
       - --template
@@ -217,9 +226,14 @@ periodics:
       - --updated=168h
       - --token=/etc/github/oauth
       - |-
-        --comment=Rotten PRs close after 7d of inactivity.
-        Reopen the PR with `/reopen`.
-        Mark the PR as fresh with `/remove-lifecycle rotten`.
+        --comment=There has been no activity on this PR for 66 days and it has been rotten for 7 days.
+        To protect limited CI resources, it has been automatically closed.
+
+        What you can do:
+
+        * If the PR is waiting on you to respond to a question or feedback and/or update the PR, please do so.
+        * You can reopen the PR with the following command: `/reopen`
+        * Raise attention on this PR at a relevant [SIG meeting or KubeVirt Community meeting](https://calendar.google.com/calendar/u/0/embed?src=kubevirt@cncf.io), or ping the [kubevirt-dev slack](https://kubernetes.slack.com/messages/kubevirt-dev) channel.
 
         /close
       - --template


### PR DESCRIPTION
## Summary

- Split lifecycle commenter jobs into separate issue and PR jobs
- **Issues** retain the existing **90/30/30** day cycle (150 days total)
- **PRs** use a new **45/14/7** day cycle (66 days total), reducing overall PR lifespan by 84 days
- Renamed existing jobs from `periodic-project-infra-{close,rotten,stale}` to `periodic-project-infra-{close,rotten,stale}-issues` for clarity
- Improved PR lifecycle messages with clearer explanations and actionable guidance

Fixes https://github.com/kubevirt/project-infra/issues/4993

## Context

Discussed and agreed upon on the kubevirt-dev mailing list:
https://groups.google.com/g/kubevirt-dev/c/_zIZdbbMVFA

Key data points:
- P85 time-to-engagement is ~5 weeks (devstats)
- ~19% of open PRs (68/363) were inactive for 45+ days
- Previous 150-day total lifecycle was excessive and consumed CI resources on stale PRs

## Test plan

- [ ] Verify YAML syntax is valid (job config validator periodic will check)
- [ ] Confirm new PR jobs appear in Prow after merge
- [ ] Monitor lifecycle labels on PRs over the following weeks

/cc @kubevirt/prow-job-taskforce

🤖 Generated with [Claude Code](https://claude.com/claude-code)