### PR TITLE
Add CRI-O 1.36 to the weekly mirror job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -24,7 +24,7 @@ periodics:
           - name: BUCKET_DIR
             value: kubevirtci-crio-mirror
           - name: CRIO_VERSIONS
-            value: "1.22,1.23,1.24,1.25,1.26,1.27,1.28,1.29,1.30,1.31,1.32,1.33,1.34,1.35,1.36"
+            value: "1.34,1.35,1.36"
         command: ["/bin/sh", "-ce"]
         args:
           - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -24,7 +24,7 @@ periodics:
           - name: BUCKET_DIR
             value: kubevirtci-crio-mirror
           - name: CRIO_VERSIONS
-            value: "1.22,1.23,1.24,1.25,1.26,1.27,1.28,1.29,1.30,1.31,1.32,1.33,1.34,1.35"
+            value: "1.22,1.23,1.24,1.25,1.26,1.27,1.28,1.29,1.30,1.31,1.32,1.33,1.34,1.35,1.36"
         command: ["/bin/sh", "-ce"]
         args:
           - |


### PR DESCRIPTION
**What this PR does / why we need it**:

CRI-O 1.36 stable has been released. This adds v1.36 to the
`CRIO_VERSIONS` list in the `periodic-kubevirtci-mirror-crio-repository-weekly`
job so the GCS mirror is populated with the stable packages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Companion kubevirtci PR to follow that switches k8s 1.36 provisioning from the prerelease repo to the stable GCS mirror.