### PR TITLE
Add prow job definitions for vm-file-restore-operator

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
@@ -1,0 +1,117 @@
+postsubmits:
+  kubevirt/vm-file-restore-operator:
+  - name: push-release-vm-file-restore-operator-images
+    branches:
+    - release-\d+\.\d+
+    cluster: kubevirt-prow-control-plane
+    always_run: true
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        env:
+        - name: DOCKER_REPO
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin quay.io &&
+          make buildah-manifest &&
+          # Only push images on tags
+          git fetch --tags &&
+          [ -z "$(git tag --points-at HEAD | head -1)" ] ||
+          TAG="$(git tag --points-at HEAD | head -1)" make buildah-manifest-push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-release-vm-file-restore-operator-tag
+    branches:
+    - release-\d+\.\d+
+    cluster: kubevirt-prow-control-plane
+    always_run: true
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-github-credentials: "true"
+      preset-kubevirtci-quay-credential: "false"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        env:
+        - name: DOCKER_REPO
+          value: quay.io/kubevirt
+        - name: GH_CLI_VERSION
+          value: "1.5.0"
+        - name: GITHUB_TOKEN_PATH
+          value: /etc/github/oauth
+        - name: GITHUB_REPOSITORY
+          value: kubevirt/vm-file-restore-operator
+        - name: GIT_USER_NAME
+          value: kubevirt-bot
+        command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
+        args:
+        - ./hack/release.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-latest-vm-file-restore-operator-images
+    branches:
+    - main
+    cluster: kubevirt-prow-control-plane
+    always_run: true
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "false"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20260417-7427ea2
+        env:
+        - name: DOCKER_REPO
+          value: quay.io/kubevirt
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin quay.io &&
+          make buildah-manifest &&
+          make buildah-manifest-push
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
@@ -1,0 +1,91 @@
+presubmits:
+  kubevirt/vm-file-restore-operator:
+  - name: pull-vm-file-restore-operator-e2e
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+      grace_period: 5m
+    max_concurrency: 6
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror: "true"
+      preset-shared-images: "true"
+    cluster: prow-workloads
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260417-7427ea2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make test-e2e"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "52Gi"
+  - name: pull-vm-file-restore-operator-unit-test
+    cluster: kubevirt-prow-control-plane
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260417-7427ea2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make test"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"
+  - name: pull-vm-file-restore-operator-lint
+    cluster: kubevirt-prow-control-plane
+    skip_branches:
+      - release-\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-docker-mirror-proxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260417-7427ea2
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make lint"
+          resources:
+            requests:
+              memory: "4Gi"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add presubmit and postsubmit job definitions for the vm-file-restore-operator repository, including:
- E2E tests
- Unit tests
- Linting
- Image builds and pushes for releases and main branch

**Release note**:
```release-note
NONE
```