### PR TITLE
common-instancetypes: Switch presubmit jobs to kubevirt make targets

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -164,7 +164,7 @@ presubmits:
         - /usr/local/bin/runner.sh
         - "/bin/sh"
         - "-c"
-        - "make cluster-up && make cluster-sync && make cluster-functest"
+        - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
         env:
         - name: CGO_ENABLED
           value: "0"


### PR DESCRIPTION
**What this PR does / why we need it**:

Switch common-instancetypes presubmit jobs from `cluster-up`/`cluster-sync`/`cluster-functest` to `kubevirt-up`/`kubevirt-sync`/`kubevirt-functest` make targets.

This aligns all jobs to test against the latest `main` branch of `kubevirt/kubevirt` instead of a released version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```