### PR TITLE
kubevirtci: Add centos10 provision jobs for k8s 1.35 and 1.36

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -620,6 +620,38 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-provision-k8s-1.35-centos10
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.35 && ../provision.sh
+        env:
+        - name: GIMME_GO_VERSION
+          value: 1.24.7
+        - name: PROVISION_CENTOS_VERSION
+          value: "10"
+        image: quay.io/kubevirtci/golang:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - always_run: false
     cluster: prow-workloads
     decorate: true
@@ -675,6 +707,38 @@ presubmits:
         env:
         - name: GIMME_GO_VERSION
           value: 1.24.7
+        image: quay.io/kubevirtci/golang:v20260417-7427ea2
+        name: ""
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-provision-k8s-1.36-centos10
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.36 && ../provision.sh
+        env:
+        - name: GIMME_GO_VERSION
+          value: 1.24.7
+        - name: PROVISION_CENTOS_VERSION
+          value: "10"
         image: quay.io/kubevirtci/golang:v20260417-7427ea2
         name: ""
         resources:


### PR DESCRIPTION
## Summary

- Add `check-provision-k8s-1.35-centos10` and `check-provision-k8s-1.36-centos10` presubmit jobs
- Both mirror the existing `check-provision-k8s-1.34-centos10` pattern: `PHASES=linux,k8s` with `PROVISION_CENTOS_VERSION=10`, `always_run: true`, `optional: true`
- Currently only k8s 1.34 has centos10 provision coverage, which is insufficient as versions migrate to CentOS Stream 10

Related:
- kubevirt/kubevirtci#1665 — Move k8s 1.36 to CentOS Stream 10
- kubevirt/kubevirtci#1695 — Fix centos10 NM connection for PHASES=k8s

## Test plan

- [ ] YAML is valid (CI check)
- [ ] New jobs appear on kubevirtci PRs after merge