### PR TITLE
ci(ci-health): add presubmit job to run tests

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-presubmits.yaml
@@ -1,0 +1,30 @@
+presubmits:
+  kubevirt/ci-health:
+  - name: pull-ci-health-test
+    run_if_changed: "cmd/.*|e2e/.*|pkg/.*|go\\..*"
+    optional: false
+    decorate: true
+    cluster: kubevirt-prow-control-plane
+    annotations:
+      testgrid-create-test-group: "false"
+    labels:
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/golang:v20260417-7427ea2
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
+        - |
+          go test ./...
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.24.3"
+        - name: GITHUB_TOKEN_PATH
+          value: "/etc/github/oauth"
+        resources:
+          requests:
+            memory: "1Gi"
+          limits:
+            memory: "1Gi"


### PR DESCRIPTION
## Summary
- Adds a Prow presubmit job `pull-ci-health-test` for `kubevirt/ci-health` that runs `go test ./...`
- Uses `preset-github-credentials` to mount the OAuth token at `/etc/github/oauth`, exposed via `GITHUB_TOKEN_PATH` for the e2e tests
- Replaces the GitHub Actions test workflow (removal PR to follow in ci-health repo)

## Test plan
- [ ] `check-prow-config` presubmit passes in this PR
- [ ] After merge, open a test PR in ci-health to verify the presubmit triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)