### PR TITLE
Fix CS10 builder prow jobs to use correct Makefile targets

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -270,7 +270,7 @@ postsubmits:
             - "-c"
             - >
               cat $QUAY_PASSWORD | podman login quay.io --username $(cat $QUAY_USER) --password-stdin=true &&
-              make builder-publish-cs10
+              make builder-publish-centos-stream-10
           securityContext:
             privileged: true
           resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1383,7 +1383,7 @@ presubmits:
         - /bin/sh
         - -ce
         - |
-          make builder-build-cs10
+          make builder-build-centos-stream-10
         image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
         name: ""
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

The presubmit (`build-kubevirt-builder-cs10`) and postsubmit (`publish-kubevirt-builder-cs10`) prow jobs call `make builder-build-cs10` and `make builder-publish-cs10` respectively, but these targets don't exist in the kubevirt Makefile. The actual targets are `builder-build-centos-stream-10` and `builder-publish-centos-stream-10`.

This mismatch means the CS10 builder image has not been automatically rebuilt by the postsubmit since it was introduced, leaving the image stale at `2605290816-89fad9a940` (May 29) with libvirt 11.10.0 — even though libvirt 12.4.0 is now available in CentOS Stream 10.

**Special notes for your reviewer**:

Once this merges, the next change to `hack/builder/` in kubevirt/kubevirt will trigger the postsubmit and rebuild the CS10 builder image, picking up libvirt 12.4.0 from CS10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and publish commands for CentOS Stream 10 builder components to use standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->