### PR TITLE
fix(release-tag): increase timeout to 5h

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
       testgrid-num-failures-to-alert: "1"
     decorate: true
     decoration_config:
-      timeout: 3h
+      timeout: 5h
       grace_period: 5m
     labels:
       preset-podman-in-container-enabled: "true"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

since we need a bit more headroom when the cluster is loaded we are increasing the timeout for the release-tag job for kubevirt/kubevirt.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted release job configuration to prevent timeout issues during longer builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->