### PR TITLE
Enable prow for the new vm-file-restore-operator repository

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -148,6 +148,7 @@ tide:
     kubevirt/virt-template: merge
     kubevirt/kubevirt-migration-controller: squash
     kubevirt/kubevirt-migration-operator: squash
+    kubevirt/vm-file-restore-operator: merge
     kubevirt/iommufd-device-plugin: merge
     kubevirt/kubevirt-aie: merge
     kubevirt/kubevirt-aie-webhook: merge
@@ -227,6 +228,7 @@ tide:
     - kubevirt/virt-template
     - kubevirt/kubevirt-migration-controller
     - kubevirt/kubevirt-migration-operator
+    - kubevirt/vm-file-restore-operator
     - kubevirt/iommufd-device-plugin
     - kubevirt/kubevirt-aie
     - kubevirt/kubevirt-aie-webhook

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -511,6 +511,14 @@ plugins:
     - release-note
     - trigger
 
+  kubevirt/vm-file-restore-operator:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+
   kubevirt/iommufd-device-plugin:
     plugins:
     - approve
@@ -690,6 +698,7 @@ approve:
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
   - kubevirt/kubevirt-migration-operator
+  - kubevirt/vm-file-restore-operator
   - kubevirt/iommufd-device-plugin
   - kubevirt/kubevirt-aie
   - kubevirt/kubevirt-aie-webhook
@@ -836,6 +845,7 @@ lgtm:
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
   - kubevirt/kubevirt-migration-operator
+  - kubevirt/vm-file-restore-operator
   - kubevirt/ci-health
   - kubevirt/redfish-controller
   review_acts_as_lgtm: true
@@ -898,6 +908,7 @@ triggers:
   - kubevirt/virt-template
   - kubevirt/kubevirt-migration-controller
   - kubevirt/kubevirt-migration-operator
+  - kubevirt/vm-file-restore-operator
   - kubevirt/ci-health
   - kubevirt/redfish-controller
   ignore_ok_to_test: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables prow for the new vm-file-restore-operator repository

**Release note**:
```release-note
NONE
```