### PR TITLE
SEV: mark lanes as optional due to expired token

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -175,6 +175,8 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 5
     name: pull-kubevirt-e2e-kind-1.34-sev-1.7
+    # TODO: revert once the service-account token has been renewed
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -175,6 +175,8 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 5
     name: pull-kubevirt-e2e-kind-1.34-sev-1.8
+    # TODO: revert once the service-account token has been renewed
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -185,6 +185,8 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 5
     name: pull-kubevirt-e2e-kind-1.34-sev
+    # TODO: revert once the service-account token has been renewed
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The service-account token is expired since 2026-04-29 afternoon:

=> https://prow.ci.kubevirt.io/?state=error&cluster=amd-workloads

**Special notes for your reviewer**:

/cc @dhiller