### PR TITLE
Onboard ci-health to coverage external plugin

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -609,6 +609,11 @@ external_plugins:
     endpoint: http://prow-coverage:9901
     events:
       - pull_request
+  kubevirt/ci-health:
+  - name: coverage
+    endpoint: http://prow-coverage:9901
+    events:
+      - pull_request
   kubevirt/kubevirt:
   - name: phased
     endpoint: http://prow-phased:9900

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
@@ -25,3 +25,5 @@ data:
     repos:
       kubevirt/project-infra:
         testPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/..."
+      kubevirt/ci-health:
+        testPackages: "./pkg/... ./cmd/..."


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR onboards the [k/ci-health](https://github.com/kubevirt/ci-health) repo with coverage external plugin.
Coverage will now be ran on pkg and cmd paths. 

**Special notes for your reviewer**:
/cc @dhiller 
