### PR TITLE
feat: add recency indicator to most-flaky-tests report

### DIFF
--- a/pkg/searchci/searchci.go
+++ b/pkg/searchci/searchci.go
@@ -170,7 +170,7 @@ func HasMinRecentFailures(maxAge time.Duration, minCount int, minInterval time.D
 				recentIntervals = append(recentIntervals, buildURL.Interval)
 			}
 		}
-		if len(recentIntervals) < minCount {
+		if len(recentIntervals) < minCount || len(recentIntervals) == 0 {
 			return false
 		}
 		if minInterval <= 0 {

--- a/pkg/searchci/searchci.go
+++ b/pkg/searchci/searchci.go
@@ -159,6 +159,36 @@ func FilterImpacts(impacts []Impact, timeRange TimeRange) []Impact {
 	return FilterImpactsBy(impacts, matchingTimeRange(timeRange))
 }
 
+// HasMinRecentFailures returns a FilterOpt that keeps an Impact only if it has
+// at least minCount build failures within maxAge, and those failures span at
+// least minInterval apart (to reject same-PR bursts).
+func HasMinRecentFailures(maxAge time.Duration, minCount int, minInterval time.Duration) FilterOpt {
+	return func(i Impact) bool {
+		var recentIntervals []time.Duration
+		for _, buildURL := range i.BuildURLs {
+			if buildURL.Interval <= maxAge {
+				recentIntervals = append(recentIntervals, buildURL.Interval)
+			}
+		}
+		if len(recentIntervals) < minCount {
+			return false
+		}
+		if minInterval <= 0 {
+			return true
+		}
+		minI, maxI := recentIntervals[0], recentIntervals[0]
+		for _, d := range recentIntervals[1:] {
+			if d < minI {
+				minI = d
+			}
+			if d > maxI {
+				maxI = d
+			}
+		}
+		return maxI-minI >= minInterval
+	}
+}
+
 // FilterImpactsBy filters all impacts for which all filterOpts apply, i.e. each of them returns true
 func FilterImpactsBy(impacts []Impact, filterOpts ...FilterOpt) []Impact {
 	if impacts == nil {

--- a/pkg/searchci/searchci_test.go
+++ b/pkg/searchci/searchci_test.go
@@ -217,6 +217,68 @@ tests/migration/namespace.go:236
 			},
 		),
 	)
+	DescribeTable("HasMinRecentFailures",
+		func(impact Impact, maxAge time.Duration, minCount int, minInterval time.Duration, expected bool) {
+			filter := HasMinRecentFailures(maxAge, minCount, minInterval)
+			Expect(filter(impact)).To(Equal(expected))
+		},
+		Entry("keeps impact with 2 recent failures 24h+ apart",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 4 * time.Hour},
+					{Interval: 36 * time.Hour},
+				},
+			},
+			72*time.Hour, 2, 24*time.Hour,
+			true,
+		),
+		Entry("filters impact with 2 recent failures only 1h apart (burst)",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 2 * time.Hour},
+					{Interval: 3 * time.Hour},
+				},
+			},
+			72*time.Hour, 2, 24*time.Hour,
+			false,
+		),
+		Entry("filters impact with only 1 recent failure (below minCount)",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 4 * time.Hour},
+					{Interval: 200 * time.Hour},
+				},
+			},
+			72*time.Hour, 2, 24*time.Hour,
+			false,
+		),
+		Entry("filters impact with all old failures",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 264 * time.Hour},
+					{Interval: 288 * time.Hour},
+				},
+			},
+			72*time.Hour, 2, 24*time.Hour,
+			false,
+		),
+		Entry("filters impact with no build URLs",
+			Impact{},
+			72*time.Hour, 2, 24*time.Hour,
+			false,
+		),
+		Entry("keeps impact when minInterval is zero (no spread requirement)",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 2 * time.Hour},
+					{Interval: 3 * time.Hour},
+				},
+			},
+			72*time.Hour, 2, time.Duration(0),
+			true,
+		),
+	)
+
 	Context("ScrapeImpacts", func() {
 		var body []byte
 		var server *httptest.Server

--- a/pkg/searchci/searchci_test.go
+++ b/pkg/searchci/searchci_test.go
@@ -267,6 +267,16 @@ tests/migration/namespace.go:236
 			72*time.Hour, 2, 24*time.Hour,
 			false,
 		),
+		Entry("does not panic with minCount=0 and no build URLs",
+			Impact{},
+			72*time.Hour, 0, 24*time.Hour,
+			false,
+		),
+		Entry("does not panic with negative minCount and no build URLs",
+			Impact{},
+			72*time.Hour, -1, 24*time.Hour,
+			false,
+		),
 		Entry("keeps impact when minInterval is zero (no spread requirement)",
 			Impact{
 				BuildURLs: []JobBuildURL{

--- a/robots/quarantine/cmd/auto-quarantine.go
+++ b/robots/quarantine/cmd/auto-quarantine.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/onsi/ginkgo/v2/types"
 	log "github.com/sirupsen/logrus"
@@ -68,6 +69,9 @@ func init() {
 	autoQuarantineCmd.PersistentFlags().IntVar(&quarantineOpts.maxTestsToQuarantine, "max-tests-to-quarantine", 1, "the overall number of tests that are going to be quarantined in one run")
 	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.releaseLaneSuffix, "release-lane-suffix", "", "the suffix for the release lane to target (i.e. -1.7) or empty for targeting the main branch")
 	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.matchingLaneRegexString, "matching-lane-regex", defaultMatchingLaneRegexString, "the regular expression that the lanes need to match - note that there's a suffix placeholder required")
+	autoQuarantineCmd.PersistentFlags().DurationVar(&quarantineOpts.maxFailureAge, "max-failure-age", 72*time.Hour, "maximum age of failures to consider as recent")
+	autoQuarantineCmd.PersistentFlags().IntVar(&quarantineOpts.minRecentFailures, "min-recent-failures", 2, "minimum number of recent failures required per lane")
+	autoQuarantineCmd.PersistentFlags().DurationVar(&quarantineOpts.minFailureInterval, "min-failure-interval", 24*time.Hour, "minimum time span between recent failures to confirm a consistent pattern")
 	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.jobConfigPath, "job-config-path", "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml", "path to the Prow presubmit job config YAML used to determine required lanes")
 	autoQuarantineCmd.PersistentFlags().StringVar(&quarantineOpts.jobConfigOrgRepo, "job-config-org-repo", "kubevirt/kubevirt", "org/repo key for looking up presubmits in the job config")
 	quarantineOpts.prDescriptionOutputFileOpts = options.NewOutputFileOptions(
@@ -188,7 +192,9 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 			continue
 		}
 
-		// Filter impacts by the matching lane regex and required lane status
+		// Filter impacts by the matching lane regex, required lane status,
+		// and recency of failures
+		recentFailureFilter := searchci.HasMinRecentFailures(quarantineOpts.maxFailureAge, quarantineOpts.minRecentFailures, quarantineOpts.minFailureInterval)
 		var filteredImpacts []searchci.Impact
 		for _, impact := range candidate.RelevantImpacts {
 			elements := strings.Split(impact.URL, "/")
@@ -201,6 +207,10 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 			}
 			if _, isRequired := requiredJobs[lastElement]; !isRequired {
 				log.Debugf("skipping impact from optional lane %q for test %q", lastElement, topXTest.Name)
+				continue
+			}
+			if !recentFailureFilter(impact) {
+				log.Debugf("skipping impact from lane %q for test %q: insufficient recent failures", lastElement, topXTest.Name)
 				continue
 			}
 			filteredImpacts = append(filteredImpacts, impact)

--- a/robots/quarantine/cmd/auto-quarantine_test.go
+++ b/robots/quarantine/cmd/auto-quarantine_test.go
@@ -355,16 +355,26 @@ to contain
 			quarantineOpts.matchingLaneRegexString = defaultMatchingLaneRegexString
 			quarantineOpts.releaseLaneSuffix = ""
 			quarantineOpts.maxTestsToQuarantine = 0
+			quarantineOpts.maxFailureAge = 72 * time.Hour
+			quarantineOpts.minRecentFailures = 2
+			quarantineOpts.minFailureInterval = 24 * time.Hour
 		})
 
 		AfterEach(func() {
 			getQuarantineCandidate = originalGetQuarantineCandidate
 		})
 
