### PR TITLE
fix(crier): inject prow clusters kubeconfig

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -63,6 +63,7 @@ deck:
         - artifacts/filtered.cov
       optional_files:
         - artifacts/filtered.html
+    # podinfo.json is uploaded by crier's k8s reporter
     - lens:
         name: podinfo
       required_files:
@@ -88,7 +89,7 @@ sinker:
   max_pod_age: 30m
   terminated_pod_ttl: 2h
 
-# https://docs.prow.k8s.io/docs/components/core/crier/
+# https://docs.prow.k8s.io/docs/components/core/crier/#slack-reporter
 # https://pkg.go.dev/sigs.k8s.io/prow/pkg/apis/prowjobs/v1#SlackReporterConfig
 slack_reporter_configs:
   '*':

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/crier_deployment.yaml
@@ -18,6 +18,26 @@
     configMap:
       name: job-config
 
+# inject consolidated KUBECONFIG with federated clusters for the k8s reporter (podinfo.json)
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --kubeconfig=/etc/kubeconfig/config
+
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: kubeconfig
+    mountPath: /etc/kubeconfig
+    readOnly: true
+
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: kubeconfig
+    secret:
+      secretName: kubeconfig
+      defaultMode: 420
+
 # inject slack credentials
 - op: add
   path: /spec/template/spec/containers/0/args/-


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubeconfig` is not configured for `crier` deployment in upstream manifests by default.

However, it is used by `crier` when multiple build clusters are configured so that the k8s reporter can generate and upload the `podinfo.json` file which is used by some lenses in `deck`.

Changes in manifests generated by kustomize:

```diff
--- github/ci/prow-deploy/crier.yaml
+++ github/ci/prow-deploy/crier-kubeconfig.yaml

@@ -27,6 +27,7 @@
         - --github-app-id=$(GITHUB_APP_ID)
         - --github-app-private-key-path=/etc/github/cert
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/config
         - --slack-token-file=/etc/slack/token
         - --slack-workers=10
         env:
@@ -50,6 +51,9 @@
         - mountPath: /etc/job-config
           name: job-config
           readOnly: true
+        - mountPath: /etc/kubeconfig
+          name: kubeconfig
+          readOnly: true
         - mountPath: /etc/slack
           name: slack-token
           readOnly: true
@@ -68,6 +72,10 @@
       - configMap:
           name: job-config
         name: job-config
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig
       - name: slack-token
         secret:
           secretName: slack-token
@@ -12753,6 +12761,7 @@
             - artifacts/filtered.cov
           optional_files:
             - artifacts/filtered.html
+        # podinfo.json is uploaded by crier's k8s reporter
         - lens:
             name: podinfo
           required_files:
@@ -12778,7 +12787,7 @@
       max_pod_age: 30m
       terminated_pod_ttl: 2h
 
-    # https://docs.prow.k8s.io/docs/components/core/crier/
+    # https://docs.prow.k8s.io/docs/components/core/crier/#slack-reporter
     # https://pkg.go.dev/sigs.k8s.io/prow/pkg/apis/prowjobs/v1#SlackReporterConfig
     slack_reporter_configs:
       '*':
```

**Special notes for your reviewer**:

/cc @dhiller 