### PR TITLE
fix(docker-proxy): increase proxy_ssl_verify_depth

### DIFF
--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/kustomization.yaml
@@ -3,6 +3,12 @@ resources:
   - resources/deployment.yaml
   - resources/service.yaml
 
+images:
+  - name: ghcr.io/rpardini/docker-registry-proxy:0.6.2
+    newName: quay.io/kubevirtci/rpardini-docker-registry-proxy
+    # Include workaround for https://github.com/rpardini/docker-registry-proxy/issues/181
+    newTag: 0.6.2-ssl-verify-depth-3
+
 configMapGenerator:
   - name: mirror-proxy-config
     namespace: kubevirt-prow-jobs


### PR DESCRIPTION
**What this PR does / why we need it**:

It is required to support new Dockerhub TLS configuration:
```
[error] upstream SSL certificate verify error: (22:certificate chain too
long) while SSL handshaking to upstream, host: "auth.docker.io"
```

The upstream container image has been rebuilt using this quick and dirty Dockerfile:
```
FROM ghcr.io/rpardini/docker-registry-proxy:0.6.2

RUN sed -e 's|proxy_ssl_verify_depth 2|proxy_ssl_verify_depth 3|' -i /entrypoint.sh
```

**Special notes for your reviewer**:

/cc @dhiller