### PR TITLE
Enable reporting for coverage plugin

### DIFF
--- a/external-plugins/coverage/plugin/handler/handler.go
+++ b/external-plugins/coverage/plugin/handler/handler.go
@@ -312,7 +312,7 @@ func (h *GitHubEventsHandler) generateCoverageJob(
 		},
 		Reporter: config.Reporter{
 			Context:    "coverage-auto",
-			SkipReport: true,
+			SkipReport: false,
 		},
 	}
 	return pjutil.NewPresubmit(*pr, pr.Base.SHA, presubmit, eventGUID, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets skip report to false which enables GitHub status reporting in PR's for coverage plugin. 

Previously, SkipReport was set to true, meaning the coverage job would run but its results were not visible as a status check on PRs. With this change, coverage results will now appear directly in the PR status checks.

**Special notes for your reviewer**:
/cc @dhiller 

**Checklist**
This change has been tested by triggering the coverage plugin simultaneously against both project-infra and ci-health repositories, and it ran successfully in both.

