### PR TITLE
add additional skips on s390x cdi

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -511,7 +511,7 @@ presubmits:
           - name: CDI_NAMESPACE
             value: cdi
           - name: CDI_E2E_SKIP
-            value: "Destructive|Cert rotation|cdi-apiserver tests|Importer Test Suite-prometheus"
+            value: "Destructive|Cert rotation|cdi-apiserver tests|Importer Test Suite-prometheus|test_id:3996|test_id:8266"
           - name: SNAPSHOT_SC
             value: ocs-storagecluster-ceph-rbd
           - name: BLOCK_SC


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Addendum to https://github.com/kubevirt/project-infra/pull/4832
I'll have to add additional skips due to unnoticed failures.
- **test_id:3996** --> Prometheus. 
The existing `Importer Test Suite-prometheus` skip doesn't cover this test because it
  lives under the "DV retry count" describe block, not the prometheus suite.
- **test_id:8266** --> OpenShift specific failure

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc: @awels @dhiller

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
