### PR TITLE
feat(robots): add generic --extra-archs flag for multi-arch presubmit automation

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -494,67 +494,6 @@ presubmits:
       preset-kubevirtci-check-provision-env: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
-    name: check-provision-k8s-1.32-s390x
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/entrypoint.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.32 && ../provision.sh
-        env:
-        - name: GO_MOD_PATH
-          value: cluster-provision/gocli/go.mod
-        - name: SLIM
-          value: "true"
-        - name: RUN_KUBEVIRT_CONFORMANCE
-          value: "false"
-        image: quay.io/kubevirtci/golang:v20260715-af3e234
-        resources:
-          requests:
-            memory: 16Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    cluster: prow-s390x-workloads
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-kubevirtci-check-provision-env: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
-    name: check-provision-k8s-1.33-s390x
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/entrypoint.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.33 && ../provision.sh
-        env:
-        - name: GO_MOD_PATH
-          value: cluster-provision/gocli/go.mod
-        - name: SLIM
-          value: "true"
-        - name: RUN_KUBEVIRT_CONFORMANCE
-          value: "false"
-        image: quay.io/kubevirtci/golang:v20260715-af3e234
-        resources:
-          requests:
-            memory: 16Gi
-        securityContext:
-          privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy
-  - always_run: false
-    cluster: prow-s390x-workloads
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-kubevirtci-check-provision-env: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
     name: check-provision-k8s-1.34-s390x
     optional: true
     spec:
@@ -564,6 +503,36 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
+        env:
+        - name: GO_MOD_PATH
+          value: cluster-provision/gocli/go.mod
+        - name: SLIM
+          value: "true"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "false"
+        image: quay.io/kubevirtci/golang:v20260715-af3e234
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    cluster: prow-s390x-workloads
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-kubevirtci-check-provision-env: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-provision-k8s-1.35-s390x
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.35 && ../provision.sh
         env:
         - name: GO_MOD_PATH
           value: cluster-provision/gocli/go.mod

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -443,7 +443,7 @@ presubmits:
             memory: 1Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
     cluster: prow-s390x-workloads
     decoration_config:
       timeout: 4h0m0s
@@ -460,6 +460,36 @@ presubmits:
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
+        env:
+        - name: GO_MOD_PATH
+          value: cluster-provision/gocli/go.mod
+        - name: SLIM
+          value: "true"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "false"
+        image: quay.io/kubevirtci/golang:v20260715-af3e234
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+  - always_run: false
+    cluster: prow-s390x-workloads
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-kubevirtci-check-provision-env: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-provision-k8s-1.35-s390x
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint.sh
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.35 && ../provision.sh
         env:
         - name: GO_MOD_PATH
           value: cluster-provision/gocli/go.mod

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -675,7 +675,7 @@ periodics:
         args:
           - |
             git-pr.sh \
-              --command "go run ./robots/kubevirtci-presubmit-creator --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --dry-run=false" \
+              --command "go run ./robots/kubevirtci-presubmit-creator --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --extra-archs=s390x --dry-run=false" \
               --repo project-infra \
               --branch create-kubevirtci-presubmit \
               --target main
@@ -722,7 +722,7 @@ periodics:
               exit 0
             fi
             git-pr.sh \
-              --command "go run ./robots/kubevirtci-presubmit-remover --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --dry-run=false" \
+              --command "go run ./robots/kubevirtci-presubmit-remover --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --extra-archs=s390x --dry-run=false" \
               --repo project-infra \
               --branch remove-kubevirtci-presubmit \
               --target main

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -700,7 +700,7 @@ periodics:
         args:
           - |
             git-pr.sh \
-              --command "go run ./robots/kubevirtci-presubmit-creator --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --dry-run=false" \
+              --command "go run ./robots/kubevirtci-presubmit-creator --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --extra-archs=s390x --dry-run=false" \
               --repo project-infra \
               --branch create-kubevirtci-presubmit \
               --target main
@@ -747,7 +747,7 @@ periodics:
               exit 0
             fi
             git-pr.sh \
-              --command "go run ./robots/kubevirtci-presubmit-remover --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --dry-run=false" \
+              --command "go run ./robots/kubevirtci-presubmit-remover --job-config-path-kubevirtci-presubmit=$(pwd)/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml --github-token-path= --extra-archs=s390x --dry-run=false" \
               --repo project-infra \
               --branch remove-kubevirtci-presubmit \
               --target main

