### PR TITLE
fix(bump): add missing config path and align label_sync image

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -29,7 +29,8 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240327-a58d781f5a
+              image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
+              command: [ "/ko-app/label_sync" ]
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -29,7 +29,8 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20240327-a58d781f5a
+              image: gcr.io/k8s-staging-test-infra/label_sync:v20240801-a5d9345e59
+              command: [ "/ko-app/label_sync" ]
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/github/ci/prow-deploy/prow-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-autobump-config.yaml
@@ -11,15 +11,11 @@ excludedConfigPaths: []
 extraFiles:
   - "/config/hack/bump-prow.sh"
   - "/config/hack/checkconfig.sh"
-# TODO: re-switch to test-infra reference after the update for k8s prow has been fixed
 targetVersion: latest
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 prefixes:
   - name: "Prow"
-    prefix: "us-docker.pkg.dev/k8s-infra-prow/images"
-# TODO: re-enable see above
-#    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
-#    repo: "https://github.com/kubernetes/test-infra"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     summarise: true
     consistentImages: true
     consistentImageExceptions:

--- a/github/ci/prow-deploy/prow-job-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-job-autobump-config.yaml
@@ -8,10 +8,10 @@ targetVersion: latest
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
 prefixes:
   - name: "jobs-us-docker"
-    prefix: "us-docker.pkg.dev/k8s-infra-prow/images"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     summarise: true
-    consistentImages: true
+    consistentImages: false
   - name: "jobs-gcr.io"
-    prefix: "gcr.io/k8s-staging-test-infra"
+    prefix: "gcr.io/k8s-staging-test-infra/"
     summarise: true
     consistentImages: false

--- a/github/ci/prow-deploy/prow-job-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-job-autobump-config.yaml
@@ -2,6 +2,7 @@
 gitHubToken: "/etc/github/oauth"
 includedConfigPaths:
   - "/config/github/ci/prow-deploy/files/jobs"
+  - "/config/github/ci/prow-deploy/kustom/base/manifests/local"
 excludedConfigPaths: []
 targetVersion: latest
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
@@ -11,6 +12,6 @@ prefixes:
     summarise: true
     consistentImages: true
   - name: "jobs-gcr.io"
-    prefix: "gcr.io/k8s-staging-test-infra/"
+    prefix: "gcr.io/k8s-staging-test-infra"
     summarise: true
-    consistentImages: true
+    consistentImages: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the missing `kustom/base/manifests/local/` path to the autobump config so CronJob `gcr.io` image references get bumped too, and aligns the `label_sync` CronJob to use the same image repo as the prowjobs.

**Release note**:
```release-note
NONE
```