### PR TITLE
ci: make all prow-arm64-workloads presubmit jobs optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
@@ -134,6 +134,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-aie-unit-test-arm64-1.8-aie-nv
+    optional: true
     branches:
     - release-1.8-aie-nv
     spec:
@@ -163,6 +164,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.8-aie-nv
+    optional: true
     branches:
     - release-1.8-aie-nv
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -438,7 +438,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.5
-    optional: false
+    optional: true
     spec:
       containers:
       - command:
@@ -871,7 +871,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.5
-    optional: false
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -483,7 +483,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.6
-    optional: false
+    optional: true
     spec:
       containers:
       - command:
@@ -904,7 +904,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.6
-    optional: false
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -534,6 +534,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.7
+    optional: true
     spec:
       containers:
       - command:
@@ -960,6 +961,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64-1.7
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -536,6 +536,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.8
+    optional: true
     spec:
       containers:
       - command:
@@ -962,6 +963,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64-1.8
+    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -598,6 +598,7 @@ presubmits:
       preset-gomaxprocs-4: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1246,6 +1247,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-kind-1.35-sig-compute-arm64
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
## Summary
- Mark all presubmit jobs targeting the `prow-arm64-workloads` cluster as `optional: true`
- Affects 12 jobs across 6 files (kubevirt, kubevirt-aie repos, releases 1.5–1.8 and main)
- Jobs that were already optional (conformance jobs, kubevirtci, common-instancetypes, older releases) are unchanged

See https://github.com/kubevirt/kubevirt/issues/17908 for details

## Test plan
- [ ] Verify YAML is valid and Prow config check passes
- [ ] Confirm arm64 presubmit jobs no longer block PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)