### PR TITLE
fix(quarantine): preserve comments when quarantining tests

### DIFF
--- a/pkg/ginkgo/modify.go
+++ b/pkg/ginkgo/modify.go
@@ -40,7 +40,12 @@ func QuarantineTest(report *types.SpecReport) error {
 		return fmt.Errorf("could not quarantine test %q: %w", report.FullText(), err)
 	}
 	code = ensureImport(code, decoratorsImport)
-	formatted, err := imports.Process(report.LeafNodeLocation.FileName, []byte(code), &imports.Options{FormatOnly: true})
+	formatted, err := imports.Process(report.LeafNodeLocation.FileName, []byte(code), &imports.Options{
+		FormatOnly: true,
+		Comments:   true,
+		TabIndent:  true,
+		TabWidth:   8,
+	})
 	if err != nil {
 		return fmt.Errorf("could not format file for quarantined test %q: %w", report.FullText(), err)
 	}

--- a/pkg/ginkgo/modify_test.go
+++ b/pkg/ginkgo/modify_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/tools/imports"
 )
 
 var _ = Describe("modify", func() {
@@ -127,6 +128,67 @@ func main() {}
 `
 			result := ensureImport(code, "kubevirt.io/kubevirt/tests/decorators")
 			Expect(result).To(BeEquivalentTo(code))
+		})
+	})
+
+	When("imports.Process preserves comments", func() {
+
+		It("retains all comments when formatting with correct options", func() {
+			input := `/*
+ * License header comment.
+ */
+
+package foo
+
+import (
+	"fmt"
+)
+
+// Function comment.
+func main() {
+	// inline comment
+	fmt.Println("hello") // trailing comment
+}
+`
+			formatted, err := imports.Process("foo.go", []byte(input), &imports.Options{
+				FormatOnly: true,
+				Comments:   true,
+				TabIndent:  true,
+				TabWidth:   8,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			result := string(formatted)
+
+			By("verifying the license header is preserved")
+			Expect(result).To(ContainSubstring("License header comment."))
+
+			By("verifying the function comment is preserved")
+			Expect(result).To(ContainSubstring("// Function comment."))
+
+			By("verifying the inline comment is preserved")
+			Expect(result).To(ContainSubstring("// inline comment"))
+
+			By("verifying the trailing comment is preserved")
+			Expect(result).To(ContainSubstring("// trailing comment"))
+		})
+
+		It("strips comments when Comments is false (demonstrating the bug)", func() {
+			input := `package foo
+
+import (
+	"fmt"
+)
+
+// This comment should be stripped.
+func main() {
+	fmt.Println("hello")
+}
+`
+			formatted, err := imports.Process("foo.go", []byte(input), &imports.Options{
+				FormatOnly: true,
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(formatted)).ToNot(ContainSubstring("// This comment should be stripped."))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The quarantine `test` command was stripping all comments (including license headers, inline explanations, and TODO references) from the modified test file. The root cause is that `imports.Process` in `pkg/ginkgo/modify.go` was called with explicit `&imports.Options{FormatOnly: true}`, but the `Comments` field defaulted to `false` (Go zero value). The `imports` package interprets `Comments: false` as "strip comments from the output."

This fix sets `Comments: true` along with the other nil-options defaults (`TabIndent: true`, `TabWidth: 8`) to match the behavior of passing nil options.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

The bug can be verified by comparing the [imports.Options nil-path defaults](https://github.com/golang/tools/blob/master/imports/forward.go#L53) with the explicit options that were being passed.

Two test cases are added: one confirming comments are preserved with correct options, and one demonstrating the bug with `Comments: false`.

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting behavior for quarantined tests to ensure license headers, function comments, inline comments, and trailing comments are properly preserved during the formatting process.

* **Tests**
  * Added comprehensive test coverage to verify that the formatting process correctly preserves comments when the preservation option is enabled, and to document current behavior when preservation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->