### PR TITLE
Redesign most flaky tests report for readability & add approaching quarantine test 

### DIFF
--- a/robots/quarantine/cmd/most-flaky-tests-report.gohtml
+++ b/robots/quarantine/cmd/most-flaky-tests-report.gohtml
@@ -25,102 +25,406 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>kubevirt/kubevirt: most flaky tests report</title>
     <style>
+        :root {
+            --color-bg: #f0f2f5;
+            --color-surface: #ffffff;
+            --color-text: #1a1a2e;
+            --color-text-secondary: #555;
+            --color-border: #e0e0e0;
+            --color-accent: #3b82f6;
+            --color-critical: #dc2626;
+            --color-high: #ea580c;
+            --color-medium: #ca8a04;
+            --color-low: #16a34a;
+            --radius: 8px;
+            --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
+            --shadow-hover: 0 4px 12px rgba(0,0,0,0.1);
+        }
+
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
         body {
-            font-family: 'Segoe UI', 'Roboto', sans-serif;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--color-bg);
+            color: var(--color-text);
+            line-height: 1.5;
         }
 
         .container {
-            max-width: 1800px;
+            max-width: 1600px;
             margin: 0 auto;
-            padding: 5px;
-            width: 100%;
+            padding: 0 20px;
         }
 
-        .card-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-            gap: 10px;
-            margin-bottom: 10px;
+        /* Header */
+        .report-header {
+            background: linear-gradient(135deg, #1e293b, #334155);
+            color: #fff;
+            padding: 28px 0;
+            margin-bottom: 24px;
         }
-
-        .card {
-            background-color: #fff;
-            border-radius: var(--border-radius);
-            box-shadow: var(--box-shadow);
-            padding: 10px;
+        .report-header h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 12px;
+        }
+        .header-controls {
             display: flex;
-            flex-direction: column;
-            transition: transform var(--transition-speed);
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        .header-controls label {
+            font-size: 0.875rem;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            opacity: 0.9;
+        }
+        .header-controls input[type="checkbox"] {
+            width: 16px;
+            height: 16px;
+            cursor: pointer;
+        }
+        .header-controls input[type="text"] {
+            padding: 6px 12px;
+            border: 1px solid rgba(255,255,255,0.3);
+            border-radius: var(--radius);
+            background: rgba(255,255,255,0.1);
+            color: #fff;
+            font-size: 0.875rem;
+            width: 260px;
+        }
+        .header-controls input[type="text"]::placeholder { color: rgba(255,255,255,0.5); }
+        .timestamp {
+            font-size: 0.8rem;
+            opacity: 0.7;
+            margin-top: 8px;
         }
 
+        /* SIG nav */
+        .sig-nav {
+            background: var(--color-surface);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            padding: 16px 20px;
+            margin-bottom: 24px;
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 8px;
+        }
+        .sig-nav-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--color-text-secondary);
+            margin-right: 8px;
+        }
+        .sig-nav a {
+            display: inline-block;
+            padding: 4px 12px;
+            background: var(--color-bg);
+            border-radius: 100px;
+            text-decoration: none;
+            color: var(--color-accent);
+            font-size: 0.8rem;
+            font-weight: 500;
+            transition: background 0.15s, color 0.15s;
+        }
+        .sig-nav a:hover {
+            background: var(--color-accent);
+            color: #fff;
+        }
+
+        /* SIG sections */
+        .sig-section {
+            margin-bottom: 32px;
+        }
+        .sig-heading {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 0;
+            border-bottom: 2px solid var(--color-border);
+            margin-bottom: 16px;
+            position: sticky;
+            top: 0;
+            background: var(--color-bg);
+            z-index: 10;
+        }
+        .sig-heading h2 {
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .sig-test-count {
+            font-size: 0.8rem;
+            color: var(--color-text-secondary);
+            background: var(--color-bg);
+            border: 1px solid var(--color-border);
+            padding: 2px 10px;
+            border-radius: 100px;
+        }
+
+        /* Test card grid */
+        .test-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(520px, 1fr));
+            gap: 12px;
+            align-items: start;
+        }
+
+        /* Test card */
+        .test-card {
+            background: var(--color-surface);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+            transition: box-shadow 0.15s;
+            border-left: 4px solid var(--color-border);
+        }
+        .test-card:hover {
+            box-shadow: var(--shadow-hover);
+        }
+        .test-card.severity-critical { border-left-color: var(--color-critical); }
+        .test-card.severity-high { border-left-color: var(--color-high); }
+        .test-card.severity-medium { border-left-color: var(--color-medium); }
+        .test-card.severity-low { border-left-color: var(--color-low); }
+        .test-card.approaching-quarantine {
+            border-left-color: #eab308;
+            background: linear-gradient(135deg, #fefce8, var(--color-surface) 40%);
+        }
+        .badge-approaching {
+            background: #fef9c3;
+            color: #a16207;
+        }
+
+        .test-card-header {
+            padding: 12px 16px;
+            border-bottom: 1px solid var(--color-border);
+            display: flex;
+            align-items: flex-start;
+            gap: 8px;
+        }
+        .test-card-header .test-name {
+            font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+            font-size: 0.78rem;
+            word-break: break-word;
+            flex: 1;
+            line-height: 1.4;
+            color: var(--color-text);
+        }
+        .test-card-header .card-link {
+            font-size: 0.75rem;
+            text-decoration: none;
+            color: var(--color-text-secondary);
+            flex-shrink: 0;
+        }
+
+        .badge {
+            display: inline-block;
+            font-size: 0.7rem;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 100px;
+            flex-shrink: 0;
+        }
+        .test-card-body {
+            padding: 8px 16px 12px;
+            max-height: 320px;
+            overflow-y: auto;
+        }
+        .test-card-body::-webkit-scrollbar { width: 4px; }
+        .test-card-body::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 4px; }
+
+        /* Impact rows */
+        .impact-entry {
+            padding: 8px 0;
+            border-bottom: 1px solid #f3f4f6;
+            font-size: 0.82rem;
+        }
+        .impact-entry:last-child { border-bottom: none; }
+        .impact-row-top {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        .impact-percent {
+            font-weight: 700;
+            font-size: 0.85rem;
+            min-width: 52px;
+        }
+        .impact-percent.critical { color: var(--color-critical); }
+        .impact-percent.high { color: var(--color-high); }
+        .impact-percent.medium { color: var(--color-medium); }
+        .impact-percent.low { color: var(--color-low); }
+
+        .impact-time {
+            font-size: 0.75rem;
+            color: var(--color-text-secondary);
+            background: var(--color-bg);
+            padding: 1px 8px;
+            border-radius: 4px;
+        }
+        .impact-lane {
+            font-size: 0.78rem;
+            color: var(--color-accent);
+            text-decoration: none;
+            word-break: break-all;
+        }
+        .impact-lane:hover { text-decoration: underline; }
+        .impact-actions {
+            margin-left: auto;
+            flex-shrink: 0;
+        }
+        .impact-actions a {
+            text-decoration: none;
+            font-size: 0.8rem;
+            padding: 2px 6px;
+            border-radius: 4px;
+        }
+        .impact-actions a:hover { background: var(--color-bg); }
+        .failures-row {
+            margin-top: 4px;
+            padding-left: 60px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+        .failure-link {
+            font-size: 0.72rem;
+            padding: 1px 6px;
+            background: var(--color-bg);
+            border-radius: 4px;
+            text-decoration: none;
+            color: var(--color-text-secondary);
+            white-space: nowrap;
+        }
+        .failure-link:hover {
+            background: var(--color-border);
+            color: var(--color-text);
+        }
+
+        /* Empty state */
+        .empty-state {
+            text-align: center;
+            padding: 80px 20px;
+            color: var(--color-text-secondary);
+            font-size: 1.2rem;
+        }
+
+        @media (max-width: 600px) {
+            .test-grid { grid-template-columns: 1fr; }
+            .failures-row { padding-left: 0; }
+        }
     </style>
 </head>
 <body>
-<section class="container">
-    <h1>kubevirt/kubevirt: most flaky tests report</h1>
-    <label><input type="checkbox" id="show-release-lanes" onchange="toggleReleaseLanes()"> Show release branch lanes</label>
-</section>
+
+<header class="report-header">
+    <div class="container">
+        <h1>Most Flaky Tests Report</h1>
+        <div class="header-controls">
+            <label><input type="checkbox" id="show-release-lanes" onchange="toggleReleaseLanes()"> Show release branch lanes</label>
+            <label><input type="checkbox" id="show-approaching" onchange="toggleApproaching()"> Highlight approaching quarantine</label>
+            <input type="text" id="test-filter" placeholder="Filter tests..." oninput="filterTests()">
+        </div>
+        <div class="timestamp">Last updated: {{ $.ReportCreation.Format "02 Jan 2006, 15:04 MST" }}</div>
+    </div>
+</header>
 
 {{ if $.SIGs }}
-    <section class="container">
-        <div class="card-grid">
-            <div class="card" id="index">
-                {{ range $sig := $.SIGs }}<a href="#{{ $sig }}">{{ $sig }}</a>&nbsp;{{ end }}
-            </div>
-        </div>
-    </section>
+    <div class="container">
+        <nav class="sig-nav" id="index">
+            <span class="sig-nav-label">SIGs</span>
+            {{ range $sig := $.SIGs }}<a href="#{{ $sig }}">{{ $sig }}</a> {{ end }}
+        </nav>
+    </div>
+
     {{ range $sig := $.SIGs }}
-        <hr/>
-        <section class="container">
-            <div class="card-grid">
-                <div class="card" id="{{ $sig }}">
-                    <h1>{{ $sig }} <a href="#index">&uarr;</a></h1>
+        <div class="container">
+            <section class="sig-section" id="{{ $sig }}">
+                <div class="sig-heading">
+                    <h2>{{ $sig }}</h2>
+                    <span class="sig-test-count" data-sig-count="{{ $sig }}"></span>
                 </div>
-            </div>
-        </section>
-        <section class="container">
-            <div class="card-grid">
-                {{ range $testName := $.TestNames }}
-                    {{ $mostFlakyTests := index $.MostFlakyTestsBySig $sig $testName }}
-                    {{ if $mostFlakyTests }}
-                        <div class="card" id="test_{{ $testName }}">
-                            <a href="#test_{{ $testName }}">#</a>
-                            <code title="{{ $testName }}">{{ $testName }}</code><br/>
-                            {{ range $mostFlakyTest := $mostFlakyTests }}
-                                {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts -}}
-                                    <div class="impact-entry" data-lane="{{ $relevantImpact.URLToDisplay }}">
-                                    <span style="white-space: nowrap;">
-                                        <a href="{{ $mostFlakyTest.SearchCIURL }}" title="execute query on search.ci">🔎</a>
-                                        💥<span title="Test has impact of {{ $relevantImpact.Percent }}%"> <b>{{ $relevantImpact.Percent }}%</b> over <b>{{ $mostFlakyTest.TimeRange }}</b></span> on<br/>
-                                        <a href="{{ $relevantImpact.URL }}">{{ $relevantImpact.URLToDisplay }}</a>:</span> <span
-                                            style="white-space: nowrap;">Failures: {{ range $buildURL := $relevantImpact.BuildURLs -}}
-                                            <a href="{{ $buildURL.URL }}"
-                                               title="{{ $buildURL.URL }}">{{ $buildURL.Interval }}</a> {{ end }}
-                                    </span>
-                                    </div>
-                                {{- end }}
-                            {{ end }}
-                        </div>
+                <div class="test-grid">
+                    {{ range $testName := $.TestNames }}
+                        {{ $mostFlakyTests := index $.MostFlakyTestsBySig $sig $testName }}
+                        {{ if $mostFlakyTests }}
+                            <div class="test-card" id="test_{{ $testName }}" data-testname="{{ $testName }}" data-max-impact="0">
+                                <div class="test-card-header">
+                                    <a href="#test_{{ $testName }}" class="card-link" title="permalink">#</a>
+                                    <span class="test-name" title="{{ $testName }}">{{ $testName }}</span>
+                                </div>
+                                <div class="test-card-body">
+                                    {{ range $mostFlakyTest := $mostFlakyTests }}
+                                        {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts -}}
+                                            <div class="impact-entry" data-lane="{{ $relevantImpact.URLToDisplay }}" data-impact="{{ $relevantImpact.Percent }}" data-timerange="{{ $mostFlakyTest.TimeRange }}">
+                                                <div class="impact-row-top">
+                                                    <span class="impact-percent" data-percent="{{ $relevantImpact.Percent }}">{{ $relevantImpact.Percent }}%</span>
+                                                    <span class="impact-time">{{ $mostFlakyTest.TimeRange }}</span>
+                                                    <a href="{{ $relevantImpact.URL }}" class="impact-lane" title="{{ $relevantImpact.URLToDisplay }}">{{ $relevantImpact.URLToDisplay }}</a>
+                                                    <span class="impact-actions">
+                                                        <a href="{{ $mostFlakyTest.SearchCIURL }}" title="Search on search.ci">&#x1F50D;</a>
+                                                    </span>
+                                                </div>
+                                                {{ if $relevantImpact.BuildURLs }}
+                                                <div class="failures-row">
+                                                    {{- range $buildURL := $relevantImpact.BuildURLs -}}
+                                                    <a href="{{ $buildURL.URL }}" class="failure-link" title="{{ $buildURL.URL }}">{{ $buildURL.Interval }}</a>
+                                                    {{- end -}}
+                                                </div>
+                                                {{ end }}
+                                            </div>
+                                        {{- end }}
+                                    {{ end }}
+                                </div>
+                            </div>
+                        {{ end }}
                     {{ end }}
