### PR TITLE
feat(tide): require approved-vep label for kubevirt/kubevirt merges

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -245,7 +245,6 @@ tide:
     - "dco-signoff: no"
   - repos:
     - kubevirt/containerdisks
-    - kubevirt/kubevirt
     - kubevirt/containerized-data-importer
     - kubevirt/hostpath-provisioner
     - kubevirt/hostpath-provisioner-operator
@@ -284,6 +283,21 @@ tide:
     labels:
     - lgtm
     - approved
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/invalid-commit-message
+    - needs-rebase
+    - "dco-signoff: no"
+  - repos:
+    - kubevirt/kubevirt
+    labels:
+    - lgtm
+    - approved
+    - approved-vep
     missingLabels:
     - do-not-merge
     - do-not-merge/hold


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Move kubevirt/kubevirt into its own Tide query that requires the approved-vep label in addition to lgtm and approved.

Our CI is currently facing some significant stability issues.

Given the current situation, I believe creating the release branch right now might be counterproductive, as we will likely run into the exact same blockers when we start cherry-picking fixes.

To get us back on track, I'd like to propose the following short-term plan:

1. Temporary Tide Rule Change: Update the tide merge rules to require approved-vep + lgtm + approved. (This PR)

2. CI Clearance Window: Allow 1 to 2 days for the CI to process and merge the current queue under these rules.

3. Branch Creation: Create the release branch once the backlog is cleared and stable.

4. Rule Rollback: Revert the tide merge rules back to standard settings.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @xpivarc @dhiller 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated merge requirements for one repository path in the automated PR workflow.
  * Added a new approval label requirement and adjusted the list of required labels for merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->