### PR TITLE
vm-image-builder: bootstrap minimal libvirt services in container

### DIFF
--- a/images/vm-image-builder/Containerfile
+++ b/images/vm-image-builder/Containerfile
@@ -2,10 +2,18 @@ FROM quay.io/kubevirtci/bootstrap:v20260417-7427ea2
 
 RUN dnf install -y \
     cloud-utils \
+    dnsmasq \
+    edk2-aarch64 \
     libguestfs \
     libguestfs-tools-c \
+    libvirt-client \
+    libvirt-daemon \
+    libvirt-daemon-config-network \
+    libvirt-daemon-driver-qemu \
     libvirt \
+    iptables-nft \
     qemu-img \
+    qemu-kvm \
     qemu-system-aarch64 \
     qemu-system-s390x \
     genisoimage \
@@ -15,3 +23,5 @@ RUN dnf install -y \
 
 COPY qemu.conf /etc/libvirt/qemu.conf
 COPY start_libvirtd.sh /usr/local/bin/start_libvirtd.sh
+COPY bootstrap_libvirt_minimal.sh /usr/local/bin/bootstrap_libvirt_minimal.sh
+RUN chmod +x /usr/local/bin/start_libvirtd.sh /usr/local/bin/bootstrap_libvirt_minimal.sh

--- a/images/vm-image-builder/bootstrap_libvirt_minimal.sh
+++ b/images/vm-image-builder/bootstrap_libvirt_minimal.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Set qemu.conf key to a value, whether commented, uncommented, or missing.
+set_qemu_conf_value() {
+    local key="${1:?}"
+    local value="${2:?}"
+    local file="/etc/libvirt/qemu.conf"
+    local pattern="^[[:space:]]*#?[[:space:]]*${key}[[:space:]]*="
+
+    if grep -Eq "${pattern}" "${file}"; then
+        sed -Ei "s|${pattern}.*|${key} = ${value}|" "${file}"
+    else
+        printf "%s = %s\n" "${key}" "${value}" >> "${file}"
+    fi
+}
+
+mkdir -p /run/libvirt /var/lib/libvirt/dnsmasq
+
+# Required container-specific libvirt settings.
+set_qemu_conf_value "user" '"root"'
+set_qemu_conf_value "group" '"root"'
+set_qemu_conf_value "security_driver" '"none"'
+set_qemu_conf_value "dynamic_ownership" "0"
+set_qemu_conf_value "remember_owner" "0"
+
+# Start required daemons in the container.
+for daemon in virtlogd virtlockd virtnetworkd virtstoraged virtqemud; do
+    if ! pgrep -x "${daemon}" >/dev/null 2>&1; then
+        "${daemon}" -d
+    fi
+done
+
+export LIBVIRT_DEFAULT_URI=qemu:///system
+virsh net-start default >/dev/null 2>&1 || true
+virsh net-autostart default >/dev/null 2>&1 || true
+
+echo "Libvirt bootstrap completed."
+echo "Use 'export LIBVIRT_DEFAULT_URI=qemu:///system' in your shell if needed."


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a dedicated bootstrap helper and required libvirt/qemu packages 
so vm-image-builder can initialize libvirt in containerized CI runs.

Seems the previous script is not working, and that no one use this image.
once we converge we can update the README and clean the script if needed,
for now, kept it, and just added a new script + some rpms.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
