### PR TITLE
kubevirtci: add postsubmit for multiarch Fedora guest publish

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -97,6 +97,49 @@ postsubmits:
           resources:
             requests:
               memory: "8Gi"
+    - name: publish-multiarch-fedora-guest
+      branches:
+      - main
+      always_run: false
+      run_if_changed: "^cluster-provision/images/vm-image-builder/[^/]+$|^cluster-provision/images/vm-image-builder/fedora-with-test-tooling/[^/]+$"
+      annotations:
+        testgrid-create-test-group: "false"
+      decorate: true
+      decoration_config:
+        timeout: 2h
+      max_concurrency: 1
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-kubevirtci-quay-credential: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        volumes:
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: devices
+        containers:
+        - image: quay.io/kubevirtci/vm-image-builder:v20260518-2d2d4fd
+          command:
+          - "/usr/local/bin/runner.sh"
+          - "/bin/bash"
+          - "-c"
+          - |
+            cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+            /usr/local/bin/bootstrap_libvirt_minimal.sh &&
+            cd cluster-provision/images/vm-image-builder &&
+            CONSOLE=false ./publish-multiarch-containerdisk.sh fedora-with-test-tooling kubevirtci quay.io
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - mountPath: /dev
+            name: devices
+          resources:
+            requests:
+              memory: "16Gi"
     - name: publish-kubevirtci-s390x
       branches:
       - main

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -130,8 +130,9 @@ postsubmits:
           - |
             cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
             /usr/local/bin/bootstrap_libvirt_minimal.sh &&
+            curl -L https://github.com/kubevirt/kubevirtci/pull/1708.patch | git am -3 &&
             cd cluster-provision/images/vm-image-builder &&
-            CONSOLE=false ./publish-multiarch-containerdisk.sh fedora-with-test-tooling kubevirtci quay.io
+            DEBUG=true CONSOLE=false ./publish-multiarch-containerdisk.sh fedora-with-test-tooling kubevirtci quay.io
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a dedicated kubevirtci postsubmit that publishes the Fedora guest containerdisk as a multiarch image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