--- a/robots/kubevirtci-presubmit-creator/main.go
+++ b/robots/kubevirtci-presubmit-creator/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"kubevirt.io/project-infra/pkg/querier"
@@ -34,6 +35,32 @@ import (
 
 const OrgAndRepoForJobConfig = "kubevirt/kubevirtci"
 
+// ArchConfig holds architecture-specific job parameters for non-default architectures.
+type ArchConfig struct {
+	Cluster      string
+	Timeout      time.Duration
+	AlwaysRun    bool
+	Labels       map[string]string
+	EnvVars      []v1.EnvVar
+	NodeSelector map[string]string
+}
+
+var knownArchConfigs = map[string]ArchConfig{
+	"s390x": {
+		Cluster:   "prow-s390x-workloads",
+		Timeout:   4 * time.Hour,
+		AlwaysRun: false,
+		Labels: map[string]string{
+			"preset-kubevirtci-check-provision-env": "true",
+			"preset-podman-in-container-enabled":    "true",
+		},
+		EnvVars: []v1.EnvVar{
+			{Name: "SLIM", Value: "true"},
+			{Name: "RUN_KUBEVIRT_CONFORMANCE", Value: "false"},
+		},
+	},
+}
+
 type options struct {
 	dryRun bool
 
@@ -41,6 +68,7 @@ type options struct {
 	endpoint                         string
 	jobConfigPathKubevirtciPresubmit string
 	k8sReleaseSemver                 string
+	extraArchs                       string
 }
 
 func (o *options) Validate() error {
@@ -50,7 +78,40 @@ func (o *options) Validate() error {
 	if o.k8sReleaseSemver != "" && !querier.SemVerMinorRegex.MatchString(o.k8sReleaseSemver) {
 		return fmt.Errorf("k8s-release-semver does not match SemVerMinorRegex: %s", o.k8sReleaseSemver)
 	}
+	for _, arch := range parseExtraArchs(o.extraArchs) {
+		if _, ok := knownArchConfigs[arch]; !ok {
+			return fmt.Errorf("unknown architecture %q in extra-archs, known: %v", arch, knownArchNames())
+		}
+	}
 	return nil
+}
+
+func parseExtraArchs(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var archs []string
+	seen := make(map[string]struct{})
+	for _, a := range strings.Split(raw, ",") {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		archs = append(archs, a)
+	}
+	return archs
+}
+
+func knownArchNames() []string {
+	names := make([]string, 0, len(knownArchConfigs))
+	for name := range knownArchConfigs {
+		names = append(names, name)
+	}
+	return names
 }
 
 func gatherOptions() options {
@@ -61,6 +122,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.jobConfigPathKubevirtciPresubmit, "job-config-path-kubevirtci-presubmit", "", "The directory of the k8s providers")
 	fs.StringVar(&o.k8sReleaseSemver, "k8s-release-semver", "", "The semver of the k8s release to create a presubmit for")
+	fs.StringVar(&o.extraArchs, "extra-archs", "", "Comma-separated list of extra architectures to create presubmit jobs for (e.g. s390x)")
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to parse args: %v", err))
@@ -131,8 +193,10 @@ func main() {
 		log.Panicln(err)
 	}
 
-	newJobConfig, exists := AddNewPresubmitIfNotExists(jobConfig, latestReleaseSemver)
-	if exists && !o.dryRun {
+	extraArchs := parseExtraArchs(o.extraArchs)
+
+	newJobConfig, allExist := AddNewPresubmitIfNotExists(jobConfig, latestReleaseSemver, extraArchs)
+	if allExist && !o.dryRun {
 		log.Info(fmt.Sprintf("presubmit job for %v exists, nothing to do.", latestReleaseSemver))
 		os.Exit(0)
 	}
@@ -156,21 +220,33 @@ func main() {
 	}
 }
 
-func AddNewPresubmitIfNotExists(jobConfig config.JobConfig, latestReleaseSemver *querier.SemVer) (newJobConfig config.JobConfig, jobExists bool) {
+func AddNewPresubmitIfNotExists(jobConfig config.JobConfig, latestReleaseSemver *querier.SemVer, extraArchs []string) (newJobConfig config.JobConfig, allExist bool) {
 	newJobConfig = jobConfig
 	kubevirtciJobs := make(map[string]config.Presubmit, len(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig]))
 	for _, job := range newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] {
 		kubevirtciJobs[job.Name] = job
 	}
 
+	allExist = true
+
 	wantedCheckProvisionJobName := createKubevirtciPresubmitJobName(latestReleaseSemver)
-	if _, exists := kubevirtciJobs[wantedCheckProvisionJobName]; exists {
-		return newJobConfig, true
+	if _, exists := kubevirtciJobs[wantedCheckProvisionJobName]; !exists {
+		newPresubmitJobForRelease := CreatePresubmitJobForRelease(latestReleaseSemver)
+		newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] = append(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig], newPresubmitJobForRelease)
+		allExist = false
 	}
 
-	newPresubmitJobForRelease := CreatePresubmitJobForRelease(latestReleaseSemver)
-	newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] = append(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig], newPresubmitJobForRelease)
-	return newJobConfig, false
+	for _, arch := range extraArchs {
+		archJobName := createKubevirtciPresubmitJobNameArch(latestReleaseSemver, arch)
+		if _, exists := kubevirtciJobs[archJobName]; !exists {
+			archCfg := knownArchConfigs[arch]
+			archJob := CreatePresubmitJobForReleaseArch(latestReleaseSemver, arch, archCfg)
+			newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] = append(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig], archJob)
+			allExist = false
+		}
+	}
+
+	return newJobConfig, allExist
 }
 
 func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
@@ -235,6 +311,64 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 	return res
 }
 
