### PR TITLE
ci(greenhouse): add weekly cache wipe periodic job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1341,3 +1341,46 @@ periodics:
       env:
       - name: CLUSTER_KUBECONFIG_NAME
         value: prow-s390x-secure-execution
+- name: periodic-project-infra-greenhouse-cache-wipe
+  cron: "0 14 * * 6"
+  annotations:
+    testgrid-create-test-group: "true"
+    testgrid-dashboards: kubevirt-project-infra-periodics
+    testgrid-days-of-results: "30"
+    testgrid-num-failures-to-alert: "1"
+    testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
+  cluster: kubevirt-prow-control-plane
+  decorate: true
+  decoration_config:
+    timeout: 15m
+    grace_period: 5m
+  extra_refs:
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+    workdir: true
+    clone_depth: 1
+  labels:
+    preset-github-credentials: "true"
+    preset-pgp-bot-key: "true"
+  max_concurrency: 1
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -ceu
+      args:
+      - |
+        source ./hack/manage-secrets.sh
+        decrypt_secrets
+        install -Dm400 "${secrets_repo_dir}"/secrets/kubeconfigs/prow-workloads ~/.kube/config
+        cleanup_secrets
+
+        ./hack/clear-bazel-cache.sh
+      resources:
+        requests:
+          memory: 200Mi
+      securityContext:
+        runAsUser: 0


### PR DESCRIPTION
## Summary
- Adds `periodic-project-infra-greenhouse-cache-wipe` job that runs `hack/clear-bazel-cache.sh` every Saturday at 14:00 UTC (16:00 CEST)
- Extracts the `prow-workloads` KUBECONFIG from the secrets repo, then clears the greenhouse bazel cache

## Test plan
- [ ] Verify YAML is valid (done locally)
- [ ] Trigger manually after merge to confirm secrets extraction and cache wipe work end-to-end

🤖 Assisted by Claude