### PR TITLE
fix: filter auto-quarantine by required lane status

### DIFF
--- a/robots/quarantine/cmd/auto-quarantine.go
+++ b/robots/quarantine/cmd/auto-quarantine.go
@@ -30,10 +30,12 @@ import (
 	"github.com/onsi/ginkgo/v2/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	flakestats "kubevirt.io/project-infra/pkg/flake-stats"
 	"kubevirt.io/project-infra/pkg/ginkgo"
 	"kubevirt.io/project-infra/pkg/options"
 	"kubevirt.io/project-infra/pkg/searchci"
+	"sigs.k8s.io/prow/pkg/config"
+
+	flakestats "kubevirt.io/project-infra/pkg/flake-stats"
 )
 
 const (
@@ -66,6 +68,8 @@ func init() {
 	autoQuarantineCmd.PersistentFlags().IntVar(&quarantineOpts.maxTestsToQuarantine, "max-tests-to-quarantine", 1, "the overall number of tests that are going to be quarantined in one run")
 	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.releaseLaneSuffix, "release-lane-suffix", "", "the suffix for the release lane to target (i.e. -1.7) or empty for targeting the main branch")
 	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.matchingLaneRegexString, "matching-lane-regex", defaultMatchingLaneRegexString, "the regular expression that the lanes need to match - note that there's a suffix placeholder required")
+	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.jobConfigPath, "job-config-path", "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml", "path to the Prow presubmit job config YAML used to determine required lanes")
+	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.jobConfigOrgRepo, "job-config-org-repo", "kubevirt/kubevirt", "org/repo key for looking up presubmits in the job config")
 	quarantineOpts.prDescriptionOutputFileOpts = options.NewOutputFileOptions(
 		"pr-description-*.md",
 		options.WithOverwrite(),
@@ -79,11 +83,38 @@ func init() {
 	}
 }
 
+func loadRequiredJobNames(jobConfigPath, orgRepo string) (map[string]struct{}, error) {
+	jobConfig, err := config.ReadJobConfig(jobConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read job config from %q: %w", jobConfigPath, err)
+	}
+	presubmits, ok := jobConfig.PresubmitsStatic[orgRepo]
+	if !ok {
+		return nil, fmt.Errorf("no presubmits found for org/repo %q in job config", orgRepo)
+	}
+	requiredJobs := make(map[string]struct{})
+	for _, ps := range presubmits {
+		if ps.ContextRequired() {
+			requiredJobs[ps.Name] = struct{}{}
+		}
+	}
+	return requiredJobs, nil
+}
+
 func AutoQuarantine(_ *cobra.Command, _ []string) error {
 	err := quarantineOpts.prDescriptionOutputFileOpts.Validate()
 	if err != nil {
 		return err
 	}
+
+	requiredJobs, err := loadRequiredJobNames(quarantineOpts.jobConfigPath, quarantineOpts.jobConfigOrgRepo)
+	if err != nil {
+		return fmt.Errorf("could not load required job names: %w", err)
+	}
+	if len(requiredJobs) == 0 {
+		return fmt.Errorf("no required jobs found in %q for %q", quarantineOpts.jobConfigPath, quarantineOpts.jobConfigOrgRepo)
+	}
+	log.Infof("loaded %d required job names from %q", len(requiredJobs), quarantineOpts.jobConfigPath)
 
 	reportOpts := flakestats.NewDefaultReportOpts(
 		flakestats.DaysInThePast(quarantineOpts.daysInThePast),
@@ -110,7 +141,7 @@ func AutoQuarantine(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("could not find ginkgo test reports: %w", err)
 	}
 
-	testsToQuarantine, err := determineTestsForQuarantine(topXTests, reports)
+	testsToQuarantine, err := determineTestsForQuarantine(topXTests, reports, requiredJobs)
 	if err != nil {
 		return err
 	}
@@ -135,7 +166,7 @@ func AutoQuarantine(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types.Report) ([]*TestToQuarantine, error) {
+func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types.Report, requiredJobs map[string]struct{}) ([]*TestToQuarantine, error) {
 	var jobHistoryURLMatcher = regexp.MustCompile(quarantineOpts.MatchingLaneRegexString())
 	var ceilingForTestsToQuarantine = quarantineOpts.maxTestsToQuarantine
 	var testsToQuarantine []*TestToQuarantine
@@ -157,7 +188,7 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 			continue
 		}
 
-		// Additionally filter impacts by the matching lane regex to target the right branch
+		// Filter impacts by the matching lane regex and required lane status
 		var filteredImpacts []searchci.Impact
 		for _, impact := range candidate.RelevantImpacts {
 			elements := strings.Split(impact.URL, "/")
@@ -168,10 +199,14 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 			if !jobHistoryURLMatcher.MatchString(lastElement) {
 				continue
 			}
+			if _, isRequired := requiredJobs[lastElement]; !isRequired {
+				log.Debugf("skipping impact from optional lane %q for test %q", lastElement, topXTest.Name)
+				continue
+			}
 			filteredImpacts = append(filteredImpacts, impact)
 		}
 		if filteredImpacts == nil {
-			log.Infof("search.ci found no matches in relevant jobs for %q", topXTest.Name)
+			log.Infof("search.ci found no matches in required jobs for %q", topXTest.Name)
 			continue
 		}
 		candidate.RelevantImpacts = filteredImpacts

--- a/robots/quarantine/cmd/auto-quarantine_test.go
+++ b/robots/quarantine/cmd/auto-quarantine_test.go
@@ -21,13 +21,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	flakestats "kubevirt.io/project-infra/pkg/flake-stats"
 	"kubevirt.io/project-infra/pkg/searchci"
-	"os"
-	"strings"
-	"time"
 )
 
 var _ = Describe("auto-quarantine", func() {
@@ -252,6 +254,146 @@ to contain
 						},
 					},
 				},