+// CreatePresubmitJobForReleaseArch creates a presubmit job for a specific
+// architecture using the provided ArchConfig.
+func CreatePresubmitJobForReleaseArch(semver *querier.SemVer, arch string, archCfg ArchConfig) config.Presubmit {
+	yes := true
+	golangImage := "quay.io/kubevirtci/golang:v20260319-c8f1db8"
+
+	envVars := []v1.EnvVar{
+		{Name: "GO_MOD_PATH", Value: "cluster-provision/gocli/go.mod"},
+	}
+	envVars = append(envVars, archCfg.EnvVars...)
+
+	res := config.Presubmit{
+		AlwaysRun: archCfg.AlwaysRun,
+		Optional:  true,
+		JobBase: config.JobBase{
+			UtilityConfig: config.UtilityConfig{
+				DecorationConfig: &prowjobs.DecorationConfig{
+					Timeout: &prowjobs.Duration{Duration: archCfg.Timeout},
+				},
+			},
+			Name:           createKubevirtciPresubmitJobNameArch(semver, arch),
+			MaxConcurrency: 3,
+			Labels:         archCfg.Labels,
+			Cluster:        archCfg.Cluster,
+			Spec: &v1.PodSpec{
+				NodeSelector: archCfg.NodeSelector,
+				Containers: []v1.Container{
+					{
+						Image: golangImage,
+						Command: []string{
+							"/usr/local/bin/entrypoint.sh",
+						},
+						Args: []string{
+							"/bin/sh",
+							"-c",
+							fmt.Sprintf("cd cluster-provision/k8s/%s.%s && ../provision.sh", semver.Major, semver.Minor),
+						},
+						Env: envVars,
+						SecurityContext: &v1.SecurityContext{
+							Privileged: &yes,
+						},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: *resource.NewQuantity(16*1024*1024*1024, resource.BinarySI),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return res
+}
+
 func createKubevirtciPresubmitJobName(latestReleaseSemver *querier.SemVer) string {
 	return fmt.Sprintf("check-provision-k8s-%s.%s", latestReleaseSemver.Major, latestReleaseSemver.Minor)
+}
+
+func createKubevirtciPresubmitJobNameArch(semver *querier.SemVer, arch string) string {
+	return fmt.Sprintf("check-provision-k8s-%s.%s-%s", semver.Major, semver.Minor, arch)
 }

--- a/robots/kubevirtci-presubmit-creator/main.go
+++ b/robots/kubevirtci-presubmit-creator/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"kubevirt.io/project-infra/pkg/querier"
@@ -34,6 +35,32 @@ import (
 
 const OrgAndRepoForJobConfig = "kubevirt/kubevirtci"
 
+// ArchConfig holds architecture-specific job parameters for non-default architectures.
+type ArchConfig struct {
+	Cluster      string
+	Timeout      time.Duration
+	AlwaysRun    bool
+	Labels       map[string]string
+	EnvVars      []v1.EnvVar
+	NodeSelector map[string]string
+}
+
+var knownArchConfigs = map[string]ArchConfig{
+	"s390x": {
+		Cluster:   "prow-s390x-workloads",
+		Timeout:   4 * time.Hour,
+		AlwaysRun: false,
+		Labels: map[string]string{
+			"preset-kubevirtci-check-provision-env": "true",
+			"preset-podman-in-container-enabled":    "true",
+		},
+		EnvVars: []v1.EnvVar{
+			{Name: "SLIM", Value: "true"},
+			{Name: "RUN_KUBEVIRT_CONFORMANCE", Value: "false"},
+		},
+	},
+}
+
 type options struct {
 	dryRun bool
 
@@ -41,6 +68,7 @@ type options struct {
 	endpoint                         string
 	jobConfigPathKubevirtciPresubmit string
 	k8sReleaseSemver                 string
+	extraArchs                       string
 }
 
 func (o *options) Validate() error {
@@ -50,7 +78,40 @@ func (o *options) Validate() error {
 	if o.k8sReleaseSemver != "" && !querier.SemVerMinorRegex.MatchString(o.k8sReleaseSemver) {
 		return fmt.Errorf("k8s-release-semver does not match SemVerMinorRegex: %s", o.k8sReleaseSemver)
 	}
+	for _, arch := range parseExtraArchs(o.extraArchs) {
+		if _, ok := knownArchConfigs[arch]; !ok {
+			return fmt.Errorf("unknown architecture %q in extra-archs, known: %v", arch, knownArchNames())
+		}
+	}
 	return nil
+}
+
+func parseExtraArchs(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var archs []string
+	seen := make(map[string]struct{})
+	for _, a := range strings.Split(raw, ",") {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		archs = append(archs, a)
+	}
+	return archs
+}
+
+func knownArchNames() []string {
+	names := make([]string, 0, len(knownArchConfigs))
+	for name := range knownArchConfigs {
+		names = append(names, name)
+	}
+	return names
 }
 
 func gatherOptions() options {
@@ -61,6 +122,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.jobConfigPathKubevirtciPresubmit, "job-config-path-kubevirtci-presubmit", "", "The directory of the k8s providers")
 	fs.StringVar(&o.k8sReleaseSemver, "k8s-release-semver", "", "The semver of the k8s release to create a presubmit for")
+	fs.StringVar(&o.extraArchs, "extra-archs", "", "Comma-separated list of extra architectures to create presubmit jobs for (e.g. s390x)")
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to parse args: %v", err))
@@ -131,8 +193,10 @@ func main() {
 		log.Panicln(err)
 	}
 
-	newJobConfig, exists := AddNewPresubmitIfNotExists(jobConfig, latestReleaseSemver)
-	if exists && !o.dryRun {
+	extraArchs := parseExtraArchs(o.extraArchs)
+
+	newJobConfig, allExist := AddNewPresubmitIfNotExists(jobConfig, latestReleaseSemver, extraArchs)
+	if allExist && !o.dryRun {
 		log.Info(fmt.Sprintf("presubmit job for %v exists, nothing to do.", latestReleaseSemver))
 		os.Exit(0)
 	}
@@ -156,21 +220,33 @@ func main() {
 	}
 }
 
-func AddNewPresubmitIfNotExists(jobConfig config.JobConfig, latestReleaseSemver *querier.SemVer) (newJobConfig config.JobConfig, jobExists bool) {
+func AddNewPresubmitIfNotExists(jobConfig config.JobConfig, latestReleaseSemver *querier.SemVer, extraArchs []string) (newJobConfig config.JobConfig, allExist bool) {
 	newJobConfig = jobConfig
 	kubevirtciJobs := make(map[string]config.Presubmit, len(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig]))
 	for _, job := range newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] {
 		kubevirtciJobs[job.Name] = job
 	}
 
+	allExist = true
+
 	wantedCheckProvisionJobName := createKubevirtciPresubmitJobName(latestReleaseSemver)
-	if _, exists := kubevirtciJobs[wantedCheckProvisionJobName]; exists {
-		return newJobConfig, true
+	if _, exists := kubevirtciJobs[wantedCheckProvisionJobName]; !exists {
+		newPresubmitJobForRelease := CreatePresubmitJobForRelease(latestReleaseSemver)
+		newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] = append(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig], newPresubmitJobForRelease)
+		allExist = false
 	}
 
-	newPresubmitJobForRelease := CreatePresubmitJobForRelease(latestReleaseSemver)
-	newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] = append(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig], newPresubmitJobForRelease)
-	return newJobConfig, false
+	for _, arch := range extraArchs {
+		archJobName := createKubevirtciPresubmitJobNameArch(latestReleaseSemver, arch)
+		if _, exists := kubevirtciJobs[archJobName]; !exists {
+			archCfg := knownArchConfigs[arch]
+			archJob := CreatePresubmitJobForReleaseArch(latestReleaseSemver, arch, archCfg)
+			newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] = append(newJobConfig.PresubmitsStatic[OrgAndRepoForJobConfig], archJob)
+			allExist = false
+		}
+	}
+
+	return newJobConfig, allExist
 }
 
 func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
@@ -202,17 +278,68 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 					{
 						Image: golangImage,
 						Command: []string{
-							"/usr/local/bin/runner.sh",
+							"/usr/local/bin/entrypoint.sh",
 							"/bin/sh",
 							"-c",
 							fmt.Sprintf("cd cluster-provision/k8s/%s.%s && ../provision.sh", semver.Major, semver.Minor),
 						},
-						Env: []v1.EnvVar{
-							{
-								Name:  "GIMME_GO_VERSION",
-								Value: "1.24.7",
+					Env: []v1.EnvVar{
+						{
+							Name:  "GO_MOD_PATH",
+							Value: "cluster-provision/gocli/go.mod",
+						},
+					},
+						SecurityContext: &v1.SecurityContext{
+							Privileged: &yes,
+						},
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: *resource.NewQuantity(16*1024*1024*1024, resource.BinarySI),
 							},
 						},
+					},
+				},
+			},
+		},
+	}
+	return res
+}
+
+func CreatePresubmitJobForReleaseArch(semver *querier.SemVer, arch string, archCfg ArchConfig) config.Presubmit {
+	yes := true
+	golangImage := "quay.io/kubevirtci/golang:v20260319-c8f1db8"
+
+	envVars := []v1.EnvVar{
+		{Name: "GO_MOD_PATH", Value: "cluster-provision/gocli/go.mod"},
+	}
+	envVars = append(envVars, archCfg.EnvVars...)
+
+	res := config.Presubmit{
+		AlwaysRun: archCfg.AlwaysRun,
+		Optional:  true,
+		JobBase: config.JobBase{
+			UtilityConfig: config.UtilityConfig{
+				Decorate: &yes,
+				DecorationConfig: &prowjobs.DecorationConfig{
+					Timeout: &prowjobs.Duration{Duration: archCfg.Timeout},
+				},
+			},
+			Name:           createKubevirtciPresubmitJobNameArch(semver, arch),
+			MaxConcurrency: 3,
+			Labels:         archCfg.Labels,
+			Cluster:        archCfg.Cluster,
+			Spec: &v1.PodSpec{
+				NodeSelector: archCfg.NodeSelector,
+				Containers: []v1.Container{
+					{
+						Image: golangImage,
+						Command: []string{
+							"/usr/local/bin/entrypoint.sh",
+							"/bin/sh",
+							"-c",
+							fmt.Sprintf("cd cluster-provision/k8s/%s.%s && ../provision.sh", semver.Major, semver.Minor),
+						},
+						Env: envVars,
 						SecurityContext: &v1.SecurityContext{
 							Privileged: &yes,
 						},
@@ -231,4 +358,8 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 
 func createKubevirtciPresubmitJobName(latestReleaseSemver *querier.SemVer) string {
 	return fmt.Sprintf("check-provision-k8s-%s.%s", latestReleaseSemver.Major, latestReleaseSemver.Minor)
+}
+
+func createKubevirtciPresubmitJobNameArch(semver *querier.SemVer, arch string) string {
+	return fmt.Sprintf("check-provision-k8s-%s.%s-%s", semver.Major, semver.Minor, arch)
 }

--- a/robots/kubevirtci-presubmit-creator/main_test.go
+++ b/robots/kubevirtci-presubmit-creator/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"kubevirt.io/project-infra/pkg/querier"
@@ -28,7 +29,7 @@ func TestCreateBumpedJobForRelease(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Command: []string{
-										"/usr/local/bin/runner.sh",
+										"/usr/local/bin/entrypoint.sh",
 										"/bin/sh",
 										"-c",
 										"cd cluster-provision/k8s/1.37 && ../provision.sh",
@@ -53,7 +54,7 @@ func TestCreateBumpedJobForRelease(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Command: []string{
-										"/usr/local/bin/runner.sh",
+										"/usr/local/bin/entrypoint.sh",
 										"/bin/sh",
 										"-c",
 										"cd cluster-provision/k8s/1.42 && ../provision.sh",
@@ -88,10 +89,66 @@ func TestCreateBumpedJobForRelease(t *testing.T) {
 	}
 }
 
+func TestCreateBumpedJobForReleaseArch(t *testing.T) {
+	semver := newMinorSemver("1", "37")
+	archCfg := knownArchConfigs["s390x"]
+	job := CreatePresubmitJobForReleaseArch(semver, "s390x", archCfg)
+
+	if job.Name != "check-provision-k8s-1.37-s390x" {
+		t.Errorf("job name = %v, want check-provision-k8s-1.37-s390x", job.Name)
+	}
+	if job.Cluster != "prow-s390x-workloads" {
+		t.Errorf("cluster = %v, want prow-s390x-workloads", job.Cluster)
+	}
+	if job.DecorationConfig.Timeout.Duration != 4*time.Hour {
+		t.Errorf("timeout = %v, want 4h", job.DecorationConfig.Timeout.Duration)
+	}
+	if job.AlwaysRun != false {
+		t.Errorf("AlwaysRun = %v, want false", job.AlwaysRun)
+	}
+	if _, ok := job.Labels["preset-docker-mirror-proxy"]; ok {
+		t.Error("arch job should not have preset-docker-mirror-proxy label")
+	}
+	if job.Labels["preset-kubevirtci-check-provision-env"] != "true" {
+		t.Error("arch job should have preset-kubevirtci-check-provision-env label")
+	}
+	if job.Labels["preset-podman-in-container-enabled"] != "true" {
+		t.Error("arch job should have preset-podman-in-container-enabled label")
+	}
+	if job.Spec.NodeSelector != nil {
+		t.Errorf("arch job should have nil NodeSelector, got %v", job.Spec.NodeSelector)
+	}
+
+	envMap := make(map[string]string)
+	for _, env := range job.Spec.Containers[0].Env {
+		envMap[env.Name] = env.Value
+	}
+	if envMap["SLIM"] != "true" {
+		t.Error("arch job should have SLIM=true env var")
+	}
+	if envMap["RUN_KUBEVIRT_CONFORMANCE"] != "false" {
+		t.Error("arch job should have RUN_KUBEVIRT_CONFORMANCE=false env var")
+	}
+	if envMap["GO_MOD_PATH"] != "cluster-provision/gocli/go.mod" {
+		t.Error("arch job should have GO_MOD_PATH env var")
+	}
+
+	expectedCmd := []string{
+		"/usr/local/bin/entrypoint.sh",
+		"/bin/sh",
+		"-c",
+		"cd cluster-provision/k8s/1.37 && ../provision.sh",
+	}
+	if !reflect.DeepEqual(job.Spec.Containers[0].Command, expectedCmd) {
+		t.Errorf("command = %v, want %v", job.Spec.Containers[0].Command, expectedCmd)
+	}
+}
+
 func TestAddNewPresubmitIfNotExists(t *testing.T) {
 	type args struct {
 		jobConfig           config.JobConfig
 		latestReleaseSemver *querier.SemVer
+		extraArchs          []string
 	}
 	tests := []struct {
 		name             string
@@ -182,10 +239,101 @@ func TestAddNewPresubmitIfNotExists(t *testing.T) {
 			},
 			wantJobExists: true,
 		},
+		{
+			name: "no job exists with extra archs",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+					},
+				},
+			},
+			wantJobExists: false,
+		},
+		{
+			name: "amd64 exists but arch job missing",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+					},
+				},
+			},
+			wantJobExists: false,
+		},
+		{
+			name: "arch job exists but amd64 missing",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+					},
+				},
+			},
+			wantJobExists: false,
+		},
+		{
+			name: "both amd64 and arch jobs exist",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+							CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+					},
+				},
+			},
+			wantJobExists: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotNewJobConfig, gotJobExists := AddNewPresubmitIfNotExists(tt.args.jobConfig, tt.args.latestReleaseSemver)
+			gotNewJobConfig, gotJobExists := AddNewPresubmitIfNotExists(tt.args.jobConfig, tt.args.latestReleaseSemver, tt.args.extraArchs)
 			if !reflect.DeepEqual(gotNewJobConfig, tt.wantNewJobConfig) {
 				t.Errorf("AddNewPresubmitIfNotExists() gotNewJobConfig = %v, want %v", gotNewJobConfig, tt.wantNewJobConfig)
 			}

