### PR TITLE
ci: mark ci-search deploy test as optional

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -774,7 +774,7 @@ presubmits:
             requests:
               memory: "2Gi"
   - name: pull-project-infra-ci-search-deploy-test
-    optional: false
+    optional: true
     run_if_changed: "github/ci/services/ci-search/.*|github/ci/services/common/.*"
     decorate: true
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Marks `pull-project-infra-ci-search-deploy-test` as `optional: true`. The test is consistently failing due to an infrastructure issue unrelated to PR content, blocking PRs that touch `github/ci/services/common/` or `github/ci/services/ci-search/` paths.

**Evidence of independent failure**:

The test was investigated across two unrelated PRs:

1. **PR #5132** (golangci-lint onboarding) — 3/3 failures, 2 distinct failure modes:
   - [Run 1](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5132/pull-project-infra-ci-search-deploy-test/2065089213266661376): StatefulSet never became ready (timeout after ~3 min)
   - [Run 2](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5132/pull-project-infra-ci-search-deploy-test/2065362330182488064): StatefulSet ready, but port 8080 refused connections inside pod → `panic: lost connection to pod`
   - [Run 3](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5132/pull-project-infra-ci-search-deploy-test/2065420442709004288): Same as run 2

2. **PR #5139** (Go toolchain bump — no code changes) — 2/2 failures with the same symptoms:
   - [Run 1](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5139/pull-project-infra-ci-search-deploy-test/2065439571629334528): StatefulSet timeout
   - [Run 2](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5139/pull-project-infra-ci-search-deploy-test/2065452488818954240): StatefulSet timeout

**Root cause analysis**:

The ci-search StatefulSet deploys `registry.ci.openshift.org/ci/ci-search:latest` (built 2026-03-30 from [openshift/ci-search](https://github.com/openshift/ci-search)). The pod either fails to start in time or starts but the search process doesn't listen on port 8080. The StatefulSet has no readiness/liveness probes, so "ready" only means the container is running, not that the service is serving. The job triggers rarely (`run_if_changed` on ci-search/common paths), so this breakage went unnoticed.

**Special notes for your reviewer**:

- This unblocks PR #5132 and PR #5139 which are stuck on this failing required check
- The underlying issue should be investigated separately (likely the ci-search image or the test's lack of readiness probes)

🤖 Assisted by Claude