### PR TITLE
ci: remove release-note plugin from ci-health

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -180,6 +180,7 @@ tide:
     - kubevirt/test-benchmarks
     - kubevirt/sig-release
     - kubevirt/enhancements
+    - kubevirt/ci-health
     - kubevirt/redfish-controller
     labels:
     - lgtm
@@ -229,7 +230,6 @@ tide:
     - kubevirt/iommufd-device-plugin
     - kubevirt/kubevirt-aie
     - kubevirt/kubevirt-aie-webhook
-    - kubevirt/ci-health
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -89,7 +89,6 @@ plugins:
     plugins:
     - approve
     - lgtm
-    - release-note
     - trigger
 
   kubevirt/cloud-image-builder:


### PR DESCRIPTION
## Summary
- Remove the `release-note` plugin from `kubevirt/ci-health` since it's an internal CI tool that doesn't produce release notes
- Move `kubevirt/ci-health` to the Tide query that doesn't require release-note labels, so PRs won't be blocked by `do-not-merge/release-note-label-needed`

## Test plan
- [ ] Verify prow config check passes in CI
- [ ] Verify existing ci-health PRs are no longer blocked by release-note labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)