### PR TITLE
fix(tide): separate approved-vep PRs into own merge pool

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -235,6 +235,25 @@ tide:
     - do-not-merge/invalid-commit-message
     - needs-rebase
     - "dco-signoff: no"
+  # approved-vep PRs for kubevirt/kubevirt are in a separate pool so that Tide
+  # batches them independently. Tide's priority config only affects individual
+  # merge order, not batch composition, so without this separation VEP PRs
+  # compete with the full merge queue and get mixed into large batches.
+  - repos:
+    - kubevirt/kubevirt
+    labels:
+    - lgtm
+    - approved
+    - approved-vep
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/invalid-commit-message
+    - needs-rebase
+    - "dco-signoff: no"
   - repos:
     - kubevirt/containerdisks
     - kubevirt/kubevirt
@@ -285,6 +304,7 @@ tide:
     - do-not-merge/invalid-commit-message
     - needs-rebase
     - "dco-signoff: no"
+    - approved-vep
   # dependabot PRs that have been labeled skip-review by the commenter periodic
   - author: dependabot[bot]
     repos:
@@ -336,7 +356,6 @@ tide:
   - labels: [ "kind/flake", "priority/critical-urgent" ]
   - labels: [ "kind/failing-test", "priority/critical-urgent" ]
   - labels: [ "kind/bug", "priority/critical-urgent" ]
-  - labels: [ "approved-vep" ]
 
 branch-protection:
   required_status_checks:


### PR DESCRIPTION
**What this PR does / why we need it**:

Separates `approved-vep` PRs for `kubevirt/kubevirt` into their own Tide merge pool so they are batched independently from the general queue.

**Problem**: Tide's `priority` config only affects individual merge ordering (`pickHighestPriorityPR`), **not** batch composition (`pickBatch`). With the previous config, `approved-vep` was listed under `priority:` which had no effect on batching — VEP PRs were mixed into large batches of 8 alongside non-VEP PRs, defeating the intent of prioritizing them.

**Fix**: Create a dedicated Tide query requiring the `approved-vep` label so these PRs form an independent merge pool. Tide batches each pool separately, giving VEP PRs their own fast lane through CI. Add `approved-vep` to `missingLabels` in the general query to prevent pool overlap (which Tide forbids).

The `approved-vep` entry is removed from the `priority:` section since the separate pool already provides the desired effect. Critical-urgent bug/flake/failing-test priority entries remain as they still help with individual merge ordering within the general pool.

**Special notes for your reviewer**:

References:
- [`pickHighestPriorityPR` in Tide source](https://github.com/kubernetes-sigs/prow/blob/main/pkg/tide/tide.go) — priority only used here, not in `pickBatch`
- [`hasAllLabels`](https://github.com/kubernetes-sigs/prow/blob/main/pkg/tide/tide.go) — confirms labels within a priority entry are ANDed
- [TidePriority config struct](https://github.com/kubernetes-sigs/prow/blob/main/pkg/config/tide.go) — "PRs should match all labels contained in a set to be prioritized"

🤖 Assisted by Claude