### PR TITLE
Fix 1.36-compute parallel lane target name

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2281,7 +2281,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.36-sig-compute
+          value: k8s-1.36-sig-compute-parallel
         - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
           value: --usb 30M --usb 40M
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY


### PR DESCRIPTION
Same as #4673 

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test automation configuration to enable parallel execution of Kubernetes 1.36 compute tests, improving pipeline efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->