### PR TITLE
ci: remove KUBEVIRT_ONLY_USE_TAGS, since is no longer used

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -131,8 +131,6 @@ presubmits:
           value: "go.mod"
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
-        - name: KUBEVIRT_ONLY_USE_TAGS
-          value: "true"
         - name: KUBEVIRT_BUILDER_IMAGE
           value: icr.io/kubevirt/builder:2405141107-77fe60855
         - name: FUNCTEST_EXTRA_ARGS
@@ -296,12 +294,10 @@ presubmits:
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.5
+        - name: GO_MOD_PATH
+          value: "go.mod"
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
-        - name: KUBEVIRT_ONLY_USE_TAGS
-          value: "true"
         - name: KUBEVIRT_BUILDER_IMAGE
           value: icr.io/kubevirt/builder:2405141107-77fe60855
         - name: FUNCTEST_EXTRA_ARGS
@@ -377,12 +373,10 @@ presubmits:
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.5
+        - name: GO_MOD_PATH
+          value: "go.mod"
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
-        - name: KUBEVIRT_ONLY_USE_TAGS
-          value: "true"
         - name: KUBEVIRT_BUILDER_IMAGE
           value: icr.io/kubevirt/builder:2405141107-77fe60855
         - name: FUNCTEST_EXTRA_ARGS
@@ -541,8 +535,6 @@ presubmits:
           value: "go.mod"
         - name: KUBEVIRT_MEMORY_SIZE
           value: 16G
-        - name: KUBEVIRT_ONLY_USE_TAGS
-          value: "true"
         - name: KUBEVIRT_BUILDER_IMAGE
           value: icr.io/kubevirt/builder:2405141107-77fe60855
         - name: FUNCTEST_EXTRA_ARGS


### PR DESCRIPTION
The implementation of KUBEVIRT_ONY_USE_TAGS has been removed, hence the definition deletion in the ci jobs.
Furthermore standardize GIMME_GO_VERSION by calling directly go.mod using the environment variable GO_MOD_PATH.

