### PR TITLE
fix(git-pr.sh): skip update when PR branch already has identical content

### DIFF
--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -252,7 +252,7 @@ fi
 git add -A
 
 fork_url="https://${user}@github.com/${user}/${repo}.git"
-if git fetch "${fork_url}" "${branch}" 2>/dev/null; then
+if git fetch --depth 1 --no-tags "${fork_url}" "${branch}" 2>/dev/null; then
     local_tree=$(git write-tree)
     remote_tree=$(git rev-parse "FETCH_HEAD^{tree}" 2>/dev/null || true)
     if [ -n "${remote_tree}" ] && [ "${local_tree}" = "${remote_tree}" ]; then

--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -251,6 +251,16 @@ fi
 
 git add -A
 
+fork_url="https://${user}@github.com/${user}/${repo}.git"
+if git fetch "${fork_url}" "${branch}" 2>/dev/null; then
+    local_tree=$(git write-tree)
+    remote_tree=$(git rev-parse "FETCH_HEAD^{tree}" 2>/dev/null || true)
+    if [ -n "${remote_tree}" ] && [ "${local_tree}" = "${remote_tree}" ]; then
+        echo "PR branch ${user}:${branch} already has identical content, skipping" >&2
+        exit 0
+    fi
+fi
+
 if [ -z "$dry_run" ]; then
     git commit -s -m "${summary//[@#]/}"
     git push -f "https://${user}@github.com/${user}/${repo}.git" HEAD:"${branch}"


### PR DESCRIPTION
## Summary

- After `git add -A`, fetch the existing PR branch from the fork and compare tree hashes (`git write-tree` vs `FETCH_HEAD^{tree}`)
- If the trees are identical, exit early instead of force-pushing and re-creating the PR
- Fixes the auto-quarantine periodic job repeatedly adding/removing the `approved` label on every run when the same test is still the top flaky candidate (see kubevirt/kubevirt#17454)

## Test plan

- [ ] Verify shellcheck passes on `hack/git-pr.sh`
- [ ] In a test repo, confirm that a second run with identical changes skips the push
- [ ] In a test repo, confirm that a run with different changes still proceeds normally
- [ ] Confirm first run (no existing PR branch) works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)