### PR TITLE
feat(test-execution-report): add test execution report for presubmit and periodic lanes

### DIFF
--- a/pkg/flakefinder/downloader.go
+++ b/pkg/flakefinder/downloader.go
@@ -97,7 +97,7 @@ func findUnitTestFileForJob(ctx context.Context, client *storage.Client, bucket 
 	if err != nil {
 		return nil, fmt.Errorf("error listing gcs objects: %v", err)
 	}
-	builds := sortBuilds(prJobs)
+	builds := SortBuilds(prJobs)
 	profilePath := ""
 	buildNumber := 0
 	reports := []*JobResult{}
@@ -120,14 +120,14 @@ func findUnitTestFileForJob(ctx context.Context, client *storage.Client, bucket 
 			continue
 		}
 
-		_, err = readGcsObject(ctx, client, bucket, dirOfFinishedJSON)
+		_, err = ReadGcsObject(ctx, client, bucket, dirOfFinishedJSON)
 		if err == storage.ErrObjectNotExist {
 			// build still running?
 			continue
 		} else if err != nil {
 			return nil, fmt.Errorf("Cannot read finished.json (%s) in bucket '%s'", dirOfFinishedJSON, bucket)
 		} else {
-			startedJSON, err := readGcsObject(ctx, client, bucket, dirOfStartedJSON)
+			startedJSON, err := ReadGcsObject(ctx, client, bucket, dirOfStartedJSON)
 			if err != nil {
 				return nil, fmt.Errorf("Cannot read started.json (%s) in bucket '%s'", dirOfStartedJSON, bucket)
 			}
@@ -138,7 +138,7 @@ func findUnitTestFileForJob(ctx context.Context, client *storage.Client, bucket 
 			buildNumber = build
 			artifactsDirPath := path.Join(buildDirPath, "artifacts")
 			profilePath = path.Join(artifactsDirPath, "junit.functest.xml")
-			data, err := readGcsObject(ctx, client, bucket, profilePath)
+			data, err := ReadGcsObject(ctx, client, bucket, profilePath)
 			if err == storage.ErrObjectNotExist {
 				logrus.Infof("Didn't find object '%s' in bucket '%s'\n", profilePath, bucket)
 				continue
@@ -171,7 +171,7 @@ func FindUnitTestFilesForPeriodicJob(ctx context.Context, client *storage.Client
 	if err != nil {
 		return nil, fmt.Errorf("error listing gcs objects: %v", err)
 	}
-	builds := sortBuilds(jobDirs)
+	builds := SortBuilds(jobDirs)
 
 	profilePath := ""
 	buildNumber := 0
@@ -199,7 +199,7 @@ func FindUnitTestFilesForPeriodicJob(ctx context.Context, client *storage.Client
 			continue
 		}
 
-		_, err = readGcsObject(ctx, client, bucket, dirOfFinishedJSON)
+		_, err = ReadGcsObject(ctx, client, bucket, dirOfFinishedJSON)
 
 		if err != nil {
 			return nil, err
@@ -213,7 +213,7 @@ func FindUnitTestFilesForPeriodicJob(ctx context.Context, client *storage.Client
 			buildNumber = build
 			artifactsDirPath := path.Join(buildDirPath, "artifacts")
 			profilePath = path.Join(artifactsDirPath, "junit.functest.xml")
-			data, err := readGcsObject(ctx, client, bucket, profilePath)
+			data, err := ReadGcsObject(ctx, client, bucket, profilePath)
 			lastJobDirectoryPathElement := jobDirectorySegments[len(jobDirectorySegments)-1]
 			if err == storage.ErrObjectNotExist {
 
@@ -229,7 +229,7 @@ func FindUnitTestFilesForPeriodicJob(ctx context.Context, client *storage.Client
 				submatches := testJobNameRegex.FindStringSubmatch(lastJobDirectoryPathElement)
 				testJobName := submatches[1] // take the first submatch here, see regex for details
 				openShiftCIPath := path.Join(artifactsDirPath, fmt.Sprintf("%s/test/artifacts", testJobName), "junit.functest.xml")
-				data, err = readGcsObject(ctx, client, bucket, openShiftCIPath)
+				data, err = ReadGcsObject(ctx, client, bucket, openShiftCIPath)
 				if err == storage.ErrObjectNotExist {
 					logrus.Infof("Didn't find object '%s' in bucket '%s'\n", profilePath, bucket)
 					logrus.Infof("Didn't find object '%s' in bucket '%s'\n", openShiftCIPath, bucket)
@@ -290,7 +290,7 @@ func FindUnitTestFilesForBatchJobs(ctx context.Context, client *storage.Client, 
 			return nil, fmt.Errorf("error listing gcs objects: %v", err)
 		}
 
-		builds := sortBuilds(buildDirs)
+		builds := SortBuilds(buildDirs)
 
 		profilePath := ""
 		buildNumber := 0
@@ -317,7 +317,7 @@ func FindUnitTestFilesForBatchJobs(ctx context.Context, client *storage.Client, 
 				continue
 			}
 
-			_, err = readGcsObject(ctx, client, bucket, dirOfFinishedJSON)
+			_, err = ReadGcsObject(ctx, client, bucket, dirOfFinishedJSON)
 			if err == storage.ErrObjectNotExist {
 				// build still running?
 				continue
@@ -328,7 +328,7 @@ func FindUnitTestFilesForBatchJobs(ctx context.Context, client *storage.Client, 
 
 				// we look for any PR number appearing inside the batch job definition
 				prowJobFile := path.Join(buildDirPath, prowv1.ProwJobFile)
-				prowJobData, err := readGcsObject(ctx, client, bucket, prowJobFile)
+				prowJobData, err := ReadGcsObject(ctx, client, bucket, prowJobFile)
 				if err == storage.ErrObjectNotExist {
 					continue
 				}
@@ -351,7 +351,7 @@ func FindUnitTestFilesForBatchJobs(ctx context.Context, client *storage.Client, 
 
 				artifactsDirPath := path.Join(buildDirPath, "artifacts")
 				profilePath = path.Join(artifactsDirPath, "junit.functest.xml")
-				data, err := readGcsObject(ctx, client, bucket, profilePath)
+				data, err := ReadGcsObject(ctx, client, bucket, profilePath)
 				if err == storage.ErrObjectNotExist {
 					continue
 				} else if err != nil {
@@ -380,7 +380,7 @@ func FindUnitTestFilesForBatchJobs(ctx context.Context, client *storage.Client, 
 	return reports, nil
 }
 
-func readGcsObject(ctx context.Context, client *storage.Client, bucket, object string) ([]byte, error) {
+func ReadGcsObject(ctx context.Context, client *storage.Client, bucket, object string) ([]byte, error) {
 	logrus.Infof("Trying to read gcs object '%s' in bucket '%s'\n", object, bucket)
 	o := client.Bucket(bucket).Object(object)
 	reader, err := o.NewReader(ctx)
@@ -392,9 +392,9 @@ func readGcsObject(ctx context.Context, client *storage.Client, bucket, object s
 	return io.ReadAll(reader)
 }
 
-// sortBuilds converts all build from str to int and sorts all builds in descending order and
+// SortBuilds converts all build from str to int and sorts all builds in descending order and
 // returns the sorted slice
-func sortBuilds(strBuilds []string) []int {
+func SortBuilds(strBuilds []string) []int {
 	var res []int
 	for _, buildStr := range strBuilds {
 		num, err := strconv.Atoi(buildStr)
@@ -420,7 +420,7 @@ func IsLatestCommit(jsonText []byte, change api.Change) bool {
 // readCommitIDFromCloneRecords attempts to fetch and parse clone-records.json to get the CommitID (SHA).
 func readCommitIDFromCloneRecords(ctx context.Context, client *storage.Client, bucket string, buildDirPath string) (string, error) {
 	cloneRecordsPath := path.Join(buildDirPath, cloneRecordsJSON)
-	data, err := readGcsObject(ctx, client, bucket, cloneRecordsPath)
+	data, err := ReadGcsObject(ctx, client, bucket, cloneRecordsPath)
 	if err == storage.ErrObjectNotExist {
 		logrus.Debugf("Didn't find object '%s' in bucket '%s'", cloneRecordsPath, bucket)
 		return "", nil

--- a/robots/test-execution-report/Makefile
+++ b/robots/test-execution-report/Makefile
@@ -1,0 +1,23 @@
+CONTAINER_IMAGE := test-execution-report
+CONTAINER_REPO := quay.io/kubevirtci/$(CONTAINER_IMAGE)
+
+.PHONY: all clean verify format test push
+
+all: format verify test
+
+format:
+	gofmt -w .
+
+test:
+	go test ./...
+
+verify:
+	go build .
+	go vet ./...
+
+push:
+	cd ../../images && ./publish_image.sh $(CONTAINER_IMAGE) quay.io kubevirtci
+	bash -x "../../hack/update-jobs-with-latest-image.sh" "$(CONTAINER_REPO)"
+
+clean:
+	go clean -cache -modcache

--- a/robots/test-execution-report/default-config.yaml
+++ b/robots/test-execution-report/default-config.yaml
@@ -1,0 +1,2 @@
+jobNamePattern: ^pull-kubevirt-e2e-.*$
+testNamePattern: .*

--- a/robots/test-execution-report/default-config.yaml
+++ b/robots/test-execution-report/default-config.yaml
@@ -1,2 +1,3 @@
 jobNamePattern: ^pull-kubevirt-e2e-.*$
+periodicJobNamePattern: ^periodic-kubevirt-e2e-.*$
 testNamePattern: .*

--- a/robots/test-execution-report/main.go
+++ b/robots/test-execution-report/main.go
@@ -248,17 +248,19 @@ func fetchPresubmitResults(ctx context.Context, storageClient *storage.Client, c
 	repoPrefix := path.Join("pr-logs", "pull", opts.org+"_"+opts.repo)
 
 	var allResults []*flakefinder.JobResult
-	consecutiveStale := 0
-	const maxConsecutiveStale = 20
+	consecutiveEmpty := 0
+	const maxConsecutiveEmpty = 50
 
-	for prNum := startPR; prNum > 0 && consecutiveStale < maxConsecutiveStale; prNum-- {
+	for prNum := startPR; prNum > 0 && consecutiveEmpty < maxConsecutiveEmpty; prNum-- {
 		prDir := path.Join(repoPrefix, strconv.Itoa(prNum))
 		jobDirs, err := flakefinder.ListGcsObjects(ctx, storageClient, opts.bucket, prDir+"/", "/")
 		if err != nil {
 			log.Warnf("failed to list jobs for PR %d: %v", prNum, err)
+			consecutiveEmpty++
 			continue
 		}
 		if len(jobDirs) == 0 {
+			consecutiveEmpty++
 			continue
 		}
 
@@ -292,7 +294,10 @@ func fetchPresubmitResults(ctx context.Context, storageClient *storage.Client, c
 				log.Warnf("failed to read finished.json attrs for PR %d job %s build %d: %v", prNum, jobName, latestBuild, err)
 				continue
 			}
-			if attrs.Created.Before(startOfReport) || attrs.Created.After(endOfReport) {
+			if attrs.Created.Before(startOfReport) {
+				continue
+			}
+			if attrs.Created.After(endOfReport) {
 				continue
 			}
 
@@ -316,9 +321,9 @@ func fetchPresubmitResults(ctx context.Context, storageClient *storage.Client, c
 		}
 
 		if prHasRecentBuild {
-			consecutiveStale = 0
+			consecutiveEmpty = 0
 		} else {
-			consecutiveStale++
+			consecutiveEmpty++
 		}
 	}
 

--- a/robots/test-execution-report/main.go
+++ b/robots/test-execution-report/main.go
@@ -25,22 +25,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/google/go-github/v28/github"
 	"github.com/joshdk/go-junit"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/oauth2"
-	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/yaml"
 
 	"kubevirt.io/project-infra/pkg/flakefinder"
-	ghapi "kubevirt.io/project-infra/pkg/flakefinder/github"
 )
 
 const (
@@ -49,6 +47,8 @@ const (
 	ExecRan
 	ExecQuarantined
 )
+
+var releaseBranchSuffix = regexp.MustCompile(`-\d+\.\d+$`)
 
 //go:embed default-config.yaml
 var defaultConfigBytes []byte
@@ -81,10 +81,8 @@ type ReportData struct {
 }
 
 var opts struct {
-	token      string
 	org        string
 	repo       string
-	baseBranch string
 	bucket     string
 	startFrom  time.Duration
 	configFile string
@@ -101,12 +99,10 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.Flags().StringVar(&opts.token, "token", "", "path to GitHub token (required)")
 	rootCmd.Flags().StringVar(&opts.org, "org", "kubevirt", "GitHub organization")
 	rootCmd.Flags().StringVar(&opts.repo, "repo", "kubevirt", "GitHub repository")
-	rootCmd.Flags().StringVar(&opts.baseBranch, "pr-base-branch", "main", "base branch for PR query")
 	rootCmd.Flags().StringVar(&opts.bucket, "bucket", flakefinder.BucketName, "GCS bucket name")
-	rootCmd.Flags().DurationVar(&opts.startFrom, "start-from", 14*24*time.Hour, "time window for merged PRs")
+	rootCmd.Flags().DurationVar(&opts.startFrom, "start-from", 14*24*time.Hour, "time window for report data")
 	rootCmd.Flags().StringVar(&opts.configFile, "config-file", "", "YAML config file (default: embedded config)")
 	rootCmd.Flags().StringVar(&opts.outputFile, "output-file", "", "output HTML file path (default: temp file)")
 	rootCmd.Flags().StringVar(&opts.baseURL, "base-url", "https://prow.ci.kubevirt.io", "Prow deck base URL for links")
@@ -129,10 +125,6 @@ func run(cmd *cobra.Command, args []string) error {
 	includePresubmit := source == "presubmit" || source == "all"
 	includePeriodic := source == "periodic" || source == "all"
 
-	if includePresubmit && opts.token == "" {
-		return fmt.Errorf("--token is required for presubmit source")
-	}
-
 	cfg, err := loadConfig()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
@@ -143,12 +135,6 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	if includePeriodic && cfg.periodicJobPattern == nil {
 		return fmt.Errorf("periodicJobNamePattern is required for periodic source")
-	}
-
-	if includePresubmit {
-		if err := secret.Add(opts.token); err != nil {
-			return fmt.Errorf("loading token: %v", err)
-		}
 	}
 
 	ctx := context.Background()
@@ -253,48 +239,149 @@ func run(cmd *cobra.Command, args []string) error {
 }
 
 func fetchPresubmitResults(ctx context.Context, storageClient *storage.Client, cfg *Config, startOfReport, endOfReport time.Time) ([]*flakefinder.JobResult, error) {
-	ghClient := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: string(secret.GetSecret(opts.token))},
-	)))
-	query := ghapi.NewQuery(ghClient, opts.org, opts.repo, opts.baseBranch)
-
-	log.Infof("Querying merged PRs from %s to %s", startOfReport.Format(time.RFC3339), endOfReport.Format(time.RFC3339))
-	changes, err := query.Query(ctx, startOfReport, endOfReport)
+	startPR, err := resolveLatestPR(ctx, storageClient, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("querying PRs: %v", err)
+		return nil, fmt.Errorf("resolving latest PR number: %v", err)
 	}
-	log.Infof("Found %d merged PRs", len(changes))
+	log.Infof("Starting presubmit scan from PR %d", startPR)
 
-	if len(changes) == 0 {
-		log.Warn("no merged PRs found in time window")
-		return nil, nil
-	}
+	repoPrefix := path.Join("pr-logs", "pull", opts.org+"_"+opts.repo)
 
 	var allResults []*flakefinder.JobResult
-	repoPath := strings.Join([]string{opts.org, opts.repo}, "/")
-	for _, change := range changes {
-		results, err := flakefinder.FindUnitTestFiles(ctx, storageClient, opts.bucket, repoPath, change, startOfReport, true)
+	consecutiveStale := 0
+	const maxConsecutiveStale = 20
+
+	for prNum := startPR; prNum > 0 && consecutiveStale < maxConsecutiveStale; prNum-- {
+		prDir := path.Join(repoPrefix, strconv.Itoa(prNum))
+		jobDirs, err := flakefinder.ListGcsObjects(ctx, storageClient, opts.bucket, prDir+"/", "/")
 		if err != nil {
-			log.Warnf("failed to load JUnit for PR %d: %v", change.ID(), err)
+			log.Warnf("failed to list jobs for PR %d: %v", prNum, err)
 			continue
 		}
-		allResults = append(allResults, results...)
-	}
+		if len(jobDirs) == 0 {
+			continue
+		}
 
-	batchResults, err := flakefinder.FindUnitTestFilesForBatchJobs(ctx, storageClient, opts.bucket, nil, changes, startOfReport, endOfReport)
-	if err != nil {
-		log.Warnf("failed to load batch job JUnit: %v", err)
-	}
-	allResults = append(allResults, batchResults...)
+		prHasRecentBuild := false
+		for _, jobName := range jobDirs {
+			if !cfg.jobPattern.MatchString(jobName) {
+				continue
+			}
+			if releaseBranchSuffix.MatchString(jobName) {
+				continue
+			}
+			jobDir := path.Join(prDir, jobName)
+			buildDirs, err := flakefinder.ListGcsObjects(ctx, storageClient, opts.bucket, jobDir+"/", "/")
+			if err != nil {
+				log.Warnf("failed to list builds for PR %d job %s: %v", prNum, jobName, err)
+				continue
+			}
+			builds := flakefinder.SortBuilds(buildDirs)
+			if len(builds) == 0 {
+				continue
+			}
 
-	var filtered []*flakefinder.JobResult
-	for _, r := range allResults {
-		if cfg.jobPattern.MatchString(r.Job) {
-			filtered = append(filtered, r)
+			latestBuild := builds[0]
+			buildDir := path.Join(jobDir, strconv.Itoa(latestBuild))
+			finishedPath := path.Join(buildDir, "finished.json")
+
+			attrs, err := flakefinder.ReadGcsObjectAttrs(ctx, storageClient, opts.bucket, finishedPath)
+			if err == storage.ErrObjectNotExist {
+				continue
+			} else if err != nil {
+				log.Warnf("failed to read finished.json attrs for PR %d job %s build %d: %v", prNum, jobName, latestBuild, err)
+				continue
+			}
+			if attrs.Created.Before(startOfReport) || attrs.Created.After(endOfReport) {
+				continue
+			}
+
+			prHasRecentBuild = true
+			profilePath := path.Join(buildDir, "artifacts", "junit.functest.xml")
+			data, err := flakefinder.ReadGcsObject(ctx, storageClient, opts.bucket, profilePath)
+			if err == storage.ErrObjectNotExist {
+				log.Infof("no junit.functest.xml for PR %d job %s build %d", prNum, jobName, latestBuild)
+				continue
+			} else if err != nil {
+				log.Warnf("failed to read JUnit for PR %d job %s: %v", prNum, jobName, err)
+				continue
+			}
+
+			report, err := junit.Ingest(data)
+			if err != nil {
+				log.Warnf("failed to parse JUnit for PR %d job %s: %v", prNum, jobName, err)
+				continue
+			}
+			allResults = append(allResults, &flakefinder.JobResult{Job: jobName, JUnit: report, BuildNumber: latestBuild, PR: prNum})
+		}
+
+		if prHasRecentBuild {
+			consecutiveStale = 0
+		} else {
+			consecutiveStale++
 		}
 	}
 
-	return filtered, nil
+	return allResults, nil
+}
+
+func resolveLatestPR(ctx context.Context, storageClient *storage.Client, cfg *Config) (int, error) {
+	jobDirs, err := flakefinder.ListGcsObjects(ctx, storageClient, opts.bucket, "pr-logs/directory/", "/")
+	if err != nil {
+		return 0, fmt.Errorf("listing presubmit job directories: %v", err)
+	}
+
+	var bestJob string
+	var bestBuildID int
+	for _, dir := range jobDirs {
+		if !cfg.jobPattern.MatchString(dir) {
+			continue
+		}
+		if releaseBranchSuffix.MatchString(dir) {
+			continue
+		}
+		latestBuildPath := path.Join("pr-logs", "directory", dir, "latest-build.txt")
+		data, err := flakefinder.ReadGcsObject(ctx, storageClient, opts.bucket, latestBuildPath)
+		if err != nil {
+			log.Debugf("skipping job %s: cannot read latest-build.txt: %v", dir, err)
+			continue
+		}
+		buildID, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			continue
+		}
+		if buildID > bestBuildID {
+			bestBuildID = buildID
+			bestJob = dir
+		}
+	}
+	if bestJob == "" {
+		return 0, fmt.Errorf("no active job matching pattern %q found in pr-logs/directory/", cfg.JobNamePattern)
+	}
+	log.Infof("Using reference job %s (build %d) to find latest PR number", bestJob, bestBuildID)
+
+	aliasPath := path.Join("pr-logs", "directory", bestJob, strconv.Itoa(bestBuildID)+".txt")
+	aliasData, err := flakefinder.ReadGcsObject(ctx, storageClient, opts.bucket, aliasPath)
+	if err != nil {
+		return 0, fmt.Errorf("reading alias file %s: %v", aliasPath, err)
+	}
+
+	return parsePRFromAliasPath(string(aliasData), opts.org+"_"+opts.repo)
+}
+
+func parsePRFromAliasPath(aliasContent, repoSlug string) (int, error) {
+	content := strings.TrimSpace(aliasContent)
+	parts := strings.Split(content, "/")
+	for i, part := range parts {
+		if part == repoSlug && i+1 < len(parts) {
+			prNum, err := strconv.Atoi(parts[i+1])
+			if err != nil {
+				return 0, fmt.Errorf("cannot parse PR number from alias path %q: %v", content, err)
+			}
+			return prNum, nil
+		}
+	}
+	return 0, fmt.Errorf("repo slug %q not found in alias path %q", repoSlug, content)
 }
 
 func fetchPeriodicResults(ctx context.Context, storageClient *storage.Client, cfg *Config, startOfReport, endOfReport time.Time) ([]*flakefinder.JobResult, error) {

--- a/robots/test-execution-report/main.go
+++ b/robots/test-execution-report/main.go
@@ -57,10 +57,12 @@ var defaultConfigBytes []byte
 var reportTemplate string
 
 type Config struct {
-	JobNamePattern  string `yaml:"jobNamePattern"`
-	TestNamePattern string `yaml:"testNamePattern"`
-	jobPattern      *regexp.Regexp
-	testPattern     *regexp.Regexp
+	JobNamePattern         string `yaml:"jobNamePattern"`
+	PeriodicJobNamePattern string `yaml:"periodicJobNamePattern"`
+	TestNamePattern        string `yaml:"testNamePattern"`
+	jobPattern             *regexp.Regexp
+	periodicJobPattern     *regexp.Regexp
+	testPattern            *regexp.Regexp
 }
 
 type ReportData struct {
@@ -70,6 +72,7 @@ type ReportData struct {
 	QuarantinedTests map[string]bool
 	SkippedTests     map[string]bool
 	Jobs             []string
+	PeriodicJobs     map[string]bool
 	Matrix           map[string]map[string]int
 	StatusLabels     map[string]int
 	StartOfReport    string
@@ -87,12 +90,13 @@ var opts struct {
 	configFile string
 	outputFile string
 	baseURL    string
+	source     string
 	dryRun     bool
 }
 
 var rootCmd = &cobra.Command{
 	Use:   "test-execution-report",
-	Short: "Creates an HTML report showing which tests are run on which presubmit lane",
+	Short: "Creates an HTML report showing which tests are run on which presubmit and/or periodic lane",
 	RunE:  run,
 }
 
@@ -106,6 +110,7 @@ func init() {
 	rootCmd.Flags().StringVar(&opts.configFile, "config-file", "", "YAML config file (default: embedded config)")
 	rootCmd.Flags().StringVar(&opts.outputFile, "output-file", "", "output HTML file path (default: temp file)")
 	rootCmd.Flags().StringVar(&opts.baseURL, "base-url", "https://prow.ci.kubevirt.io", "Prow deck base URL for links")
+	rootCmd.Flags().StringVar(&opts.source, "source", "presubmit", "data source: presubmit, periodic, or all")
 	rootCmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "list matching jobs and exit")
 }
 
@@ -116,8 +121,16 @@ func main() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	if opts.token == "" {
-		return fmt.Errorf("--token is required")
+	source := opts.source
+	if source != "presubmit" && source != "periodic" && source != "all" {
+		return fmt.Errorf("--source must be one of: presubmit, periodic, all")
+	}
+
+	includePresubmit := source == "presubmit" || source == "all"
+	includePeriodic := source == "periodic" || source == "all"
+
+	if includePresubmit && opts.token == "" {
+		return fmt.Errorf("--token is required for presubmit source")
 	}
 
 	cfg, err := loadConfig()
@@ -125,19 +138,20 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	jobPattern := cfg.jobPattern
-	testPattern := cfg.testPattern
+	if includePresubmit && cfg.jobPattern == nil {
+		return fmt.Errorf("jobNamePattern is required for presubmit source")
+	}
+	if includePeriodic && cfg.periodicJobPattern == nil {
+		return fmt.Errorf("periodicJobNamePattern is required for periodic source")
+	}
 
-	if err := secret.Add(opts.token); err != nil {
-		return fmt.Errorf("loading token: %v", err)
+	if includePresubmit {
+		if err := secret.Add(opts.token); err != nil {
+			return fmt.Errorf("loading token: %v", err)
+		}
 	}
 
 	ctx := context.Background()
-
-	ghClient := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: string(secret.GetSecret(opts.token))},
-	)))
-	query := ghapi.NewQuery(ghClient, opts.org, opts.repo, opts.baseBranch)
 
 	storageClient, err := storage.NewClient(ctx)
 	if err != nil {
@@ -147,45 +161,30 @@ func run(cmd *cobra.Command, args []string) error {
 	endOfReport := time.Now()
 	startOfReport := endOfReport.Add(-opts.startFrom)
 
-	log.Infof("Querying merged PRs from %s to %s", startOfReport.Format(time.RFC3339), endOfReport.Format(time.RFC3339))
-	changes, err := query.Query(ctx, startOfReport, endOfReport)
-	if err != nil {
-		return fmt.Errorf("querying PRs: %v", err)
-	}
-	log.Infof("Found %d merged PRs", len(changes))
-
-	if len(changes) == 0 {
-		log.Warn("no merged PRs found in time window")
-		return nil
-	}
-
 	var allResults []*flakefinder.JobResult
-	repoPath := strings.Join([]string{opts.org, opts.repo}, "/")
-	for _, change := range changes {
-		results, err := flakefinder.FindUnitTestFiles(ctx, storageClient, opts.bucket, repoPath, change, startOfReport, true)
+	periodicJobs := map[string]bool{}
+
+	if includePresubmit {
+		presubmitResults, err := fetchPresubmitResults(ctx, storageClient, cfg, startOfReport, endOfReport)
 		if err != nil {
-			log.Warnf("failed to load JUnit for PR %d: %v", change.ID(), err)
-			continue
+			return err
 		}
-		allResults = append(allResults, results...)
+		allResults = append(allResults, presubmitResults...)
 	}
 
-	batchResults, err := flakefinder.FindUnitTestFilesForBatchJobs(ctx, storageClient, opts.bucket, nil, changes, startOfReport, endOfReport)
-	if err != nil {
-		log.Warnf("failed to load batch job JUnit: %v", err)
-	}
-	allResults = append(allResults, batchResults...)
-
-	// Filter by job name pattern
-	var filtered []*flakefinder.JobResult
-	for _, r := range allResults {
-		if jobPattern.MatchString(r.Job) {
-			filtered = append(filtered, r)
+	if includePeriodic {
+		periodicResults, err := fetchPeriodicResults(ctx, storageClient, cfg, startOfReport, endOfReport)
+		if err != nil {
+			return err
+		}
+		allResults = append(allResults, periodicResults...)
+		for _, r := range periodicResults {
+			periodicJobs[r.Job] = true
 		}
 	}
 
 	jobSet := map[string]struct{}{}
-	for _, r := range filtered {
+	for _, r := range allResults {
 		jobSet[r.Job] = struct{}{}
 	}
 	jobs := sortedKeys(jobSet)
@@ -202,7 +201,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	matrix := buildMatrix(filtered, testPattern)
+	matrix := buildMatrix(allResults, cfg.testPattern)
 
 	testNames, skippedTests, quarantinedTests := classifyTests(matrix)
 
@@ -217,6 +216,7 @@ func run(cmd *cobra.Command, args []string) error {
 		QuarantinedTests: quarantinedTests,
 		SkippedTests:     skippedTests,
 		Jobs:             jobs,
+		PeriodicJobs:     periodicJobs,
 		Matrix:           matrix,
 		StatusLabels: map[string]int{
 			"ExecNoData":      ExecNoData,
@@ -252,6 +252,77 @@ func run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func fetchPresubmitResults(ctx context.Context, storageClient *storage.Client, cfg *Config, startOfReport, endOfReport time.Time) ([]*flakefinder.JobResult, error) {
+	ghClient := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: string(secret.GetSecret(opts.token))},
+	)))
+	query := ghapi.NewQuery(ghClient, opts.org, opts.repo, opts.baseBranch)
+
+	log.Infof("Querying merged PRs from %s to %s", startOfReport.Format(time.RFC3339), endOfReport.Format(time.RFC3339))
+	changes, err := query.Query(ctx, startOfReport, endOfReport)
+	if err != nil {
+		return nil, fmt.Errorf("querying PRs: %v", err)
+	}
+	log.Infof("Found %d merged PRs", len(changes))
+
+	if len(changes) == 0 {
+		log.Warn("no merged PRs found in time window")
+		return nil, nil
+	}
+
+	var allResults []*flakefinder.JobResult
+	repoPath := strings.Join([]string{opts.org, opts.repo}, "/")
+	for _, change := range changes {
+		results, err := flakefinder.FindUnitTestFiles(ctx, storageClient, opts.bucket, repoPath, change, startOfReport, true)
+		if err != nil {
+			log.Warnf("failed to load JUnit for PR %d: %v", change.ID(), err)
+			continue
+		}
+		allResults = append(allResults, results...)
+	}
+
+	batchResults, err := flakefinder.FindUnitTestFilesForBatchJobs(ctx, storageClient, opts.bucket, nil, changes, startOfReport, endOfReport)
+	if err != nil {
+		log.Warnf("failed to load batch job JUnit: %v", err)
+	}
+	allResults = append(allResults, batchResults...)
+
+	var filtered []*flakefinder.JobResult
+	for _, r := range allResults {
+		if cfg.jobPattern.MatchString(r.Job) {
+			filtered = append(filtered, r)
+		}
+	}
+
+	return filtered, nil
+}
+
+func fetchPeriodicResults(ctx context.Context, storageClient *storage.Client, cfg *Config, startOfReport, endOfReport time.Time) ([]*flakefinder.JobResult, error) {
+	jobDir := "logs"
+	log.Infof("Listing periodic jobs from gs://%s/%s/", opts.bucket, jobDir)
+
+	periodicJobDirs, err := flakefinder.ListGcsObjects(ctx, storageClient, opts.bucket, jobDir+"/", "/")
+	if err != nil {
+		return nil, fmt.Errorf("listing periodic job directories: %v", err)
+	}
+
+	var allResults []*flakefinder.JobResult
+	for _, dir := range periodicJobDirs {
+		if !cfg.periodicJobPattern.MatchString(dir) {
+			continue
+		}
+		log.Infof("Fetching JUnit for periodic job %s", dir)
+		results, err := flakefinder.FindUnitTestFilesForPeriodicJob(ctx, storageClient, opts.bucket, []string{jobDir, dir}, startOfReport, endOfReport)
+		if err != nil {
+			log.Warnf("failed to load JUnit for periodic job %s: %v", dir, err)
+			continue
+		}
+		allResults = append(allResults, results...)
+	}
+
+	return allResults, nil
+}
+
 func loadConfig() (*Config, error) {
 	var raw []byte
 	if opts.configFile != "" {
@@ -268,12 +339,17 @@ func loadConfig() (*Config, error) {
 	if err = yaml.UnmarshalStrict(raw, &cfg); err != nil {
 		return nil, err
 	}
-	if cfg.JobNamePattern == "" {
-		return nil, fmt.Errorf("jobNamePattern is required")
+	if cfg.JobNamePattern != "" {
+		cfg.jobPattern, err = regexp.Compile(cfg.JobNamePattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regexp for jobNamePattern: %w", err)
+		}
 	}
-	cfg.jobPattern, err = regexp.Compile(cfg.JobNamePattern)
-	if err != nil {
-		return nil, fmt.Errorf("invalid regexp for jobNamePattern: %w", err)
+	if cfg.PeriodicJobNamePattern != "" {
+		cfg.periodicJobPattern, err = regexp.Compile(cfg.PeriodicJobNamePattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regexp for periodicJobNamePattern: %w", err)
+		}
 	}
 	if cfg.TestNamePattern == "" {
 		return nil, fmt.Errorf("testNamePattern is required")

--- a/robots/test-execution-report/main.go
+++ b/robots/test-execution-report/main.go
@@ -59,6 +59,8 @@ var reportTemplate string
 type Config struct {
 	JobNamePattern  string `yaml:"jobNamePattern"`
 	TestNamePattern string `yaml:"testNamePattern"`
+	jobPattern      *regexp.Regexp
+	testPattern     *regexp.Regexp
 }
 
 type ReportData struct {
@@ -120,11 +122,11 @@ func run(cmd *cobra.Command, args []string) error {
 
 	cfg, err := loadConfig()
 	if err != nil {
-		return fmt.Errorf("loading config: %v", err)
+		return fmt.Errorf("loading config: %w", err)
 	}
 
-	jobPattern := regexp.MustCompile(cfg.JobNamePattern)
-	testPattern := regexp.MustCompile(cfg.TestNamePattern)
+	jobPattern := cfg.jobPattern
+	testPattern := cfg.testPattern
 
 	if err := secret.Add(opts.token); err != nil {
 		return fmt.Errorf("loading token: %v", err)
@@ -204,7 +206,10 @@ func run(cmd *cobra.Command, args []string) error {
 
 	testNames, skippedTests, quarantinedTests := classifyTests(matrix)
 
-	configBytes, _ := yaml.Marshal(cfg)
+	configBytes, err := yaml.Marshal(cfg)
+	if err != nil {
+		return err
+	}
 	data := ReportData{
 		BaseURL:          opts.baseURL,
 		Bucket:           opts.bucket,
@@ -259,8 +264,23 @@ func loadConfig() (*Config, error) {
 		raw = defaultConfigBytes
 	}
 	var cfg Config
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+	var err error
+	if err = yaml.UnmarshalStrict(raw, &cfg); err != nil {
 		return nil, err
+	}
+	if cfg.JobNamePattern == "" {
+		return nil, fmt.Errorf("jobNamePattern is required")
+	}
+	cfg.jobPattern, err = regexp.Compile(cfg.JobNamePattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regexp for jobNamePattern: %w", err)
+	}
+	if cfg.TestNamePattern == "" {
+		return nil, fmt.Errorf("testNamePattern is required")
+	}
+	cfg.testPattern, err = regexp.Compile(cfg.TestNamePattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regexp for testNamePattern: %w", err)
 	}
 	return &cfg, nil
 }

--- a/robots/test-execution-report/main.go
+++ b/robots/test-execution-report/main.go
@@ -1,0 +1,359 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/go-github/v28/github"
+	"github.com/joshdk/go-junit"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/oauth2"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/yaml"
+
+	"kubevirt.io/project-infra/pkg/flakefinder"
+	ghapi "kubevirt.io/project-infra/pkg/flakefinder/github"
+)
+
+const (
+	ExecNoData = iota
+	ExecSkipped
+	ExecRan
+	ExecQuarantined
+)
+
+//go:embed default-config.yaml
+var defaultConfigBytes []byte
+
+//go:embed report.gohtml
+var reportTemplate string
+
+type Config struct {
+	JobNamePattern  string `yaml:"jobNamePattern"`
+	TestNamePattern string `yaml:"testNamePattern"`
+}
+
+type ReportData struct {
+	BaseURL          string
+	Bucket           string
+	TestNames        []string
+	QuarantinedTests map[string]bool
+	SkippedTests     map[string]bool
+	Jobs             []string
+	Matrix           map[string]map[string]int
+	StatusLabels     map[string]int
+	StartOfReport    string
+	EndOfReport      string
+	Config           string
+}
+
+var opts struct {
+	token      string
+	org        string
+	repo       string
+	baseBranch string
+	bucket     string
+	startFrom  time.Duration
+	configFile string
+	outputFile string
+	baseURL    string
+	dryRun     bool
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "test-execution-report",
+	Short: "Creates an HTML report showing which tests are run on which presubmit lane",
+	RunE:  run,
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&opts.token, "token", "", "path to GitHub token (required)")
+	rootCmd.Flags().StringVar(&opts.org, "org", "kubevirt", "GitHub organization")
+	rootCmd.Flags().StringVar(&opts.repo, "repo", "kubevirt", "GitHub repository")
+	rootCmd.Flags().StringVar(&opts.baseBranch, "pr-base-branch", "main", "base branch for PR query")
+	rootCmd.Flags().StringVar(&opts.bucket, "bucket", flakefinder.BucketName, "GCS bucket name")
+	rootCmd.Flags().DurationVar(&opts.startFrom, "start-from", 14*24*time.Hour, "time window for merged PRs")
+	rootCmd.Flags().StringVar(&opts.configFile, "config-file", "", "YAML config file (default: embedded config)")
+	rootCmd.Flags().StringVar(&opts.outputFile, "output-file", "", "output HTML file path (default: temp file)")
+	rootCmd.Flags().StringVar(&opts.baseURL, "base-url", "https://prow.ci.kubevirt.io", "Prow deck base URL for links")
+	rootCmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "list matching jobs and exit")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	if opts.token == "" {
+		return fmt.Errorf("--token is required")
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("loading config: %v", err)
+	}
+
+	jobPattern := regexp.MustCompile(cfg.JobNamePattern)
+	testPattern := regexp.MustCompile(cfg.TestNamePattern)
+
+	if err := secret.Add(opts.token); err != nil {
+		return fmt.Errorf("loading token: %v", err)
+	}
+
+	ctx := context.Background()
+
+	ghClient := github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: string(secret.GetSecret(opts.token))},
+	)))
+	query := ghapi.NewQuery(ghClient, opts.org, opts.repo, opts.baseBranch)
+
+	storageClient, err := storage.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("creating GCS client: %v", err)
+	}
+
+	endOfReport := time.Now()
+	startOfReport := endOfReport.Add(-opts.startFrom)
+
+	log.Infof("Querying merged PRs from %s to %s", startOfReport.Format(time.RFC3339), endOfReport.Format(time.RFC3339))
+	changes, err := query.Query(ctx, startOfReport, endOfReport)
+	if err != nil {
+		return fmt.Errorf("querying PRs: %v", err)
+	}
+	log.Infof("Found %d merged PRs", len(changes))
+
+	if len(changes) == 0 {
+		log.Warn("no merged PRs found in time window")
+		return nil
+	}
+
+	var allResults []*flakefinder.JobResult
+	repoPath := strings.Join([]string{opts.org, opts.repo}, "/")
+	for _, change := range changes {
+		results, err := flakefinder.FindUnitTestFiles(ctx, storageClient, opts.bucket, repoPath, change, startOfReport, true)
+		if err != nil {
+			log.Warnf("failed to load JUnit for PR %d: %v", change.ID(), err)
+			continue
+		}
+		allResults = append(allResults, results...)
+	}
+
+	batchResults, err := flakefinder.FindUnitTestFilesForBatchJobs(ctx, storageClient, opts.bucket, nil, changes, startOfReport, endOfReport)
+	if err != nil {
+		log.Warnf("failed to load batch job JUnit: %v", err)
+	}
+	allResults = append(allResults, batchResults...)
+
+	// Filter by job name pattern
+	var filtered []*flakefinder.JobResult
+	for _, r := range allResults {
+		if jobPattern.MatchString(r.Job) {
+			filtered = append(filtered, r)
+		}
+	}
+
+	jobSet := map[string]struct{}{}
+	for _, r := range filtered {
+		jobSet[r.Job] = struct{}{}
+	}
+	jobs := sortedKeys(jobSet)
+
+	log.Infof("Matched %d jobs: %s", len(jobs), strings.Join(jobs, ", "))
+	if opts.dryRun {
+		for _, j := range jobs {
+			fmt.Println(j)
+		}
+		return nil
+	}
+	if len(jobs) == 0 {
+		log.Warn("no matching jobs found")
+		return nil
+	}
+
+	matrix := buildMatrix(filtered, testPattern)
+
+	testNames, skippedTests, quarantinedTests := classifyTests(matrix)
+
+	configBytes, _ := yaml.Marshal(cfg)
+	data := ReportData{
+		BaseURL:          opts.baseURL,
+		Bucket:           opts.bucket,
+		TestNames:        testNames,
+		QuarantinedTests: quarantinedTests,
+		SkippedTests:     skippedTests,
+		Jobs:             jobs,
+		Matrix:           matrix,
+		StatusLabels: map[string]int{
+			"ExecNoData":      ExecNoData,
+			"ExecSkipped":     ExecSkipped,
+			"ExecRan":         ExecRan,
+			"ExecQuarantined": ExecQuarantined,
+		},
+		StartOfReport: startOfReport.Format(time.RFC1123),
+		EndOfReport:   endOfReport.Format(time.RFC1123),
+		Config:        string(configBytes),
+	}
+
+	outputFile, err := resolveOutputFile()
+	if err != nil {
+		return err
+	}
+
+	if err := writeJSONSidecar(outputFile, matrix); err != nil {
+		return err
+	}
+
+	htmlWriter, err := os.OpenFile(outputFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("opening output file: %v", err)
+	}
+	defer func() { _ = htmlWriter.Close() }()
+
+	log.Infof("Writing HTML report to %s", outputFile)
+	if err := flakefinder.WriteTemplateToOutput(reportTemplate, data, htmlWriter); err != nil {
+		return fmt.Errorf("rendering report: %v", err)
+	}
+
+	return nil
+}
+
+func loadConfig() (*Config, error) {
+	var raw []byte
+	if opts.configFile != "" {
+		var err error
+		raw, err = os.ReadFile(opts.configFile)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		raw = defaultConfigBytes
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func buildMatrix(results []*flakefinder.JobResult, testPattern *regexp.Regexp) map[string]map[string]int {
+	matrix := map[string]map[string]int{}
+
+	for _, r := range results {
+		for _, suite := range r.JUnit {
+			for _, test := range suite.Tests {
+				if !testPattern.MatchString(test.Name) {
+					continue
+				}
+				if _, ok := matrix[test.Name]; !ok {
+					matrix[test.Name] = map[string]int{}
+				}
+
+				status := execStatus(test)
+				cur := matrix[test.Name][r.Job]
+				if status > cur {
+					matrix[test.Name][r.Job] = status
+				}
+			}
+		}
+	}
+
+	return matrix
+}
+
+func execStatus(test junit.Test) int {
+	if test.Status == junit.StatusSkipped {
+		if strings.Contains(test.Name, "[QUARANTINE]") {
+			return ExecQuarantined
+		}
+		return ExecSkipped
+	}
+	return ExecRan
+}
+
+func classifyTests(matrix map[string]map[string]int) (testNames []string, skippedTests, quarantinedTests map[string]bool) {
+	skippedTests = map[string]bool{}
+	quarantinedTests = map[string]bool{}
+
+	for name, jobs := range matrix {
+		testNames = append(testNames, name)
+
+		if strings.Contains(name, "[QUARANTINE]") {
+			quarantinedTests[name] = true
+		}
+
+		ranOnAnyLane := false
+		for _, status := range jobs {
+			if status == ExecRan {
+				ranOnAnyLane = true
+				break
+			}
+		}
+		if !ranOnAnyLane {
+			skippedTests[name] = true
+		}
+	}
+
+	sort.Strings(testNames)
+	return
+}
+
+func resolveOutputFile() (string, error) {
+	if opts.outputFile != "" {
+		return opts.outputFile, nil
+	}
+	f, err := os.CreateTemp("", "test-execution-report-*.html")
+	if err != nil {
+		return "", fmt.Errorf("creating temp file: %v", err)
+	}
+	_ = f.Close()
+	return f.Name(), nil
+}
+
+func writeJSONSidecar(htmlPath string, matrix map[string]map[string]int) error {
+	jsonPath := strings.TrimSuffix(htmlPath, ".html") + ".json"
+	data, err := json.MarshalIndent(matrix, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshalling JSON: %v", err)
+	}
+	log.Infof("Writing JSON to %s", jsonPath)
+	return os.WriteFile(jsonPath, data, 0644)
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/robots/test-execution-report/main_test.go
+++ b/robots/test-execution-report/main_test.go
@@ -1,0 +1,249 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright the KubeVirt Authors.
+ *
+ */
+
+package main
+
+import (
+	"regexp"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/joshdk/go-junit"
+
+	"kubevirt.io/project-infra/pkg/flakefinder"
+)
+
+func TestTestExecutionReport(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test-execution-report Main Suite")
+}
+
+var _ = Describe("buildMatrix", func() {
+
+	matchAll := regexp.MustCompile(`.*`)
+
+	newResult := func(job string, tests ...junit.Test) *flakefinder.JobResult {
+		return &flakefinder.JobResult{
+			Job: job,
+			JUnit: []junit.Suite{
+				{Tests: tests},
+			},
+		}
+	}
+
+	passedTest := func(name string) junit.Test {
+		return junit.Test{Name: name, Status: junit.StatusPassed}
+	}
+
+	skippedTest := func(name string) junit.Test {
+		return junit.Test{Name: name, Status: junit.StatusSkipped}
+	}
+
+	failedTest := func(name string) junit.Test {
+		return junit.Test{Name: name, Status: junit.StatusFailed}
+	}
+
+	DescribeTable("returns empty matrix",
+		func(results []*flakefinder.JobResult) {
+			Expect(buildMatrix(results, matchAll)).To(BeEmpty())
+		},
+		Entry("for nil input", nil),
+		Entry("for empty results", []*flakefinder.JobResult{}),
+		Entry("for results with no JUnit suites",
+			[]*flakefinder.JobResult{{Job: "job-a", JUnit: nil}}),
+		Entry("for suites with no tests",
+			[]*flakefinder.JobResult{{Job: "job-a", JUnit: []junit.Suite{{Tests: nil}}}}),
+	)
+
+	DescribeTable("maps execution status",
+		func(results []*flakefinder.JobResult, testName, jobName string, expectedStatus int) {
+			matrix := buildMatrix(results, matchAll)
+			Expect(matrix[testName][jobName]).To(Equal(expectedStatus))
+		},
+		Entry("passed test as ExecRan",
+			[]*flakefinder.JobResult{newResult("job-a", passedTest("test-1"))},
+			"test-1", "job-a", ExecRan),
+		Entry("skipped test as ExecSkipped",
+			[]*flakefinder.JobResult{newResult("job-a", skippedTest("test-1"))},
+			"test-1", "job-a", ExecSkipped),
+		Entry("quarantined test as ExecQuarantined",
+			[]*flakefinder.JobResult{newResult("job-a", skippedTest("[QUARANTINE] test-1"))},
+			"[QUARANTINE] test-1", "job-a", ExecQuarantined),
+		Entry("failed test as ExecRan",
+			[]*flakefinder.JobResult{newResult("job-a", failedTest("test-1"))},
+			"test-1", "job-a", ExecRan),
+		Entry("promotes skipped to ran across multiple results",
+			[]*flakefinder.JobResult{
+				newResult("job-a", skippedTest("test-1")),
+				newResult("job-a", passedTest("test-1")),
+			},
+			"test-1", "job-a", ExecRan),
+		Entry("does not demote a higher status",
+			[]*flakefinder.JobResult{
+				newResult("job-a", passedTest("test-1")),
+				newResult("job-a", skippedTest("test-1")),
+			},
+			"test-1", "job-a", ExecRan),
+		Entry("quarantine beats skipped for the same test on the same job",
+			[]*flakefinder.JobResult{
+				newResult("job-a", skippedTest("[QUARANTINE] test-q")),
+				newResult("job-a", skippedTest("[QUARANTINE] test-q")),
+			},
+			"[QUARANTINE] test-q", "job-a", ExecQuarantined),
+		Entry("ExecQuarantined beats ExecRan because it has a higher iota value",
+			[]*flakefinder.JobResult{
+				newResult("job-a", passedTest("[QUARANTINE] test-q")),
+				newResult("job-a", skippedTest("[QUARANTINE] test-q")),
+			},
+			"[QUARANTINE] test-q", "job-a", ExecQuarantined),
+		Entry("returns ExecNoData for jobs a test was not seen on",
+			[]*flakefinder.JobResult{
+				newResult("job-a", passedTest("test-1")),
+				newResult("job-b", passedTest("test-2")),
+			},
+			"test-1", "job-b", ExecNoData),
+	)
+
+	DescribeTable("builds correct matrix",
+		func(results []*flakefinder.JobResult, expected map[string]map[string]int) {
+			Expect(buildMatrix(results, matchAll)).To(Equal(expected))
+		},
+		Entry("tracks tests across multiple jobs independently",
+			[]*flakefinder.JobResult{
+				newResult("job-a", passedTest("test-1")),
+				newResult("job-b", skippedTest("test-1")),
+			},
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecRan, "job-b": ExecSkipped},
+			}),
+		Entry("tracks multiple tests across multiple jobs",
+			[]*flakefinder.JobResult{
+				newResult("job-a", passedTest("test-1"), skippedTest("test-2")),
+				newResult("job-b", skippedTest("test-1"), passedTest("test-2")),
+			},
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecRan, "job-b": ExecSkipped},
+				"test-2": {"job-a": ExecSkipped, "job-b": ExecRan},
+			}),
+		Entry("handles multiple suites within a single JobResult",
+			[]*flakefinder.JobResult{
+				{
+					Job: "job-a",
+					JUnit: []junit.Suite{
+						{Tests: []junit.Test{passedTest("test-1")}},
+						{Tests: []junit.Test{passedTest("test-2")}},
+					},
+				},
+			},
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecRan},
+				"test-2": {"job-a": ExecRan},
+			}),
+	)
+
+	It("filters tests by the provided pattern", func() {
+		pattern := regexp.MustCompile(`^include-`)
+		results := []*flakefinder.JobResult{
+			newResult("job-a", passedTest("include-this"), passedTest("exclude-that")),
+		}
+		matrix := buildMatrix(results, pattern)
+		Expect(matrix).To(HaveKey("include-this"))
+		Expect(matrix).NotTo(HaveKey("exclude-that"))
+	})
+})
+
+var _ = Describe("classifyTests", func() {
+
+	DescribeTable("classifies tests",
+		func(matrix map[string]map[string]int, expectedNames []string, expectedSkipped, expectedQuarantined map[string]bool) {
+			names, skipped, quarantined := classifyTests(matrix)
+			Expect(names).To(Equal(expectedNames))
+			Expect(skipped).To(Equal(expectedSkipped))
+			Expect(quarantined).To(Equal(expectedQuarantined))
+		},
+		Entry("empty matrix",
+			map[string]map[string]int{},
+			([]string)(nil),
+			map[string]bool{},
+			map[string]bool{}),
+		Entry("single test that ran",
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecRan},
+			},
+			[]string{"test-1"},
+			map[string]bool{},
+			map[string]bool{}),
+		Entry("single test that was only skipped",
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecSkipped},
+			},
+			[]string{"test-1"},
+			map[string]bool{"test-1": true},
+			map[string]bool{}),
+		Entry("quarantined test is in both skipped and quarantined",
+			map[string]map[string]int{
+				"[QUARANTINE] test-1": {"job-a": ExecQuarantined},
+			},
+			[]string{"[QUARANTINE] test-1"},
+			map[string]bool{"[QUARANTINE] test-1": true},
+			map[string]bool{"[QUARANTINE] test-1": true}),
+		Entry("quarantined test that also ran is quarantined but not skipped",
+			map[string]map[string]int{
+				"[QUARANTINE] test-1": {"job-a": ExecRan, "job-b": ExecQuarantined},
+			},
+			[]string{"[QUARANTINE] test-1"},
+			map[string]bool{},
+			map[string]bool{"[QUARANTINE] test-1": true}),
+		Entry("test ran on one job but skipped on another is not skipped",
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecRan, "job-b": ExecSkipped},
+			},
+			[]string{"test-1"},
+			map[string]bool{},
+			map[string]bool{}),
+		Entry("test with only ExecNoData is skipped",
+			map[string]map[string]int{
+				"test-1": {"job-a": ExecNoData},
+			},
+			[]string{"test-1"},
+			map[string]bool{"test-1": true},
+			map[string]bool{}),
+		Entry("test names are sorted",
+			map[string]map[string]int{
+				"z-test": {"job-a": ExecRan},
+				"a-test": {"job-a": ExecRan},
+				"m-test": {"job-a": ExecRan},
+			},
+			[]string{"a-test", "m-test", "z-test"},
+			map[string]bool{},
+			map[string]bool{}),
+		Entry("mixed: ran, skipped, and quarantined tests",
+			map[string]map[string]int{
+				"test-ran":                {"job-a": ExecRan},
+				"test-skipped":            {"job-a": ExecSkipped},
+				"[QUARANTINE] test-qskip": {"job-a": ExecQuarantined},
+				"[QUARANTINE] test-qran":  {"job-a": ExecRan},
+			},
+			[]string{"[QUARANTINE] test-qran", "[QUARANTINE] test-qskip", "test-ran", "test-skipped"},
+			map[string]bool{"test-skipped": true, "[QUARANTINE] test-qskip": true},
+			map[string]bool{"[QUARANTINE] test-qskip": true, "[QUARANTINE] test-qran": true}),
+	)
+})

--- a/robots/test-execution-report/report.gohtml
+++ b/robots/test-execution-report/report.gohtml
@@ -1,0 +1,314 @@
+<html>
+<head>
+    <title>test execution report</title>
+    <meta charset="UTF-8"/>
+    <style>
+        table, th, td {
+            border: 1px solid black;
+        }
+        table.noborder, th.noborder, td.noborder {
+            border: 0;
+        }
+        th.vertical {
+            writing-mode: vertical-rl;
+            text-orientation: mixed;
+            text-align: right;
+        }
+        td.stateCell {
+            min-width: 2em;
+            text-align: center;
+        }
+        td.filler {
+            min-width: 2em;
+        }
+        .yellow {
+            background-color: #ffff80;
+        }
+        .green {
+            background-color: #9fff80;
+        }
+        .red {
+            background-color: #ff8080;
+        }
+        .gray {
+            background-color: #898989;
+        }
+        .right {
+            text-align: right;
+            width: 100%;
+        }
+        .quarantined {
+            text-decoration-line: underline;
+            text-decoration-style: dotted;
+        }
+
+        .popup .popuptextReportConfig {
+            display: none;
+            width: 1280px;
+            background-color: #FFFFFF;
+            text-align: left;
+            border-radius: 6px;
+            border: 1px solid black;
+            padding: 8px 8px;
+            position: absolute;
+            z-index: 1;
+            left: 100%;
+            margin-left: -1280px;
+        }
+
+        .popup:hover .popuptextReportConfig {
+            display: block;
+            -webkit-animation: fadeIn 1s;
+            animation: fadeIn 1s;
+        }
+
+    </style>
+    <script>
+        function enableFilterFields() {
+            document.getElementById("filterByName").disabled = false;
+            document.getElementById("excludeByName").disabled = false;
+            document.getElementById("filterByNotRunCheckBox").disabled = false;
+            document.getElementById("showQuarantinedCheckBox").disabled = false;
+            document.getElementById("filterByJobName").disabled = false;
+            document.getElementById("excludeByJobName").disabled = false;
+        }
+        function updateFilteredRows() {
+            let filterTerms, excludeTerms, table, tr, td, i, txtValue, filterByNotRunChecked, showQuarantinedChecked, shouldShow, rowsShown;
+            filterTerms = document.getElementById("filterByName").value.toUpperCase().split("|");
+            excludeTerms = document.getElementById("excludeByName").value.toUpperCase().split("|");
+            filterByNotRunChecked = document.getElementById("filterByNotRunCheckBox").checked;
+            showQuarantinedChecked = document.getElementById("showQuarantinedCheckBox").checked;
+            table = document.getElementById("report");
+            tr = table.getElementsByTagName("tr");
+
+            rowsShown = 0;
+            for (i = 1; i < tr.length; i++) {
+                td = tr[i].getElementsByTagName("td")[1];
+                if (td) {
+                    shouldShow = true
+                    txtValue = td.textContent || td.innerText;
+                    if (filterByNotRunChecked && td.className.indexOf("red") == -1) {
+                        shouldShow = false
+                    }
+                    if (!showQuarantinedChecked && td.className.indexOf("quarantined") !== -1) {
+                        shouldShow = false
+                    }
+                    if (excludeTerms.length > 0 && excludeTerms[0] !== "") {
+                        for (k = 0; k < excludeTerms.length; k++) {
+                            if (txtValue.toUpperCase().indexOf(excludeTerms[k]) !== -1) {
+                                shouldShow = false
+                                break;
+                            }
+                        }
+                    }
+                    if (shouldShow === true && filterTerms.length > 0 && filterTerms[0] !== "") {
+                        let found = false
+                        for (k = 0; k < filterTerms.length; k++) {
+                            if (txtValue.toUpperCase().indexOf(filterTerms[k]) !== -1) {
+                                found = true
+                                break;
+                            }
+                        }
+                        if (found !== true) {
+                            shouldShow = false
+                        }
+                    }
+                    if (shouldShow === true) {
+                        tr[i].style.display = "";
+                        rowsShown++;
+                    } else {
+                        tr[i].style.display = "none";
+                    }
+                }
+            }
+            updateRowsShown(rowsShown);
+        }
+        function updateFilteredColumns() {
+            let filterByJobNameTerms, excludeByJobNameTerms, table, tr, th, td, i, shouldShow, txtValue;
+            filterByJobNameTerms = document.getElementById("filterByJobName").value.toUpperCase().split("|");
+            excludeByJobNameTerms = document.getElementById("excludeByJobName").value.toUpperCase().split("|");
+            table = document.getElementById("report");
+            tr = table.getElementsByTagName("tr");
+            th = tr[0].getElementsByTagName("th");
+
+            for (i = 2; i < th.length; i++) {
+                if (th[i]) {
+                    shouldShow = true
+                    txtValue = th[i].textContent || th[i].innerText;
+                    if (excludeByJobNameTerms.length > 0 && excludeByJobNameTerms[0] !== "") {
+                        for (k = 0; k < excludeByJobNameTerms.length; k++) {
+                            if (txtValue.toUpperCase().indexOf(excludeByJobNameTerms[k]) !== -1) {
+                                shouldShow = false
+                                break;
+                            }
+                        }
+                    }
+                    if (shouldShow === true && filterByJobNameTerms.length > 0 && filterByJobNameTerms[0] !== "") {
+                        let found = false
+                        for (k = 0; k < filterByJobNameTerms.length; k++) {
+                            if (txtValue.toUpperCase().indexOf(filterByJobNameTerms[k]) !== -1) {
+                                found = true
+                                break;
+                            }
+                        }
+                        if (found !== true) {
+                            shouldShow = false
+                        }
+                    }
+                    if (shouldShow === true) {
+                        th[i].style.display = "";
+                    } else {
+                        th[i].style.display = "none";
+                    }
+                    for (k = 1; k < tr.length; k++) {
+                        td = tr[k].getElementsByTagName("td")[i];
+                        if (td) {
+                            if (shouldShow === true) {
+                                td.style.display = "";
+                            } else {
+                                td.style.display = "none";
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        function initRowsShown() {
+            updateRowsShown(document.getElementById("report").getElementsByTagName("tr").length - 1);
+        }
+        function updateRowsShown(rowsShown) {
+            let rowsTotal = document.getElementById("report").getElementsByTagName("tr").length - 1;
+            document.getElementById("totalRowsShown").innerText = "Showing "+rowsShown+" of "+rowsTotal+"";
+        }
+    </script>
+</head>
+<body onload="initRowsShown();updateFilteredRows();enableFilterFields();">
+{{- /* gotype: main.ReportData */ -}}
+<h1>test execution report</h1>
+<div>
+    data from <b>{{ $.StartOfReport }}</b> till <b>{{ $.EndOfReport }}</b><br/>
+</div>
+
+<div id="reportConfig" class="popup right" >
+    <u>report configuration</u>
+    <pre class="popuptextReportConfig right" id="targetReportConfig">{{ $.Config }}</pre>
+</div>
+
+<table class="noborder">
+    <tr>
+        <td class="noborder">
+            <b>Test filters:</b>
+        </td>
+        <td class="noborder">
+            <label for="filterByNotRunCheckBox">Only <span class="red">not run tests</span></label>
+        </td>
+        <td class="noborder">
+            <input type="checkbox" id="filterByNotRunCheckBox" onClick="updateFilteredRows()" title="Show only rows that have not been run on any lane" disabled checked>
+        </td>
+        <td class="noborder filler">
+        </td>
+        <td class="noborder">
+            <b>Job filters:</b>
+        </td>
+        <td class="noborder">
+            <label for="filterByJobName">Exclude lanes that don't contain</label>
+        </td>
+        <td class="noborder">
+            <input type="text" id="filterByJobName" onkeyup="updateFilteredColumns()" placeholder="term1|term2|..." title="Show only lanes that contain term(s)" disabled>
+        </td>
+    </tr>
+    <tr>
+        <td class="noborder">
+        </td>
+        <td class="noborder">
+            <label for="showQuarantinedCheckBox">Include <span class="red quarantined">quarantined tests</span></label>
+        </td>
+        <td class="noborder">
+            <input type="checkbox" id="showQuarantinedCheckBox" onClick="updateFilteredRows()" title="Include tests marked with [QUARANTINE]" disabled checked>
+        </td>
+        <td class="noborder filler">
+        </td>
+        <td class="noborder">
+        </td>
+        <td class="noborder">
+            <label for="excludeByJobName">Exclude lanes that contain</label>
+        </td>
+        <td class="noborder">
+            <input type="text" id="excludeByJobName" onkeyup="updateFilteredColumns()" placeholder="term1|term2|..." title="Exclude lanes that contain term(s)" disabled>
+        </td>
+    </tr>
+    <tr>
+        <td class="noborder">
+        </td>
+        <td class="noborder">
+            <label for="filterByName">Exclude tests that don't contain</label>
+        </td>
+        <td class="noborder">
+            <input type="text" id="filterByName" onkeyup="updateFilteredRows()" placeholder="term1|term2|..." disabled>
+        </td>
+        <td class="noborder filler">
+        </td>
+        <td class="noborder" colspan="3"/>
+    </tr>
+    <tr>
+        <td class="noborder">
+        </td>
+        <td class="noborder">
+            <label for="excludeByName">Exclude tests that contain</label>
+        </td>
+        <td class="noborder">
+            <input type="text" id="excludeByName" onkeyup="updateFilteredRows()" placeholder="term1|term2|..." disabled>
+        </td>
+        <td class="noborder filler">
+        </td>
+        <td class="noborder" colspan="3"/>
+    </tr>
+    <tr>
+        <td class="noborder">
+        </td>
+        <td class="noborder" colspan="2">
+            <div id="totalRowsShown"><i>Loading rows...</i></div>
+        </td>
+        <td class="noborder filler">
+        </td>
+        <td class="noborder" colspan="3"/>
+    </tr>
+</table>
+
+
+<table id="report">
+    <tr>
+        <th></th>
+        <th></th>
+        {{ range $job := $.Jobs }}
+            <th class="vertical"><a href="{{ $.BaseURL }}/job-history/gs/{{ $.Bucket }}/pr-logs/directory/{{ $job }}">{{ $job }}</a></th>
+        {{ end }}
+    </tr>
+    {{ range $row, $test := $.TestNames }}
+        <tr>
+            <td><div id="row{{$row}}"><a href="#row{{$row}}">{{ $row }}</a></div></td>
+            <td class="{{ if (index $.SkippedTests $test) }}red{{ end }}{{ if (index $.QuarantinedTests $test) }} quarantined{{ end }}">{{ $test }}</td>
+            {{ range $col, $job := $.Jobs }}
+                <td class="center stateCell">{{ with $status := (index $.Matrix $test $job) }}
+                        <div id="r{{$row}}c{{$col}}" title="test
+                                {{- if eq $status (index $.StatusLabels "ExecSkipped") }} skipped
+                                {{- else if eq $status (index $.StatusLabels "ExecRan") }} run
+                                {{- else if eq $status (index $.StatusLabels "ExecQuarantined") }} quarantined
+                                {{- else }}
+                                {{ end -}}"
+                             class="
+                                {{- if eq $status (index $.StatusLabels "ExecSkipped") }}yellow
+                                {{- else if eq $status (index $.StatusLabels "ExecRan") }}green
+                                {{- else if eq $status (index $.StatusLabels "ExecQuarantined") }}gray
+                                {{- else }}
+                                {{ end -}}" >
+                            <input title="{{ $test }} &#013; {{ $job }}" type="checkbox" disabled
+                                   {{- if eq $status (index $.StatusLabels "ExecRan") }} checked{{ end -}}/>
+                        </div>
+                    {{ else }}n/a{{ end }}</td>
+            {{ end }}
+        </tr>
+    {{ end }}
+</table>
+</body>
+</html>

--- a/robots/test-execution-report/report.gohtml
+++ b/robots/test-execution-report/report.gohtml
@@ -281,7 +281,7 @@
         <th></th>
         <th></th>
         {{ range $job := $.Jobs }}
-            <th class="vertical"><a href="{{ $.BaseURL }}/job-history/gs/{{ $.Bucket }}/pr-logs/directory/{{ $job }}">{{ $job }}</a></th>
+            <th class="vertical"><a href="https://testgrid.k8s.io/kubevirt-{{ if index $.PeriodicJobs $job }}periodics{{ else }}presubmits{{ end }}#{{ $job }}">{{ $job }}</a></th>
         {{ end }}
     </tr>
     {{ range $row, $test := $.TestNames }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new `robots/test-execution-report` that generates an HTML report showing which tests are run on which CI lane (presubmit and/or periodic), answering: **which tests are not being covered by any CI lane?**

This replaces the Jenkins-based `robots/test-report` execution command for upstream KubeVirt CI by sourcing data from Prow artifacts in GCS instead.

**(Click to view live report)**
[<img width="1964" height="1552" alt="image" src="https://github.com/user-attachments/assets/8a5be3b6-bd7b-4614-83f5-1e93c59313e5" />](https://storage.googleapis.com/kubevirt-prow/reports/test-execution-reports/kubevirt/kubevirt/preview.html)

**How it works**:

- `--source` flag selects data sources: `presubmit`, `periodic`, or `all`
- **Presubmit discovery** is purely GCS-based (no GitHub API needed):
  - Resolves the latest PR number via Prow's alias files (`latest-build.txt` → `<buildID>.txt`) under `pr-logs/directory/`, picking the job with the highest build ID across all matching lanes
  - Walks PR directories descending from that starting point, reading JUnit artifacts directly from `pr-logs/pull/`
  - Release branch jobs (suffixed `-N.N`) are excluded
- **Periodic discovery** lists job directories from `logs/` in GCS, filtered by `periodicJobNamePattern`
- Builds a test × lane matrix and renders an interactive HTML report
- Tests with `[QUARANTINE]` in their name are detected from JUnit data and marked distinctly (gray cells, dotted underline)
- Job column headers link to TestGrid dashboards (`kubevirt-presubmits` / `kubevirt-periodics`)
- Job/test filtering via YAML config with regex patterns
- No GitHub API dependency — requires only GCS access

**Special notes for your reviewer**:

The old `robots/test-report` remains untouched — it can continue serving downstream (Jenkins/CNV) use cases. This is a clean new implementation rather than a port.

Exports `ReadGcsObject` and `SortBuilds` from `pkg/flakefinder` so the new tool can reuse them.

🤖 Assisted by Claude