-		newImpact := func(lane string, percent float64) searchci.Impact {
+		newImpact := func(lane string, percent float64, buildURLs ...searchci.JobBuildURL) searchci.Impact {
+			if len(buildURLs) == 0 {
+				buildURLs = []searchci.JobBuildURL{
+					{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/1", Interval: 4 * time.Hour},
+					{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/2", Interval: 36 * time.Hour},
+				}
+			}
 			return searchci.Impact{
-				URL:     "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/" + lane,
-				Percent: percent,
+				URL:       "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/" + lane,
+				Percent:   percent,
+				BuildURLs: buildURLs,
 			}
 		}
 
@@ -377,7 +387,7 @@ to contain
 				{
 					SpecReports: []SpecReport{
 						{
-							LeafNodeText:         leafNodeText,
+							LeafNodeText:            leafNodeText,
 							ContainerHierarchyTexts: containerTexts,
 						},
 					},
@@ -439,11 +449,11 @@ to contain
 				{
 					SpecReports: []SpecReport{
 						{
-							LeafNodeText:         "should do something",
+							LeafNodeText:            "should do something",
 							ContainerHierarchyTexts: []string{"[sig-compute] my flaky test"},
 						},
 						{
-							LeafNodeText:         "should work",
+							LeafNodeText:            "should work",
 							ContainerHierarchyTexts: []string{"[sig-network] another flaky test"},
 						},
 					},
@@ -507,6 +517,61 @@ to contain
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].RelevantImpacts).To(HaveLen(1))
 			Expect(result[0].RelevantImpacts[0].URL).To(ContainSubstring(requiredLane))
+		})
+
+		It("skips candidates where all failures are stale", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10,
+					searchci.JobBuildURL{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/1", Interval: 264 * time.Hour},
+					searchci.JobBuildURL{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/2", Interval: 288 * time.Hour},
+				),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("skips candidates where recent failures are clustered", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10,
+					searchci.JobBuildURL{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/1", Interval: 2 * time.Hour},
+					searchci.JobBuildURL{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/2", Interval: 3 * time.Hour},
+				),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("keeps candidates with recent spread-out failures", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10,
+					searchci.JobBuildURL{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/1", Interval: 4 * time.Hour},
+					searchci.JobBuildURL{URL: "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/2", Interval: 36 * time.Hour},
+				),
+			})
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{newTopXTest(testName)},
+				reportsContaining("should do something", "[sig-compute] my flaky test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].RelevantImpacts).To(HaveLen(1))
 		})
 
 		It("keeps required and filters optional from mixed impacts", func() {

--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/joshdk/go-junit"
 	log "github.com/sirupsen/logrus"
@@ -69,6 +70,9 @@ func init() {
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&outputFileOpts.OverwriteOutputFile, "overwrite-output-file", false, "whether to overwrite the output file")
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.filterPeriodicJobRunResults, "filter-periodic-job-run-results", true, "whether to filter the results for periodics")
 	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.filterLaneRegex, "filter-lane-regex", filterLaneRegexDefault, "the regular expression to use to filter test lanes with")
+	mostFlakyTestsReportCmd.PersistentFlags().DurationVar(&quarantineOpts.maxFailureAge, "max-failure-age", 72*time.Hour, "maximum age of failures to consider as recent")
+	mostFlakyTestsReportCmd.PersistentFlags().IntVar(&quarantineOpts.minRecentFailures, "min-recent-failures", 2, "minimum number of recent failures required per lane")
+	mostFlakyTestsReportCmd.PersistentFlags().DurationVar(&quarantineOpts.minFailureInterval, "min-failure-interval", 24*time.Hour, "minimum time span between recent failures to confirm a consistent pattern")
 }
 
 var sigMatcher = regexp.MustCompile(`\[(sig-[^]]+)]`)
@@ -115,6 +119,7 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 const noSIGKey = "NONE"
 
 func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string, testNames []string, mostFlakyTestsBySIG map[string]TestsPerSIG, err error) {
+	recentFailureFilter := searchci.HasMinRecentFailures(quarantineOpts.maxFailureAge, quarantineOpts.minRecentFailures, quarantineOpts.minFailureInterval)
 	mostFlakyTests := make(map[string][]*TestToQuarantine)
 	for _, topXTest := range topXTests {
 		for _, timeRange := range mostFlakyTestsTimeRanges {
@@ -124,6 +129,12 @@ func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string
 			}
 			if candidate == nil {
 				continue
+			}
+			for _, impact := range candidate.RelevantImpacts {
+				if recentFailureFilter(impact) {
+					candidate.HasRecentFailures = true
+					break
+				}
 			}
 			mostFlakyTests[topXTest.Name] = append(mostFlakyTests[topXTest.Name], candidate)
 		}

--- a/robots/quarantine/cmd/most-flaky-tests-report.gohtml
+++ b/robots/quarantine/cmd/most-flaky-tests-report.gohtml
@@ -55,6 +55,38 @@
             transition: transform var(--transition-speed);
         }
 
+        .card.recent-failures {
+            border-left: 4px solid #e53e3e;
+        }
+
+        .card.stale-failures {
+            border-left: 4px solid #cbd5e0;
+            opacity: 0.6;
+        }
+
+        .card.stale-failures:hover {
+            opacity: 1;
+        }
+
+        .recency-badge {
+            display: inline-block;
+            font-size: 0.75em;
+            padding: 1px 6px;
+            border-radius: 3px;
+            margin-left: 4px;
+            vertical-align: middle;
+        }
+
+        .recency-badge.active {
+            background-color: #fed7d7;
+            color: #9b2c2c;
+        }
+
+        .recency-badge.stale {
+            background-color: #edf2f7;
+            color: #718096;
+        }
+
     </style>
 </head>
 <body>
@@ -85,9 +117,18 @@
                 {{ range $testName := $.TestNames }}
                     {{ $mostFlakyTests := index $.MostFlakyTestsBySig $sig $testName }}
                     {{ if $mostFlakyTests }}
-                        <div class="card" id="test_{{ $testName }}">
+                        {{- $hasRecent := false -}}
+                        {{- range $t := $mostFlakyTests -}}
+                            {{- if $t.HasRecentFailures -}}{{- $hasRecent = true -}}{{- end -}}
+                        {{- end -}}
+                        <div class="card {{ if $hasRecent }}recent-failures{{ else }}stale-failures{{ end }}" id="test_{{ $testName }}">
                             <a href="#test_{{ $testName }}">#</a>
-                            <code title="{{ $testName }}">{{ $testName }}</code><br/>
+                            <code title="{{ $testName }}">{{ $testName }}</code>
+                            {{ if $hasRecent -}}
+                                <span class="recency-badge active">active</span>
+                            {{- else -}}
+                                <span class="recency-badge stale">stale</span>
+                            {{- end }}<br/>
                             {{ range $mostFlakyTest := $mostFlakyTests }}
                                 {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts -}}
                                     <div class="impact-entry" data-lane="{{ $relevantImpact.URLToDisplay }}">

