### PR TITLE
SEV: disable lanes reporting

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -164,6 +164,7 @@ presubmits:
         name: vfio
   # TODO: revert once the AMD workloads cluster certificate has been renewed
   - always_run: false
+    skip_report: true
     branches:
     - release-1.7
     cluster: amd-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -164,6 +164,7 @@ presubmits:
         name: vfio
   # TODO: revert once the AMD workloads cluster certificate has been renewed
   - always_run: false
+    skip_report: true
     branches:
     - release-1.8
     cluster: amd-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -174,6 +174,7 @@ presubmits:
         name: vfio
   # TODO: revert once the AMD workloads cluster certificate has been renewed
   - always_run: false
+    skip_report: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits


### PR DESCRIPTION
**What this PR does / why we need it**:

While the SEV lanes are declared with `always_run: false`, they are still triggered by the phased plugin and blocking the PRs from getting merged.

As a workaround, disable the reporting of those lanes so that they are actually ignored.

**Special notes for your reviewer**:

/cc @dhiller