### PR TITLE
fix: Run make generate after bumping virt-template

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
@@ -39,6 +39,7 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
+    preset-podman-in-container-enabled: "true"
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -65,7 +66,7 @@ periodics:
         description="Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
 
         git-pr.sh \
-          --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH}" \
+          --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \
           --repo-path ../kubevirt \
           --description-command "echo -e \"${description}\"" \
           --repo kubevirt \
@@ -74,7 +75,9 @@ periodics:
           --missing-labels lgtm,approved,do-not-merge/hold
       resources:
         requests:
-          memory: "200Mi"
+          memory: 2Gi
+      securityContext:
+        privileged: true
 - name: periodic-update-virt-template-kubevirt-release-1.8
   cron: 0 2 * * *
   cluster: kubevirt-prow-control-plane
@@ -83,6 +86,7 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
+    preset-podman-in-container-enabled: "true"
   decorate: true
   decoration_config:
     grace_period: 5m0s
@@ -109,7 +113,7 @@ periodics:
         description="Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
 
         git-pr.sh \
-          --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH}" \
+          --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \
           --repo-path ../kubevirt \
           --description-command "echo -e \"${description}\"" \
           --repo kubevirt \
@@ -118,4 +122,6 @@ periodics:
           --missing-labels lgtm,approved,do-not-merge/hold
       resources:
         requests:
-          memory: "200Mi"
+          memory: 2Gi
+      securityContext:
+        privileged: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

After bumping virt-template it is required to run make generate, so all generated files are updated too.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