-                {{ end }}
-            </div>
-        </section>
+                </div>
+            </section>
+        </div>
     {{ end }}
 {{ else }}
-    <section class="container">
-        <div class="card-grid">
-            No results for any SIG! 🥳 💃🕺
-        </div>
-    </section>
+    <div class="container">
+        <div class="empty-state">No results for any SIG!</div>
+    </div>
 {{ end }}
 
-<section class="container">
-    <div style="text-align: right"><i>Last updated: {{ $.ReportCreation }}</i></div>
-</section>
 <script>
     var releaseLanePattern = /-\d+\.\d+$/;
+
+    function applyImpactColors() {
+        document.querySelectorAll('.impact-percent[data-percent]').forEach(function(el) {
+            var p = parseFloat(el.getAttribute('data-percent'));
+            if (p >= 10) el.classList.add('critical');
+            else if (p >= 5) el.classList.add('high');
+            else if (p >= 2) el.classList.add('medium');
+            else el.classList.add('low');
+        });
+        document.querySelectorAll('.test-card[data-max-impact]').forEach(function(card) {
+            var max = 0;
+            card.querySelectorAll('.impact-percent[data-percent]').forEach(function(el) {
+                var p = parseFloat(el.getAttribute('data-percent'));
+                if (p > max) max = p;
+            });
+            card.setAttribute('data-max-impact', max);
+            card.classList.remove('severity-critical', 'severity-high', 'severity-medium', 'severity-low');
+            if (max >= 10) card.classList.add('severity-critical');
+            else if (max >= 5) card.classList.add('severity-high');
+            else if (max >= 2) card.classList.add('severity-medium');
+            else card.classList.add('severity-low');
+        });
+    }
+
     function toggleReleaseLanes() {
         var show = document.getElementById('show-release-lanes').checked;
         document.querySelectorAll('.impact-entry').forEach(function(el) {
@@ -129,7 +433,7 @@
                 el.style.display = show ? '' : 'none';
             }
         });
