### PR TITLE
fix(golangci): use stable installation script

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       containers:
       - args:
         - |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
+          curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
           make lint
         command:
         - "/usr/local/bin/runner.sh"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -131,7 +131,7 @@ presubmits:
         - "/bin/sh"
         - "-ce"
         - |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
+          curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
           make lint
         env:
         - name: GIMME_GO_VERSION


### PR DESCRIPTION
**What this PR does / why we need it**:

Latest installation script have issue with checksum and sbom artifacts and fails with the following error.

```
golangci/golangci-lint err hash_sha256_verify checksum for '/tmp/tmp.0yt8BTGBcH/golangci-lint-2.12.2-linux-amd64.tar.gz' did not verify 8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
fd3a137c7e722128143cc8932bcaa00bc73e10adadee18bdb0893453edb2c137 vs 8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553
```

Switch to the stable version of the script as recommended in https://github.com/golangci/golangci-lint/issues/6572.

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI build infrastructure to use the official golangci-lint installer source for enhanced reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->