--- a/robots/quarantine/cmd/most-flaky-tests-report_test.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report_test.go
@@ -20,6 +20,8 @@
 package cmd
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	flakestats "kubevirt.io/project-infra/pkg/flake-stats"
@@ -67,5 +69,76 @@ var _ = Describe("most-flaky-tests", func() {
 				},
 			),
 		)
+	})
+
+	When("aggregating most flaky tests by SIG", func() {
+		var originalGetQuarantineCandidate func(*flakestats.TopXTest, searchci.TimeRange) (*TestToQuarantine, error)
+
+		BeforeEach(func() {
+			originalGetQuarantineCandidate = getQuarantineCandidate
+			quarantineOpts.maxFailureAge = 72 * time.Hour
+			quarantineOpts.minRecentFailures = 2
+			quarantineOpts.minFailureInterval = 24 * time.Hour
+		})
+
+		AfterEach(func() {
+			getQuarantineCandidate = originalGetQuarantineCandidate
+		})
+
+		It("marks candidate with recent spread-out failures as HasRecentFailures", func() {
+			getQuarantineCandidate = func(topXTest *flakestats.TopXTest, _ searchci.TimeRange) (*TestToQuarantine, error) {
+				return &TestToQuarantine{
+					Test: topXTest,
+					RelevantImpacts: []searchci.Impact{
+						{
+							URL:     "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute",
+							Percent: 10,
+							BuildURLs: []searchci.JobBuildURL{
+								{Interval: 4 * time.Hour},
+								{Interval: 36 * time.Hour},
+							},
+						},
+					},
+				}, nil
+			}
+
+			_, _, result, err := aggregateMostFlakyTestsBySIG(flakestats.TopXTests{
+				flakestats.NewTopXTest("[sig-compute] my recent flaky test"),
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveKey("sig-compute"))
+			tests := result["sig-compute"]["[sig-compute] my recent flaky test"]
+			Expect(tests).ToNot(BeEmpty())
+			Expect(tests[0].HasRecentFailures).To(BeTrue())
+		})
+
+		It("marks candidate with only stale failures as not HasRecentFailures", func() {
+			getQuarantineCandidate = func(topXTest *flakestats.TopXTest, _ searchci.TimeRange) (*TestToQuarantine, error) {
+				return &TestToQuarantine{
+					Test: topXTest,
+					RelevantImpacts: []searchci.Impact{
+						{
+							URL:     "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute",
+							Percent: 10,
+							BuildURLs: []searchci.JobBuildURL{
+								{Interval: 264 * time.Hour},
+								{Interval: 288 * time.Hour},
+							},
+						},
+					},
+				}, nil
+			}
+
+			_, _, result, err := aggregateMostFlakyTestsBySIG(flakestats.TopXTests{
+				flakestats.NewTopXTest("[sig-compute] my stale flaky test"),
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveKey("sig-compute"))
+			tests := result["sig-compute"]["[sig-compute] my stale flaky test"]
+			Expect(tests).ToNot(BeEmpty())
+			Expect(tests[0].HasRecentFailures).To(BeFalse())
+		})
 	})
 })

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -64,11 +64,12 @@ type quarantineOptions struct {
 }
 
 type TestToQuarantine struct {
-	Test            *flakestats.TopXTest
-	TimeRange       searchci.TimeRange
-	SearchCIURL     string
-	RelevantImpacts []searchci.Impact
-	SpecReport      *types.SpecReport
+	Test              *flakestats.TopXTest
+	TimeRange         searchci.TimeRange
+	SearchCIURL       string
+	RelevantImpacts   []searchci.Impact
+	HasRecentFailures bool
+	SpecReport        *types.SpecReport
 }
 
 type TestsPerSIG map[string][]*TestToQuarantine

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -36,6 +36,10 @@ type autoQuarantineOptions struct {
 	releaseLaneSuffix       string
 	matchingLaneRegexString string
 
+	maxFailureAge      time.Duration
+	minRecentFailures  int
+	minFailureInterval time.Duration
+
 	jobConfigPath    string
 	jobConfigOrgRepo string
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds visual distinction between actively flaky tests and stale entries in the most-flaky-tests report, so reviewers can focus on tests that are currently failing.

- Tests with recent consistent failures: red left border + "active" badge
- Tests with only stale failures: dimmed (60% opacity) with gray border + "stale" badge (hover restores full opacity)
- Reuses `HasMinRecentFailures` filter from #5125 with the same configurable flags

**Which issue(s) this PR fixes**:

Depends on #5125

**Special notes for your reviewer**:

- Unit tests verify `HasRecentFailures` flag is set correctly for recent and stale candidates
- All quarantine tests pass, `go vet` clean

🤖 Assisted by Claude Code