### PR TITLE
fix(testgrid): remove `gs://` prefix from gcs_prefix

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -71,7 +71,9 @@ plank:
   default_decoration_config_entries:
     - config:
         gcs_configuration:
-          bucket: gs://kubevirt-prow
+          # `gs://` prefix must be stripped for testgrid integration
+          # => https://github.com/GoogleCloudPlatform/testgrid/pull/107
+          bucket: kubevirt-prow
           path_strategy: explicit
         gcs_credentials_secret: gcs-credentials
         github_api_endpoints:


### PR DESCRIPTION
**What this PR does / why we need it**:

When the gs:// prefix is present, testgrid generates wrong spyglass links, e.g: https://prow.ci.kubevirt.io/view/gs/gs:/kubevirt-prow/logs/...

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to ensure proper testgrid integration by adjusting GCS bucket reference format and added documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->