### PR TITLE
Fix bump-kubevirt-rpms-cs10-weekly periodic job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -686,7 +686,7 @@ periodics:
       args:
       - |
         ../project-infra/hack/git-pr.sh \
-          --command "cd ../kubevirt && KUBEVIRT_CENTOS_STREAM_VERSION=10 make rpm-deps" \
+          --command "cd ../kubevirt && KUBEVIRT_CENTOS_STREAM_VERSION=10 KUBEVIRT_CS10_BUILDER_VERSION=2605290816-89fad9a940 make rpm-deps" \
           --branch bump-rpm-dependencies-cs10 \
           --repo-path ../kubevirt \
           --target main \

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -492,7 +492,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2602251001-25ce1ccb15
+          value: 2605290816-89fad9a940
         image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
         name: ""
         resources:
@@ -734,7 +734,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2602251001-25ce1ccb15
+          value: 2605290816-89fad9a940
         image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
         name: ""
         resources:
@@ -769,7 +769,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2602251001-25ce1ccb15
+          value: 2605290816-89fad9a940
         - name: BUILD_ARCH
           value: crossbuild-aarch64
         image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
@@ -806,7 +806,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2602251001-25ce1ccb15
+          value: 2605290816-89fad9a940
         - name: BUILD_ARCH
           value: crossbuild-s390x
         image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `bump-kubevirt-rpms-cs10-weekly` periodic job which has been failing since it was introduced. The job runs `KUBEVIRT_CENTOS_STREAM_VERSION=10 make rpm-deps` but `hack/dockerized` in kubevirt/kubevirt requires `KUBEVIRT_CS10_BUILDER_VERSION` to be set when using CS10, otherwise it errors out with:

```
ERROR: KUBEVIRT_CENTOS_STREAM_VERSION=10 requires KUBEVIRT_CS10_BUILDER_VERSION to be set
```

This passes the current CS10 builder version (`2605290816-89fad9a940`) in the command to unblock the job.

See failed run: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/bump-kubevirt-rpms-cs10-weekly/2066283361252413440

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

Longer term, `hack/dockerized` in kubevirt/kubevirt should hardcode a default `KUBEVIRT_CS10_BUILDER_VERSION` (like it does for CS9 at line 15), so this job doesn't need to pass it explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CS10 RPM dependency build configuration in the continuous integration pipeline to specify a builder version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->