### PR TITLE
fix(tide): store status files in our GCS bucket

### DIFF
--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/tide_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/tide_deployment.yaml
@@ -1,10 +1,12 @@
 ---
-# Removes history-uri and status-path which point to a
-# remote google storage location
-- op: remove
-  path: /spec/template/spec/containers/0/args/7
-- op: remove
+# store tide status files in our GCS bucket
+- op: replace
   path: /spec/template/spec/containers/0/args/6
+  value: --status-path=gs://kubevirt-prow/tide-status
+
+- op: replace
+  path: /spec/template/spec/containers/0/args/7
+  value: --history-uri=gs://kubevirt-prow/tide-history.json
 
 # inject jobs configmap
 - op: add


### PR DESCRIPTION
**What this PR does / why we need it**:

For historical reason, tide parameters related to status files have been removed from our deployment.

Restore them so that tide status is preserved when the deployment is restarted.

**Special notes for your reviewer**:

/cc @dhiller 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI status and history settings to use GCS-backed locations, improving reliability of stored status information.
  * Added support for loading job configuration from a shared config source, enabling more consistent job behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->