--- a/robots/kubevirtci-presubmit-creator/main_test.go
+++ b/robots/kubevirtci-presubmit-creator/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"kubevirt.io/project-infra/pkg/querier"
@@ -92,10 +93,69 @@ func TestCreateBumpedJobForRelease(t *testing.T) {
 	}
 }
 
+func TestCreateBumpedJobForReleaseArch(t *testing.T) {
+	semver := newMinorSemver("1", "37")
+	archCfg := knownArchConfigs["s390x"]
+	job := CreatePresubmitJobForReleaseArch(semver, "s390x", archCfg)
+
+	if job.Name != "check-provision-k8s-1.37-s390x" {
+		t.Errorf("job name = %v, want check-provision-k8s-1.37-s390x", job.Name)
+	}
+	if job.Cluster != "prow-s390x-workloads" {
+		t.Errorf("cluster = %v, want prow-s390x-workloads", job.Cluster)
+	}
+	if job.DecorationConfig.Timeout.Duration != 4*time.Hour {
+		t.Errorf("timeout = %v, want 4h", job.DecorationConfig.Timeout.Duration)
+	}
+	if job.AlwaysRun {
+		t.Errorf("AlwaysRun = %v, want false", job.AlwaysRun)
+	}
+	if _, ok := job.Labels["preset-docker-mirror-proxy"]; ok {
+		t.Error("arch job should not have preset-docker-mirror-proxy label")
+	}
+	if job.Labels["preset-kubevirtci-check-provision-env"] != "true" {
+		t.Error("arch job should have preset-kubevirtci-check-provision-env label")
+	}
+	if job.Labels["preset-podman-in-container-enabled"] != "true" {
+		t.Error("arch job should have preset-podman-in-container-enabled label")
+	}
+	if job.Spec.NodeSelector != nil {
+		t.Errorf("arch job should have nil NodeSelector, got %v", job.Spec.NodeSelector)
+	}
+
+	envMap := make(map[string]string)
+	for _, env := range job.Spec.Containers[0].Env {
+		envMap[env.Name] = env.Value
+	}
+	if envMap["SLIM"] != "true" {
+		t.Error("arch job should have SLIM=true env var")
+	}
+	if envMap["RUN_KUBEVIRT_CONFORMANCE"] != "false" {
+		t.Error("arch job should have RUN_KUBEVIRT_CONFORMANCE=false env var")
+	}
+	if envMap["GO_MOD_PATH"] != "cluster-provision/gocli/go.mod" {
+		t.Error("arch job should have GO_MOD_PATH env var")
+	}
+
+	expectedCmd := []string{"/usr/local/bin/entrypoint.sh"}
+	if !reflect.DeepEqual(job.Spec.Containers[0].Command, expectedCmd) {
+		t.Errorf("command = %v, want %v", job.Spec.Containers[0].Command, expectedCmd)
+	}
+	expectedArgs := []string{
+		"/bin/sh",
+		"-c",
+		"cd cluster-provision/k8s/1.37 && ../provision.sh",
+	}
+	if !reflect.DeepEqual(job.Spec.Containers[0].Args, expectedArgs) {
+		t.Errorf("args = %v, want %v", job.Spec.Containers[0].Args, expectedArgs)
+	}
+}
+
 func TestAddNewPresubmitIfNotExists(t *testing.T) {
 	type args struct {
 		jobConfig           config.JobConfig
 		latestReleaseSemver *querier.SemVer
+		extraArchs          []string
 	}
 	tests := []struct {
 		name             string
@@ -186,10 +246,101 @@ func TestAddNewPresubmitIfNotExists(t *testing.T) {
 			},
 			wantJobExists: true,
 		},
+		{
+			name: "no job exists with extra archs",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+					},
+				},
+			},
+			wantJobExists: false,
+		},
+		{
+			name: "amd64 exists but arch job missing",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+					},
+				},
+			},
+			wantJobExists: false,
+		},
+		{
+			name: "arch job exists but amd64 missing",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+					},
+				},
+			},
+			wantJobExists: false,
+		},
+		{
+			name: "both amd64 and arch jobs exist",
+			args: args{
+				jobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+							CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+						},
+					},
+				},
+				latestReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						CreatePresubmitJobForRelease(newMinorSemver("1", "37")),
+						CreatePresubmitJobForReleaseArch(newMinorSemver("1", "37"), "s390x", knownArchConfigs["s390x"]),
+					},
+				},
+			},
+			wantJobExists: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotNewJobConfig, gotJobExists := AddNewPresubmitIfNotExists(tt.args.jobConfig, tt.args.latestReleaseSemver)
+			gotNewJobConfig, gotJobExists := AddNewPresubmitIfNotExists(tt.args.jobConfig, tt.args.latestReleaseSemver, tt.args.extraArchs)
 			if !reflect.DeepEqual(gotNewJobConfig, tt.wantNewJobConfig) {
 				t.Errorf("AddNewPresubmitIfNotExists() gotNewJobConfig = %v, want %v", gotNewJobConfig, tt.wantNewJobConfig)
 			}

