### PR TITLE
Add recency indicator to most-flaky-tests report

### DIFF
--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/joshdk/go-junit"
 	log "github.com/sirupsen/logrus"
@@ -70,6 +71,9 @@ func init() {
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.filterPeriodicJobRunResults, "filter-periodic-job-run-results", true, "whether to filter the results for periodics")
 	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.filterLaneRegex, "filter-lane-regex", filterLaneRegexDefault, "the regular expression to use to filter test lanes with")
 	mostFlakyTestsReportCmd.PersistentFlags().BoolVar(&quarantineOpts.includeRollingWindow, "include-rolling-window", true, "whether to include today's rolling window flakefinder data")
+	mostFlakyTestsReportCmd.PersistentFlags().DurationVar(&quarantineOpts.maxFailureAge, "max-failure-age", 72*time.Hour, "maximum age of failures to consider as recent")
+	mostFlakyTestsReportCmd.PersistentFlags().IntVar(&quarantineOpts.minRecentFailures, "min-recent-failures", 2, "minimum number of recent failures required per lane")
+	mostFlakyTestsReportCmd.PersistentFlags().DurationVar(&quarantineOpts.minFailureInterval, "min-failure-interval", 24*time.Hour, "minimum time span between recent failures to confirm a consistent pattern")
 }
 
 var sigMatcher = regexp.MustCompile(`\[(sig-[^]]+)]`)
