### PR TITLE
Add config map to coverage auto

### DIFF
--- a/external-plugins/coverage/plugin/handler/handler.go
+++ b/external-plugins/coverage/plugin/handler/handler.go
@@ -47,53 +47,114 @@ type JobConfig struct {
 	GCS                GCSConfig           `yaml:"gcs"`
 }
 
-func LoadJobConfig(path string) (*JobConfig, error) {
+type Config struct {
+	Defaults JobConfig            `yaml:"defaults"`
+	Repos    map[string]JobConfig `yaml:"repos"`
+}
+
+func (c *Config) RepoConfig(repo string) (*JobConfig, bool) {
+	repoCfg, ok := c.Repos[repo]
+	if !ok {
+		return nil, false
+	}
+	merged := c.Defaults
+	if repoCfg.TestPackages != "" {
+		merged.TestPackages = repoCfg.TestPackages
+	}
+	if repoCfg.Image != "" {
+		merged.Image = repoCfg.Image
+	}
+	if repoCfg.Namespace != "" {
+		merged.Namespace = repoCfg.Namespace
+	}
+	if repoCfg.Cluster != "" {
+		merged.Cluster = repoCfg.Cluster
+	}
+	if len(repoCfg.Env) > 0 {
+		merged.Env = repoCfg.Env
+	}
+	if repoCfg.TimeoutMinutes != 0 {
+		merged.TimeoutMinutes = repoCfg.TimeoutMinutes
+	}
+	if repoCfg.GracePeriodSeconds != 0 {
+		merged.GracePeriodSeconds = repoCfg.GracePeriodSeconds
+	}
+	if repoCfg.UtilityImages != (UtilityImagesConfig{}) {
+		merged.UtilityImages = repoCfg.UtilityImages
+	}
+	if repoCfg.GCS != (GCSConfig{}) {
+		merged.GCS = repoCfg.GCS
+	}
+	return &merged, true
+}
+
+func LoadConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file %s: %w", path, err)
 	}
 
-	cfg := &JobConfig{}
+	cfg := &Config{}
+	
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
 	}
 
