### PR TITLE
fix(require-presubmits): update run_before_merge

### DIFF
--- a/pkg/kubevirt/cmd/require/presubmits.go
+++ b/pkg/kubevirt/cmd/require/presubmits.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"kubevirt.io/project-infra/pkg/kubevirt/cmd/flags"
@@ -77,7 +78,7 @@ func RequirePresubmitsCommand() *cobra.Command {
 }
 
 func init() {
-	requirePresubmitsCommand.PersistentFlags().StringVar(&requirePresubmitsOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The directory of the kubevirt presubmit job definitions")
+	requirePresubmitsCommand.PersistentFlags().StringVar(&requirePresubmitsOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml", "The directory of the kubevirt presubmit job definitions")
 }
 
 func run(cmd *cobra.Command, args []string) error {
@@ -109,10 +110,14 @@ func run(cmd *cobra.Command, args []string) error {
 
 	latestReleaseSemver := querier.ParseRelease(releases[0])
 
-	updated := updatePresubmitsAlwaysRunAndOptionalFields(&jobConfig, latestReleaseSemver)
+	updated, phase := updatePresubmitsAlwaysRunAndOptionalFields(&jobConfig, latestReleaseSemver)
 	if !updated && !flags.Options.DryRun {
 		log.Log().Info(fmt.Sprintf("presubmit jobs for %v weren't modified, nothing to do.", latestReleaseSemver))
 		return nil
+	}
+	if phase == phase2 {
+		previousReleaseSemver := querier.SemVer{Major: latestReleaseSemver.Major, Minor: strconv.Itoa(latestReleaseSemver.MinorInt() - 1)}
+		setPresubmitsToRunBeforeMergeOnly(&jobConfig, &previousReleaseSemver)
 	}
 
 	marshalledConfig, err := yaml.Marshal(&jobConfig)
@@ -135,12 +140,19 @@ func run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func updatePresubmitsAlwaysRunAndOptionalFields(jobConfig *config.JobConfig, latestReleaseSemver *querier.SemVer) (updated bool) {
+type phase int
+
+const (
+	phase1 = iota
+	phase2
+)
+
+func updatePresubmitsAlwaysRunAndOptionalFields(jobConfig *config.JobConfig, releaseSemver *querier.SemVer) (updated bool, phase phase) {
 	jobsToCheck := map[string]string{}
 	for _, sigName := range prowjobconfigs.SigNames {
-		jobsToCheck[prowjobconfigs.CreatePresubmitJobName(latestReleaseSemver, sigName)] = ""
+		jobsToCheck[prowjobconfigs.CreatePresubmitJobName(releaseSemver, sigName)] = ""
 	}
-	jobsToCheck[prowjobconfigs.CreatePresubmitJobName(latestReleaseSemver, "sig-compute-serial")] = ""
+	jobsToCheck[prowjobconfigs.CreatePresubmitJobName(releaseSemver, "sig-compute-serial")] = ""
 
 	for index := range jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig] {
 		job := &jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig][index]
@@ -153,6 +165,7 @@ func updatePresubmitsAlwaysRunAndOptionalFields(jobConfig *config.JobConfig, lat
 		if !job.AlwaysRun {
 			job.AlwaysRun = true
 			updated = true
+			phase = phase1
 
 			// -- fix skip_report: true -> false
 			job.SkipReport = false
@@ -164,9 +177,34 @@ func updatePresubmitsAlwaysRunAndOptionalFields(jobConfig *config.JobConfig, lat
 		if job.Optional {
 			job.Optional = false
 			updated = true
+			phase = phase2
 		}
 
 	}
 
 	return
+}
+
+func setPresubmitsToRunBeforeMergeOnly(jobConfig *config.JobConfig, releaseSemver *querier.SemVer) {
+	jobsToCheck := map[string]string{}
+	for _, sigName := range prowjobconfigs.SigNames {
+		jobsToCheck[prowjobconfigs.CreatePresubmitJobName(releaseSemver, sigName)] = ""
+	}
+	jobsToCheck[prowjobconfigs.CreatePresubmitJobName(releaseSemver, "sig-compute-serial")] = ""
+
+	for index := range jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig] {
+		job := &jobConfig.PresubmitsStatic[prowjobconfigs.OrgAndRepoForJobConfig][index]
+		name := job.Name
+		if _, exists := jobsToCheck[name]; !exists {
+			continue
+		}
+
+		if job.AlwaysRun {
+			job.AlwaysRun = false
+		}
+
+		if !job.RunBeforeMerge {
+			job.RunBeforeMerge = true
+		}
+	}
 }

--- a/pkg/kubevirt/cmd/require/presubmits_test.go
+++ b/pkg/kubevirt/cmd/require/presubmits_test.go
@@ -34,6 +34,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 		args             args
 		wantNewJobConfig config.JobConfig
 		wantUpdated      bool
+		wantPhase        phase
 	}{
 		{
 			name: "no job exists",
@@ -114,6 +115,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 				},
 			},
 			wantUpdated: true,
+			wantPhase:   phase1,
 		},
 		{
 			name: "sig-network job exists, always_run = true",
@@ -135,6 +137,7 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 				},
 			},
 			wantUpdated: true,
+			wantPhase:   phase2,
 		},
 		{
 			name: "sig-network job exists, always_run = true, optional = false",
@@ -160,9 +163,12 @@ func TestUpdatePresubmitsAlwaysRunAndOptionalFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			updated := updatePresubmitsAlwaysRunAndOptionalFields(&tt.args.jobConfig, tt.args.latestReleaseSemver)
+			updated, phase := updatePresubmitsAlwaysRunAndOptionalFields(&tt.args.jobConfig, tt.args.latestReleaseSemver)
 			if updated != tt.wantUpdated {
 				t.Errorf("updatePresubmitsAlwaysRunAndOptionalFields() updated = %v, want %v", updated, tt.wantUpdated)
+			}
+			if phase != tt.wantPhase {
+				t.Errorf("updatePresubmitsAlwaysRunAndOptionalFields() phase = %v, want %v", phase, tt.wantPhase)
 			}
 			if !reflect.DeepEqual(tt.args.jobConfig, tt.wantNewJobConfig) {
 				presubmit := tt.args.jobConfig.PresubmitsStatic["kubevirt/kubevirt"][0]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

For the previous release we want to have run_before_merge set to true and always_run set to false, since when the latest lanes are getting required we want only those to get triggered directly - phased plugin will take care of the rest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @Whitedyl @enp0s3 