### PR TITLE
build: bump Go to 1.26.4

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.25"
+  go: "1.26"
   modules-download-mode: readonly
 linters:
   default: standard

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -135,9 +135,9 @@ presubmits:
           make lint
         env:
         - name: GIMME_GO_VERSION
-          value: "1.25.1"
+          value: "1.26.4"
         - name: GOLANGCI_LINT_VERSION
-          value: "v2.4.0"
+          value: "v2.12.2"
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
         resources:
           requests:

--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,6 @@ replace (
 	k8s.io/client-go => k8s.io/client-go v0.30.1
 )
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.1
+toolchain go1.26.4

--- a/robots/per-test-execution/main.go
+++ b/robots/per-test-execution/main.go
@@ -361,12 +361,12 @@ func readTopXFromFile(filename string, topX int) (string, []*TestExecutions, err
 		}
 		atoi, err := strconv.Atoi(record[1])
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to convert value %q: %v", atoi, err)
+			return "", nil, fmt.Errorf("failed to convert value %q: %v", record[1], err)
 		}
 		totalExecutions := atoi
 		atoi, err = strconv.Atoi(record[2])
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to convert value %q: %v", atoi, err)
+			return "", nil, fmt.Errorf("failed to convert value %q: %v", record[2], err)
 		}
 		failedExecutions := atoi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps Go from 1.25.0/go1.25.1 to 1.26.0/go1.26.4 (latest stable release).

Also:
- Bumps golangci-lint from v2.4.0 to v2.12.2 and GIMME_GO_VERSION to 1.26.4 in the lint job — v2.4.0 was built with Go 1.25 and panics on Go 1.26 packages
- Fixes a `go vet` error in `robots/per-test-execution/main.go` caught by Go 1.26's stricter vet checks: `%q` format verb was used with an `int` argument instead of the original string value

**Which issue(s) this PR fixes**:

N/A — routine maintenance.

🤖 Assisted by Claude