-	if cfg.Namespace == "" {
-		return nil, fmt.Errorf("config: namespace is required")
+	d := cfg.Defaults
+	if d.Namespace == "" {
+		return nil, fmt.Errorf("config: defaults.namespace is required")
 	}
-	if cfg.Image == "" {
-		return nil, fmt.Errorf("config: image is required")
+	if d.Image == "" {
+		return nil, fmt.Errorf("config: defaults.image is required")
 	}
-	if cfg.Cluster == "" {
-		return nil, fmt.Errorf("config: cluster is required")
+	if d.Cluster == "" {
+		return nil, fmt.Errorf("config: defaults.cluster is required")
 	}
-	if cfg.TestPackages == "" {
-		return nil, fmt.Errorf("config: testPackages is required")
+	if d.GCS.Bucket == "" {
+		return nil, fmt.Errorf("config: defaults.gcs.bucket is required")
 	}
-	if cfg.GCS.Bucket == "" {
-		return nil, fmt.Errorf("config: gcs.bucket is required")
+	if d.GCS.CredentialsSecret == "" {
+		return nil, fmt.Errorf("config: defaults.gcs.credentialsSecret is required")
 	}
-	if cfg.GCS.CredentialsSecret == "" {
-		return nil, fmt.Errorf("config: gcs.credentialsSecret is required")
+	if d.UtilityImages.CloneRefs == "" {
+		return nil, fmt.Errorf("config: defaults.utilityImages.cloneRefs is required")
 	}
-	if cfg.UtilityImages.CloneRefs == "" {
-		return nil, fmt.Errorf("config: utilityImages.cloneRefs is required")
+	if d.UtilityImages.InitUpload == "" {
+		return nil, fmt.Errorf("config: defaults.utilityImages.initUpload is required")
 	}
-	if cfg.UtilityImages.InitUpload == "" {
-		return nil, fmt.Errorf("config: utilityImages.initUpload is required")
+	if d.UtilityImages.Entrypoint == "" {
+		return nil, fmt.Errorf("config: defaults.utilityImages.entrypoint is required")
 	}
-	if cfg.UtilityImages.Entrypoint == "" {
-		return nil, fmt.Errorf("config: utilityImages.entrypoint is required")
-	}
-	if cfg.UtilityImages.Sidecar == "" {
-		return nil, fmt.Errorf("config: utilityImages.sidecar is required")
+	if d.UtilityImages.Sidecar == "" {
+		return nil, fmt.Errorf("config: defaults.utilityImages.sidecar is required")
 	}
 
-	if cfg.TimeoutMinutes == 0 {
-		cfg.TimeoutMinutes = 120
+	if cfg.Defaults.TimeoutMinutes < 0 {
+		return nil, fmt.Errorf("config: defaults.timeoutMinutes must not be negative")
 	}
-	if cfg.GracePeriodSeconds == 0 {
-		cfg.GracePeriodSeconds = 15
+	if cfg.Defaults.GracePeriodSeconds < 0 {
+		return nil, fmt.Errorf("config: defaults.gracePeriodSeconds must not be negative")
+	}
+	if cfg.Defaults.TimeoutMinutes == 0 {
+		cfg.Defaults.TimeoutMinutes = 120
+	}
+	if cfg.Defaults.GracePeriodSeconds == 0 {
+		cfg.Defaults.GracePeriodSeconds = 15
+	}
+
+	if len(cfg.Repos) == 0 {
+		return nil, fmt.Errorf("config: at least one repo must be configured")
+	}
+	for repo, repoCfg := range cfg.Repos {
+		if repoCfg.TestPackages == "" {
+			return nil, fmt.Errorf("config: repos.%s.testPackages is required", repo)
+		}
+		if repoCfg.TimeoutMinutes < 0 {
+			return nil, fmt.Errorf("config: repos.%s.timeoutMinutes must not be negative", repo)
+		}
+		if repoCfg.GracePeriodSeconds < 0 {
+			return nil, fmt.Errorf("config: repos.%s.gracePeriodSeconds must not be negative", repo)
+		}
 	}
 
 	return cfg, nil
@@ -116,7 +177,7 @@ type GitHubEventsHandler struct {
 	logger        *logrus.Logger
 	prowJobClient prowv1.ProwJobInterface
 	githubClient  githubClient
-	jobConfig     *JobConfig
+	config        *Config
 	dryrun        bool
 }
 
@@ -125,14 +186,14 @@ func NewGitHubEventsHandler(
 	logger *logrus.Logger,
 	prowJobClient prowv1.ProwJobInterface,
 	githubClient githubClient,
-	jobConfig *JobConfig,
+	config *Config,
 	dryrun bool,
 ) *GitHubEventsHandler {
 	return &GitHubEventsHandler{
 		logger:        logger,
 		prowJobClient: prowJobClient,
 		githubClient:  githubClient,
-		jobConfig:     jobConfig,
+		config:        config,
 		dryrun:        dryrun,
 	}
 }
@@ -187,9 +248,8 @@ func shouldActOnPREvent(action string) bool {
 
 // generateCoverageJob creates a ProwJob for running coverage on the given pull request.
 func (h *GitHubEventsHandler) generateCoverageJob(
-	pr *github.PullRequest, eventGUID string) prowapi.ProwJob {
+	pr *github.PullRequest, eventGUID string, cfg *JobConfig) prowapi.ProwJob {
 	decorate := true
-	cfg := h.jobConfig
 
 	envKeys := make([]string, 0, len(cfg.Env))
 	for k := range cfg.Env {
@@ -274,7 +334,15 @@ func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, prEvent 
 		return
 	}
 
-	changes, err := h.getPullRequestChanges(&prEvent.PullRequest)
+	pr := &prEvent.PullRequest
+	repoKey := fmt.Sprintf("%s/%s", pr.Base.Repo.Owner.Login, pr.Base.Repo.Name)
+	jobCfg, ok := h.config.RepoConfig(repoKey)
+	if !ok {
+		log.Infof("No coverage config for %s, skipping", repoKey)
+		return
+	}
+
+	changes, err := h.getPullRequestChanges(pr)
 	if err != nil {
 		log.WithError(err).Error("Failed to get pull request changes")
 		return
@@ -286,10 +354,10 @@ func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, prEvent 
 	}
 
 	eventGUID := log.Data["event-guid"].(string)
-	job := h.generateCoverageJob(&prEvent.PullRequest, eventGUID)
+	job := h.generateCoverageJob(pr, eventGUID, jobCfg)
 
 	if h.dryrun {
-		log.Infof("Dry-run: would create coverage job for PR #%d", prEvent.PullRequest.Number)
+		log.Infof("Dry-run: would create coverage job for PR #%d", pr.Number)
 		return
 	}
 
@@ -298,5 +366,5 @@ func (h *GitHubEventsHandler) handlePullRequestEvent(log *logrus.Entry, prEvent 
 		return
 	}
 
-	log.Infof("Created coverage job for PR #%d", prEvent.PullRequest.Number)
+	log.Infof("Created coverage job for PR #%d", pr.Number)
 }

--- a/external-plugins/coverage/plugin/handler/handler.go
+++ b/external-plugins/coverage/plugin/handler/handler.go
@@ -3,6 +3,9 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -10,12 +13,91 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowv1 "sigs.k8s.io/prow/pkg/client/clientset/versioned/typed/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/pjutil"
 )
+
+type UtilityImagesConfig struct {
+	CloneRefs  string `yaml:"cloneRefs"`
+	InitUpload string `yaml:"initUpload"`
+	Entrypoint string `yaml:"entrypoint"`
+	Sidecar    string `yaml:"sidecar"`
+}
+
+type GCSConfig struct {
+	Bucket            string `yaml:"bucket"`
+	PathStrategy      string `yaml:"pathStrategy"`
+	CredentialsSecret string `yaml:"credentialsSecret"`
+}
+
+type JobConfig struct {
+	Namespace          string              `yaml:"namespace"`
+	Image              string              `yaml:"image"`
+	Cluster            string              `yaml:"cluster"`
+	TestPackages       string              `yaml:"testPackages"`
+	Env                map[string]string   `yaml:"env"`
+	TimeoutMinutes     int                 `yaml:"timeoutMinutes"`
+	GracePeriodSeconds int                 `yaml:"gracePeriodSeconds"`
+	UtilityImages      UtilityImagesConfig `yaml:"utilityImages"`
+	GCS                GCSConfig           `yaml:"gcs"`
+}
+
+func LoadJobConfig(path string) (*JobConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file %s: %w", path, err)
+	}
+
+	cfg := &JobConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+
+	if cfg.Namespace == "" {
+		return nil, fmt.Errorf("config: namespace is required")
+	}
+	if cfg.Image == "" {
+		return nil, fmt.Errorf("config: image is required")
+	}
+	if cfg.Cluster == "" {
+		return nil, fmt.Errorf("config: cluster is required")
+	}
+	if cfg.TestPackages == "" {
+		return nil, fmt.Errorf("config: testPackages is required")
+	}
+	if cfg.GCS.Bucket == "" {
+		return nil, fmt.Errorf("config: gcs.bucket is required")
+	}
+	if cfg.GCS.CredentialsSecret == "" {
+		return nil, fmt.Errorf("config: gcs.credentialsSecret is required")
+	}
+	if cfg.UtilityImages.CloneRefs == "" {
+		return nil, fmt.Errorf("config: utilityImages.cloneRefs is required")
+	}
+	if cfg.UtilityImages.InitUpload == "" {
+		return nil, fmt.Errorf("config: utilityImages.initUpload is required")
+	}
+	if cfg.UtilityImages.Entrypoint == "" {
+		return nil, fmt.Errorf("config: utilityImages.entrypoint is required")
+	}
+	if cfg.UtilityImages.Sidecar == "" {
+		return nil, fmt.Errorf("config: utilityImages.sidecar is required")
+	}
+
+	if cfg.TimeoutMinutes == 0 {
+		cfg.TimeoutMinutes = 120
+	}
+	if cfg.GracePeriodSeconds == 0 {
+		cfg.GracePeriodSeconds = 15
+	}
+
+	return cfg, nil
+}
 
 // GitHubEvent represents a GitHub webhook event.
 type GitHubEvent struct {
@@ -34,7 +116,7 @@ type GitHubEventsHandler struct {
 	logger        *logrus.Logger
 	prowJobClient prowv1.ProwJobInterface
 	githubClient  githubClient
-	jobsNamespace string
+	jobConfig     *JobConfig
 	dryrun        bool
 }
 
@@ -43,14 +125,14 @@ func NewGitHubEventsHandler(
 	logger *logrus.Logger,
 	prowJobClient prowv1.ProwJobInterface,
 	githubClient githubClient,
-	jobsNamespace string,
+	jobConfig *JobConfig,
 	dryrun bool,
 ) *GitHubEventsHandler {
 	return &GitHubEventsHandler{
 		logger:        logger,
 		prowJobClient: prowJobClient,
 		githubClient:  githubClient,
-		jobsNamespace: jobsNamespace,
+		jobConfig:     jobConfig,
 		dryrun:        dryrun,
 	}
 }
@@ -107,62 +189,69 @@ func shouldActOnPREvent(action string) bool {
 func (h *GitHubEventsHandler) generateCoverageJob(
 	pr *github.PullRequest, eventGUID string) prowapi.ProwJob {
 	decorate := true
+	cfg := h.jobConfig
+
+	envKeys := make([]string, 0, len(cfg.Env))
+	for k := range cfg.Env {
+		envKeys = append(envKeys, k)
+	}
+	sort.Strings(envKeys)
+	envVars := make([]corev1.EnvVar, 0, len(cfg.Env))
+	for _, k := range envKeys {
+		envVars = append(envVars, corev1.EnvVar{Name: k, Value: cfg.Env[k]})
+	}
+
+	pathStrategy := prowapi.PathStrategyExplicit
+	if cfg.GCS.PathStrategy != "" {
+		pathStrategy = cfg.GCS.PathStrategy
+	}
+
 	presubmit := config.Presubmit{
 		JobBase: config.JobBase{
 			Name:    "coverage-auto",
 			Agent:   string(prowapi.KubernetesAgent),
-			Cluster: "kubevirt-prow-control-plane",
+			Cluster: cfg.Cluster,
 			Labels: map[string]string{
 				"coverage-plugin": "true",
 			},
 			Spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Image: "quay.io/kubevirtci/covreport:latest",
+						Image: cfg.Image,
 						Command: []string{
 							"/usr/local/bin/entrypoint.sh",
 							"/bin/sh",
 							"-ce",
 						},
 						Args: []string{
-							"go test ./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/... -coverprofile=${ARTIFACTS}/filtered.cov && " +
-								"covreport -i ${ARTIFACTS}/filtered.cov -o ${ARTIFACTS}/filtered.html",
+							fmt.Sprintf("go test %s -coverprofile=${ARTIFACTS}/filtered.cov && covreport -i ${ARTIFACTS}/filtered.cov -o ${ARTIFACTS}/filtered.html", cfg.TestPackages),
 						},
-						Env: []corev1.EnvVar{
-							{
-								Name:  "GO_MOD_PATH",
-								Value: "go.mod",
-							},
-							{
-								Name:  "GOTOOLCHAIN",
-								Value: "local",
-							},
-						},
+						Env:  envVars,
 					},
 				},
 			},
-			Namespace: &h.jobsNamespace,
+			Namespace: &cfg.Namespace,
 			UtilityConfig: config.UtilityConfig{
 				Decorate: &decorate,
 				DecorationConfig: &prowapi.DecorationConfig{
-					Timeout:     &prowapi.Duration{Duration: 2 * time.Hour},
-					GracePeriod: &prowapi.Duration{Duration: 15 * time.Second},
+					Timeout:     &prowapi.Duration{Duration: time.Duration(cfg.TimeoutMinutes) * time.Minute},
+					GracePeriod: &prowapi.Duration{Duration: time.Duration(cfg.GracePeriodSeconds) * time.Second},
 					UtilityImages: &prowapi.UtilityImages{
-						CloneRefs:  "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260401-f6cc3990c",
-						InitUpload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260401-f6cc3990c",
-						Entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260401-f6cc3990c",
-						Sidecar:    "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260401-f6cc3990c",
+						CloneRefs:  cfg.UtilityImages.CloneRefs,
+						InitUpload: cfg.UtilityImages.InitUpload,
+						Entrypoint: cfg.UtilityImages.Entrypoint,
+						Sidecar:    cfg.UtilityImages.Sidecar,
 					},
 					GCSConfiguration: &prowapi.GCSConfiguration{
-						Bucket:       "kubevirt-prow",
-						PathStrategy: prowapi.PathStrategyExplicit,
+						Bucket:       cfg.GCS.Bucket,
+						PathStrategy: pathStrategy,
 					},
-					GCSCredentialsSecret: pStr("gcs"),
+					GCSCredentialsSecret: pStr(cfg.GCS.CredentialsSecret),
 				},
 			},
 		},
 		Reporter: config.Reporter{
-			Context: "coverage-auto",
+			Context:    "coverage-auto",
 			SkipReport: true,
 		},
 	}

--- a/external-plugins/coverage/plugin/handler/handler_test.go
+++ b/external-plugins/coverage/plugin/handler/handler_test.go
@@ -111,12 +111,11 @@ var _ = Describe("generateCoverageJob", func() {
 	)
 
 	BeforeEach(func() {
-		handler = &GitHubEventsHandler{
-			jobConfig: &JobConfig{
-				Namespace:    "kubevirt-prow-jobs",
-				Image:        "quay.io/kubevirtci/covreport:latest",
-				Cluster:      "kubevirt-prow-control-plane",
-				TestPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/...",
+		cfg := &Config{
+			Defaults: JobConfig{
+				Namespace: "kubevirt-prow-jobs",
+				Image:     "quay.io/kubevirtci/covreport:latest",
+				Cluster:   "kubevirt-prow-control-plane",
 				Env: map[string]string{
 					"GO_MOD_PATH": "go.mod",
 					"GOTOOLCHAIN": "local",
@@ -135,7 +134,13 @@ var _ = Describe("generateCoverageJob", func() {
 					CredentialsSecret: "gcs",
 				},
 			},
+			Repos: map[string]JobConfig{
+				"kubevirt/project-infra": {
+					TestPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/...",
+				},
+			},
 		}
+		handler = &GitHubEventsHandler{config: cfg}
 
 		pr = &github.PullRequest{
 			Number: 123,
@@ -154,7 +159,8 @@ var _ = Describe("generateCoverageJob", func() {
 			User: github.User{Login: "testuser"},
 		}
 
-		job = handler.generateCoverageJob(pr, "test-event-123")
+		jobCfg, _ := cfg.RepoConfig("kubevirt/project-infra")
+		job = handler.generateCoverageJob(pr, "test-event-123", jobCfg)
 	})
 
 	DescribeTable("Should set the correct configuration",
@@ -247,20 +253,26 @@ var _ = Describe("Handle", func() {
 
 		//Create handler
 		handler = &GitHubEventsHandler{
-			logger:       logger,
-			githubClient: fakeGithubClient,
+			logger:        logger,
+			githubClient:  fakeGithubClient,
 			prowJobClient: fakeProwClient.ProwJobs("test-namespace"),
-			jobConfig: &JobConfig{
-				Namespace:    "test-namespace",
-				Image:        "test-image:latest",
-				Cluster:      "test-cluster",
-				TestPackages: "./...",
-				GCS:          GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
-				UtilityImages: UtilityImagesConfig{
-					CloneRefs:  "clonerefs:latest",
-					InitUpload: "initupload:latest",
-					Entrypoint: "entrypoint:latest",
-					Sidecar:    "sidecar:latest",
+			config: &Config{
+				Defaults: JobConfig{
+					Namespace: "test-namespace",
+					Image:     "test-image:latest",
+					Cluster:   "test-cluster",
+					GCS:       GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+					UtilityImages: UtilityImagesConfig{
+						CloneRefs:  "clonerefs:latest",
+						InitUpload: "initupload:latest",
+						Entrypoint: "entrypoint:latest",
+						Sidecar:    "sidecar:latest",
+					},
+				},
+				Repos: map[string]JobConfig{
+					"kubevirt/project-infra": {
+						TestPackages: "./...",
+					},
 				},
 			},
 			dryrun: false,
@@ -329,6 +341,22 @@ var _ = Describe("Handle", func() {
 
 			Expect(fakeProwClient.Actions()).To(HaveLen(1))
 			Expect(fakeProwClient.Actions()[0].GetVerb()).To(Equal("create"))
+		})
+	})
+
+	Context("When the PR is from an unconfigured repo", func() {
+		It("Should not create a job", func() {
+			event := &GitHubEvent{
+				Type:    "pull_request",
+				GUID:    "event-guid-unknown-repo",
+				Payload: createPREventPayload(github.PullRequestActionOpened, 600, "kubevirt", "unknown-repo"),
+			}
+			fakeGithubClient.PullRequestChanges[600] = []github.PullRequestChange{
+				{Filename: "main.go"},
+			}
+			handler.Handle(event)
+
+			Expect(fakeProwClient.Actions()).To(BeEmpty())
 		})
 	})
 

--- a/external-plugins/coverage/plugin/handler/handler_test.go
+++ b/external-plugins/coverage/plugin/handler/handler_test.go
@@ -112,7 +112,29 @@ var _ = Describe("generateCoverageJob", func() {
 
 	BeforeEach(func() {
 		handler = &GitHubEventsHandler{
-			jobsNamespace: "kubevirt-prow-jobs",
+			jobConfig: &JobConfig{
+				Namespace:    "kubevirt-prow-jobs",
+				Image:        "quay.io/kubevirtci/covreport:latest",
+				Cluster:      "kubevirt-prow-control-plane",
+				TestPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/...",
+				Env: map[string]string{
+					"GO_MOD_PATH": "go.mod",
+					"GOTOOLCHAIN": "local",
+				},
+				TimeoutMinutes:     120,
+				GracePeriodSeconds: 15,
+				UtilityImages: UtilityImagesConfig{
+					CloneRefs:  "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260401-f6cc3990c",
+					InitUpload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260401-f6cc3990c",
+					Entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260401-f6cc3990c",
+					Sidecar:    "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260401-f6cc3990c",
+				},
+				GCS: GCSConfig{
+					Bucket:            "kubevirt-prow",
+					PathStrategy:      "explicit",
+					CredentialsSecret: "gcs",
+				},
+			},
 		}
 
 		pr = &github.PullRequest{
@@ -225,11 +247,23 @@ var _ = Describe("Handle", func() {
 
 		//Create handler
 		handler = &GitHubEventsHandler{
-			logger:        logger,
-			githubClient:  fakeGithubClient,
+			logger:       logger,
+			githubClient: fakeGithubClient,
 			prowJobClient: fakeProwClient.ProwJobs("test-namespace"),
-			jobsNamespace: "test-namespace",
-			dryrun:        false,
+			jobConfig: &JobConfig{
+				Namespace:    "test-namespace",
+				Image:        "test-image:latest",
+				Cluster:      "test-cluster",
+				TestPackages: "./...",
+				GCS:          GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+				UtilityImages: UtilityImagesConfig{
+					CloneRefs:  "clonerefs:latest",
+					InitUpload: "initupload:latest",
+					Entrypoint: "entrypoint:latest",
+					Sidecar:    "sidecar:latest",
+				},
+			},
+			dryrun: false,
 		}
 	})
 

--- a/external-plugins/coverage/plugin/main.go
+++ b/external-plugins/coverage/plugin/main.go
@@ -29,14 +29,14 @@ type options struct {
 	endpoint       string
 	port           int
 	kubeconfig     string
-	jobsNs         string
+	configPath     string
 	github         prowflagutil.GitHubOptions
 }
 
 func (o *options) validate() {
 	var errs []error
-	if o.jobsNs == "" {
-		errs = append(errs, fmt.Errorf("jobs-namespace can't be empty"))
+	if o.configPath == "" {
+		errs = append(errs, fmt.Errorf("config can't be empty"))
 	}
 
 	err := o.github.Validate(o.dryRun)
@@ -81,10 +81,10 @@ func gatherOptions() *options {
 		"",
 		"Path to kubeconfig. If empty, will try to use K8s defaults.")
 
-	fs.StringVar(&o.jobsNs,
-		"jobs-namespace",
-		"",
-		"The namespace in which Prow jobs should be created.")
+	fs.StringVar(&o.configPath,
+		"config",
+		"/etc/coverage/config.yaml",
+		"Path to the job configuration file.")
 
 	for _, group := range []flagutil.OptionGroup{&o.github} {
 		group.AddFlags(fs)
@@ -114,6 +114,9 @@ func main() {
 	prowClient, err := v1.NewForConfig(config)
 	mustSucceed(err, "Could not create Prow client.")
 
+	jobConfig, err := handler.LoadJobConfig(opts.configPath)
+	mustSucceed(err, "Could not load job configuration.")
+
 	if err := secret.Add(opts.github.TokenPath, opts.hmacSecretFile); err != nil {
 		logrus.WithError(err).Fatalf("Failed to load secrets.")
 	}
@@ -123,9 +126,9 @@ func main() {
 
 	eventsHandler := handler.NewGitHubEventsHandler(
 		logger,
-		prowClient.ProwJobs(opts.jobsNs),
+		prowClient.ProwJobs(jobConfig.Namespace),
 		githubClient,
-		opts.jobsNs,
+		jobConfig,
 		opts.dryRun,
 	)
 

--- a/external-plugins/coverage/plugin/main.go
+++ b/external-plugins/coverage/plugin/main.go
@@ -114,7 +114,7 @@ func main() {
 	prowClient, err := v1.NewForConfig(config)
 	mustSucceed(err, "Could not create Prow client.")
 
-	jobConfig, err := handler.LoadJobConfig(opts.configPath)
+	cfg, err := handler.LoadConfig(opts.configPath)
 	mustSucceed(err, "Could not load job configuration.")
 
 	if err := secret.Add(opts.github.TokenPath, opts.hmacSecretFile); err != nil {
@@ -126,9 +126,9 @@ func main() {
 
 	eventsHandler := handler.NewGitHubEventsHandler(
 		logger,
-		prowClient.ProwJobs(jobConfig.Namespace),
+		prowClient.ProwJobs(cfg.Defaults.Namespace),
 		githubClient,
-		jobConfig,
+		cfg,
 		opts.dryRun,
 	)
 

--- a/external-plugins/coverage/plugin/server/eventsserver_test.go
+++ b/external-plugins/coverage/plugin/server/eventsserver_test.go
@@ -35,21 +35,27 @@ var _ = Describe("GitHubEventsServer", func() {
 		}
 		fakeGithubClient := fakegithub.NewFakeClient()
 
-		jobConfig := &handler.JobConfig{
-			Namespace:    "test-namespace",
-			Image:        "test-image:latest",
-			Cluster:      "test-cluster",
-			TestPackages: "./...",
-			GCS:          handler.GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
-			UtilityImages: handler.UtilityImagesConfig{
-				CloneRefs:  "clonerefs:latest",
-				InitUpload: "initupload:latest",
-				Entrypoint: "entrypoint:latest",
-				Sidecar:    "sidecar:latest",
+		cfg := &handler.Config{
+			Defaults: handler.JobConfig{
+				Namespace: "test-namespace",
+				Image:     "test-image:latest",
+				Cluster:   "test-cluster",
+				GCS:       handler.GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+				UtilityImages: handler.UtilityImagesConfig{
+					CloneRefs:  "clonerefs:latest",
+					InitUpload: "initupload:latest",
+					Entrypoint: "entrypoint:latest",
+					Sidecar:    "sidecar:latest",
+				},
+			},
+			Repos: map[string]handler.JobConfig{
+				"kubevirt/project-infra": {
+					TestPackages: "./...",
+				},
 			},
 		}
 		eventsHandler := handler.NewGitHubEventsHandler(
-			logger, fakeProwClient.ProwJobs(jobConfig.Namespace), fakeGithubClient, jobConfig, true,
+			logger, fakeProwClient.ProwJobs(cfg.Defaults.Namespace), fakeGithubClient, cfg, true,
 		)
 		eventsServer = NewGitHubEventsServer(
 			func() []byte { return hmacSecret },

--- a/external-plugins/coverage/plugin/server/eventsserver_test.go
+++ b/external-plugins/coverage/plugin/server/eventsserver_test.go
@@ -35,8 +35,21 @@ var _ = Describe("GitHubEventsServer", func() {
 		}
 		fakeGithubClient := fakegithub.NewFakeClient()
 
+		jobConfig := &handler.JobConfig{
+			Namespace:    "test-namespace",
+			Image:        "test-image:latest",
+			Cluster:      "test-cluster",
+			TestPackages: "./...",
+			GCS:          handler.GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+			UtilityImages: handler.UtilityImagesConfig{
+				CloneRefs:  "clonerefs:latest",
+				InitUpload: "initupload:latest",
+				Entrypoint: "entrypoint:latest",
+				Sidecar:    "sidecar:latest",
+			},
+		}
 		eventsHandler := handler.NewGitHubEventsHandler(
-			logger, fakeProwClient.ProwJobs("test-namespace"), fakeGithubClient, "test-namespace", true,
+			logger, fakeProwClient.ProwJobs(jobConfig.Namespace), fakeGithubClient, jobConfig, true,
 		)
 		eventsServer = NewGitHubEventsServer(
 			func() []byte { return hmacSecret },

--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - manifests/local/test-subset-deployment.yaml
   - manifests/local/test-subset-service.yaml
   - manifests/local/prow-coverage-rbac.yaml
+  - manifests/local/prow-coverage-configmap.yaml
   - manifests/local/prow-coverage-deployment.yaml
   - manifests/local/prow-coverage-service.yaml
   - manifests/local/release-blocker_deployment.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
@@ -4,21 +4,24 @@ metadata:
   name: prow-coverage-config
 data:
   config.yaml: |
-    namespace: kubevirt-prow-jobs
-    image: "quay.io/kubevirtci/covreport:latest"
-    cluster: kubevirt-prow-control-plane
-    testPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/..."
-    env:
-      GO_MOD_PATH: go.mod
-      GOTOOLCHAIN: local
-    timeoutMinutes: 120
-    gracePeriodSeconds: 15
-    utilityImages:
-      cloneRefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260401-f6cc3990c"
-      initUpload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260401-f6cc3990c"
-      entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260401-f6cc3990c"
-      sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260401-f6cc3990c"
-    gcs:
-      bucket: kubevirt-prow
-      pathStrategy: explicit
-      credentialsSecret: gcs
+    defaults:
+      namespace: kubevirt-prow-jobs
+      image: "quay.io/kubevirtci/covreport:latest"
+      cluster: kubevirt-prow-control-plane
+      env:
+        GO_MOD_PATH: go.mod
+        GOTOOLCHAIN: local
+      timeoutMinutes: 120
+      gracePeriodSeconds: 15
+      utilityImages:
+        cloneRefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260401-f6cc3990c"
+        initUpload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260401-f6cc3990c"
+        entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260401-f6cc3990c"
+        sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260401-f6cc3990c"
+      gcs:
+        bucket: kubevirt-prow
+        pathStrategy: explicit
+        credentialsSecret: gcs
+    repos:
+      kubevirt/project-infra:
+        testPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/..."

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prow-coverage-config
+data:
+  config.yaml: |
+    namespace: kubevirt-prow-jobs
+    image: "quay.io/kubevirtci/covreport:latest"
+    cluster: kubevirt-prow-control-plane
+    testPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/..."
+    env:
+      GO_MOD_PATH: go.mod
+      GOTOOLCHAIN: local
+    timeoutMinutes: 120
+    gracePeriodSeconds: 15
+    utilityImages:
+      cloneRefs: "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260401-f6cc3990c"
+      initUpload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260401-f6cc3990c"
+      entrypoint: "us-docker.pkg.dev/k8s-infra-prow/images/entrypoint:v20260401-f6cc3990c"
+      sidecar: "us-docker.pkg.dev/k8s-infra-prow/images/sidecar:v20260401-f6cc3990c"
+    gcs:
+      bucket: kubevirt-prow
+      pathStrategy: explicit
+      credentialsSecret: gcs

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-deployment.yaml
@@ -22,6 +22,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --dry-run=false
+            - --config=/etc/coverage/config.yaml
             - --github-token-path=/etc/github/oauth
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
@@ -36,6 +37,9 @@ spec:
             - name: oauth
               mountPath: /etc/github
               readOnly: true
+            - name: config
+              mountPath: /etc/coverage
+              readOnly: true
       volumes:
         - name: hmac
           secret:
@@ -43,3 +47,6 @@ spec:
         - name: oauth
           secret:
             secretName: oauth-token
+        - name: config
+          configMap:
+            name: prow-coverage-config

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -29,10 +29,6 @@ patches:
     path: patches/JsonRFC6902/prow-rehearse-deployment.yaml
   - target:
       <<: *deployment_target
-      name: coverage
-    path: patches/JsonRFC6902/prow-coverage-deployment.yaml
-  - target:
-      <<: *deployment_target
       name: test-subset
     path: patches/JsonRFC6902/test-subset-deployment.yaml
   - target:

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-coverage-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/prow-coverage-deployment.yaml
@@ -1,3 +1,0 @@
-- op: add
-  path: /spec/template/spec/containers/0/args/1
-  value: --jobs-namespace=kubevirt-prow-jobs


### PR DESCRIPTION
**What this PR does / why we need it**:
Extracts hardcoded values from job configuration in the coverage plugin into a custom config map.

Previously values such as container image, cluster, test packages , GCS settings and env variables were hardcoded directly in the go source. 

- Introduces a JobConfig struct and LoadJobConfig function to read configuration from a config map YAML file.
- Adds a config map manifest that is mounted into the coverage plugins deployment and loaded at startup
- Removes the kustomize overlay patch that injected the namespace
- Updates unit tests across handler_test and eventsserver_test to use new JobConfig struct


These changes make the coverage plugin configurable without code changes and support repo specific configuration.


**Special notes for your reviewer**:
/cc @dhiller 
**Checklist**

