### PR TITLE
ci: add postsubmit to bump migration-operator on controller API changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-postsubmits.yaml
@@ -120,3 +120,39 @@ postsubmits:
         resources:
           requests:
             memory: "8Gi"
+  - name: bump-kubevirt-migration-operator-on-api-change
+    branches:
+    - main
+    run_if_changed: "api/.*|config/controller/.*|config/rbac/.*"
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    max_concurrency: 1
+    extra_refs:
+    - org: kubevirt
+      repo: kubevirt-migration-operator
+      base_ref: main
+    labels:
+      preset-github-credentials: "true"
+    cluster: kubevirt-prow-control-plane
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20260421-3a4bd4e
+        command: ["/bin/sh", "-ce"]
+        args:
+        - |
+          CONTROLLER_DIR=/home/prow/go/src/github.com/kubevirt/kubevirt-migration-controller
+          CONTROLLER_SHA=$(cd "${CONTROLLER_DIR}" && git rev-parse HEAD)
+          (cd "${CONTROLLER_DIR}" && git diff HEAD~1 -- api/ config/controller/ config/rbac/) > /tmp/controller.diff
+          git-pr.sh \
+            --command "cp /tmp/controller.diff ../kubevirt-migration-operator/CONTROLLER_BUMP" \
+            --branch bump-migration-controller \
+            --repo kubevirt-migration-operator \
+            --repo-path ../kubevirt-migration-operator \
+            --target main \
+            --summary "Bump kubevirt-migration-controller to ${CONTROLLER_SHA:0:12}" \
+            --missing-labels lgtm,approved,do-not-merge/hold


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Opens a dummy PR in kubevirt-migration-operator when api/ or
config/controller/ files change in kubevirt-migration-controller,
signaling that the operator may need corresponding updates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
