### PR TITLE
ci: revert arm64 presubmit jobs to non-optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
@@ -134,7 +134,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-aie-unit-test-arm64-1.8-aie-nv
-    optional: true
     branches:
     - release-1.8-aie-nv
     spec:
@@ -164,7 +163,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.8-aie-nv
-    optional: true
     branches:
     - release-1.8-aie-nv
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -438,7 +438,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.5
-    optional: true
+    optional: false
     spec:
       containers:
       - command:
@@ -871,7 +871,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.5
-    optional: true
+    optional: false
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -483,7 +483,7 @@ presubmits:
       preset-bazel-unnested: "false"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.6
-    optional: true
+    optional: false
     spec:
       containers:
       - command:
@@ -904,7 +904,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     name: pull-kubevirt-e2e-arm64-1.6
-    optional: true
+    optional: false
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -534,7 +534,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.7
-    optional: true
     spec:
       containers:
       - command:
@@ -961,7 +960,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64-1.7
-    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -536,7 +536,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64-1.8
-    optional: true
     spec:
       containers:
       - command:
@@ -963,7 +962,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64-1.8
-    optional: true
     spec:
       containers:
       - command:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -598,7 +598,6 @@ presubmits:
       preset-gomaxprocs-4: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1247,7 +1246,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-e2e-kind-1.35-sig-compute-arm64
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
## Summary
- Revert arm64 presubmit jobs back to required (non-optional) now that the cgroup exhaustion issue (kubevirt/kubevirt#17908) is resolved
- Reverses changes from #5086 and #5092 across 6 files, affecting 12 jobs in kubevirt and kubevirt-aie repos (releases 1.5–1.8 and main)
- Conformance jobs and `build-cs10-arm64` remain optional as they were before #5086/#5092

Closes kubevirt/kubevirt#17945

## Test plan
- [ ] Verify YAML is valid and Prow config check passes
- [ ] Confirm arm64 presubmit jobs are required again and block PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)