### PR TITLE
fix(grafana-token): fixup early exit condition

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
@@ -68,7 +68,7 @@ periodics:
         install -Dm400 "${secrets_repo_dir}"/secrets/kubeconfigs/kubevirt-prow-control-plane ~/.kube/config
 
         kubectl create token grafana-sa -n monitoring --duration=1440h > "${secrets_repo_dir}"/secrets/grafana/prometheus-token
-        [ -s "${secrets_repo_dir}"/secrets/grafana/prometheus-token ] || echo "ERROR: failed to create token" && exit 1
+        [ -s "${secrets_repo_dir}"/secrets/grafana/prometheus-token ] || { echo "ERROR: failed to create token" >&2; exit 1; }
 
         hack/git-pr.sh \
           --command "true" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixup the shell scriptlet to actually execute the early `exit 1` only if the token was not generated properly.

**Special notes for your reviewer**:

/cc @Whitedyl