--- a/robots/kubevirtci-presubmit-remover/main.go
+++ b/robots/kubevirtci-presubmit-remover/main.go
@@ -18,6 +18,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"kubevirt.io/project-infra/pkg/kubevirt/release"
 	"kubevirt.io/project-infra/pkg/querier"
@@ -31,17 +32,27 @@ import (
 
 const OrgAndRepoForJobConfig = "kubevirt/kubevirtci"
 
+var knownArchs = map[string]struct{}{
+	"s390x": {},
+}
+
 type options struct {
 	dryRun bool
 
 	TokenPath                        string
 	endpoint                         string
 	jobConfigPathKubevirtciPresubmit string
+	extraArchs                       string
 }
 
 func (o *options) Validate() error {
 	if _, err := os.Stat(o.jobConfigPathKubevirtciPresubmit); os.IsNotExist(err) {
 		return fmt.Errorf("jobConfigPathKubevirtciPresubmit is required: %v", err)
+	}
+	for _, arch := range parseExtraArchs(o.extraArchs) {
+		if _, ok := knownArchs[arch]; !ok {
+			return fmt.Errorf("unknown architecture %q in extra-archs", arch)
+		}
 	}
 	return nil
 }
@@ -53,6 +64,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.jobConfigPathKubevirtciPresubmit, "job-config-path-kubevirtci-presubmit", "", "The directory of the k8s providers")
+	fs.StringVar(&o.extraArchs, "extra-archs", "", "Comma-separated list of extra architectures whose presubmit jobs should also be removed (e.g. s390x)")
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to parse args: %v", err))
@@ -117,7 +129,8 @@ func main() {
 	}
 
 	targetRelease := latestMinorReleases[3]
