### PR TITLE
feat(robots): add lane-doctor CLI tool

### DIFF
--- a/robots/lane-doctor/README.md
+++ b/robots/lane-doctor/README.md
@@ -1,0 +1,62 @@
+# lane-doctor
+
+CLI tool to diagnose and remediate stuck Prow lane statuses on open PRs.
+
+## Background
+
+During lane migrations (e.g. bumping to k8s 1.36), the statusreconciler can
+post bare `pending` GitHub commit statuses (no `target_url`, no actual prowjob)
+on open PRs. When the affected lane is a required status check, those PRs are
+blocked from merging. This tool automates the detection, triage, and
+remediation workflow.
+
+## Commands
+
+### scan
+
+Scans all open PRs for a given lane and classifies each as
+stuck/missing/running/success/failed. Outputs a YAML report.
+
+```bash
+lane-doctor scan --lane pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations -o scan.yaml
+```
+
+### prioritize
+
+Reads a scan report and groups stuck PRs into priority tiers (P1–P4) based on
+merge-readiness labels (`lgtm`, `approved`, hold status, draft).
+
+```bash
+lane-doctor prioritize -i scan.yaml -o priority.yaml
+```
+
+### trigger
+
+Posts `/test <lane>` comments on PRs from a priority report in configurable
+batches with wait intervals between them.
+
+```bash
+# Preview what would happen
+lane-doctor trigger -i priority.yaml --group P1 --batch-size 10 --dry-run
+
+# Run interactively (press Enter between batches)
+lane-doctor trigger -i priority.yaml --group P1 --batch-size 10
+
+# Run unattended with 4h waits between batches
+lane-doctor trigger -i priority.yaml --yes --batch-wait 4h --batch-size 10
+```
+
+## Authentication
+
+Provide a GitHub token via `--token-path` (path to a file) or the
+`GITHUB_TOKEN` environment variable. The tool uses the Prow GitHub client
+which supports both personal access tokens and GitHub App credentials.
+
+## Global Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--repo` | `kubevirt/kubevirt` | GitHub repository in owner/repo format |
+| `--token-path` | | Path to GitHub token file |
+| `--dry-run` | `false` | Print actions without executing them |
+| `--endpoint` | `https://api.github.com` | GitHub API endpoint |

--- a/robots/lane-doctor/cmd/cmd_suite_test.go
+++ b/robots/lane-doctor/cmd/cmd_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lane Doctor Cmd Suite")
+}

--- a/robots/lane-doctor/cmd/github_test.go
+++ b/robots/lane-doctor/cmd/github_test.go
@@ -1,0 +1,573 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"time"
+
+	"github.com/google/go-github/v32/github"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func newTestServer(mux *http.ServeMux) (*github.Client, *httptest.Server) {
+	server := httptest.NewServer(mux)
+	DeferCleanup(server.Close)
+
+	client := github.NewClient(nil)
+	baseURL, _ := url.Parse(server.URL + "/")
+	client.BaseURL = baseURL
+	return client, server
+}
+
+func newTestClient(mux *http.ServeMux) *github.Client {
+	client, _ := newTestServer(mux)
+	return client
+}
+
+func mustJSON(v any) []byte {
+	data, err := json.Marshal(v)
+	Expect(err).NotTo(HaveOccurred())
+	return data
+}
+
+var _ = Describe("verifyRequiredCheck", func() {
+
+	It("succeeds when lane is a required check", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"required_status_checks":{"strict":true,"contexts":["pull-kubevirt-e2e-k8s-1.36-sig-compute","other-check"]}}`)
+		})
+		client := newTestClient(mux)
+
+		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "pull-kubevirt-e2e-k8s-1.36-sig-compute")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns error when lane is not a required check", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"required_status_checks":{"strict":true,"contexts":["other-check"]}}`)
+		})
+		client := newTestClient(mux)
+
+		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "nonexistent-lane")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not a required status check"))
+	})
+
+	It("returns error when no required status checks are configured", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{}`)
+		})
+		client := newTestClient(mux)
+
+		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "some-lane")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no required status checks"))
+	})
+
+	It("returns error when API fails", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		})
+		client := newTestClient(mux)
+
+		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "some-lane")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("fetching branch protection"))
+	})
+})
+
+var _ = Describe("listOpenPRs", func() {
+
+	It("fetches all open PRs across pages", func() {
+		mux := http.NewServeMux()
+		client, server := newTestServer(mux)
+		mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+			page := r.URL.Query().Get("page")
+			w.Header().Set("Content-Type", "application/json")
+			if page == "" || page == "1" {
+				w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/pulls?page=2>; rel="next"`, server.URL))
+				w.Write(mustJSON([]*github.PullRequest{
+					{Number: intPtr(1), Title: strPtr("PR 1")},
+					{Number: intPtr(2), Title: strPtr("PR 2")},
+				}))
+			} else {
+				w.Write(mustJSON([]*github.PullRequest{
+					{Number: intPtr(3), Title: strPtr("PR 3")},
+				}))
+			}
+		})
+
+		prs, err := listOpenPRs(context.Background(), client, "owner", "repo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(prs).To(HaveLen(3))
+		Expect(prs[0].GetNumber()).To(Equal(1))
+		Expect(prs[2].GetNumber()).To(Equal(3))
+	})
+
+	It("returns error on API failure", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		client := newTestClient(mux)
+
+		_, err := listOpenPRs(context.Background(), client, "owner", "repo")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("listing PRs"))
+	})
+
+	It("returns empty slice for repo with no open PRs", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.PullRequest{}))
+		})
+		client := newTestClient(mux)
+
+		prs, err := listOpenPRs(context.Background(), client, "owner", "repo")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(prs).To(BeEmpty())
+	})
+})
+
+var _ = Describe("getCombinedStatusInfo", func() {
+
+	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
+
+	It("finds the lane status and detects e2e statuses", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("pending")},
+					{Context: strPtr("pull-kubevirt-e2e-k8s-1.35-sig-network"), State: strPtr("success")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		status, hasE2E, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).NotTo(BeNil())
+		Expect(status.GetState()).To(Equal("pending"))
+		Expect(hasE2E).To(BeTrue())
+	})
+
+	It("returns nil status when lane is not present", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr("other-check"), State: strPtr("success")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		status, hasE2E, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(BeNil())
+		Expect(hasE2E).To(BeFalse())
+	})
+
+	It("detects e2e statuses even when lane is missing", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr("pull-kubevirt-e2e-k8s-1.35-sig-storage"), State: strPtr("success")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		status, hasE2E, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(BeNil())
+		Expect(hasE2E).To(BeTrue())
+	})
+
+	It("returns error on API failure", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		client := newTestClient(mux)
+
+		_, _, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("checkRawStatuses", func() {
+
+	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
+
+	It("returns hasURL=true when latest status has a target URL", func() {
+		ts := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr(lane), TargetURL: strPtr("https://prow.example.com/job/123"), UpdatedAt: &ts},
+			}))
+		})
+		client := newTestClient(mux)
+
+		hasURL, updatedAt := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(hasURL).To(BeTrue())
+		Expect(updatedAt).To(Equal("2026-06-10T12:00:00Z"))
+	})
+
+	It("returns hasURL=false when latest status has no target URL (stuck)", func() {
+		ts := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &ts},
+			}))
+		})
+		client := newTestClient(mux)
+
+		hasURL, _ := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(hasURL).To(BeFalse())
+	})
+
+	It("picks the latest status when multiple exist for the lane", func() {
+		older := time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC)
+		newer := time.Date(2026, 6, 10, 14, 0, 0, 0, time.UTC)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &older},
+				{Context: strPtr(lane), TargetURL: strPtr("https://prow.example.com/job/456"), UpdatedAt: &newer},
+			}))
+		})
+		client := newTestClient(mux)
+
+		hasURL, updatedAt := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(hasURL).To(BeTrue())
+		Expect(updatedAt).To(Equal("2026-06-10T14:00:00Z"))
+	})
+
+	It("returns empty when lane has no statuses", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr("other-check"), TargetURL: strPtr("https://ci.example.com")},
+			}))
+		})
+		client := newTestClient(mux)
+
+		hasURL, updatedAt := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+		Expect(hasURL).To(BeFalse())
+		Expect(updatedAt).To(BeEmpty())
+	})
+})
+
+var _ = Describe("classifyPR", func() {
+
+	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
+
+	makePR := func(number int, sha string) *github.PullRequest {
+		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		return &github.PullRequest{
+			Number:    intPtr(number),
+			Title:     strPtr(fmt.Sprintf("PR %d", number)),
+			User:      &github.User{Login: strPtr("user")},
+			Head:      &github.PullRequestBranch{SHA: strPtr(sha)},
+			Draft:     boolPtr(false),
+			UpdatedAt: &updated,
+		}
+	}
+
+	It("classifies a PR with successful lane status as success", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-ok/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("success")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(1, "sha-ok"))
+		Expect(result.category).To(Equal("success"))
+		Expect(result.pr).To(BeNil())
+	})
+
+	It("classifies a PR with failed lane status as failed", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-fail/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("failure")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(2, "sha-fail"))
+		Expect(result.category).To(Equal("failed"))
+		Expect(result.pr).To(BeNil())
+	})
+
+	It("classifies a PR with error lane status as failed", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-err/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("error")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(3, "sha-err"))
+		Expect(result.category).To(Equal("failed"))
+	})
+
+	It("classifies a pending lane with target URL as running", func() {
+		ts := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-run/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("pending")},
+				},
+			}))
+		})
+		mux.HandleFunc("/repos/owner/repo/commits/sha-run/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr(lane), TargetURL: strPtr("https://prow.example.com/job/789"), UpdatedAt: &ts},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(4, "sha-run"))
+		Expect(result.category).To(Equal("running"))
+		Expect(result.pr).To(BeNil())
+	})
+
+	It("classifies a pending lane without target URL as stuck", func() {
+		ts := time.Date(2026, 6, 10, 11, 0, 0, 0, time.UTC)
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-stuck/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("pending")},
+				},
+			}))
+		})
+		mux.HandleFunc("/repos/owner/repo/commits/sha-stuck/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &ts},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(5, "sha-stuck"))
+		Expect(result.category).To(Equal("stuck"))
+		Expect(result.pr).NotTo(BeNil())
+		Expect(result.pr.Number).To(Equal(5))
+		Expect(result.pr.StatusState).To(Equal("pending"))
+	})
+
+	It("classifies a PR with no lane status and no e2e statuses as success", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-clean/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr("ci/lint"), State: strPtr("success")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(6, "sha-clean"))
+		Expect(result.category).To(Equal("success"))
+	})
+
+	It("classifies a PR with no lane status but e2e statuses as missing", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-miss/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr("pull-kubevirt-e2e-k8s-1.35-sig-network"), State: strPtr("success")},
+				},
+			}))
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(7, "sha-miss"))
+		Expect(result.category).To(Equal("missing"))
+		Expect(result.pr).NotTo(BeNil())
+		Expect(result.pr.StatusState).To(Equal("missing"))
+	})
+
+	It("classifies as failed when combined status API errors", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/commits/sha-api-err/status", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		client := newTestClient(mux)
+
+		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(8, "sha-api-err"))
+		Expect(result.category).To(Equal("failed"))
+	})
+})
+
+var _ = Describe("classifyPRs", func() {
+
+	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
+
+	It("aggregates classification results across multiple PRs", func() {
+		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		ts := time.Date(2026, 6, 10, 11, 0, 0, 0, time.UTC)
+		mux := http.NewServeMux()
+
+		// PR 1: success
+		mux.HandleFunc("/repos/owner/repo/commits/sha-1/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("success")},
+				},
+			}))
+		})
+
+		// PR 2: stuck (pending, no target URL)
+		mux.HandleFunc("/repos/owner/repo/commits/sha-2/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("pending")},
+				},
+			}))
+		})
+		mux.HandleFunc("/repos/owner/repo/commits/sha-2/statuses", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON([]*github.RepoStatus{
+				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &ts},
+			}))
+		})
+
+		// PR 3: failed
+		mux.HandleFunc("/repos/owner/repo/commits/sha-3/status", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.CombinedStatus{
+				Statuses: []*github.RepoStatus{
+					{Context: strPtr(lane), State: strPtr("failure")},
+				},
+			}))
+		})
+
+		client := newTestClient(mux)
+
+		prs := []*github.PullRequest{
+			{Number: intPtr(1), Title: strPtr("PR 1"), User: &github.User{Login: strPtr("u")}, Head: &github.PullRequestBranch{SHA: strPtr("sha-1")}, Draft: boolPtr(false), UpdatedAt: &updated},
+			{Number: intPtr(2), Title: strPtr("PR 2"), User: &github.User{Login: strPtr("u")}, Head: &github.PullRequestBranch{SHA: strPtr("sha-2")}, Draft: boolPtr(false), UpdatedAt: &updated},
+			{Number: intPtr(3), Title: strPtr("PR 3"), User: &github.User{Login: strPtr("u")}, Head: &github.PullRequestBranch{SHA: strPtr("sha-3")}, Draft: boolPtr(false), UpdatedAt: &updated},
+		}
+
+		summary, stuckPRs := classifyPRs(context.Background(), client, "owner", "repo", lane, prs)
+
+		Expect(summary.Total).To(Equal(3))
+		Expect(summary.Success).To(Equal(1))
+		Expect(summary.Stuck).To(Equal(1))
+		Expect(summary.Failed).To(Equal(1))
+		Expect(summary.Running).To(Equal(0))
+		Expect(summary.Missing).To(Equal(0))
+		Expect(stuckPRs).To(HaveLen(1))
+		Expect(stuckPRs[0].Number).To(Equal(2))
+	})
+})
+
+var _ = Describe("postComment", func() {
+
+	It("posts a comment on the given PR", func() {
+		var capturedBody string
+		var capturedPR int
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+			Expect(r.Method).To(Equal("POST"))
+			var body github.IssueComment
+			Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
+			capturedBody = body.GetBody()
+			capturedPR = 42
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustJSON(github.IssueComment{
+				ID:      intPtr64(1),
+				Body:    body.Body,
+				HTMLURL: strPtr("https://github.com/owner/repo/pull/42#issuecomment-1"),
+			}))
+		})
+		client := newTestClient(mux)
+
+		err := postComment(context.Background(), client, "owner", "repo", 42, "/test my-lane")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(capturedPR).To(Equal(42))
+		Expect(capturedBody).To(Equal("/test my-lane"))
+	})
+
+	It("returns error on API failure", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/repos/owner/repo/issues/99/comments", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+		client := newTestClient(mux)
+
+		err := postComment(context.Background(), client, "owner", "repo", 99, "/test my-lane")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("commenting on PR #99"))
+	})
+})
+
+func intPtr64(i int64) *int64 { return &i }

