### PR TITLE
SEV: enable lanes after API server certificate renewal

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -162,9 +162,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  # TODO: revert once the AMD workloads cluster certificate has been renewed
-  - always_run: false
-    skip_report: true
+  - always_run: true
     branches:
     - release-1.7
     cluster: amd-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -162,9 +162,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  # TODO: revert once the AMD workloads cluster certificate has been renewed
-  - always_run: false
-    skip_report: true
+  - always_run: true
     branches:
     - release-1.8
     cluster: amd-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -172,9 +172,7 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  # TODO: revert once the AMD workloads cluster certificate has been renewed
-  - always_run: false
-    skip_report: true
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits


### PR DESCRIPTION
**What this PR does / why we need it**:

SEV lanes are passing again, let's re-enable them

=> https://prow.ci.kubevirt.io/?cluster=amd-workloads

**Special notes for your reviewer**:

/cc @dhiller