@@ -117,6 +121,7 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 const noSIGKey = "NONE"
 
 func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string, testNames []string, mostFlakyTestsBySIG map[string]TestsPerSIG, err error) {
+	recentFailureFilter := searchci.HasMinRecentFailures(quarantineOpts.maxFailureAge, quarantineOpts.minRecentFailures, quarantineOpts.minFailureInterval)
 	mostFlakyTests := make(map[string][]*TestToQuarantine)
 	for _, topXTest := range topXTests {
 		for _, timeRange := range mostFlakyTestsTimeRanges {
@@ -126,6 +131,9 @@ func aggregateMostFlakyTestsBySIG(topXTests flakestats.TopXTests) (sigs []string
 			}
 			if candidate == nil {
 				continue
+			}
+			if len(searchci.FilterImpactsBy(candidate.RelevantImpacts, recentFailureFilter)) > 0 {
+				candidate.HasRecentFailures = true
 			}
 			mostFlakyTests[topXTest.Name] = append(mostFlakyTests[topXTest.Name], candidate)
 		}

--- a/robots/quarantine/cmd/most-flaky-tests-report.gohtml
+++ b/robots/quarantine/cmd/most-flaky-tests-report.gohtml
@@ -203,6 +203,29 @@
             background: #fef9c3;
             color: #a16207;
         }
+        .test-card.stale-failures {
+            border-left-color: #cbd5e0;
+            opacity: 0.6;
+        }
+        .test-card.stale-failures:hover {
+            opacity: 1;
+        }
+        .recency-badge {
+            display: inline-block;
+            font-size: 0.7rem;
+            font-weight: 600;
+            padding: 2px 8px;
+            border-radius: 100px;
+            flex-shrink: 0;
+        }
+        .recency-badge.active {
+            background: #fed7d7;
+            color: #9b2c2c;
+        }
+        .recency-badge.stale {
+            background: #edf2f7;
+            color: #718096;
+        }
 
         .test-card-header {
             padding: 12px 16px;
@@ -358,10 +381,19 @@
                     {{ range $testName := $.TestNames }}
                         {{ $mostFlakyTests := index $.MostFlakyTestsBySig $sig $testName }}
                         {{ if $mostFlakyTests }}
-                            <div class="test-card" id="test_{{ $testName }}" data-testname="{{ $testName }}" data-max-impact="0">
+                            {{- $hasRecent := false -}}
+                            {{- range $t := $mostFlakyTests -}}
+                                {{- if $t.HasRecentFailures -}}{{- $hasRecent = true -}}{{- end -}}
+                            {{- end -}}
+                            <div class="test-card {{ if not $hasRecent }}stale-failures{{ end }}" id="test_{{ $testName }}" data-testname="{{ $testName }}" data-max-impact="0">
                                 <div class="test-card-header">
                                     <a href="#test_{{ $testName }}" class="card-link" title="permalink">#</a>
                                     <span class="test-name" title="{{ $testName }}">{{ $testName }}</span>
+                                    {{ if $hasRecent -}}
+                                        <span class="recency-badge active">active</span>
+                                    {{- else -}}
+                                        <span class="recency-badge stale">stale</span>
+                                    {{- end }}
                                 </div>
                                 <div class="test-card-body">
                                     {{ range $mostFlakyTest := $mostFlakyTests }}
@@ -401,13 +433,16 @@
 
 <script>
     var releaseLanePattern = /-\d+\.\d+$/;
+    var SEVERITY_CRITICAL = 10;
+    var SEVERITY_HIGH = 5;
+    var SEVERITY_MEDIUM = 2;
 
     function applyImpactColors() {
         document.querySelectorAll('.impact-percent[data-percent]').forEach(function(el) {
             var p = parseFloat(el.getAttribute('data-percent'));
-            if (p >= 10) el.classList.add('critical');
-            else if (p >= 5) el.classList.add('high');
-            else if (p >= 2) el.classList.add('medium');
+            if (p >= SEVERITY_CRITICAL) el.classList.add('critical');
+            else if (p >= SEVERITY_HIGH) el.classList.add('high');
+            else if (p >= SEVERITY_MEDIUM) el.classList.add('medium');
             else el.classList.add('low');
         });
         document.querySelectorAll('.test-card[data-max-impact]').forEach(function(card) {
@@ -418,10 +453,12 @@
             });
             card.setAttribute('data-max-impact', max);
             card.classList.remove('severity-critical', 'severity-high', 'severity-medium', 'severity-low');
-            if (max >= 10) card.classList.add('severity-critical');
-            else if (max >= 5) card.classList.add('severity-high');
-            else if (max >= 2) card.classList.add('severity-medium');
-            else card.classList.add('severity-low');
+            if (!card.classList.contains('stale-failures')) {
+                if (max >= SEVERITY_CRITICAL) card.classList.add('severity-critical');
+                else if (max >= SEVERITY_HIGH) card.classList.add('severity-high');
+                else if (max >= SEVERITY_MEDIUM) card.classList.add('severity-medium');
+                else card.classList.add('severity-low');
+            }
         });
     }
 

--- a/robots/quarantine/cmd/most-flaky-tests-report_test.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report_test.go
@@ -20,6 +20,8 @@
 package cmd
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	flakestats "kubevirt.io/project-infra/pkg/flake-stats"
@@ -67,5 +69,76 @@ var _ = Describe("most-flaky-tests", func() {
 				},
 			),
 		)