+			),
+		)
+	})
+
+	When("loading required job names", func() {
+		var tempFile *os.File
+		BeforeEach(func() {
+			var err error
+			tempFile, err = os.CreateTemp("", "presubmits-*.yaml")
+			Expect(err).ToNot(HaveOccurred())
+		})
+		AfterEach(func() {
+			Expect(os.Remove(tempFile.Name())).ToNot(HaveOccurred())
+		})
+
+		DescribeTable("it",
+			func(yamlContent string, orgRepo string, expectedJobs map[string]struct{}, expectErr bool) {
+				_, err := tempFile.WriteString(yamlContent)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(tempFile.Close()).ToNot(HaveOccurred())
+
+				result, err := loadRequiredJobNames(tempFile.Name(), orgRepo)
+				if expectErr {
+					Expect(err).To(HaveOccurred())
+					return
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(expectedJobs))
+			},
+			Entry("returns only required jobs",
+				`presubmits:
+  kubevirt/kubevirt:
+  - name: pull-kubevirt-e2e-k8s-1.35-sig-compute
+    always_run: true
+    spec:
+      containers:
+      - image: test
+  - name: pull-kubevirt-e2e-k8s-1.36-sig-compute
+    optional: true
+    always_run: true
+    spec:
+      containers:
+      - image: test
+`,
+				"kubevirt/kubevirt",
+				map[string]struct{}{
+					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
+				},
+				false,
+			),
+			Entry("excludes skip_report jobs",
+				`presubmits:
+  kubevirt/kubevirt:
+  - name: pull-kubevirt-e2e-k8s-1.35-sig-compute
+    always_run: true
+    spec:
+      containers:
+      - image: test
+  - name: pull-kubevirt-e2e-k8s-1.35-sig-hidden
+    skip_report: true
+    always_run: true
+    spec:
+      containers:
+      - image: test
+`,
+				"kubevirt/kubevirt",
+				map[string]struct{}{
+					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
+				},
+				false,
+			),
+			Entry("fails for unknown org/repo",
+				`presubmits:
+  kubevirt/kubevirt:
+  - name: pull-kubevirt-e2e-k8s-1.35-sig-compute
+    always_run: true
+    spec:
+      containers:
+      - image: test
+`,
+				"unknown/repo",
+				nil,
+				true,
+			),
+		)
+	})
+
+	When("filtering impacts by required lanes", func() {
+		DescribeTable("it",
+			func(impacts []searchci.Impact, requiredJobs map[string]struct{}, laneRegex string, expectedCount int) {
+				quarantineOpts.matchingLaneRegexString = laneRegex
+				quarantineOpts.releaseLaneSuffix = ""
+				var jobHistoryURLMatcher = regexp.MustCompile(quarantineOpts.MatchingLaneRegexString())
+
+				var filtered []searchci.Impact
+				for _, impact := range impacts {
+					elements := strings.Split(impact.URL, "/")
+					lastElement := elements[len(elements)-1]
+					if !jobHistoryURLMatcher.MatchString(lastElement) {
+						continue
+					}
+					if _, isRequired := requiredJobs[lastElement]; !isRequired {
+						continue
+					}
+					filtered = append(filtered, impact)
+				}
+				Expect(filtered).To(HaveLen(expectedCount))
+			},
+			Entry("keeps impacts from required lanes",
+				[]searchci.Impact{
+					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute", Percent: 10},
+				},
+				map[string]struct{}{
+					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
+				},
+				defaultMatchingLaneRegexString,
+				1,
+			),
+			Entry("filters out impacts from optional lanes",
+				[]searchci.Impact{
+					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.36-sig-compute", Percent: 10},
+				},
+				map[string]struct{}{
+					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
+				},
+				defaultMatchingLaneRegexString,
+				0,
+			),
+			Entry("keeps required and filters optional from mixed set",
+				[]searchci.Impact{
+					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute", Percent: 10},
+					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.36-sig-compute", Percent: 15},
+					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-network", Percent: 8},
+				},
+				map[string]struct{}{
+					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
+					"pull-kubevirt-e2e-k8s-1.35-sig-network": {},
+				},
+				defaultMatchingLaneRegexString,
+				2,
 			),
 		)
 	})

