### PR TITLE
Add fanzhangio to kubevirt-aie-maintainers team

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -1090,6 +1090,7 @@ orgs:
           - xpivarc
           - lyarwood
           - fossedihelm
+          - fanzhangio
           - rthallisey
         repos:
           iommufd-device-plugin: admin


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds fanzhangio to the `kubevirt-aie-maintainers` team in `orgs.yaml`.

Note: This PR is blocked until fanzhangio has joined the kubevirt org via the [membership process](https://github.com/kubevirt/community/blob/master/membership_policy.md).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

rthallisey is already a member of the kubevirt-aie-maintainers team.