-	updated := deletePresubmitJobForRelease(&jobConfig, targetRelease)
+	extraArchs := parseExtraArchs(o.extraArchs)
+	updated := deletePresubmitJobForRelease(&jobConfig, targetRelease, extraArchs)
 	if !updated {
 		log.Info("Not updated, nothing to do")
 		os.Exit(0)
@@ -143,9 +156,12 @@ func main() {
 
 }
 
-func deletePresubmitJobForRelease(jobConfig *config.JobConfig, targetReleaseSemver *querier.SemVer) (updated bool) {
+func deletePresubmitJobForRelease(jobConfig *config.JobConfig, targetReleaseSemver *querier.SemVer, extraArchs []string) (updated bool) {
 	toDeleteJobNames := map[string]struct{}{}
 	toDeleteJobNames[createKubevirtciPresubmitJobName(targetReleaseSemver)] = struct{}{}
+	for _, arch := range extraArchs {
+		toDeleteJobNames[createKubevirtciPresubmitJobNameArch(targetReleaseSemver, arch)] = struct{}{}
+	}
 
 	var newPresubmits []config.Presubmit
 
@@ -164,6 +180,30 @@ func deletePresubmitJobForRelease(jobConfig *config.JobConfig, targetReleaseSemv
 	return
 }
 
+func parseExtraArchs(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var archs []string
+	seen := make(map[string]struct{})
+	for _, a := range strings.Split(raw, ",") {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		archs = append(archs, a)
+	}
+	return archs
+}
+
 func createKubevirtciPresubmitJobName(latestReleaseSemver *querier.SemVer) string {
 	return fmt.Sprintf("check-provision-k8s-%s.%s", latestReleaseSemver.Major, latestReleaseSemver.Minor)
+}
+
+func createKubevirtciPresubmitJobNameArch(semver *querier.SemVer, arch string) string {
+	return fmt.Sprintf("check-provision-k8s-%s.%s-%s", semver.Major, semver.Minor, arch)
 }

--- a/robots/kubevirtci-presubmit-remover/main_test.go
+++ b/robots/kubevirtci-presubmit-remover/main_test.go
@@ -12,6 +12,7 @@ func TestDeletePresubmitJobForRelease(t *testing.T) {
 	type args struct {
 		jobConfig           *config.JobConfig
 		targetReleaseSemver *querier.SemVer
+		extraArchs          []string
 	}
 	tests := []struct {
 		name             string
@@ -111,10 +112,84 @@ func TestDeletePresubmitJobForRelease(t *testing.T) {
 			},
 			wantUpdated: true,
 		},
+		{
+			name: "only amd64 deleted when no extra archs",
+			args: args{
+				jobConfig: &config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							{
+								JobBase: config.JobBase{
+									Name: createKubevirtciPresubmitJobName(newMinorSemver("1", "37")),
+								},
+							},
+							{
+								JobBase: config.JobBase{
+									Name: createKubevirtciPresubmitJobNameArch(newMinorSemver("1", "37"), "s390x"),
+								},
+							},
+						},
+					},
+				},
+				targetReleaseSemver: newMinorSemver("1", "37"),
+			},
+			wantNewJobConfig: &config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						{
+							JobBase: config.JobBase{
+								Name: createKubevirtciPresubmitJobNameArch(newMinorSemver("1", "37"), "s390x"),
+							},
+						},
+					},
+				},
+			},
+			wantUpdated: true,
+		},
+		{
+			name: "both amd64 and arch jobs deleted with extra archs",
+			args: args{
+				jobConfig: &config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						OrgAndRepoForJobConfig: {
+							{
+								JobBase: config.JobBase{
+									Name: createKubevirtciPresubmitJobName(newMinorSemver("1", "37")),
+								},
+							},
+							{
+								JobBase: config.JobBase{
+									Name: createKubevirtciPresubmitJobNameArch(newMinorSemver("1", "37"), "s390x"),
+								},
+							},
+							{
+								JobBase: config.JobBase{
+									Name: createKubevirtciPresubmitJobName(newMinorSemver("1", "42")),
+								},
+							},
+						},
+					},
+				},
+				targetReleaseSemver: newMinorSemver("1", "37"),
+				extraArchs:          []string{"s390x"},
+			},
+			wantNewJobConfig: &config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					OrgAndRepoForJobConfig: {
+						{
+							JobBase: config.JobBase{
+								Name: createKubevirtciPresubmitJobName(newMinorSemver("1", "42")),
+							},
+						},
+					},
+				},
+			},
+			wantUpdated: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotUpdated := deletePresubmitJobForRelease(tt.args.jobConfig, tt.args.targetReleaseSemver)
+			gotUpdated := deletePresubmitJobForRelease(tt.args.jobConfig, tt.args.targetReleaseSemver, tt.args.extraArchs)
 			if gotUpdated != tt.wantUpdated {
 				t.Errorf("deletePresubmitJobForRelease() gotUpdated = %v, want %v", gotUpdated, tt.wantUpdated)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Reworks the kubevirtci-presubmit-creator and kubevirtci-presubmit-remover robots to support optional extra architectures via a generic `--extra-archs` flag, keeping the default amd64 behavior completely unchanged.

When `--extra-archs` is empty (default), behavior is identical to upstream. When set (e.g. `--extra-archs=s390x`), the creator generates arch-specific presubmit jobs alongside the amd64 job, and the remover deletes both amd64 and arch jobs for retired k8s versions.

s390x check-provision jobs were previously added manually and never cleaned up, leaving stale entries (1.32-s390x, 1.33-s390x) while their amd64 counterparts were already removed by the robot. This PR automates the lifecycle so no manual YAML edits are needed going forward.

**Changes:**

- **Creator robot**: Added `ArchConfig` struct and `knownArchConfigs` map for arch-specific job parameters. New `CreatePresubmitJobForReleaseArch()` function builds arch jobs. `AddNewPresubmitIfNotExists()` now accepts `extraArchs` and creates arch jobs alongside amd64.
- **Remover robot**: Added `--extra-archs` flag. `deletePresubmitJobForRelease()` now includes arch job names in the deletion set.
- **YAML cleanup**: Removed stale 1.32-s390x and 1.33-s390x. 1.34-s390x changed from `always_run: true` to `false` (aligning with ArchConfig and reducing wasted CI on a lane already marked optional per #5097). Added 1.35-s390x to backfill the gap. 1.36-s390x will be created automatically by the robot on its next periodic run.
- **Periodic config**: Both creator and remover periodic jobs now pass `--extra-archs=s390x`.
- **Tests**: Added unit tests for arch-specific job creation, existence checks for mixed amd64+arch scenarios, and combined deletion.

**Adding a new architecture in the future** requires only two changes:
1. Add an entry to `knownArchConfigs` in the creator (cluster, timeout, labels, env vars)
2. Update `--extra-archs` in the periodic job config (e.g. `--extra-archs=s390x,ppc64le`)

**Which issue(s) this PR fixes**:

**Special notes for reviewer**:

The s390x ArchConfig intentionally differs from amd64 (matching existing manually-created s390x jobs):
- `cluster: prow-s390x-workloads` (not `prow-workloads`)
- `timeout: 4h` (not 3h)
- `always_run: false`, `optional: true` (manual trigger only, non-blocking)
- No `preset-docker-mirror-proxy` label
- No `NodeSelector` (s390x cluster doesn't use bare-metal-external)
- Extra env vars: `SLIM=true`, `RUN_KUBEVIRT_CONFORMANCE=false`

**jira-ticket**:

**Checklist**

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough).
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for creating and removing architecture-specific presubmit jobs via an `--extra-archs` option (including s390x variants).
  - Updated periodic presubmit maintenance to include s390x job generation/removal.

- **Updates**
  - Advanced s390x Kubernetes provisioning checks to Kubernetes 1.34 and 1.35.
  - Updated generated presubmit job execution command and environment setup to the standardized entrypoint flow.

- **Tests**
  - Expanded coverage for architecture-specific presubmit creation/detection and deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->