### PR TITLE
Add weekly CronJob to clean up pods stuck in Terminating state

### DIFF
--- a/github/ci/prow-deploy/kustom/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/base/kustomization.yaml
@@ -68,6 +68,7 @@ resources:
   - manifests/local/prow-coverage-service.yaml
   - manifests/local/release-blocker_deployment.yaml
   - manifests/local/release-blocker_service.yaml
+  - manifests/local/terminating-pod-cleanup.yaml
 
   - manifests/test_infra/current/cherrypicker_deployment.yaml
   - manifests/test_infra/current/cherrypicker_service.yaml

--- a/github/ci/prow-deploy/kustom/base/manifests/local/terminating-pod-cleanup.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/terminating-pod-cleanup.yaml
@@ -18,6 +18,7 @@ spec:
             - name: cleanup
               image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
               command:
+                - /usr/local/bin/runner.sh
                 - /bin/sh
                 - -c
                 - |
@@ -25,9 +26,9 @@ spec:
                   KC="--context=prow-workloads --kubeconfig=/etc/kubeconfig/config --request-timeout=30s"
                   CUTOFF=$(date -u -d '2 days ago' +%Y-%m-%dT%H:%M:%SZ)
                   kubectl get pods -n kubevirt-prow-jobs ${KC} \
-                    -o jsonpath='{range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name}{"\t"}{.metadata.deletionTimestamp}{"\n"}{end}' | \
-                    awk -v cutoff="${CUTOFF}" '$2 <= cutoff {print $1}' | \
-                    xargs -r kubectl delete pod -n kubevirt-prow-jobs ${KC} --force --grace-period=0
+                    -o jsonpath='{range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name}{"\t"}{.metadata.deletionTimestamp}{"\n"}{end}' \
+                    | awk -v cutoff="${CUTOFF}" '$2 <= cutoff {print $1}' \
+                    | xargs -r kubectl delete pod -n kubevirt-prow-jobs ${KC} --force --grace-period=0
                   echo "Cleanup complete."
               resources:
                 requests:

--- a/github/ci/prow-deploy/kustom/base/manifests/local/terminating-pod-cleanup.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/terminating-pod-cleanup.yaml
@@ -21,13 +21,13 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  for CONTEXT in $(kubectl config get-contexts -o name --kubeconfig=/etc/kubeconfig/config); do
-                    echo "--- Checking cluster ${CONTEXT} ---"
-                    KC="--context=${CONTEXT} --kubeconfig=/etc/kubeconfig/config"
-                    kubectl get pods -n kubevirt-prow-jobs ${KC} | \
-                      awk '/Terminating/{print $1}' | \
-                      xargs -r kubectl delete pod -n kubevirt-prow-jobs ${KC} --force --grace-period=0
-                  done
+                  set -euo pipefail
+                  KC="--context=prow-workloads --kubeconfig=/etc/kubeconfig/config --request-timeout=30s"
+                  CUTOFF=$(date -u -d '2 days ago' +%Y-%m-%dT%H:%M:%SZ)
+                  kubectl get pods -n kubevirt-prow-jobs ${KC} \
+                    -o jsonpath='{range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name}{"\t"}{.metadata.deletionTimestamp}{"\n"}{end}' | \
+                    awk -v cutoff="${CUTOFF}" '$2 <= cutoff {print $1}' | \
+                    xargs -r kubectl delete pod -n kubevirt-prow-jobs ${KC} --force --grace-period=0
                   echo "Cleanup complete."
               resources:
                 requests:

--- a/github/ci/prow-deploy/kustom/base/manifests/local/terminating-pod-cleanup.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/terminating-pod-cleanup.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: terminating-pod-cleanup
+spec:
+  schedule: "30 6 * * 1"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:
+      labels:
+        app: terminating-pod-cleanup
+    spec:
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          containers:
+            - name: cleanup
+              image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  for CONTEXT in $(kubectl config get-contexts -o name --kubeconfig=/etc/kubeconfig/config); do
+                    echo "--- Checking cluster ${CONTEXT} ---"
+                    KC="--context=${CONTEXT} --kubeconfig=/etc/kubeconfig/config"
+                    kubectl get pods -n kubevirt-prow-jobs ${KC} | \
+                      awk '/Terminating/{print $1}' | \
+                      xargs -r kubectl delete pod -n kubevirt-prow-jobs ${KC} --force --grace-period=0
+                  done
+                  echo "Cleanup complete."
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              volumeMounts:
+                - name: kubeconfig
+                  mountPath: /etc/kubeconfig
+                  readOnly: true
+          restartPolicy: Never
+          volumes:
+            - name: kubeconfig
+              secret:
+                secretName: kubeconfig
+                defaultMode: 420


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a weekly CronJob (`terminating-pod-cleanup`) that force-deletes pods stuck in Terminating state across all federated build clusters.

Follow-up from #5070: 78 Prow job pods were stuck in Terminating (up to 50 days) because their container processes entered kernel D-state from NBD device I/O or Bazel sandbox mount namespaces. In D-state, processes ignore SIGTERM and SIGKILL, so the kubelet can never confirm termination and sinker cannot clean them up.

The CronJob runs every Monday at 06:30 UTC, iterates over all cluster contexts from the consolidated kubeconfig, and force-deletes any Terminating pods in the `kubevirt-prow-jobs` namespace.

**Which issue(s) this PR fixes**
Partly addresses #5073 

**Special notes for your reviewer**:
/cc @dhiller 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated cleanup job for long-terminating pods in the cluster.
  * Included the new cleanup job in the deployed Kubernetes manifests, so it runs as part of the environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->