--- a/robots/lane-doctor/cmd/github_test.go
+++ b/robots/lane-doctor/cmd/github_test.go
@@ -20,88 +20,116 @@
 package cmd
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
 	"time"
 
-	"github.com/google/go-github/v32/github"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	github "sigs.k8s.io/prow/pkg/github"
 )
 
-func newTestServer(mux *http.ServeMux) (*github.Client, *httptest.Server) {
-	server := httptest.NewServer(mux)
-	DeferCleanup(server.Close)
+type fakeClient struct {
+	branchProtection *github.BranchProtection
+	branchProtErr    error
 
-	client := github.NewClient(nil)
-	baseURL, _ := url.Parse(server.URL + "/")
-	client.BaseURL = baseURL
-	return client, server
+	pullRequests    []github.PullRequest
+	pullRequestsErr error
+
+	combinedStatuses  map[string]*github.CombinedStatus
+	combinedStatusErr error
+
+	statuses    map[string][]github.Status
+	statusesErr error
+
+	comments   map[int][]string
+	commentErr error
 }
 
-func newTestClient(mux *http.ServeMux) *github.Client {
-	client, _ := newTestServer(mux)
-	return client
+func (f *fakeClient) GetBranchProtection(org, repo, branch string) (*github.BranchProtection, error) {
+	return f.branchProtection, f.branchProtErr
 }
 
-func mustJSON(v any) []byte {
-	data, err := json.Marshal(v)
-	Expect(err).NotTo(HaveOccurred())
-	return data
+func (f *fakeClient) GetPullRequests(org, repo string) ([]github.PullRequest, error) {
+	return f.pullRequests, f.pullRequestsErr
+}
+
+func (f *fakeClient) GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error) {
+	if f.combinedStatusErr != nil {
+		return nil, f.combinedStatusErr
+	}
+	if cs, ok := f.combinedStatuses[ref]; ok {
+		return cs, nil
+	}
+	return &github.CombinedStatus{}, nil
+}
+
+func (f *fakeClient) ListStatuses(org, repo, ref string) ([]github.Status, error) {
+	if f.statusesErr != nil {
+		return nil, f.statusesErr
+	}
+	return f.statuses[ref], nil
+}
+
+func (f *fakeClient) CreateComment(org, repo string, number int, comment string) error {
+	if f.commentErr != nil {
+		return f.commentErr
+	}
+	if f.comments == nil {
+		f.comments = make(map[int][]string)
+	}
+	f.comments[number] = append(f.comments[number], comment)
+	return nil
 }
 
 var _ = Describe("verifyRequiredCheck", func() {
 
-	It("succeeds when lane is a required check", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"required_status_checks":{"strict":true,"contexts":["pull-kubevirt-e2e-k8s-1.36-sig-compute","other-check"]}}`)
-		})
-		client := newTestClient(mux)
+	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
 
-		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "pull-kubevirt-e2e-k8s-1.36-sig-compute")
-		Expect(err).NotTo(HaveOccurred())
+	It("succeeds when lane is a required check", func() {
+		fc := &fakeClient{
+			branchProtection: &github.BranchProtection{
+				RequiredStatusChecks: &github.RequiredStatusChecks{
+					Contexts: []string{lane, "other-check"},
+				},
+			},
+		}
+		Expect(verifyRequiredCheck(fc, "owner", "repo", lane)).To(Succeed())
 	})
 
 	It("returns error when lane is not a required check", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"required_status_checks":{"strict":true,"contexts":["other-check"]}}`)
-		})
-		client := newTestClient(mux)
-
-		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "nonexistent-lane")
+		fc := &fakeClient{
+			branchProtection: &github.BranchProtection{
+				RequiredStatusChecks: &github.RequiredStatusChecks{
+					Contexts: []string{"other-check"},
+				},
+			},
+		}
+		err := verifyRequiredCheck(fc, "owner", "repo", "nonexistent-lane")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("not a required status check"))
 	})
 
 	It("returns error when no required status checks are configured", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{}`)
-		})
-		client := newTestClient(mux)
+		fc := &fakeClient{
+			branchProtection: &github.BranchProtection{},
+		}
+		err := verifyRequiredCheck(fc, "owner", "repo", "some-lane")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no required status checks"))
+	})
 
-		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "some-lane")
+	It("returns error when branch protection is nil", func() {
+		fc := &fakeClient{}
+		err := verifyRequiredCheck(fc, "owner", "repo", "some-lane")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("no required status checks"))
 	})
 
 	It("returns error when API fails", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/branches/main/protection", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-		})
-		client := newTestClient(mux)
-
-		err := verifyRequiredCheck(context.Background(), client, "owner", "repo", "some-lane")
+		fc := &fakeClient{
+			branchProtErr: fmt.Errorf("api error"),
+		}
+		err := verifyRequiredCheck(fc, "owner", "repo", "some-lane")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("fetching branch protection"))
 	})
@@ -109,126 +137,97 @@ var _ = Describe("verifyRequiredCheck", func() {
 
 var _ = Describe("listOpenPRs", func() {
 
-	It("fetches all open PRs across pages", func() {
-		mux := http.NewServeMux()
-		client, server := newTestServer(mux)
-		mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
-			page := r.URL.Query().Get("page")
-			w.Header().Set("Content-Type", "application/json")
-			if page == "" || page == "1" {
-				w.Header().Set("Link", fmt.Sprintf(`<%s/repos/owner/repo/pulls?page=2>; rel="next"`, server.URL))
-				w.Write(mustJSON([]*github.PullRequest{
-					{Number: intPtr(1), Title: strPtr("PR 1")},
-					{Number: intPtr(2), Title: strPtr("PR 2")},
-				}))
-			} else {
-				w.Write(mustJSON([]*github.PullRequest{
-					{Number: intPtr(3), Title: strPtr("PR 3")},
-				}))
-			}
-		})
-
-		prs, err := listOpenPRs(context.Background(), client, "owner", "repo")
+	It("returns all PRs from the client", func() {
+		fc := &fakeClient{
+			pullRequests: []github.PullRequest{
+				{Number: 1, Title: "PR 1"},
+				{Number: 2, Title: "PR 2"},
+				{Number: 3, Title: "PR 3"},
+			},
+		}
+		prs, err := listOpenPRs(fc, "owner", "repo")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(prs).To(HaveLen(3))
-		Expect(prs[0].GetNumber()).To(Equal(1))
-		Expect(prs[2].GetNumber()).To(Equal(3))
+		Expect(prs[0].Number).To(Equal(1))
+		Expect(prs[2].Number).To(Equal(3))
 	})
 
 	It("returns error on API failure", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
-		client := newTestClient(mux)
-
-		_, err := listOpenPRs(context.Background(), client, "owner", "repo")
+		fc := &fakeClient{
+			pullRequestsErr: fmt.Errorf("api error"),
+		}
+		_, err := listOpenPRs(fc, "owner", "repo")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("listing PRs"))
 	})
 
 	It("returns empty slice for repo with no open PRs", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.PullRequest{}))
-		})
-		client := newTestClient(mux)
-
-		prs, err := listOpenPRs(context.Background(), client, "owner", "repo")
+		fc := &fakeClient{}
+		prs, err := listOpenPRs(fc, "owner", "repo")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(prs).To(BeEmpty())
 	})
 })
 
-var _ = Describe("getCombinedStatusInfo", func() {
+var _ = Describe("getLaneStatus", func() {
 
 	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
 
 	It("finds the lane status and detects e2e statuses", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("pending")},
-					{Context: strPtr("pull-kubevirt-e2e-k8s-1.35-sig-network"), State: strPtr("success")},
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha123": {
+					Statuses: []github.Status{
+						{Context: lane, State: "pending"},
+						{Context: "pull-kubevirt-e2e-k8s-1.35-sig-network", State: "success"},
+					},
 				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		status, hasE2E, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+			},
+		}
+		status, hasE2E, err := getLaneStatus(fc, "owner", "repo", "sha123", lane)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).NotTo(BeNil())
-		Expect(status.GetState()).To(Equal("pending"))
+		Expect(status.State).To(Equal("pending"))
 		Expect(hasE2E).To(BeTrue())
 	})
 
 	It("returns nil status when lane is not present", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr("other-check"), State: strPtr("success")},
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha123": {
+					Statuses: []github.Status{
+						{Context: "other-check", State: "success"},
+					},
 				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		status, hasE2E, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+			},
+		}
+		status, hasE2E, err := getLaneStatus(fc, "owner", "repo", "sha123", lane)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(BeNil())
 		Expect(hasE2E).To(BeFalse())
 	})
 
 	It("detects e2e statuses even when lane is missing", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr("pull-kubevirt-e2e-k8s-1.35-sig-storage"), State: strPtr("success")},
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha123": {
+					Statuses: []github.Status{
+						{Context: "pull-kubevirt-e2e-k8s-1.35-sig-storage", State: "success"},
+					},
 				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		status, hasE2E, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+			},
+		}
+		status, hasE2E, err := getLaneStatus(fc, "owner", "repo", "sha123", lane)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(BeNil())
 		Expect(hasE2E).To(BeTrue())
 	})
 
 	It("returns error on API failure", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/status", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
-		client := newTestClient(mux)
-
-		_, _, err := getCombinedStatusInfo(context.Background(), client, "owner", "repo", "sha123", lane)
+		fc := &fakeClient{
+			combinedStatusErr: fmt.Errorf("api error"),
+		}
+		_, _, err := getLaneStatus(fc, "owner", "repo", "sha123", lane)
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -238,65 +237,67 @@ var _ = Describe("checkRawStatuses", func() {
 	const lane = "pull-kubevirt-e2e-k8s-1.36-sig-compute"
 
 	It("returns hasURL=true when latest status has a target URL", func() {
-		ts := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr(lane), TargetURL: strPtr("https://prow.example.com/job/123"), UpdatedAt: &ts},
-			}))
-		})
-		client := newTestClient(mux)
-
-		hasURL, updatedAt := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+		fc := &fakeClient{
+			statuses: map[string][]github.Status{
+				"sha123": {
+					{Context: lane, TargetURL: "https://prow.example.com/job/123"},
+				},
+			},
+		}
+		hasURL, _ := checkRawStatuses(fc, "owner", "repo", "sha123", lane)
 		Expect(hasURL).To(BeTrue())
-		Expect(updatedAt).To(Equal("2026-06-10T12:00:00Z"))
 	})
 
 	It("returns hasURL=false when latest status has no target URL (stuck)", func() {
-		ts := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &ts},
-			}))
-		})
-		client := newTestClient(mux)
-
-		hasURL, _ := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+		fc := &fakeClient{
+			statuses: map[string][]github.Status{
+				"sha123": {
+					{Context: lane, TargetURL: ""},
+				},
+			},
+		}
+		hasURL, _ := checkRawStatuses(fc, "owner", "repo", "sha123", lane)
 		Expect(hasURL).To(BeFalse())
 	})
 
-	It("picks the latest status when multiple exist for the lane", func() {
-		older := time.Date(2026, 6, 10, 10, 0, 0, 0, time.UTC)
-		newer := time.Date(2026, 6, 10, 14, 0, 0, 0, time.UTC)
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &older},
-				{Context: strPtr(lane), TargetURL: strPtr("https://prow.example.com/job/456"), UpdatedAt: &newer},
-			}))
-		})
-		client := newTestClient(mux)
-
-		hasURL, updatedAt := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+	It("uses the first matching status (latest in reverse-chronological order)", func() {
+		fc := &fakeClient{
+			statuses: map[string][]github.Status{
+				"sha123": {
+					{Context: lane, TargetURL: "https://prow.example.com/job/456"},
+					{Context: lane, TargetURL: ""},
+				},
+			},
+		}
+		hasURL, _ := checkRawStatuses(fc, "owner", "repo", "sha123", lane)
 		Expect(hasURL).To(BeTrue())
-		Expect(updatedAt).To(Equal("2026-06-10T14:00:00Z"))
 	})
 
 	It("returns empty when lane has no statuses", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha123/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr("other-check"), TargetURL: strPtr("https://ci.example.com")},
-			}))
-		})
-		client := newTestClient(mux)
+		fc := &fakeClient{
+			statuses: map[string][]github.Status{
+				"sha123": {
+					{Context: "other-check", TargetURL: "https://ci.example.com"},
+				},
+			},
+		}
+		hasURL, updatedAt := checkRawStatuses(fc, "owner", "repo", "sha123", lane)
+		Expect(hasURL).To(BeFalse())
+		Expect(updatedAt).To(BeEmpty())
+	})
 
-		hasURL, updatedAt := checkRawStatuses(context.Background(), client, "owner", "repo", "sha123", lane)
+	It("returns false on API error", func() {
+		fc := &fakeClient{
+			statusesErr: fmt.Errorf("api error"),
+		}
+		hasURL, updatedAt := checkRawStatuses(fc, "owner", "repo", "sha123", lane)
+		Expect(hasURL).To(BeFalse())
+		Expect(updatedAt).To(BeEmpty())
+	})
+
+	It("returns false when no statuses exist at all", func() {
+		fc := &fakeClient{}
+		hasURL, updatedAt := checkRawStatuses(fc, "owner", "repo", "sha123", lane)
 		Expect(hasURL).To(BeFalse())
 		Expect(updatedAt).To(BeEmpty())
 	})
@@ -309,109 +310,69 @@ var _ = Describe("classifyPR", func() {
 	makePR := func(number int, sha string) *github.PullRequest {
 		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 		return &github.PullRequest{
-			Number:    intPtr(number),
-			Title:     strPtr(fmt.Sprintf("PR %d", number)),
-			User:      &github.User{Login: strPtr("user")},
-			Head:      &github.PullRequestBranch{SHA: strPtr(sha)},
-			Draft:     boolPtr(false),
-			UpdatedAt: &updated,
+			Number:    number,
+			Title:     fmt.Sprintf("PR %d", number),
+			User:      github.User{Login: "user"},
+			Head:      github.PullRequestBranch{SHA: sha},
+			UpdatedAt: updated,
 		}
 	}
 
 	It("classifies a PR with successful lane status as success", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-ok/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("success")},
-				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(1, "sha-ok"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-ok": {Statuses: []github.Status{{Context: lane, State: "success"}}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(1, "sha-ok"))
 		Expect(result.category).To(Equal("success"))
 		Expect(result.pr).To(BeNil())
 	})
 
 	It("classifies a PR with failed lane status as failed", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-fail/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("failure")},
-				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(2, "sha-fail"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-fail": {Statuses: []github.Status{{Context: lane, State: "failure"}}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(2, "sha-fail"))
 		Expect(result.category).To(Equal("failed"))
-		Expect(result.pr).To(BeNil())
 	})
 
 	It("classifies a PR with error lane status as failed", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-err/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("error")},
-				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(3, "sha-err"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-err": {Statuses: []github.Status{{Context: lane, State: "error"}}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(3, "sha-err"))
 		Expect(result.category).To(Equal("failed"))
 	})
 
 	It("classifies a pending lane with target URL as running", func() {
-		ts := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-run/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("pending")},
-				},
-			}))
-		})
-		mux.HandleFunc("/repos/owner/repo/commits/sha-run/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr(lane), TargetURL: strPtr("https://prow.example.com/job/789"), UpdatedAt: &ts},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(4, "sha-run"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-run": {Statuses: []github.Status{{Context: lane, State: "pending"}}},
+			},
+			statuses: map[string][]github.Status{
+				"sha-run": {{Context: lane, TargetURL: "https://prow.example.com/job/789"}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(4, "sha-run"))
 		Expect(result.category).To(Equal("running"))
 		Expect(result.pr).To(BeNil())
 	})
 
 	It("classifies a pending lane without target URL as stuck", func() {
-		ts := time.Date(2026, 6, 10, 11, 0, 0, 0, time.UTC)
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-stuck/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("pending")},
-				},
-			}))
-		})
-		mux.HandleFunc("/repos/owner/repo/commits/sha-stuck/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &ts},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(5, "sha-stuck"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-stuck": {Statuses: []github.Status{{Context: lane, State: "pending"}}},
+			},
+			statuses: map[string][]github.Status{
+				"sha-stuck": {{Context: lane, TargetURL: ""}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(5, "sha-stuck"))
 		Expect(result.category).To(Equal("stuck"))
 		Expect(result.pr).NotTo(BeNil())
 		Expect(result.pr.Number).To(Equal(5))
@@ -419,47 +380,32 @@ var _ = Describe("classifyPR", func() {
 	})
 
 	It("classifies a PR with no lane status and no e2e statuses as success", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-clean/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr("ci/lint"), State: strPtr("success")},
-				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(6, "sha-clean"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-clean": {Statuses: []github.Status{{Context: "ci/lint", State: "success"}}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(6, "sha-clean"))
 		Expect(result.category).To(Equal("success"))
 	})
 
 	It("classifies a PR with no lane status but e2e statuses as missing", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-miss/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr("pull-kubevirt-e2e-k8s-1.35-sig-network"), State: strPtr("success")},
-				},
-			}))
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(7, "sha-miss"))
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-miss": {Statuses: []github.Status{{Context: "pull-kubevirt-e2e-k8s-1.35-sig-network", State: "success"}}},
+			},
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(7, "sha-miss"))
 		Expect(result.category).To(Equal("missing"))
 		Expect(result.pr).NotTo(BeNil())
 		Expect(result.pr.StatusState).To(Equal("missing"))
 	})
 
 	It("classifies as failed when combined status API errors", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/commits/sha-api-err/status", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})
-		client := newTestClient(mux)
-
-		result := classifyPR(context.Background(), client, "owner", "repo", lane, makePR(8, "sha-api-err"))
+		fc := &fakeClient{
+			combinedStatusErr: fmt.Errorf("api error"),
+		}
+		result := classifyPR(fc, "owner", "repo", lane, makePR(8, "sha-api-err"))
 		Expect(result.category).To(Equal("failed"))
 	})
 })
@@ -470,54 +416,24 @@ var _ = Describe("classifyPRs", func() {
 
 	It("aggregates classification results across multiple PRs", func() {
 		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
-		ts := time.Date(2026, 6, 10, 11, 0, 0, 0, time.UTC)
-		mux := http.NewServeMux()
-
-		// PR 1: success
-		mux.HandleFunc("/repos/owner/repo/commits/sha-1/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("success")},
-				},
-			}))
-		})
-
-		// PR 2: stuck (pending, no target URL)
-		mux.HandleFunc("/repos/owner/repo/commits/sha-2/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("pending")},
-				},
-			}))
-		})
-		mux.HandleFunc("/repos/owner/repo/commits/sha-2/statuses", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON([]*github.RepoStatus{
-				{Context: strPtr(lane), TargetURL: strPtr(""), UpdatedAt: &ts},
-			}))
-		})
-
-		// PR 3: failed
-		mux.HandleFunc("/repos/owner/repo/commits/sha-3/status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.CombinedStatus{
-				Statuses: []*github.RepoStatus{
-					{Context: strPtr(lane), State: strPtr("failure")},
-				},
-			}))
-		})
-
-		client := newTestClient(mux)
-
-		prs := []*github.PullRequest{
-			{Number: intPtr(1), Title: strPtr("PR 1"), User: &github.User{Login: strPtr("u")}, Head: &github.PullRequestBranch{SHA: strPtr("sha-1")}, Draft: boolPtr(false), UpdatedAt: &updated},
-			{Number: intPtr(2), Title: strPtr("PR 2"), User: &github.User{Login: strPtr("u")}, Head: &github.PullRequestBranch{SHA: strPtr("sha-2")}, Draft: boolPtr(false), UpdatedAt: &updated},
-			{Number: intPtr(3), Title: strPtr("PR 3"), User: &github.User{Login: strPtr("u")}, Head: &github.PullRequestBranch{SHA: strPtr("sha-3")}, Draft: boolPtr(false), UpdatedAt: &updated},
+		fc := &fakeClient{
+			combinedStatuses: map[string]*github.CombinedStatus{
+				"sha-1": {Statuses: []github.Status{{Context: lane, State: "success"}}},
+				"sha-2": {Statuses: []github.Status{{Context: lane, State: "pending"}}},
+				"sha-3": {Statuses: []github.Status{{Context: lane, State: "failure"}}},
+			},
+			statuses: map[string][]github.Status{
+				"sha-2": {{Context: lane, TargetURL: ""}},
+			},
 		}
 
-		summary, stuckPRs := classifyPRs(context.Background(), client, "owner", "repo", lane, prs)
+		prs := []github.PullRequest{
+			{Number: 1, Title: "PR 1", User: github.User{Login: "u"}, Head: github.PullRequestBranch{SHA: "sha-1"}, UpdatedAt: updated},
+			{Number: 2, Title: "PR 2", User: github.User{Login: "u"}, Head: github.PullRequestBranch{SHA: "sha-2"}, UpdatedAt: updated},
+			{Number: 3, Title: "PR 3", User: github.User{Login: "u"}, Head: github.PullRequestBranch{SHA: "sha-3"}, UpdatedAt: updated},
+		}
+
+		summary, stuckPRs := classifyPRs(fc, "owner", "repo", lane, prs)
 
 		Expect(summary.Total).To(Equal(3))
 		Expect(summary.Success).To(Equal(1))
@@ -533,41 +449,18 @@ var _ = Describe("classifyPRs", func() {
 var _ = Describe("postComment", func() {
 
 	It("posts a comment on the given PR", func() {
-		var capturedBody string
-		var capturedPR int
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
-			Expect(r.Method).To(Equal("POST"))
-			var body github.IssueComment
-			Expect(json.NewDecoder(r.Body).Decode(&body)).To(Succeed())
-			capturedBody = body.GetBody()
-			capturedPR = 42
-			w.Header().Set("Content-Type", "application/json")
-			w.Write(mustJSON(github.IssueComment{
-				ID:      intPtr64(1),
-				Body:    body.Body,
-				HTMLURL: strPtr("https://github.com/owner/repo/pull/42#issuecomment-1"),
-			}))
-		})
-		client := newTestClient(mux)
-
-		err := postComment(context.Background(), client, "owner", "repo", 42, "/test my-lane")
+		fc := &fakeClient{}
+		err := postComment(fc, "owner", "repo", 42, "/test my-lane")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(capturedPR).To(Equal(42))
-		Expect(capturedBody).To(Equal("/test my-lane"))
+		Expect(fc.comments[42]).To(ConsistOf("/test my-lane"))
 	})
 
 	It("returns error on API failure", func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/repos/owner/repo/issues/99/comments", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusForbidden)
-		})
-		client := newTestClient(mux)
-
-		err := postComment(context.Background(), client, "owner", "repo", 99, "/test my-lane")
+		fc := &fakeClient{
+			commentErr: fmt.Errorf("forbidden"),
+		}
+		err := postComment(fc, "owner", "repo", 99, "/test my-lane")
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("commenting on PR #99"))
 	})
 })
-
-func intPtr64(i int64) *int64 { return &i }

--- a/robots/lane-doctor/cmd/prioritize.go
+++ b/robots/lane-doctor/cmd/prioritize.go
@@ -38,7 +38,15 @@ var (
 var prioritizeCmd = &cobra.Command{
 	Use:   "prioritize",
 	Short: "Group stuck PRs into priority tiers based on merge-readiness labels",
-	RunE:  runPrioritize,
+	Long: `Group stuck PRs from a scan report into priority tiers:
+
+  P1  lgtm + approved     — blocked from merging, highest priority
+  P2  lgtm or approved    — close to merging
+  P3  no merge labels     — under review
+  P4  do-not-merge/hold   — on hold
+
+Draft PRs and PRs labeled do-not-merge/work-in-progress are excluded.`,
+	RunE: runPrioritize,
 }
 
 func init() {

--- a/robots/lane-doctor/cmd/prioritize.go
+++ b/robots/lane-doctor/cmd/prioritize.go
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	prioritizeInput  string
+	prioritizeOutput string
+)
+
+var prioritizeCmd = &cobra.Command{
+	Use:   "prioritize",
+	Short: "Group stuck PRs into priority tiers based on merge-readiness labels",
+	RunE:  runPrioritize,
+}
+
+func init() {
+	prioritizeCmd.Flags().StringVarP(&prioritizeInput, "input", "i", "", "path to scan report YAML (required)")
+	prioritizeCmd.Flags().StringVarP(&prioritizeOutput, "output", "o", "", "output YAML file path (default: stdout)")
+	_ = prioritizeCmd.MarkFlagRequired("input")
+}
+
+func runPrioritize(_ *cobra.Command, _ []string) error {
+	data, err := os.ReadFile(prioritizeInput)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	var scan ScanReport
+	if err := yaml.Unmarshal(data, &scan); err != nil {
+		return fmt.Errorf("parsing scan report: %w", err)
+	}
+
+	groups := classify(scan.StuckPRs)
+
+	report := PriorityReport{
+		Lane:          scan.Lane,
+		Repo:          scan.Repo,
+		PrioritizedAt: time.Now().UTC().Format(time.RFC3339),
+		Groups:        groups,
+	}
+
+	out, err := yaml.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("marshaling priority report: %w", err)
+	}
+	return writeOutput(out, prioritizeOutput)
+}
+
+func classify(prs []StuckPR) []PriorityGroup {
+	var p1, p2, p3, p4 []int
+
+	for _, pr := range prs {
+		if pr.IsDraft || hasLabel(pr.Labels, "do-not-merge/work-in-progress") {
+			continue
+		}
+
+		hold := hasLabel(pr.Labels, "do-not-merge/hold")
+		lgtm := hasLabel(pr.Labels, "lgtm")
+		approved := hasAnyApprovedLabel(pr.Labels)
+
+		switch {
+		case hold:
+			p4 = append(p4, pr.Number)
+		case lgtm && approved:
+			p1 = append(p1, pr.Number)
+		case lgtm || approved:
+			p2 = append(p2, pr.Number)
+		default:
+			p3 = append(p3, pr.Number)
+		}
+	}
+
+	sort.Ints(p1)
+	sort.Ints(p2)
+	sort.Ints(p3)
+	sort.Ints(p4)
+
+	var groups []PriorityGroup
+	if len(p1) > 0 {
+		groups = append(groups, PriorityGroup{Name: "P1", Description: "lgtm + approved — blocked from merging", PRNumbers: p1})
+	}
+	if len(p2) > 0 {
+		groups = append(groups, PriorityGroup{Name: "P2", Description: "lgtm or approved — close to merging", PRNumbers: p2})
+	}
+	if len(p3) > 0 {
+		groups = append(groups, PriorityGroup{Name: "P3", Description: "under review", PRNumbers: p3})
+	}
+	if len(p4) > 0 {
+		groups = append(groups, PriorityGroup{Name: "P4", Description: "on hold", PRNumbers: p4})
+	}
+	return groups
+}
+
+func hasLabel(labels []string, target string) bool {
+	for _, l := range labels {
+		if l == target {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAnyApprovedLabel(labels []string) bool {
+	for _, l := range labels {
+		if l == "approved" || strings.HasPrefix(l, "approved-") {
+			return true
+		}
+	}
+	return false
+}

--- a/robots/lane-doctor/cmd/prioritize_test.go
+++ b/robots/lane-doctor/cmd/prioritize_test.go
@@ -1,0 +1,166 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("hasLabel", func() {
+
+	DescribeTable("matches labels",
+		func(labels []string, target string, expected bool) {
+			Expect(hasLabel(labels, target)).To(Equal(expected))
+		},
+		Entry("found", []string{"lgtm", "approved"}, "lgtm", true),
+		Entry("not found", []string{"lgtm", "approved"}, "hold", false),
+		Entry("empty labels", []string{}, "lgtm", false),
+		Entry("nil labels", nil, "lgtm", false),
+	)
+})
+
+var _ = Describe("hasAnyApprovedLabel", func() {
+
+	DescribeTable("matches approved variants",
+		func(labels []string, expected bool) {
+			Expect(hasAnyApprovedLabel(labels)).To(Equal(expected))
+		},
+		Entry("exact approved", []string{"approved"}, true),
+		Entry("approved with prefix", []string{"approved-for-merge"}, true),
+		Entry("no approved", []string{"lgtm", "hold"}, false),
+		Entry("empty labels", []string{}, false),
+		Entry("nil labels", nil, false),
+	)
+})
+
+var _ = Describe("classify", func() {
+
+	It("assigns P1 to PRs with lgtm + approved", func() {
+		prs := []StuckPR{
+			{Number: 1, Labels: []string{"lgtm", "approved"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].Name).To(Equal("P1"))
+		Expect(groups[0].PRNumbers).To(ConsistOf(1))
+	})
+
+	It("assigns P2 to PRs with lgtm only", func() {
+		prs := []StuckPR{
+			{Number: 2, Labels: []string{"lgtm"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].Name).To(Equal("P2"))
+		Expect(groups[0].PRNumbers).To(ConsistOf(2))
+	})
+
+	It("assigns P2 to PRs with approved only", func() {
+		prs := []StuckPR{
+			{Number: 3, Labels: []string{"approved"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].Name).To(Equal("P2"))
+		Expect(groups[0].PRNumbers).To(ConsistOf(3))
+	})
+
+	It("assigns P3 to PRs with no merge-readiness labels", func() {
+		prs := []StuckPR{
+			{Number: 4, Labels: []string{"size/M"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].Name).To(Equal("P3"))
+		Expect(groups[0].PRNumbers).To(ConsistOf(4))
+	})
+
+	It("assigns P4 to PRs on hold", func() {
+		prs := []StuckPR{
+			{Number: 5, Labels: []string{"lgtm", "approved", "do-not-merge/hold"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].Name).To(Equal("P4"))
+		Expect(groups[0].PRNumbers).To(ConsistOf(5))
+	})
+
+	It("skips draft PRs", func() {
+		prs := []StuckPR{
+			{Number: 6, Labels: []string{"lgtm", "approved"}, IsDraft: true},
+		}
+		groups := classify(prs)
+		Expect(groups).To(BeEmpty())
+	})
+
+	It("skips work-in-progress PRs", func() {
+		prs := []StuckPR{
+			{Number: 7, Labels: []string{"lgtm", "approved", "do-not-merge/work-in-progress"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(BeEmpty())
+	})
+
+	It("distributes mixed PRs across all priority groups", func() {
+		prs := []StuckPR{
+			{Number: 10, Labels: []string{"lgtm", "approved"}},
+			{Number: 20, Labels: []string{"lgtm"}},
+			{Number: 30, Labels: []string{"size/S"}},
+			{Number: 40, Labels: []string{"do-not-merge/hold"}},
+			{Number: 50, Labels: []string{"lgtm", "approved"}, IsDraft: true},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(4))
+		Expect(groups[0].Name).To(Equal("P1"))
+		Expect(groups[0].PRNumbers).To(ConsistOf(10))
+		Expect(groups[1].Name).To(Equal("P2"))
+		Expect(groups[1].PRNumbers).To(ConsistOf(20))
+		Expect(groups[2].Name).To(Equal("P3"))
+		Expect(groups[2].PRNumbers).To(ConsistOf(30))
+		Expect(groups[3].Name).To(Equal("P4"))
+		Expect(groups[3].PRNumbers).To(ConsistOf(40))
+	})
+
+	It("sorts PR numbers within each group", func() {
+		prs := []StuckPR{
+			{Number: 30, Labels: []string{"lgtm", "approved"}},
+			{Number: 10, Labels: []string{"lgtm", "approved"}},
+			{Number: 20, Labels: []string{"lgtm", "approved"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].PRNumbers).To(Equal([]int{10, 20, 30}))
+	})
+
+	It("returns empty groups for empty input", func() {
+		groups := classify(nil)
+		Expect(groups).To(BeEmpty())
+	})
+
+	It("recognizes approved- prefix variants for P1", func() {
+		prs := []StuckPR{
+			{Number: 8, Labels: []string{"lgtm", "approved-for-merge"}},
+		}
+		groups := classify(prs)
+		Expect(groups).To(HaveLen(1))
+		Expect(groups[0].Name).To(Equal("P1"))
+	})
+})

--- a/robots/lane-doctor/cmd/root.go
+++ b/robots/lane-doctor/cmd/root.go
@@ -20,21 +20,29 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v32/github"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	github "sigs.k8s.io/prow/pkg/github"
 )
+
+type ghClient interface {
+	GetBranchProtection(org, repo, branch string) (*github.BranchProtection, error)
+	GetPullRequests(org, repo string) ([]github.PullRequest, error)
+	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
+	ListStatuses(org, repo, ref string) ([]github.Status, error)
+	CreateComment(org, repo string, number int, comment string) error
+}
 
 var (
 	repo      string
 	tokenPath string
 	dryRun    bool
+	endpoint  string
 )
 
 var rootCmd = &cobra.Command{
@@ -46,12 +54,14 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&repo, "repo", "kubevirt/kubevirt", "GitHub repository in owner/repo format")
 	rootCmd.PersistentFlags().StringVar(&tokenPath, "token-path", "", "path to GitHub token file (falls back to GITHUB_TOKEN env var)")
 	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print actions without executing them")
+	rootCmd.PersistentFlags().StringVar(&endpoint, "endpoint", github.DefaultAPIEndpoint, "GitHub API endpoint")
 
 	rootCmd.AddCommand(scanCmd)
 	rootCmd.AddCommand(prioritizeCmd)
 	rootCmd.AddCommand(triggerCmd)
 }
 
+// Execute runs the root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -66,33 +76,47 @@ func parseRepo() (owner, repoName string, err error) {
 	return parts[0], parts[1], nil
 }
 
-func newGitHubClient(ctx context.Context) (*github.Client, error) {
-	token, err := resolveToken()
+func newGitHubClient() (ghClient, error) {
+	path, err := resolveTokenPath()
 	if err != nil {
 		return nil, err
 	}
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
+	if err := secret.Add(path); err != nil {
+		return nil, fmt.Errorf("starting secrets agent: %w", err)
+	}
+	if dryRun {
+		return github.NewDryRunClient(secret.GetTokenGenerator(path), secret.Censor, "", endpoint)
+	}
+	return github.NewClient(secret.GetTokenGenerator(path), secret.Censor, "", endpoint)
 }
 
-func resolveToken() (string, error) {
+func resolveTokenPath() (string, error) {
 	if tokenPath != "" {
-		data, err := os.ReadFile(tokenPath)
-		if err != nil {
-			return "", fmt.Errorf("reading token file: %w", err)
-		}
-		return strings.TrimSpace(string(data)), nil
+		return tokenPath, nil
 	}
 	if t := os.Getenv("GITHUB_TOKEN"); t != "" {
-		return t, nil
+		f, err := os.CreateTemp("", "lane-doctor-token-*")
+		if err != nil {
+			return "", fmt.Errorf("creating temp token file: %w", err)
+		}
+		if _, err := f.WriteString(t); err != nil {
+			f.Close()
+			return "", fmt.Errorf("writing temp token file: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return "", fmt.Errorf("closing temp token file: %w", err)
+		}
+		return f.Name(), nil
 	}
 	return "", fmt.Errorf("no GitHub token: set --token-path or GITHUB_TOKEN env var")
 }
 
 func writeOutput(data []byte, outputPath string) error {
 	if outputPath == "" {
-		_, err := os.Stdout.Write(data)
-		return err
+		if _, err := os.Stdout.Write(data); err != nil {
+			return fmt.Errorf("writing to stdout: %w", err)
+		}
+		return nil
 	}
 	if err := os.WriteFile(outputPath, data, 0644); err != nil {
 		return fmt.Errorf("writing output file: %w", err)

--- a/robots/lane-doctor/cmd/root.go
+++ b/robots/lane-doctor/cmd/root.go
@@ -1,0 +1,102 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+)
+
+var (
+	repo      string
+	tokenPath string
+	dryRun    bool
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "lane-doctor",
+	Short: "Diagnose and remediate stuck Prow lane statuses on open PRs",
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&repo, "repo", "kubevirt/kubevirt", "GitHub repository in owner/repo format")
+	rootCmd.PersistentFlags().StringVar(&tokenPath, "token-path", "", "path to GitHub token file (falls back to GITHUB_TOKEN env var)")
+	rootCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "print actions without executing them")
+
+	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(prioritizeCmd)
+	rootCmd.AddCommand(triggerCmd)
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func parseRepo() (owner, repoName string, err error) {
+	parts := strings.SplitN(repo, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid repo format %q, expected owner/repo", repo)
+	}
+	return parts[0], parts[1], nil
+}
+
+func newGitHubClient(ctx context.Context) (*github.Client, error) {
+	token, err := resolveToken()
+	if err != nil {
+		return nil, err
+	}
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	return github.NewClient(oauth2.NewClient(ctx, ts)), nil
+}
+
+func resolveToken() (string, error) {
+	if tokenPath != "" {
+		data, err := os.ReadFile(tokenPath)
+		if err != nil {
+			return "", fmt.Errorf("reading token file: %w", err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+	if t := os.Getenv("GITHUB_TOKEN"); t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("no GitHub token: set --token-path or GITHUB_TOKEN env var")
+}
+
+func writeOutput(data []byte, outputPath string) error {
+	if outputPath == "" {
+		_, err := os.Stdout.Write(data)
+		return err
+	}
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		return fmt.Errorf("writing output file: %w", err)
+	}
+	logrus.WithField("path", outputPath).Info("wrote output file")
+	return nil
+}

--- a/robots/lane-doctor/cmd/root_test.go
+++ b/robots/lane-doctor/cmd/root_test.go
@@ -65,47 +65,53 @@ var _ = Describe("writeOutput", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(data)).To(Equal("test-data"))
 	})
+
+	It("writes to stdout when no path is given", func() {
+		err := writeOutput([]byte("stdout-data"), "")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns wrapped error for invalid file path", func() {
+		err := writeOutput([]byte("data"), "/nonexistent-dir/foo/bar.yaml")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("writing output file"))
+	})
 })
 
-var _ = Describe("resolveToken", func() {
+var _ = Describe("resolveTokenPath", func() {
 
-	It("reads token from file", func() {
+	It("returns the token path directly when set", func() {
 		dir := GinkgoT().TempDir()
 		path := filepath.Join(dir, "token")
-		Expect(os.WriteFile(path, []byte("  my-token \n"), 0644)).To(Succeed())
+		Expect(os.WriteFile(path, []byte("my-token"), 0644)).To(Succeed())
 
 		tokenPath = path
 		defer func() { tokenPath = "" }()
 
-		token, err := resolveToken()
+		resolved, err := resolveTokenPath()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(token).To(Equal("my-token"))
+		Expect(resolved).To(Equal(path))
 	})
 
-	It("falls back to GITHUB_TOKEN env var", func() {
+	It("creates a temp file from GITHUB_TOKEN env var", func() {
 		tokenPath = ""
 		GinkgoT().Setenv("GITHUB_TOKEN", "env-token")
 
-		token, err := resolveToken()
+		resolved, err := resolveTokenPath()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(token).To(Equal("env-token"))
+		Expect(resolved).NotTo(BeEmpty())
+
+		data, err := os.ReadFile(resolved)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("env-token"))
 	})
 
 	It("returns error when no token source is available", func() {
 		tokenPath = ""
 		GinkgoT().Setenv("GITHUB_TOKEN", "")
 
-		_, err := resolveToken()
+		_, err := resolveTokenPath()
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("no GitHub token"))
-	})
-
-	It("returns error for nonexistent token file", func() {
-		tokenPath = "/nonexistent/path/token"
-		defer func() { tokenPath = "" }()
-
-		_, err := resolveToken()
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("reading token file"))
 	})
 })

--- a/robots/lane-doctor/cmd/root_test.go
+++ b/robots/lane-doctor/cmd/root_test.go
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseRepo", func() {
+
+	DescribeTable("parses owner/repo format",
+		func(input string, expectedOwner, expectedRepo string, expectErr bool) {
+			repo = input
+			owner, repoName, err := parseRepo()
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(owner).To(Equal(expectedOwner))
+				Expect(repoName).To(Equal(expectedRepo))
+			}
+		},
+		Entry("valid repo", "kubevirt/kubevirt", "kubevirt", "kubevirt", false),
+		Entry("valid repo with different owner", "openshift/origin", "openshift", "origin", false),
+		Entry("missing repo name", "kubevirt/", "", "", true),
+		Entry("missing owner", "/kubevirt", "", "", true),
+		Entry("no slash", "kubevirt", "", "", true),
+		Entry("empty string", "", "", "", true),
+		Entry("only slash", "/", "", "", true),
+		Entry("extra slashes preserved in repo name", "owner/repo/extra", "owner", "repo/extra", false),
+	)
+})
+
+var _ = Describe("writeOutput", func() {
+
+	It("writes to a file when path is given", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "out.yaml")
+
+		err := writeOutput([]byte("test-data"), path)
+		Expect(err).NotTo(HaveOccurred())
+
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("test-data"))
+	})
+})
+
+var _ = Describe("resolveToken", func() {
+
+	It("reads token from file", func() {
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "token")
+		Expect(os.WriteFile(path, []byte("  my-token \n"), 0644)).To(Succeed())
+
+		tokenPath = path
+		defer func() { tokenPath = "" }()
+
+		token, err := resolveToken()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(token).To(Equal("my-token"))
+	})
+
+	It("falls back to GITHUB_TOKEN env var", func() {
+		tokenPath = ""
+		GinkgoT().Setenv("GITHUB_TOKEN", "env-token")
+
+		token, err := resolveToken()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(token).To(Equal("env-token"))
+	})
+
+	It("returns error when no token source is available", func() {
+		tokenPath = ""
+		GinkgoT().Setenv("GITHUB_TOKEN", "")
+
+		_, err := resolveToken()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no GitHub token"))
+	})
+
+	It("returns error for nonexistent token file", func() {
+		tokenPath = "/nonexistent/path/token"
+		defer func() { tokenPath = "" }()
+
+		_, err := resolveToken()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("reading token file"))
+	})
+})

--- a/robots/lane-doctor/cmd/scan.go
+++ b/robots/lane-doctor/cmd/scan.go
@@ -20,16 +20,15 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/google/go-github/v32/github"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	github "sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/yaml"
 )
 
@@ -45,37 +44,36 @@ var scanCmd = &cobra.Command{
 }
 
 func init() {
-	scanCmd.Flags().StringVar(&scanLane, "lane", "", "required status check context name (required)")
+	scanCmd.Flags().StringVar(&scanLane, "lane", "", "Prow job name or GitHub status context (they are usually identical)")
 	scanCmd.Flags().StringVarP(&scanOutput, "output", "o", "", "output YAML file path (default: stdout)")
 	_ = scanCmd.MarkFlagRequired("lane")
 }
 
 func runScan(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
 	owner, repoName, err := parseRepo()
 	if err != nil {
 		return err
 	}
 
-	client, err := newGitHubClient(ctx)
+	client, err := newGitHubClient()
 	if err != nil {
 		return err
 	}
 
 	log := logrus.WithFields(logrus.Fields{"lane": scanLane, "repo": repo})
 
-	if err := verifyRequiredCheck(ctx, client, owner, repoName, scanLane); err != nil {
+	if err := verifyRequiredCheck(client, owner, repoName, scanLane); err != nil {
 		return err
 	}
 	log.Info("confirmed lane is a required status check")
 
-	prs, err := listOpenPRs(ctx, client, owner, repoName)
+	prs, err := listOpenPRs(client, owner, repoName)
 	if err != nil {
 		return err
 	}
 	log.WithField("count", len(prs)).Info("fetched open PRs")
 
-	summary, stuckPRs := classifyPRs(ctx, client, owner, repoName, scanLane, prs)
+	summary, stuckPRs := classifyPRs(client, owner, repoName, scanLane, prs)
 
 	sort.Slice(stuckPRs, func(i, j int) bool {
 		return stuckPRs[i].Number < stuckPRs[j].Number
@@ -96,12 +94,12 @@ func runScan(cmd *cobra.Command, _ []string) error {
 	return writeOutput(data, scanOutput)
 }
 
-func verifyRequiredCheck(ctx context.Context, client *github.Client, owner, repoName, lane string) error {
-	protection, _, err := client.Repositories.GetBranchProtection(ctx, owner, repoName, "main")
+func verifyRequiredCheck(client ghClient, owner, repoName, lane string) error {
+	protection, err := client.GetBranchProtection(owner, repoName, "main")
 	if err != nil {
 		return fmt.Errorf("fetching branch protection: %w", err)
 	}
-	if protection.RequiredStatusChecks == nil {
+	if protection == nil || protection.RequiredStatusChecks == nil {
 		return fmt.Errorf("no required status checks configured on main")
 	}
 	for _, check := range protection.RequiredStatusChecks.Contexts {
@@ -112,25 +110,12 @@ func verifyRequiredCheck(ctx context.Context, client *github.Client, owner, repo
 	return fmt.Errorf("lane %q is not a required status check on main", lane)
 }
 
-func listOpenPRs(ctx context.Context, client *github.Client, owner, repoName string) ([]*github.PullRequest, error) {
-	var allPRs []*github.PullRequest
-	opts := &github.PullRequestListOptions{
-		State:       "open",
-		Base:        "main",
-		ListOptions: github.ListOptions{PerPage: 100},
+func listOpenPRs(client ghClient, owner, repoName string) ([]github.PullRequest, error) {
+	prs, err := client.GetPullRequests(owner, repoName)
+	if err != nil {
+		return nil, fmt.Errorf("listing PRs: %w", err)
 	}
-	for {
-		prs, resp, err := client.PullRequests.List(ctx, owner, repoName, opts)
-		if err != nil {
-			return nil, fmt.Errorf("listing PRs: %w", err)
-		}
-		allPRs = append(allPRs, prs...)
-		if resp.NextPage == 0 {
-			break
-		}
-		opts.Page = resp.NextPage
-	}
-	return allPRs, nil
+	return prs, nil
 }
 
 type prResult struct {
@@ -138,20 +123,20 @@ type prResult struct {
 	pr       *StuckPR
 }
 
-func classifyPRs(ctx context.Context, client *github.Client, owner, repoName, lane string, prs []*github.PullRequest) (ScanSummary, []StuckPR) {
+func classifyPRs(client ghClient, owner, repoName, lane string, prs []github.PullRequest) (ScanSummary, []StuckPR) {
 	const workers = 10
 	sem := make(chan struct{}, workers)
 	results := make([]prResult, len(prs))
 	var wg sync.WaitGroup
 
-	for i, pr := range prs {
+	for i := range prs {
 		wg.Add(1)
-		go func(idx int, pr *github.PullRequest) {
+		go func(idx int) {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			results[idx] = classifyPR(ctx, client, owner, repoName, lane, pr)
-		}(i, pr)
+			results[idx] = classifyPR(client, owner, repoName, lane, &prs[idx])
+		}(i)
 	}
 	wg.Wait()
 
@@ -179,30 +164,30 @@ func classifyPRs(ctx context.Context, client *github.Client, owner, repoName, la
 	return summary, stuckPRs
 }
 
-func classifyPR(ctx context.Context, client *github.Client, owner, repoName, lane string, pr *github.PullRequest) prResult {
-	log := logrus.WithField("pr", pr.GetNumber())
-	sha := pr.GetHead().GetSHA()
+func classifyPR(client ghClient, owner, repoName, lane string, pr *github.PullRequest) prResult {
+	log := logrus.WithField("pr", pr.Number)
+	sha := pr.Head.SHA
 
-	combinedStatus, hasE2E, err := getCombinedStatusInfo(ctx, client, owner, repoName, sha, lane)
+	laneStatus, hasE2E, err := getLaneStatus(client, owner, repoName, sha, lane)
 	if err != nil {
 		log.WithError(err).Warn("failed to get combined status")
 		return prResult{category: "failed"}
 	}
 
-	if combinedStatus == nil {
+	if laneStatus == nil {
 		if !hasE2E {
 			return prResult{category: "success"}
 		}
 		return prResult{category: "missing", pr: buildStuckPR(pr, "missing", "", false)}
 	}
 
-	switch combinedStatus.GetState() {
+	switch laneStatus.State {
 	case "success":
 		return prResult{category: "success"}
 	case "failure", "error":
 		return prResult{category: "failed"}
 	case "pending":
-		hasURL, statusUpdatedAt := checkRawStatuses(ctx, client, owner, repoName, sha, lane)
+		hasURL, statusUpdatedAt := checkRawStatuses(client, owner, repoName, sha, lane)
 		if hasURL {
 			return prResult{category: "running"}
 		}
@@ -212,70 +197,52 @@ func classifyPR(ctx context.Context, client *github.Client, owner, repoName, lan
 	}
 }
 
-func getCombinedStatusInfo(ctx context.Context, client *github.Client, owner, repoName, sha, lane string) (laneStatus *github.RepoStatus, hasE2E bool, err error) {
-	opts := &github.ListOptions{PerPage: 100}
-	for {
-		combined, resp, err := client.Repositories.GetCombinedStatus(ctx, owner, repoName, sha, opts)
-		if err != nil {
-			return nil, false, err
+func getLaneStatus(client ghClient, owner, repoName, sha, lane string) (laneStatus *github.Status, hasE2E bool, err error) {
+	combined, err := client.GetCombinedStatus(owner, repoName, sha)
+	if err != nil {
+		return nil, false, err
+	}
+	for i, s := range combined.Statuses {
+		if s.Context == lane {
+			laneStatus = &combined.Statuses[i]
 		}
-		for _, s := range combined.Statuses {
-			if s.GetContext() == lane {
-				laneStatus = s
-			}
-			if strings.HasPrefix(s.GetContext(), "pull-kubevirt-e2e") {
-				hasE2E = true
-			}
+		if strings.HasPrefix(s.Context, "pull-kubevirt-e2e") {
+			hasE2E = true
 		}
-		if resp.NextPage == 0 {
-			break
-		}
-		opts.Page = resp.NextPage
 	}
 	return laneStatus, hasE2E, nil
 }
 
-func checkRawStatuses(ctx context.Context, client *github.Client, owner, repoName, sha, lane string) (hasURL bool, updatedAt string) {
-	opts := &github.ListOptions{PerPage: 100}
-	var latest *github.RepoStatus
-	for {
-		statuses, resp, err := client.Repositories.ListStatuses(ctx, owner, repoName, sha, opts)
-		if err != nil {
-			logrus.WithError(err).Warn("failed to list raw statuses")
-			return false, ""
-		}
-		for i := range statuses {
-			if statuses[i].GetContext() != lane {
-				continue
-			}
-			if latest == nil || statuses[i].GetUpdatedAt().After(latest.GetUpdatedAt()) {
-				latest = statuses[i]
-			}
-		}
-		if resp.NextPage == 0 {
-			break
-		}
-		opts.Page = resp.NextPage
-	}
-	if latest == nil {
+func checkRawStatuses(client ghClient, owner, repoName, sha, lane string) (hasURL bool, updatedAt string) {
+	statuses, err := client.ListStatuses(owner, repoName, sha)
+	if err != nil {
+		logrus.WithError(err).Warn("failed to list raw statuses")
 		return false, ""
 	}
-	return latest.GetTargetURL() != "", latest.GetUpdatedAt().Format(time.RFC3339)
+	for _, s := range statuses {
+		if s.Context != lane {
+			continue
+		}
+		// ListStatuses returns statuses in reverse-chronological order;
+		// the first match for our lane is the latest.
+		return s.TargetURL != "", ""
+	}
+	return false, ""
 }
 
 func buildStuckPR(pr *github.PullRequest, statusState, statusUpdatedAt string, hasURL bool) *StuckPR {
 	var labels []string
 	for _, l := range pr.Labels {
-		labels = append(labels, l.GetName())
+		labels = append(labels, l.Name)
 	}
 	return &StuckPR{
-		Number:          pr.GetNumber(),
-		Title:           pr.GetTitle(),
-		Author:          pr.GetUser().GetLogin(),
-		HeadSHA:         pr.GetHead().GetSHA(),
-		UpdatedAt:       pr.GetUpdatedAt().Format(time.RFC3339),
+		Number:          pr.Number,
+		Title:           pr.Title,
+		Author:          pr.User.Login,
+		HeadSHA:         pr.Head.SHA,
+		UpdatedAt:       pr.UpdatedAt.Format(time.RFC3339),
 		Labels:          labels,
-		IsDraft:         pr.GetDraft(),
+		IsDraft:         pr.Draft,
 		StatusState:     statusState,
 		StatusUpdatedAt: statusUpdatedAt,
 		HasTargetURL:    hasURL,

--- a/robots/lane-doctor/cmd/scan.go
+++ b/robots/lane-doctor/cmd/scan.go
@@ -1,0 +1,283 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	scanLane   string
+	scanOutput string
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan open PRs for stuck or missing lane statuses",
+	RunE:  runScan,
+}
+
+func init() {
+	scanCmd.Flags().StringVar(&scanLane, "lane", "", "required status check context name (required)")
+	scanCmd.Flags().StringVarP(&scanOutput, "output", "o", "", "output YAML file path (default: stdout)")
+	_ = scanCmd.MarkFlagRequired("lane")
+}
+
+func runScan(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	owner, repoName, err := parseRepo()
+	if err != nil {
+		return err
+	}
+
+	client, err := newGitHubClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	log := logrus.WithFields(logrus.Fields{"lane": scanLane, "repo": repo})
+
+	if err := verifyRequiredCheck(ctx, client, owner, repoName, scanLane); err != nil {
+		return err
+	}
+	log.Info("confirmed lane is a required status check")
+
+	prs, err := listOpenPRs(ctx, client, owner, repoName)
+	if err != nil {
+		return err
+	}
+	log.WithField("count", len(prs)).Info("fetched open PRs")
+
+	summary, stuckPRs := classifyPRs(ctx, client, owner, repoName, scanLane, prs)
+
+	sort.Slice(stuckPRs, func(i, j int) bool {
+		return stuckPRs[i].Number < stuckPRs[j].Number
+	})
+
+	report := ScanReport{
+		Lane:      scanLane,
+		Repo:      repo,
+		ScannedAt: time.Now().UTC().Format(time.RFC3339),
+		Summary:   summary,
+		StuckPRs:  stuckPRs,
+	}
+
+	data, err := yaml.Marshal(report)
+	if err != nil {
+		return fmt.Errorf("marshaling report: %w", err)
+	}
+	return writeOutput(data, scanOutput)
+}
+
+func verifyRequiredCheck(ctx context.Context, client *github.Client, owner, repoName, lane string) error {
+	protection, _, err := client.Repositories.GetBranchProtection(ctx, owner, repoName, "main")
+	if err != nil {
+		return fmt.Errorf("fetching branch protection: %w", err)
+	}
+	if protection.RequiredStatusChecks == nil {
+		return fmt.Errorf("no required status checks configured on main")
+	}
+	for _, check := range protection.RequiredStatusChecks.Contexts {
+		if check == lane {
+			return nil
+		}
+	}
+	return fmt.Errorf("lane %q is not a required status check on main", lane)
+}
+
+func listOpenPRs(ctx context.Context, client *github.Client, owner, repoName string) ([]*github.PullRequest, error) {
+	var allPRs []*github.PullRequest
+	opts := &github.PullRequestListOptions{
+		State:       "open",
+		Base:        "main",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	for {
+		prs, resp, err := client.PullRequests.List(ctx, owner, repoName, opts)
+		if err != nil {
+			return nil, fmt.Errorf("listing PRs: %w", err)
+		}
+		allPRs = append(allPRs, prs...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return allPRs, nil
+}
+
+type prResult struct {
+	category string // "stuck", "missing", "running", "success", "failed"
+	pr       *StuckPR
+}
+
+func classifyPRs(ctx context.Context, client *github.Client, owner, repoName, lane string, prs []*github.PullRequest) (ScanSummary, []StuckPR) {
+	const workers = 10
+	sem := make(chan struct{}, workers)
+	results := make([]prResult, len(prs))
+	var wg sync.WaitGroup
+
+	for i, pr := range prs {
+		wg.Add(1)
+		go func(idx int, pr *github.PullRequest) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[idx] = classifyPR(ctx, client, owner, repoName, lane, pr)
+		}(i, pr)
+	}
+	wg.Wait()
+
+	var summary ScanSummary
+	var stuckPRs []StuckPR
+	summary.Total = len(prs)
+
+	for _, r := range results {
+		switch r.category {
+		case "stuck":
+			summary.Stuck++
+		case "missing":
+			summary.Missing++
+		case "running":
+			summary.Running++
+		case "success":
+			summary.Success++
+		case "failed":
+			summary.Failed++
+		}
+		if r.pr != nil {
+			stuckPRs = append(stuckPRs, *r.pr)
+		}
+	}
+	return summary, stuckPRs
+}
+
+func classifyPR(ctx context.Context, client *github.Client, owner, repoName, lane string, pr *github.PullRequest) prResult {
+	log := logrus.WithField("pr", pr.GetNumber())
+	sha := pr.GetHead().GetSHA()
+
+	combinedStatus, hasE2E, err := getCombinedStatusInfo(ctx, client, owner, repoName, sha, lane)
+	if err != nil {
+		log.WithError(err).Warn("failed to get combined status")
+		return prResult{category: "failed"}
+	}
+
+	if combinedStatus == nil {
+		if !hasE2E {
+			return prResult{category: "success"}
+		}
+		return prResult{category: "missing", pr: buildStuckPR(pr, "missing", "", false)}
+	}
+
+	switch combinedStatus.GetState() {
+	case "success":
+		return prResult{category: "success"}
+	case "failure", "error":
+		return prResult{category: "failed"}
+	case "pending":
+		hasURL, statusUpdatedAt := checkRawStatuses(ctx, client, owner, repoName, sha, lane)
+		if hasURL {
+			return prResult{category: "running"}
+		}
+		return prResult{category: "stuck", pr: buildStuckPR(pr, "pending", statusUpdatedAt, false)}
+	default:
+		return prResult{category: "failed"}
+	}
+}
+
+func getCombinedStatusInfo(ctx context.Context, client *github.Client, owner, repoName, sha, lane string) (laneStatus *github.RepoStatus, hasE2E bool, err error) {
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		combined, resp, err := client.Repositories.GetCombinedStatus(ctx, owner, repoName, sha, opts)
+		if err != nil {
+			return nil, false, err
+		}
+		for _, s := range combined.Statuses {
+			if s.GetContext() == lane {
+				laneStatus = s
+			}
+			if strings.HasPrefix(s.GetContext(), "pull-kubevirt-e2e") {
+				hasE2E = true
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	return laneStatus, hasE2E, nil
+}
+
+func checkRawStatuses(ctx context.Context, client *github.Client, owner, repoName, sha, lane string) (hasURL bool, updatedAt string) {
+	opts := &github.ListOptions{PerPage: 100}
+	var latest *github.RepoStatus
+	for {
+		statuses, resp, err := client.Repositories.ListStatuses(ctx, owner, repoName, sha, opts)
+		if err != nil {
+			logrus.WithError(err).Warn("failed to list raw statuses")
+			return false, ""
+		}
+		for i := range statuses {
+			if statuses[i].GetContext() != lane {
+				continue
+			}
+			if latest == nil || statuses[i].GetUpdatedAt().After(latest.GetUpdatedAt()) {
+				latest = statuses[i]
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+	if latest == nil {
+		return false, ""
+	}
+	return latest.GetTargetURL() != "", latest.GetUpdatedAt().Format(time.RFC3339)
+}
+
+func buildStuckPR(pr *github.PullRequest, statusState, statusUpdatedAt string, hasURL bool) *StuckPR {
+	var labels []string
+	for _, l := range pr.Labels {
+		labels = append(labels, l.GetName())
+	}
+	return &StuckPR{
+		Number:          pr.GetNumber(),
+		Title:           pr.GetTitle(),
+		Author:          pr.GetUser().GetLogin(),
+		HeadSHA:         pr.GetHead().GetSHA(),
+		UpdatedAt:       pr.GetUpdatedAt().Format(time.RFC3339),
+		Labels:          labels,
+		IsDraft:         pr.GetDraft(),
+		StatusState:     statusState,
+		StatusUpdatedAt: statusUpdatedAt,
+		HasTargetURL:    hasURL,
+	}
+}

--- a/robots/lane-doctor/cmd/scan_test.go
+++ b/robots/lane-doctor/cmd/scan_test.go
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"time"
+
+	"github.com/google/go-github/v32/github"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func strPtr(s string) *string   { return &s }
+func intPtr(i int) *int         { return &i }
+func boolPtr(b bool) *bool      { return &b }
+
+var _ = Describe("buildStuckPR", func() {
+
+	It("extracts fields from a GitHub PullRequest", func() {
+		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		pr := &github.PullRequest{
+			Number: intPtr(42),
+			Title:  strPtr("Fix flaky test"),
+			User:   &github.User{Login: strPtr("dhiller")},
+			Head:   &github.PullRequestBranch{SHA: strPtr("abc123")},
+			Labels: []*github.Label{
+				{Name: strPtr("lgtm")},
+				{Name: strPtr("approved")},
+			},
+			Draft:     boolPtr(false),
+			UpdatedAt: &updated,
+		}
+
+		result := buildStuckPR(pr, "pending", "2026-06-10T11:00:00Z", false)
+
+		Expect(result.Number).To(Equal(42))
+		Expect(result.Title).To(Equal("Fix flaky test"))
+		Expect(result.Author).To(Equal("dhiller"))
+		Expect(result.HeadSHA).To(Equal("abc123"))
+		Expect(result.Labels).To(ConsistOf("lgtm", "approved"))
+		Expect(result.IsDraft).To(BeFalse())
+		Expect(result.StatusState).To(Equal("pending"))
+		Expect(result.StatusUpdatedAt).To(Equal("2026-06-10T11:00:00Z"))
+		Expect(result.HasTargetURL).To(BeFalse())
+	})
+
+	It("handles a draft PR with no labels", func() {
+		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+		pr := &github.PullRequest{
+			Number:    intPtr(99),
+			Title:     strPtr("WIP: something"),
+			User:      &github.User{Login: strPtr("user")},
+			Head:      &github.PullRequestBranch{SHA: strPtr("def456")},
+			Labels:    nil,
+			Draft:     boolPtr(true),
+			UpdatedAt: &updated,
+		}
+
+		result := buildStuckPR(pr, "missing", "", true)
+
+		Expect(result.Number).To(Equal(99))
+		Expect(result.IsDraft).To(BeTrue())
+		Expect(result.Labels).To(BeNil())
+		Expect(result.StatusState).To(Equal("missing"))
+		Expect(result.StatusUpdatedAt).To(BeEmpty())
+		Expect(result.HasTargetURL).To(BeTrue())
+	})
+})

--- a/robots/lane-doctor/cmd/scan_test.go
+++ b/robots/lane-doctor/cmd/scan_test.go
@@ -22,30 +22,26 @@ package cmd
 import (
 	"time"
 
-	"github.com/google/go-github/v32/github"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	github "sigs.k8s.io/prow/pkg/github"
 )
-
-func strPtr(s string) *string   { return &s }
-func intPtr(i int) *int         { return &i }
-func boolPtr(b bool) *bool      { return &b }
 
 var _ = Describe("buildStuckPR", func() {
 
 	It("extracts fields from a GitHub PullRequest", func() {
 		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 		pr := &github.PullRequest{
-			Number: intPtr(42),
-			Title:  strPtr("Fix flaky test"),
-			User:   &github.User{Login: strPtr("dhiller")},
-			Head:   &github.PullRequestBranch{SHA: strPtr("abc123")},
-			Labels: []*github.Label{
-				{Name: strPtr("lgtm")},
-				{Name: strPtr("approved")},
+			Number: 42,
+			Title:  "Fix flaky test",
+			User:   github.User{Login: "dhiller"},
+			Head:   github.PullRequestBranch{SHA: "abc123"},
+			Labels: []github.Label{
+				{Name: "lgtm"},
+				{Name: "approved"},
 			},
-			Draft:     boolPtr(false),
-			UpdatedAt: &updated,
+			Draft:     false,
+			UpdatedAt: updated,
 		}
 
 		result := buildStuckPR(pr, "pending", "2026-06-10T11:00:00Z", false)
@@ -64,13 +60,12 @@ var _ = Describe("buildStuckPR", func() {
 	It("handles a draft PR with no labels", func() {
 		updated := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 		pr := &github.PullRequest{
-			Number:    intPtr(99),
-			Title:     strPtr("WIP: something"),
-			User:      &github.User{Login: strPtr("user")},
-			Head:      &github.PullRequestBranch{SHA: strPtr("def456")},
-			Labels:    nil,
-			Draft:     boolPtr(true),
-			UpdatedAt: &updated,
+			Number:    99,
+			Title:     "WIP: something",
+			User:      github.User{Login: "user"},
+			Head:      github.PullRequestBranch{SHA: "def456"},
+			Draft:     true,
+			UpdatedAt: updated,
 		}
 
 		result := buildStuckPR(pr, "missing", "", true)

--- a/robots/lane-doctor/cmd/trigger.go
+++ b/robots/lane-doctor/cmd/trigger.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v32/github"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
@@ -38,7 +37,7 @@ var (
 	triggerBatchSize int
 	triggerGroup     string
 	triggerBatchWait time.Duration
-	triggerYes bool
+	triggerYes       bool
 )
 
 var triggerCmd = &cobra.Command{
@@ -48,6 +47,12 @@ var triggerCmd = &cobra.Command{
 	PreRunE: func(cmd *cobra.Command, _ []string) error {
 		if triggerYes && !cmd.Flags().Changed("batch-wait") {
 			return fmt.Errorf("--yes requires --batch-wait to be explicitly set")
+		}
+		if triggerBatchSize < 1 {
+			return fmt.Errorf("--batch-size must be a positive integer, got %d", triggerBatchSize)
+		}
+		if triggerBatchWait < 0 {
+			return fmt.Errorf("--batch-wait cannot be negative")
 		}
 		return nil
 	},
@@ -87,14 +92,14 @@ func runTrigger(cmd *cobra.Command, _ []string) error {
 
 	batches := splitBatches(prNumbers, triggerBatchSize)
 	logrus.WithFields(logrus.Fields{
-		"total_prs": len(prNumbers),
-		"batches":   len(batches),
+		"total_prs":  len(prNumbers),
+		"batches":    len(batches),
 		"batch_size": triggerBatchSize,
 	}).Info("triggering lane")
 
-	var client *github.Client
+	var client ghClient
 	if !dryRun {
-		client, err = newGitHubClient(ctx)
+		client, err = newGitHubClient()
 		if err != nil {
 			return err
 		}
@@ -114,14 +119,14 @@ func runTrigger(cmd *cobra.Command, _ []string) error {
 				fmt.Printf("[dry-run] would comment on PR #%d: %s\n", prNum, comment)
 				continue
 			}
-			if err := postComment(ctx, client, owner, repoName, prNum, comment); err != nil {
+			if err := postComment(client, owner, repoName, prNum, comment); err != nil {
 				logrus.WithError(err).WithField("pr", prNum).Error("failed to post comment")
 				continue
 			}
 		}
 
 		if i < len(batches)-1 {
-			if err := waitBetweenBatches(i+1, len(batches)); err != nil {
+			if err := waitBetweenBatches(ctx, i+1, len(batches)); err != nil {
 				return err
 			}
 		}
@@ -154,20 +159,15 @@ func splitBatches(items []int, size int) [][]int {
 	return batches
 }
 
-func postComment(ctx context.Context, client *github.Client, owner, repoName string, prNumber int, body string) error {
-	comment := &github.IssueComment{Body: &body}
-	created, _, err := client.Issues.CreateComment(ctx, owner, repoName, prNumber, comment)
-	if err != nil {
+func postComment(client ghClient, owner, repoName string, prNumber int, body string) error {
+	if err := client.CreateComment(owner, repoName, prNumber, body); err != nil {
 		return fmt.Errorf("commenting on PR #%d: %w", prNumber, err)
 	}
-	logrus.WithFields(logrus.Fields{
-		"pr":  prNumber,
-		"url": created.GetHTMLURL(),
-	}).Info("triggered lane")
+	logrus.WithField("pr", prNumber).Info("triggered lane")
 	return nil
 }
 
-func waitBetweenBatches(completedBatch, totalBatches int) error {
+func waitBetweenBatches(ctx context.Context, completedBatch, totalBatches int) error {
 	if dryRun {
 		fmt.Printf("[dry-run] would wait %s before batch %d/%d\n", triggerBatchWait, completedBatch+1, totalBatches)
 		return nil
@@ -180,18 +180,19 @@ func waitBetweenBatches(completedBatch, totalBatches int) error {
 		}).Info("waiting before next batch")
 
 		deadline := time.Now().Add(triggerBatchWait)
+		timer := time.NewTimer(time.Until(deadline))
+		defer timer.Stop()
 		ticker := time.NewTicker(5 * time.Minute)
 		defer ticker.Stop()
 		for {
 			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-timer.C:
+				return nil
 			case <-ticker.C:
 				remaining := time.Until(deadline).Truncate(time.Second)
-				if remaining <= 0 {
-					return nil
-				}
 				logrus.WithField("remaining", remaining).Info("waiting for next batch")
-			case <-time.After(time.Until(deadline)):
-				return nil
 			}
 		}
 	}

--- a/robots/lane-doctor/cmd/trigger.go
+++ b/robots/lane-doctor/cmd/trigger.go
@@ -1,0 +1,207 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v32/github"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	triggerInput     string
+	triggerBatchSize int
+	triggerGroup     string
+	triggerBatchWait time.Duration
+	triggerYes bool
+)
+
+var triggerCmd = &cobra.Command{
+	Use:   "trigger",
+	Short: "Trigger the stuck lane on PRs in batches",
+	RunE:  runTrigger,
+	PreRunE: func(cmd *cobra.Command, _ []string) error {
+		if triggerYes && !cmd.Flags().Changed("batch-wait") {
+			return fmt.Errorf("--yes requires --batch-wait to be explicitly set")
+		}
+		return nil
+	},
+}
+
+func init() {
+	triggerCmd.Flags().StringVarP(&triggerInput, "input", "i", "", "path to priority report YAML (required)")
+	triggerCmd.Flags().IntVarP(&triggerBatchSize, "batch-size", "b", 10, "number of PRs to trigger per batch")
+	triggerCmd.Flags().StringVarP(&triggerGroup, "group", "g", "", "trigger only a specific priority group (e.g. P1)")
+	triggerCmd.Flags().DurationVar(&triggerBatchWait, "batch-wait", 4*time.Hour, "wait duration between batches")
+	triggerCmd.Flags().BoolVarP(&triggerYes, "yes", "y", false, "auto-continue between batches (requires --batch-wait)")
+	_ = triggerCmd.MarkFlagRequired("input")
+}
+
+func runTrigger(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	owner, repoName, err := parseRepo()
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(triggerInput)
+	if err != nil {
+		return fmt.Errorf("reading input: %w", err)
+	}
+
+	var report PriorityReport
+	if err := yaml.Unmarshal(data, &report); err != nil {
+		return fmt.Errorf("parsing priority report: %w", err)
+	}
+
+	prNumbers := collectPRNumbers(report.Groups, triggerGroup)
+	if len(prNumbers) == 0 {
+		logrus.Info("no PRs to trigger")
+		return nil
+	}
+
+	batches := splitBatches(prNumbers, triggerBatchSize)
+	logrus.WithFields(logrus.Fields{
+		"total_prs": len(prNumbers),
+		"batches":   len(batches),
+		"batch_size": triggerBatchSize,
+	}).Info("triggering lane")
+
+	var client *github.Client
+	if !dryRun {
+		client, err = newGitHubClient(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	comment := fmt.Sprintf("/test %s", report.Lane)
+
+	for i, batch := range batches {
+		logrus.WithFields(logrus.Fields{
+			"batch":    i + 1,
+			"of":       len(batches),
+			"pr_count": len(batch),
+		}).Info("processing batch")
+
+		for _, prNum := range batch {
+			if dryRun {
+				fmt.Printf("[dry-run] would comment on PR #%d: %s\n", prNum, comment)
+				continue
+			}
+			if err := postComment(ctx, client, owner, repoName, prNum, comment); err != nil {
+				logrus.WithError(err).WithField("pr", prNum).Error("failed to post comment")
+				continue
+			}
+		}
+
+		if i < len(batches)-1 {
+			if err := waitBetweenBatches(i+1, len(batches)); err != nil {
+				return err
+			}
+		}
+	}
+
+	logrus.Info("all batches processed")
+	return nil
+}
+
+func collectPRNumbers(groups []PriorityGroup, filterGroup string) []int {
+	var numbers []int
+	for _, g := range groups {
+		if filterGroup != "" && g.Name != filterGroup {
+			continue
+		}
+		numbers = append(numbers, g.PRNumbers...)
+	}
+	return numbers
+}
+
+func splitBatches(items []int, size int) [][]int {
+	var batches [][]int
+	for i := 0; i < len(items); i += size {
+		end := i + size
+		if end > len(items) {
+			end = len(items)
+		}
+		batches = append(batches, items[i:end])
+	}
+	return batches
+}
+
+func postComment(ctx context.Context, client *github.Client, owner, repoName string, prNumber int, body string) error {
+	comment := &github.IssueComment{Body: &body}
+	created, _, err := client.Issues.CreateComment(ctx, owner, repoName, prNumber, comment)
+	if err != nil {
+		return fmt.Errorf("commenting on PR #%d: %w", prNumber, err)
+	}
+	logrus.WithFields(logrus.Fields{
+		"pr":  prNumber,
+		"url": created.GetHTMLURL(),
+	}).Info("triggered lane")
+	return nil
+}
+
+func waitBetweenBatches(completedBatch, totalBatches int) error {
+	if dryRun {
+		fmt.Printf("[dry-run] would wait %s before batch %d/%d\n", triggerBatchWait, completedBatch+1, totalBatches)
+		return nil
+	}
+
+	if triggerYes {
+		logrus.WithFields(logrus.Fields{
+			"wait":       triggerBatchWait,
+			"next_batch": completedBatch + 1,
+		}).Info("waiting before next batch")
+
+		deadline := time.Now().Add(triggerBatchWait)
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				remaining := time.Until(deadline).Truncate(time.Second)
+				if remaining <= 0 {
+					return nil
+				}
+				logrus.WithField("remaining", remaining).Info("waiting for next batch")
+			case <-time.After(time.Until(deadline)):
+				return nil
+			}
+		}
+	}
+
+	fmt.Printf("\nBatch %d/%d complete. Press Enter to continue (or Ctrl+C to abort)... ", completedBatch, totalBatches)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Scan()
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading stdin: %w", err)
+	}
+	_ = strings.TrimSpace(scanner.Text())
+	return nil
+}

--- a/robots/lane-doctor/cmd/trigger_test.go
+++ b/robots/lane-doctor/cmd/trigger_test.go
@@ -1,0 +1,83 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("splitBatches", func() {
+
+	DescribeTable("splits items into batches of given size",
+		func(items []int, size int, expected [][]int) {
+			Expect(splitBatches(items, size)).To(Equal(expected))
+		},
+		Entry("exact split",
+			[]int{1, 2, 3, 4}, 2,
+			[][]int{{1, 2}, {3, 4}},
+		),
+		Entry("remainder batch",
+			[]int{1, 2, 3, 4, 5}, 2,
+			[][]int{{1, 2}, {3, 4}, {5}},
+		),
+		Entry("single batch when size >= len",
+			[]int{1, 2, 3}, 10,
+			[][]int{{1, 2, 3}},
+		),
+		Entry("batch size of 1",
+			[]int{1, 2, 3}, 1,
+			[][]int{{1}, {2}, {3}},
+		),
+		Entry("empty input",
+			[]int{}, 5,
+			nil,
+		),
+		Entry("nil input",
+			nil, 5,
+			nil,
+		),
+	)
+})
+
+var _ = Describe("collectPRNumbers", func() {
+
+	groups := []PriorityGroup{
+		{Name: "P1", PRNumbers: []int{10, 20}},
+		{Name: "P2", PRNumbers: []int{30}},
+		{Name: "P3", PRNumbers: []int{40, 50, 60}},
+	}
+
+	It("collects all PR numbers when no filter is set", func() {
+		Expect(collectPRNumbers(groups, "")).To(Equal([]int{10, 20, 30, 40, 50, 60}))
+	})
+
+	It("filters by group name", func() {
+		Expect(collectPRNumbers(groups, "P1")).To(Equal([]int{10, 20}))
+	})
+
+	It("returns nil for non-existent group", func() {
+		Expect(collectPRNumbers(groups, "P99")).To(BeNil())
+	})
+
+	It("returns nil for empty groups", func() {
+		Expect(collectPRNumbers(nil, "")).To(BeNil())
+	})
+})

--- a/robots/lane-doctor/cmd/types.go
+++ b/robots/lane-doctor/cmd/types.go
@@ -19,6 +19,7 @@
 
 package cmd
 
+// ScanReport is the output of the scan command, listing all stuck PRs for a lane.
 type ScanReport struct {
 	Lane      string      `json:"lane"`
 	Repo      string      `json:"repo"`
@@ -27,6 +28,7 @@ type ScanReport struct {
 	StuckPRs  []StuckPR   `json:"stuckPRs"`
 }
 
+// ScanSummary counts PRs in each classification category.
 type ScanSummary struct {
 	Total   int `json:"total"`
 	Stuck   int `json:"stuck"`
@@ -36,6 +38,7 @@ type ScanSummary struct {
 	Failed  int `json:"failed"`
 }
 
+// StuckPR describes a PR whose lane status is stuck or missing.
 type StuckPR struct {
 	Number          int      `json:"number"`
 	Title           string   `json:"title"`
@@ -49,6 +52,7 @@ type StuckPR struct {
 	HasTargetURL    bool     `json:"hasTargetURL"`
 }
 
+// PriorityReport is the output of the prioritize command.
 type PriorityReport struct {
 	Lane          string          `json:"lane"`
 	Repo          string          `json:"repo"`
@@ -56,6 +60,7 @@ type PriorityReport struct {
 	Groups        []PriorityGroup `json:"groups"`
 }
 
+// PriorityGroup is a named tier (P1–P4) of PR numbers.
 type PriorityGroup struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`

--- a/robots/lane-doctor/cmd/types.go
+++ b/robots/lane-doctor/cmd/types.go
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package cmd
+
+type ScanReport struct {
+	Lane      string      `json:"lane"`
+	Repo      string      `json:"repo"`
+	ScannedAt string      `json:"scannedAt"`
+	Summary   ScanSummary `json:"summary"`
+	StuckPRs  []StuckPR   `json:"stuckPRs"`
+}
+
+type ScanSummary struct {
+	Total   int `json:"total"`
+	Stuck   int `json:"stuck"`
+	Missing int `json:"missing"`
+	Running int `json:"running"`
+	Success int `json:"success"`
+	Failed  int `json:"failed"`
+}
+
+type StuckPR struct {
+	Number          int      `json:"number"`
+	Title           string   `json:"title"`
+	Author          string   `json:"author"`
+	HeadSHA         string   `json:"headSHA"`
+	UpdatedAt       string   `json:"updatedAt"`
+	Labels          []string `json:"labels"`
+	IsDraft         bool     `json:"isDraft"`
+	StatusState     string   `json:"statusState"`
+	StatusUpdatedAt string   `json:"statusUpdatedAt,omitempty"`
+	HasTargetURL    bool     `json:"hasTargetURL"`
+}
+
+type PriorityReport struct {
+	Lane          string          `json:"lane"`
+	Repo          string          `json:"repo"`
+	PrioritizedAt string          `json:"prioritizedAt"`
+	Groups        []PriorityGroup `json:"groups"`
+}
+
+type PriorityGroup struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	PRNumbers   []int  `json:"prNumbers"`
+}