-        document.querySelectorAll('.card[id^="test_"]').forEach(function(card) {
+        document.querySelectorAll('.test-card').forEach(function(card) {
             var entries = card.querySelectorAll('.impact-entry');
             var anyVisible = false;
             entries.forEach(function(el) {
@@ -137,8 +441,70 @@
             });
             card.style.display = (entries.length > 0 && !anyVisible) ? 'none' : '';
         });
+        updateSIGCounts();
     }
+
+    function filterTests() {
+        var query = document.getElementById('test-filter').value.toLowerCase();
+        document.querySelectorAll('.test-card').forEach(function(card) {
+            var name = (card.getAttribute('data-testname') || '').toLowerCase();
+            if (!query || name.indexOf(query) !== -1) {
+                card.removeAttribute('data-filtered');
+            } else {
+                card.setAttribute('data-filtered', '1');
+            }
+        });
+        toggleReleaseLanes();
+        document.querySelectorAll('.test-card[data-filtered="1"]').forEach(function(card) {
+            card.style.display = 'none';
+        });
+    }
+
+    function updateSIGCounts() {
+        document.querySelectorAll('.sig-section').forEach(function(section) {
+            var visible = section.querySelectorAll('.test-card:not([style*="display: none"])').length;
+            var total = section.querySelectorAll('.test-card').length;
+            var label = section.querySelector('.sig-test-count');
+            if (label) {
+                label.textContent = visible === total ? total + ' tests' : visible + ' / ' + total + ' tests';
+            }
+        });
+    }
+
+    function isApproachingQuarantine(card) {
+        var dominated = false;
+        card.querySelectorAll('.impact-entry').forEach(function(entry) {
+            if (entry.style.display === 'none') return;
+            var pct = parseFloat(entry.getAttribute('data-impact'));
+            var tr = entry.getAttribute('data-timerange') || '';
+            if (tr === '336h' && pct >= 3 && pct < 5) dominated = true;
+            if (tr === '72h' && pct >= 18 && pct < 20) dominated = true;
+        });
+        return dominated;
+    }
+
+    function toggleApproaching() {
+        var show = document.getElementById('show-approaching').checked;
+        document.querySelectorAll('.test-card').forEach(function(card) {
+            card.classList.remove('approaching-quarantine');
+            var existing = card.querySelector('.badge-approaching');
+            if (existing) existing.remove();
+            if (show && isApproachingQuarantine(card)) {
+                card.classList.add('approaching-quarantine');
+                var header = card.querySelector('.test-card-header');
+                if (header && !header.querySelector('.badge-approaching')) {
+                    var badge = document.createElement('span');
+                    badge.className = 'badge badge-approaching';
+                    badge.textContent = 'approaching quarantine';
+                    header.appendChild(badge);
+                }
+            }
+        });
+    }
+
+    applyImpactColors();
     toggleReleaseLanes();
+    updateSIGCounts();
 </script>
 </body>
 </html>


### PR DESCRIPTION
**What this PR does / why we need it**:
Redesigns the most flaky tests report HTML template for better readability and usability. The old template had undefined CSS variables causing missing styles, cards that overlapped when tests had many failure
entries, and long test names that overflowed.

Changes:
- Proper CSS with color-coded severity borders on cards
- Cards use a max-height with scrollable overflow so they don't overlap in the grid
- Added a text filter to search tests by name
- SIG navigation bar with links and per-SIG test counts
- Sticky SIG headings that stay visible when scrolling
- "Highlight approaching quarantine" checkbox, highlights tests near the quarantine threshold (3-5% over 14d or 18-20% over 3d)

**Special notes for your reviewer**:
/cc @dhiller  @dollierp 

**Checklist**
[x] Ran report locally with screenshot of output below:
<img width="1627" height="622" alt="image" src="https://github.com/user-attachments/assets/6ef01843-bbf5-4f4d-be1c-b74213700187" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned most flaky tests report with dark-themed, card-based layout for improved readability
  * Added filtering controls: release-lane visibility toggle and text-based search
  * Added "approaching quarantine" highlighting to identify tests at risk of quarantine
  * Organized results by SIG with visible test-count badges and sticky headings
  * Enhanced responsive design for better test organization and discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->