### PR TITLE
Add CS10 automation for v1.9.0 provider and e2e lanes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2495,6 +2495,10 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.36-sig-network
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2602251001-25ce1ccb15
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2542,6 +2546,10 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.36-sig-storage
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2602251001-25ce1ccb15
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2589,6 +2597,10 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.36-sig-compute
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2602251001-25ce1ccb15
       - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
         value: --usb 30M --usb 40M
       - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
@@ -2640,6 +2652,10 @@ periodics:
         value: "true"
       - name: TARGET
         value: k8s-1.36-sig-operator
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2602251001-25ce1ccb15
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2239,6 +2239,10 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-network
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2602251001-25ce1ccb15
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2282,6 +2286,10 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-storage
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2602251001-25ce1ccb15
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2325,6 +2333,10 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-compute
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2602251001-25ce1ccb15
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -2370,6 +2382,10 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-compute-serial
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2602251001-25ce1ccb15
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -2415,6 +2431,10 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-operator
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2602251001-25ce1ccb15
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -716,35 +716,3 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
-    cluster: prow-workloads
-    decorate: true
-    decoration_config:
-      timeout: 3h0m0s
-    labels:
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
-    name: check-provision-k8s-1.36-centos10
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.36 && ../provision.sh
-        env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
-        - name: PROVISION_CENTOS_VERSION
-          value: "10"
-        image: quay.io/kubevirtci/golang:v20260417-7427ea2
-        name: ""
-        resources:
-          requests:
-            memory: 16Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates CI automation for CentOS Stream 10 support in v1.9.0 (VEP 210):

1. Removes the redundant `check-provision-k8s-1.36-centos10` presubmit job from kubevirtci. The 1.36 provider now defaults to CS10 via the `base` file so the standard `check-provision-k8s-1.36` job already provisions with CS10.

2. Adds `KUBEVIRT_CENTOS_STREAM_VERSION=10` and `KUBEVIRT_CS10_BUILDER_VERSION` to all k8s-1.36 e2e presubmit and periodic jobs so kubevirt images are built against CentOS Stream 10, matching the provider base OS.

**Which issue(s) this PR fixes**:

Related: https://github.com/kubevirt/enhancements/issues/210

**Special notes for your reviewer**:

This PR depends on https://github.com/kubevirt/kubevirtci/pull/1665 which moves the 1.36 provider to default to CS10 via the `base` file.