### PR TITLE
Bump arm64 jobs to kind-1.36 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -726,7 +726,7 @@ periodics:
       - automation/test.sh
       env:
       - name: TARGET
-        value: kind-1.34-wg-arm64
+        value: kind-1.36-wg-arm64
       - name: KUBEVIRT_NUM_NODES
         value: "2"
       image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
@@ -772,9 +772,9 @@ periodics:
         automation/conformance.sh
       env:
       - name: TARGET
-        value: kind-1.34
+        value: kind-1.36
       - name: KUBEVIRT_PROVIDER
-        value: kind-1.34
+        value: kind-1.36
       - name: KUBEVIRT_NUM_NODES
         value: "3"
       - name: IPFAMILY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1245,7 +1245,7 @@ presubmits:
       preset-gomaxprocs-16: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
-    name: pull-kubevirt-e2e-kind-1.35-sig-compute-arm64
+    name: pull-kubevirt-e2e-kind-1.36-sig-compute-arm64
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -1258,7 +1258,7 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.35-wg-arm64
+          value: kind-1.36-wg-arm64
         - name: KUBEVIRT_NUM_NODES
           value: "2"
         image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
@@ -1289,7 +1289,7 @@ presubmits:
       preset-gomaxprocs-16: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 2
-    name: pull-kubevirt-e2e-kind-1.35-sig-compute-conformance-arm64
+    name: pull-kubevirt-e2e-kind-1.36-sig-compute-conformance-arm64
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1303,9 +1303,9 @@ presubmits:
           automation/conformance.sh
         env:
         - name: TARGET
-          value: kind-1.35-wg-arm64
+          value: kind-1.36-wg-arm64
         - name: KUBEVIRT_PROVIDER
-          value: kind-1.35
+          value: kind-1.36
         - name: KUBEVIRT_NUM_NODES
           value: "2"
         - name: IPFAMILY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -274,6 +274,83 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - always_run: false
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-up-kind-1.36
+    optional: true
+    run_if_changed: cluster-up/cluster/kind(-1\.36)?
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - make cluster-up
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.36
+        - name: KUBEVIRT_NUM_NODES
+          value: "2"
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 11264M
+        image: quay.io/kubevirtci/golang:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 24Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+  - always_run: false
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      timeout: 3h0m0s
+    max_concurrency: 1
+    name: check-up-kind-1.36-arm64
+    optional: true
+    run_if_changed: cluster-up/cluster/kind(-1\.36)?
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - make cluster-up
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.36
+        - name: KUBEVIRT_DEPLOY_CDI
+          value: "true"
+        image: quay.io/kubevirtci/golang:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 24Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
   - always_run: true
     cluster: prow-workloads
     decorate: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps all arm64 CI jobs on main to use the kind-1.36 provider now that it's available in kubevirtci:

- Presubmits: `pull-kubevirt-e2e-kind-1.36-sig-compute-arm64` and `pull-kubevirt-e2e-kind-1.36-sig-compute-conformance-arm64` (were on 1.35)
- Periodics: `periodic-kubevirt-kind-e2e-test-ARM64` and `periodic-kubevirt-kind-conformance-test-ARM64` (were on 1.34)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Infrastructure Updates**
  * Updated scheduled periodic jobs to run against `kind-1.36` artifacts for ARM64 targets.
  * Updated KubeVirt presubmits to use `kind-1.36` job names and corresponding environment settings.

* **New Features**
  * Added new cluster bring-up presubmission tests for Kubernetes `kind` 1.36 on both AMD64 and ARM64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->