--- a/robots/quarantine/cmd/auto-quarantine_test.go
+++ b/robots/quarantine/cmd/auto-quarantine_test.go
@@ -22,7 +22,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"time"
 
@@ -341,60 +340,191 @@ to contain
 		)
 	})
 
-	When("filtering impacts by required lanes", func() {
-		DescribeTable("it",
-			func(impacts []searchci.Impact, requiredJobs map[string]struct{}, laneRegex string, expectedCount int) {
-				quarantineOpts.matchingLaneRegexString = laneRegex
-				quarantineOpts.releaseLaneSuffix = ""
-				var jobHistoryURLMatcher = regexp.MustCompile(quarantineOpts.MatchingLaneRegexString())
-
-				var filtered []searchci.Impact
-				for _, impact := range impacts {
-					elements := strings.Split(impact.URL, "/")
-					lastElement := elements[len(elements)-1]
-					if !jobHistoryURLMatcher.MatchString(lastElement) {
-						continue
-					}
-					if _, isRequired := requiredJobs[lastElement]; !isRequired {
-						continue
-					}
-					filtered = append(filtered, impact)
-				}
-				Expect(filtered).To(HaveLen(expectedCount))
-			},
-			Entry("keeps impacts from required lanes",
-				[]searchci.Impact{
-					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute", Percent: 10},
-				},
-				map[string]struct{}{
-					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
-				},
-				defaultMatchingLaneRegexString,
-				1,
-			),
-			Entry("filters out impacts from optional lanes",
-				[]searchci.Impact{
-					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.36-sig-compute", Percent: 10},
-				},
-				map[string]struct{}{
-					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
-				},
-				defaultMatchingLaneRegexString,
-				0,
-			),
-			Entry("keeps required and filters optional from mixed set",
-				[]searchci.Impact{
-					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute", Percent: 10},
-					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.36-sig-compute", Percent: 15},
-					{URL: "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-network", Percent: 8},
-				},
-				map[string]struct{}{
-					"pull-kubevirt-e2e-k8s-1.35-sig-compute": {},
-					"pull-kubevirt-e2e-k8s-1.35-sig-network": {},
-				},
-				defaultMatchingLaneRegexString,
-				2,
-			),
+	When("determining tests for quarantine", func() {
+		const (
+			testName      = "[sig-compute] my flaky test should do something"
+			requiredLane  = "pull-kubevirt-e2e-k8s-1.35-sig-compute"
+			optionalLane  = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
+			requiredLane2 = "pull-kubevirt-e2e-k8s-1.35-sig-network"
 		)
+
+		var originalGetQuarantineCandidate func(*flakestats.TopXTest, searchci.TimeRange) (*TestToQuarantine, error)
+
+		BeforeEach(func() {
+			originalGetQuarantineCandidate = getQuarantineCandidate
+			quarantineOpts.matchingLaneRegexString = defaultMatchingLaneRegexString
+			quarantineOpts.releaseLaneSuffix = ""
+			quarantineOpts.maxTestsToQuarantine = 0
+		})
+
+		AfterEach(func() {
+			getQuarantineCandidate = originalGetQuarantineCandidate
+		})
+
+		newImpact := func(lane string, percent float64) searchci.Impact {
+			return searchci.Impact{
+				URL:     "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/" + lane,
+				Percent: percent,
+			}
+		}
+
+		newTopXTest := func(name string) *flakestats.TopXTest {
+			return flakestats.NewTopXTest(name)
+		}
+
+		reportsContaining := func(leafNodeText string, containerTexts ...string) []Report {
+			return []Report{
+				{
+					SpecReports: []SpecReport{
+						{
+							LeafNodeText:         leafNodeText,
+							ContainerHierarchyTexts: containerTexts,
+						},
+					},
+				},
+			}
+		}
+
+		stubCandidate := func(impacts []searchci.Impact) {
+			getQuarantineCandidate = func(topXTest *flakestats.TopXTest, _ searchci.TimeRange) (*TestToQuarantine, error) {
+				return &TestToQuarantine{
+					Test:            topXTest,
+					RelevantImpacts: impacts,
+				}, nil
+			}
+		}
+
+		It("filters out impacts from optional lanes and keeps required ones", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10),
+				newImpact(optionalLane, 15),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].RelevantImpacts).To(HaveLen(1))
+			Expect(result[0].RelevantImpacts[0].URL).To(ContainSubstring(requiredLane))
+		})
+
+		It("skips candidates where no impacts match required lanes", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(optionalLane, 10),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("respects maxTestsToQuarantine ceiling", func() {
+			const testName2 = "[sig-network] another flaky test should work"
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10),
+				newImpact(requiredLane2, 8),
+			})
+			quarantineOpts.maxTestsToQuarantine = 1
+
+			reports := []Report{
+				{
+					SpecReports: []SpecReport{
+						{
+							LeafNodeText:         "should do something",
+							ContainerHierarchyTexts: []string{"[sig-compute] my flaky test"},
+						},
+						{
+							LeafNodeText:         "should work",
+							ContainerHierarchyTexts: []string{"[sig-network] another flaky test"},
+						},
+					},
+				},
+			}
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName), newTopXTest(testName2)},
+				reports,
+				map[string]struct{}{requiredLane: {}, requiredLane2: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+		})
+
+		It("skips tests with no matching spec report", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("completely different test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("propagates error from getQuarantineCandidate", func() {
+			getQuarantineCandidate = func(_ *flakestats.TopXTest, _ searchci.TimeRange) (*TestToQuarantine, error) {
+				return nil, fmt.Errorf("scrape failed")
+			}
+
+			_, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scrape failed"))
+		})
+
+		It("filters out impacts not matching lane regex", func() {
+			nonMatchingLane := "pull-kubevirt-unit-test"
+			stubCandidate([]searchci.Impact{
+				newImpact(nonMatchingLane, 20),
+				newImpact(requiredLane, 10),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{nonMatchingLane: {}, requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].RelevantImpacts).To(HaveLen(1))
+			Expect(result[0].RelevantImpacts[0].URL).To(ContainSubstring(requiredLane))
+		})
+
+		It("keeps required and filters optional from mixed impacts", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10),
+				newImpact(optionalLane, 15),
+				newImpact(requiredLane2, 8),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}, requiredLane2: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].RelevantImpacts).To(HaveLen(2))
+		})
 	})
 })

