### PR TITLE
Add yanirq as kubevirt member

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -123,6 +123,7 @@ orgs:
       - xpivarc
       - weshayutin
       - Whitedyl
+      - yanirq
       - zhencliu
       - zhlhahaha
     members_can_create_repositories: false


### PR DESCRIPTION
Request opened for https://github.com/kubevirt/redfish-controller/ maintainership (reviewer permissions) 

# GitHub Username
@yanirq

## Requirements

[x] I have reviewed the community code of conduct (https://github.com/kubevirt/kubevirt/blob/master/CODE_OF_CONDUCT.md)<br>
[x] I have enabled 2FA on my GitHub account (https://github.com/settings/security)<br>
[x] I have subscribed to the kubevirt-dev e-mail list (https://groups.google.com/forum/#!forum/kubevirt-dev)<br>
[x] I am actively contributing to KubeVirt<br>
[x] I have two sponsors that meet the sponsor requirements listed in the community membership guidelines<br>
[x] I have spoken to my sponsors ahead of this application and they have agreed to sponsor my application<br>
[x] I have publicly introduced myself to the community through one of the community communication channels<br>

(https://github.com/kubevirt/community#socializing)

## Sponsors

* @MarSik 
* @vladikr 

## List of contributions to the KubeVirt project

* PRs reviewed and/or authored in the past
- https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+yanirq 
- https://github.com/kubevirt/kubevirt-ssp-operator/pulls?q=yanirq
- https://github.com/kubevirt/common-templates/pulls?q=yanirq

> [!IMPORTANT]
> After this pull request has been merged, an invitation to the KubeVirt GitHub organization will be automatically sent to the new member. The new member needs to accept the invitation to receive member status.