### PR TITLE
fix(shared-images-controller): defer image cleanup after tag change

### DIFF
--- a/images/shared-images-controller/main.go
+++ b/images/shared-images-controller/main.go
@@ -19,7 +19,9 @@ import (
 const (
 	registryVersion = "2.8.2"
 	checkInterval   = 6 * time.Hour
-	kubevirtciRepo  = "quay.io/kubevirtci/"
+	// Wait before cleaning old images after a tag change so running jobs have time to finish.
+	cleanupDelay   = 24 * time.Hour
+	kubevirtciRepo = "quay.io/kubevirtci/"
 )
 
 var log *logrus.Logger
@@ -153,6 +155,8 @@ func main() {
 	if err != nil {
 		log.WithError(err).Fatalf("Could not connect to podman socket %s", socket)
 	}
+	var lastTag string
+	var tagChangedAt time.Time
 	for {
 		log.Infof("Waiting for %.0f hours before checking again", checkInterval.Hours())
 		time.Sleep(checkInterval)
@@ -167,6 +171,18 @@ func main() {
 			log.WithError(err).Errorf("Failed to fetch image names")
 			continue
 		}
+
+		if tag != lastTag {
+			tagChangedAt = time.Now()
+			lastTag = tag
+			log.Infof("Tag changed to %s, deferring cleanup for %.0f hours", tag, cleanupDelay.Hours())
+		}
+
+		if time.Since(tagChangedAt) < cleanupDelay {
+			log.Infof("Skipping cleanup: %.0f hours remaining until cleanup delay expires", (cleanupDelay - time.Since(tagChangedAt)).Hours())
+			continue
+		}
+
 		err = cleanOldImages(connText, tag)
 		if err != nil {
 			log.WithError(err).Errorf("Failure occurred when deleting old images")


### PR DESCRIPTION
## Summary
- The shared-images-controller was deleting old container images immediately after pulling new ones when the kubevirtci tag changed
- This caused "read-only filesystem" errors in running CI jobs whose overlay layers were removed mid-execution (seen 8x in PR #16885)
- Adds a 24-hour cleanup delay after a tag change, giving running jobs time to finish before old images are removed

## Context
- Slack thread: https://redhat-internal.slack.com/archives/C01EX3K1FGE/p1774434905534859
- Root cause: `cleanOldImages()` ran in the same cycle as `pullRequiredImages()`, removing layers from under active jobs

## Test plan
- [ ] Verify container image builds successfully (requires `btrfs-progs-devel`, builds in CI via Containerfile)
- [ ] Deploy to staging and observe logs: on first cycle, expect "Tag changed to X, deferring cleanup for 24 hours"
- [ ] Confirm old images are NOT deleted until 24 hours after the tag change
- [ ] Confirm new images are still pulled promptly every 6 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)