### PR TITLE
Add explicit BUILD_ARCHES to AAQ CI jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
@@ -22,6 +22,8 @@ postsubmits:
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
+        - name: BUILD_ARCHES
+          value: "amd64 arm64 s390x"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"
@@ -58,6 +60,8 @@ postsubmits:
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
+        - name: BUILD_ARCHES
+          value: "amd64 arm64 s390x"
         command:
         - "/usr/local/bin/runner.sh"
         - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.8.yaml
@@ -78,6 +78,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3
+          env:
+            - name: BUILD_ARCHES
+              value: "amd64 arm64 s390x"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
@@ -81,6 +81,9 @@ presubmits:
         type: bare-metal-external
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+          env:
+            - name: BUILD_ARCHES
+              value: "amd64 arm64 s390x"
           command:
             - "/usr/local/bin/runner.sh"
             - "/bin/sh"


### PR DESCRIPTION
Set BUILD_ARCHES=amd64 arm64 s390x explicitly in AAQ CI jobs that build
and push multi-arch images, so the default in the AAQ repo can be changed
to amd64-only for faster local development and debugging.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set BUILD_ARCHES explicitly in AAQ CI jobs
```
