### PR TITLE
chore(kustomize): use kubectl instead of old standalone binary

### DIFF
--- a/github/ci/prow-deploy/README.md
+++ b/github/ci/prow-deploy/README.md
@@ -66,10 +66,7 @@ then renders the yaml configurations, then copy them to the environment director
 When configuration and secrets are in place in the overlay specific directories,
 we can finally call kustomize to generate overlay specific manifests:
 
-    kustomize build kustom/overlays/$overlay > prow-deploy.yaml
-
-WARNING: There is a version of kustomize that is embedded in kubectl, but it's not the version
-required by this deployment, so don't use it.
+    kubectl kustomize kustom/overlays/$overlay > prow-deploy.yaml
 
 After the manifests are rendered without errors, you can directly apply them with kubectl
 

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/kustomization.yaml
@@ -10,14 +10,13 @@ images:
     newTag: 0.6.2-ssl-verify-depth-3
 
 configMapGenerator:
-  - name: mirror-proxy-config
-    namespace: kubevirt-prow-jobs
-    files:
-      - configs/ca.crt
-  - name: mirror-proxy-config
+  - &mirror_proxy_config
+    name: mirror-proxy-config
     namespace: kubevirt-prow
     files:
       - configs/ca.crt
+  - <<: *mirror_proxy_config
+    namespace: kubevirt-prow-jobs
   - name: docker-daemon-mirror-config
     namespace: kubevirt-prow-jobs
     files:

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -132,12 +132,12 @@ patches:
   - target: &configmap_target
       version: v1
       kind: ConfigMap
-      namespace: ""
+      namespace: default
       name: .*
     path: patches/JsonRFC6902/prow-namespace.yaml
   - target:
       <<: *configmap_target
-      namespace: default
+      namespace: prow
       name: .*
     path: patches/JsonRFC6902/prow-namespace.yaml
   - target: &serviceaccount_target
@@ -222,7 +222,7 @@ patches:
       group: batch
       version: v1
       kind: CronJob
-      namespace: ""
+      namespace: default
       name: .*
     path: patches/JsonRFC6902/prow-namespace.yaml
 

--- a/github/ci/prow-deploy/tasks/cleanup.yml
+++ b/github/ci/prow-deploy/tasks/cleanup.yml
@@ -2,7 +2,7 @@
 # So you run it twice and the second time it will fail, and there's no easy way to understand if it's legit
 - name: Delete all remote resources.
   shell: |
-    kustomize build overlays/{{ deploy_environment }} | kubectl delete -f -
+    kubectl delete -k overlays/{{ deploy_environment }}
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
   environment: "{{ shell_environment }}"

--- a/github/ci/prow-deploy/tasks/deploy.yml
+++ b/github/ci/prow-deploy/tasks/deploy.yml
@@ -6,7 +6,7 @@
 
 - name: validate Kustomize result
   shell: |
-    kustomize build overlays/{{ deploy_environment }}
+    kubectl kustomize overlays/{{ deploy_environment }}
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
 
@@ -45,14 +45,7 @@
 
 - name: Launch deployment
   shell: |
-    # for now cant execute "kubectl apply --server-side" reliably on
-    # "workloads-production" env (which runs k8s 1.19)
-    APPLY_OPTIONS=
-    if [ "{{deploy_environment}}" != "workloads-production" ]; then
-      APPLY_OPTIONS="--server-side --force-conflicts"
-    fi
-
-    kustomize build overlays/{{ deploy_environment }} | kubectl apply ${APPLY_OPTIONS} -f -
+    kubectl apply --server-side --force-conflicts -k overlays/{{ deploy_environment }}
   args:
     chdir: "{{ project_infra_root}}/github/ci/prow-deploy/kustom"
   environment:

--- a/images/kubevirt-infra-bootstrap/Dockerfile
+++ b/images/kubevirt-infra-bootstrap/Dockerfile
@@ -18,10 +18,3 @@ RUN dnf update -y \
         rsync \
         podman \
         && dnf clean all -y
-RUN export KUSTOMIZE_DIR=/opt/kustomize \
-    && mkdir -p $KUSTOMIZE_DIR \
-    && cd $KUSTOMIZE_DIR \
-    && wget "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv3.5.4/kustomize_v3.5.4_linux_amd64.tar.gz" \
-    && tar xzf ./kustomize_v3.5.4_linux_amd64.tar.gz \
-    && rm kustomize_v3.5.4_linux_amd64.tar.gz \
-    && ln -s $KUSTOMIZE_DIR/kustomize /usr/bin/kustomize

--- a/images/prow-deploy/Dockerfile
+++ b/images/prow-deploy/Dockerfile
@@ -12,11 +12,6 @@ FROM quay.io/kubevirtci/bootstrap:v20260612-73bc71e
 COPY --from=builder /usr/local/bin/phony /usr/local/bin/
 COPY --from=cfg-bootstrap /ko-app/config-bootstrapper /usr/local/bin/
 
-RUN curl -fLo ./kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v3.8.7/kustomize_v3.8.7_linux_amd64.tar.gz && \
-  tar -xvf kustomize.tar.gz && \
-  mv ./kustomize /usr/local/bin && \
-  rm kustomize.tar.gz
-
 RUN curl -fLRO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
   chmod a+x ./kubectl && \
   mv ./kubectl /google-cloud-sdk/bin/ && \


### PR DESCRIPTION
**What this PR does / why we need it**:

Manifests generation is relying on a kustomize standalone binary pinned at version 3.8.7 which is 6 years old.

Fix compatibility with current version and switch to kustomize embedded in kubectl.

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment and cleanup workflows now use `kubectl`’s built-in Kustomize support for rendering, applying, and deleting resources.

* **Bug Fixes**
  * Adjusted namespace handling for several deployment targets to match the intended environments.
  * Updated generated manifest instructions to reflect the supported command format.

* **Chores**
  * Streamlined container images by removing bundled Kustomize installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->