### PR TITLE
fix: use find instead of glob in clear-bazel-cache.sh

### DIFF
--- a/hack/clear-bazel-cache.sh
+++ b/hack/clear-bazel-cache.sh
@@ -43,7 +43,7 @@ function rescale_greenhouse_deployment() {
 
 function remove_greenhouse_data() {
     greenhouse_pod_name=$(kubectl get pods --no-headers -n kubevirt-prow -l app=greenhouse --field-selector=status.phase=Running | head -1 | awk '{print $1}')
-    kubectl exec "$greenhouse_pod_name" -n kubevirt-prow -- rm -rf /data/*
+    kubectl exec "$greenhouse_pod_name" -n kubevirt-prow -- find /data -mindepth 1 -delete
 }
 
 function wait_for_running_pods_number() {


### PR DESCRIPTION
## Summary
- The `rm -rf /data/*` in `kubectl exec` was never expanding the glob because there's no shell on the remote side to do so — the literal string `/data/*` was passed to `rm`, which matched nothing
- Replaced with `find /data -mindepth 1 -delete` which doesn't need glob expansion and also handles hidden files

## Test plan
- [x] Ran the script manually against the greenhouse pod and confirmed cache data was removed