--- a/robots/lane-doctor/main.go
+++ b/robots/lane-doctor/main.go
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+	"kubevirt.io/project-infra/robots/lane-doctor/cmd"
+)
+
+func init() {
+	log.SetFormatter(&log.JSONFormatter{})
+}
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary

Adds a new `lane-doctor` CLI tool under `robots/` to diagnose and remediate stuck Prow lane statuses on open PRs, caused by statusreconciler surges during lane migrations.

During the 1.36 lane migration, the statusreconciler posted bare `pending` GitHub commit statuses (no `target_url`, no actual prowjob) on ~170 open PRs. Since the affected lane is a required status check, those PRs were blocked from merging. This tool automates the detection, triage, and remediation workflow.

## Commands

- **`scan`** — scans all open PRs for a given lane, classifies each as stuck/missing/running/success/failed, outputs a YAML report
- **`prioritize`** — reads the scan report, groups stuck PRs into P1–P4 tiers based on merge-readiness labels (`lgtm`, `approved`, hold status, draft)
- **`trigger`** — reads the priority report, posts `/test <lane>` comments in configurable batches with `--batch-wait` intervals and `--yes` for unattended operation

## Example workflow

```bash
lane-doctor scan --lane pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations -o scan.yaml
lane-doctor prioritize -i scan.yaml -o priority.yaml
lane-doctor trigger -i priority.yaml --group P1 --batch-size 10 --dry-run
lane-doctor trigger -i priority.yaml --yes --batch-wait 4h --batch-size 10
```

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line tool for scanning lane status, ranking stuck pull requests by priority, and triggering retries in batches.
  * Supports reading and writing YAML reports, with optional file output or standard output.
  * Added dry-run mode, batch confirmation/waiting, and filtering by priority group.

* **Bug Fixes**
  * Skips draft and work-in-progress pull requests when prioritizing.
  * Improves lane status handling by classifying pull requests into clear outcome buckets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->