+	})
+
+	When("aggregating most flaky tests by SIG", func() {
+		var originalGetQuarantineCandidate func(*flakestats.TopXTest, searchci.TimeRange) (*TestToQuarantine, error)
+
+		BeforeEach(func() {
+			originalGetQuarantineCandidate = getQuarantineCandidate
+			quarantineOpts.maxFailureAge = 72 * time.Hour
+			quarantineOpts.minRecentFailures = 2
+			quarantineOpts.minFailureInterval = 24 * time.Hour
+		})
+
+		AfterEach(func() {
+			getQuarantineCandidate = originalGetQuarantineCandidate
+		})
+
+		It("marks candidate with recent spread-out failures as HasRecentFailures", func() {
+			getQuarantineCandidate = func(topXTest *flakestats.TopXTest, _ searchci.TimeRange) (*TestToQuarantine, error) {
+				return &TestToQuarantine{
+					Test: topXTest,
+					RelevantImpacts: []searchci.Impact{
+						{
+							URL:     "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute",
+							Percent: 10,
+							BuildURLs: []searchci.JobBuildURL{
+								{Interval: 4 * time.Hour},
+								{Interval: 36 * time.Hour},
+							},
+						},
+					},
+				}, nil
+			}
+
+			_, _, result, err := aggregateMostFlakyTestsBySIG(flakestats.TopXTests{
+				flakestats.NewTopXTest("[sig-compute] my recent flaky test"),
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveKey("sig-compute"))
+			tests := result["sig-compute"]["[sig-compute] my recent flaky test"]
+			Expect(tests).ToNot(BeEmpty())
+			Expect(tests[0].HasRecentFailures).To(BeTrue())
+		})
+
+		It("marks candidate with only stale failures as not HasRecentFailures", func() {
+			getQuarantineCandidate = func(topXTest *flakestats.TopXTest, _ searchci.TimeRange) (*TestToQuarantine, error) {
+				return &TestToQuarantine{
+					Test: topXTest,
+					RelevantImpacts: []searchci.Impact{
+						{
+							URL:     "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.35-sig-compute",
+							Percent: 10,
+							BuildURLs: []searchci.JobBuildURL{
+								{Interval: 264 * time.Hour},
+								{Interval: 288 * time.Hour},
+							},
+						},
+					},
+				}, nil
+			}
+
+			_, _, result, err := aggregateMostFlakyTestsBySIG(flakestats.TopXTests{
+				flakestats.NewTopXTest("[sig-compute] my stale flaky test"),
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveKey("sig-compute"))
+			tests := result["sig-compute"]["[sig-compute] my stale flaky test"]
+			Expect(tests).ToNot(BeEmpty())
+			Expect(tests[0].HasRecentFailures).To(BeFalse())
+		})
 	})
 })

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -65,11 +65,12 @@ type quarantineOptions struct {
 }
 
 type TestToQuarantine struct {
-	Test            *flakestats.TopXTest
-	TimeRange       searchci.TimeRange
-	SearchCIURL     string
-	RelevantImpacts []searchci.Impact
-	SpecReport      *types.SpecReport
+	Test              *flakestats.TopXTest
+	TimeRange         searchci.TimeRange
+	SearchCIURL       string
+	RelevantImpacts   []searchci.Impact
+	HasRecentFailures bool
+	SpecReport        *types.SpecReport
 }
 
 type TestsPerSIG map[string][]*TestToQuarantine


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds active/stale visual distinction to the most-flaky-tests report, based on the work from #5129. Tests with recent consistent failures are highlighted so reviewers can focus on what's currently broken rather than tests that may already be stabilizing.

- Active: tests with at least 2 failures within 72h, spread 24h+ apart — full opacity, colored severity border, red "active" badge
- Stale: tests with only older failures — dimmed (60% opacity), gray border, gray "stale" badge (hover restores full opacity)
- Extracts severity thresholds to named JS constants for maintainability
- Adds CLI flags (--max-failure-age, --min-recent-failures, --min-failure-interval) to the report command, reusing the HasMinRecentFailures filter already used by auto-quarantine


**Special notes for your reviewer**:
/cc @dhiller 
Based on #5129 by @dhiller
**Checklist**
[x]Confirmed working locally (screenshot below)
<img width="1627" height="622" alt="image" src="https://github.com/user-attachments/assets/c3f58700-91f2-4819-b4d0-42b8ca2701be" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI filtering flags (`--max-failure-age`, `--min-recent-failures`, `--min-failure-interval`) to parameterize “recent failure” detection in test reports
  * Added recency indicators (active/stale badges) to test cards

* **Improvements**
  * Updated impact/severity classification to use severity threshold constants instead of hard-coded numeric values

* **Tests**
  * Added coverage for recent-vs-stale failure aggregation behavior by SIG
<!-- end of auto-generated comment: release notes by coderabbit.ai -->