### PR TITLE
ci: make check-provision-k8s-1.36 always run

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -653,7 +653,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: false
+  - always_run: true
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -664,7 +664,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
     name: check-provision-k8s-1.36
-    optional: true
+    optional: false
     spec:
       containers:
       - command:


### PR DESCRIPTION
## Summary
- Set `always_run: true` and `optional: false` for the `check-provision-k8s-1.36` presubmit job so it runs on every kubevirtci PR

## Test plan
- [ ] Verify the job triggers on a new PR to kubevirtci

🤖 Generated with [Claude Code](https://claude.com/claude-code)