### PR TITLE
feat: add HCO s390x e2e test lanes for k8s-1.36

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -78,6 +78,74 @@ presubmits:
             resources:
               requests:
                 memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.35-s390x
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
+      always_run: true
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 8h
+        grace_period: 5m
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-podman-shared-images: "true"
+      cluster: prow-s390x-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.35 && export SLIM=true && automation/test.sh"
+            env:
+              - name: GO_MOD_PATH
+                value: "go.mod"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY'
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.36-s390x
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
+      always_run: true
+      optional: true
+      decorate: true
+      decoration_config:
+        timeout: 8h
+        grace_period: 5m
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-podman-shared-images: "true"
+      cluster: prow-s390x-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.36 && export SLIM=true && automation/test.sh"
+            env:
+              - name: GO_MOD_PATH
+                value: "go.mod"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY'
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
     - name: build-hco-test-utils-image
       always_run: false
       branches:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -76,6 +76,38 @@ presubmits:
             resources:
               requests:
                 memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.36-s390x
+      skip_branches:
+        - release-\d+\.\d+
+      annotations:
+        fork-per-release: "true"
+        testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
+      always_run: true
+      optional: true
+      decoration_config:
+        timeout: 8h
+        grace_period: 5m
+      labels:
+        preset-podman-in-container-enabled: "true"
+      cluster: prow-s390x-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260715-af3e234
+            command:
+              - "/usr/local/bin/entrypoint.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.36 && export SLIM=true && automation/test.sh"
+            env:
+              - name: GO_MOD_PATH
+                value: "go.mod"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY && !AIE'
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
     - name: build-hco-test-utils-image
       always_run: false
       branches:


### PR DESCRIPTION
##### What this PR does / why we need it:

This adds presubmit e2e test lanes for HCO on s390x, targeting k8s-1.35 and k8s-1.36 to match the amd64 version coverage. The jobs mirror the existing amd64 e2e lanes but run on the s390x Prow cluster with adjusted settings (longer timeout, slim images, no docker mirror proxy, no node selector). They are marked optional initially so they do not block PRs while we validate stability.

Depends on:
- kubevirt/kubevirtci#1734 (s390x images for all k8s versions)
- kubevirt/hyperconverged-cluster-operator#4337 (multi-arch functest build)

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added optional end-to-end presubmit validation for s390x environments running Kubernetes 1.36.
  - The check runs in a dedicated testing environment with an eight-hour timeout and privileged container execution.
  - Validation uses the podman-in-container setup and slim configuration.
  - This expands pre-release coverage for the s390x and Kubernetes 1.36 combination without changing the default validation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->