### PR TITLE
chore(org): create wg-arch-s390x team

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -966,6 +966,14 @@ orgs:
           web-ui: write
           web-ui-components: write
           web-ui-operator: write
+      wg-arch-s390x:
+        description: >-
+          Working group which takes care of all things related to supporting
+          s390x architecture on KubeVirt.
+          Ref: https://github.com/kubevirt/community/blob/main/wg-arch-s390x/charter.md
+        maintainers:
+          - chandramerla
+        privacy: closed
       community-team:
         description: "Maintainers of KubeVirt community and websites"
         maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:

Create a `wg-arch-s390x` team to allow its members to re-run s390x jobs in #5181.

**Special notes for your reviewer**:

/cc @chandramerla
/cc @dhiller