### PR TITLE
Increase most flaky report freshness

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -190,7 +190,7 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
-  cron: 45 3 * * *
+  cron: '*/30 * * * *'
   decorate: true
   extra_refs:
   - base_ref: main

--- a/pkg/flake-stats/options.go
+++ b/pkg/flake-stats/options.go
@@ -85,6 +85,12 @@ func IgnoreTests(tests []string) func(r *ReportOptions) {
 	}
 }
 
+func IncludeRollingWindow(b bool) func(r *ReportOptions) {
+	return func(r *ReportOptions) {
+		r.IncludeRollingWindow = b
+	}
+}
+
 func NewDefaultReportOpts(opts ...ReportOption) *ReportOptions {
 	r := &ReportOptions{
 		DaysInThePast:               defaultDaysInThePast,
@@ -109,6 +115,7 @@ type ReportOptions struct {
 	MatchingLaneRegexString     string
 	matchingLaneRegex           *regexp.Regexp
 	TestsToIgnore               []string
+	IncludeRollingWindow        bool
 }
 
 func (o *ReportOptions) Validate() error {

--- a/pkg/flake-stats/report.go
+++ b/pkg/flake-stats/report.go
@@ -122,6 +122,17 @@ func (r FlakeStats) AggregateData() (TopXTests, error) {
 
 func (r FlakeStats) fetchFlakeFinder24hReportsForRecentDays() ([]*flakefinder.Params, error) {
 	var recentFlakeFinderReports []*flakefinder.Params
+
+	if r.reportOpts.IncludeRollingWindow {
+		today := time.Now()
+		flakeFinderReportData, err := r.fetchFlakeFinder24hReportData(today)
+		if err != nil {
+			logrus.Warnf("could not fetch today's rolling window report for %v, skipping: %v", today.Format(time.DateOnly), err)
+		} else {
+			recentFlakeFinderReports = append(recentFlakeFinderReports, flakeFinderReportData)
+		}
+	}
+
 	targetReportDate := previousDay(time.Now())
 	for i := 0; i < r.reportOpts.DaysInThePast; i++ {
 		flakeFinderReportData, err := r.fetchFlakeFinder24hReportData(targetReportDate)

--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -69,6 +69,7 @@ func init() {
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&outputFileOpts.OverwriteOutputFile, "overwrite-output-file", false, "whether to overwrite the output file")
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.filterPeriodicJobRunResults, "filter-periodic-job-run-results", true, "whether to filter the results for periodics")
 	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.filterLaneRegex, "filter-lane-regex", filterLaneRegexDefault, "the regular expression to use to filter test lanes with")
+	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.includeRollingWindow, "include-rolling-window", true, "whether to include today's rolling window flakefinder data")
 }
 
 var sigMatcher = regexp.MustCompile(`\[(sig-[^]]+)]`)
@@ -78,6 +79,7 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 		flakestats.DaysInThePast(quarantineOpts.daysInThePast),
 		flakestats.FilterPeriodicJobRunResults(quarantineOpts.filterPeriodicJobRunResults),
 		flakestats.FilterLaneRegex(quarantineOpts.filterLaneRegex),
+		flakestats.IncludeRollingWindow(quarantineOpts.includeRollingWindow),
 	)
 	err := reportOpts.Validate()
 	if err != nil {

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -53,6 +53,7 @@ type quarantineOptions struct {
 
 	filterPeriodicJobRunResults bool
 	filterLaneRegex             string
+	includeRollingWindow        bool
 
 	testName string
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The most-flaky-tests report currently has a blind spot for today's data. It only aggregates flakefinder reports starting from yesterday, meaning a test that starts flaking from a newly merged PR won't appear in the report until the next day. 

This PR fixes this issue by:
- Including today's rolling window flakefinder data in the report aggregation, so newly introduced flakes are visible within the hour they're detected
- Increasing the report job frequency from once daily to every 30 minutes.

**Special notes for your reviewer**:
/cc @dhiller @dollierp 
