### PR TITLE
Update CS10 builder image to Bazel 7.5.0 + Java 21

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -734,7 +734,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2605290816-89fad9a940
+          value: 2606301559-b9f50e380a
         image: quay.io/kubevirtci/bootstrap:v20260703-61a4923
         name: ""
         resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Updates `KUBEVIRT_CS10_BUILDER_VERSION` to `2605290816-89fad9a940` across all CS10 presubmit jobs (`pull-kubevirt-verify-rpms-cs10`, `pull-kubevirt-build-cs10`, `pull-kubevirt-build-cs10-arm64`, `pull-kubevirt-build-cs10-s390x`).
This new builder image includes Bazel 7.5.0 and Java 21, which are required by the rules_img migration in kubevirt/kubevirt#17598.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Partially Addresses**: https://github.com/kubevirt/kubevirt/issues/17113

**Special notes for your reviewer**:

- This is a prerequisite for kubevirt/kubevirt#17598 (rules_oci → rules_img migration).
- Both this PR and kubevirt/kubevirt#17598 can be merged in any order. All CS10 builder jobs (`pull-kubevirt-build-cs10`, `pull-kubevirt-build-cs10-arm64`, `pull-kubevirt-build-cs10-s390x`, `pull-kubevirt-verify-rpms-cs10`) are `optional: true`, so with only one PR merged the CS10 lanes will fail but won't block any other PRs. Once both are merged, CS10 lanes will pass again.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build environment version used by the KubeVirt RPM verification job to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->