--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -189,7 +189,9 @@ func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string
 	return sigs, testNames, mostFlakyTestsBySIG, nil
 }
 
-func getQuarantineCandidate(topXTest *flakestats.TopXTest, timeRange searchci.TimeRange) (*TestToQuarantine, error) {
+var getQuarantineCandidate = getQuarantineCandidateDefault
+
+func getQuarantineCandidateDefault(topXTest *flakestats.TopXTest, timeRange searchci.TimeRange) (*TestToQuarantine, error) {
 	impacts, err := searchci.ScrapeImpacts(topXTest.Name, timeRange)
 	if err != nil {
 		return nil, fmt.Errorf("could not scrape results for test %q: %w", topXTest.Name, err)

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -36,6 +36,9 @@ type autoQuarantineOptions struct {
 	releaseLaneSuffix       string
 	matchingLaneRegexString string
 
+	jobConfigPath    string
+	jobConfigOrgRepo string
+
 	prDescriptionOutputFileOpts *options.OutputFileOptions
 }
 


### PR DESCRIPTION
## Summary
- Load Prow presubmit job config via `--job-config-path` flag to determine which lanes are required for merge (`ContextRequired()` = not optional, not skip_report)
- Skip quarantining tests that only fail in optional lanes (e.g. k8s 1.36 lanes not yet required)
- Tests failing only in optional lanes no longer block the auto-quarantine from focusing on actually merge-blocking flakes

Example of what shouldn't happen: https://github.com/kubevirt/kubevirt/pull/17813

## Test plan
- [x] `go build ./robots/quarantine/...` passes
- [x] `go vet ./robots/quarantine/...` passes
- [x] `go test ./robots/quarantine/cmd/...` — all 14 tests pass
- [ ] Verify next auto-quarantine run skips tests only flaky in optional lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)