### PR TITLE
fix(bazel): switch back to greenhouse cache

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -675,12 +675,12 @@ presets:
   env:
     - name: BAZEL_VERSION
       value: "6.5.0"
-    - name: BAZEL_REMOTE_CACHE
-      value: https://storage.googleapis.com/kubevirt-bazel-cache
+    - name: CACHE_HOST
+      value: bazel-cache.kubevirt-prow
+    - name: CACHE_PORT
+      value: "8080"
     - name: BAZEL_REMOTE_CACHE_ENABLED
       value: "true"
-    - name: BAZEL_CACHE_GOOGLE_CREDENTIALS
-      value: /etc/bazel-cache-gcs/bazel-cache-sa.json
   volumes:
     - name: bazel-cache-gcs
       secret:


### PR DESCRIPTION
**What this PR does / why we need it**:

Jobs are currently failing to use the GCS cache:

```
ERROR: Could not open auth credentials file '/etc/bazel-cache-gcs/bazel-cache-sa.json': /etc/bazel-cache-gcs/bazel-cache-sa.json (No such file or directory)
ERROR: Error initializing RemoteModule
```

It seems the automation needs to be improved to forward the file `/etc/bazel-cache-gcs/bazel-cache-sa.json` to the bazel container.

Switch back to greenhouse cache in the meantime.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl