### PR TITLE
Update help provider for rehearse

### DIFF
--- a/external-plugins/rehearse/plugin/main.go
+++ b/external-plugins/rehearse/plugin/main.go
@@ -181,13 +181,13 @@ func main() {
 
 func helpProvider(_ []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: `The rehearse plugin is used to test modifications of Prow jobs to provide pre-merge feedback.`,
+		Description: "Test modifications to Prow job configurations before merging by rehearsing changed or new presubmit jobs directly from a PR.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/rehearse [all|job-name|?]",
-		Description: "Rehearses modified Prow jobs inside a pull request.",
+		Description: "Rehearse modified or new Prow jobs detected in a PR. /rehearse or /rehearse all runs all changed jobs. /rehearse <job-name> runs a specific job. /rehearse ? lists jobs available for rehearsal. Multiple /rehearse <job-name> lines can be included in a single comment. Rehearsal jobs are prefixed with rehearsal- and appear as separate GitHub status contexts.",
 		Featured:    true,
-		WhoCanUse:   "Project members",
+		WhoCanUse:   "Top-level approvers in project-infra, or KubeVirt org members if the PR has the ok-to-rehearse label.",
 		Examples:    []string{"/rehearse", "/rehearse all", "/rehearse job-name", "/rehearse ?"},
 	})
 	return pluginHelp, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the rehearse plugin's HelpProvider to bring the command help page at prow.ci.kubevirt.io/command-help in line with the README. Adds documentation for the /rehearse subcommands (all, job-name, ?), clarifies that multiple jobs can be rehearsed in a single comment, notes the rehearsal- prefix on status contexts, and corrects the permission requirement to top-level approvers or KubeVirt org members with the ok-to-rehearse label.


**Special notes for your reviewer**:
/cc @dhiller 
