### PR TITLE
fix(tide): separate kubevirt config for main and others

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -294,10 +294,28 @@ tide:
     - "dco-signoff: no"
   - repos:
     - kubevirt/kubevirt
+    includedBranches:
+    - "main"
     labels:
     - lgtm
     - approved
     - approved-vep
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/invalid-commit-message
+    - needs-rebase
+    - "dco-signoff: no"
+  - repos:
+    - kubevirt/kubevirt
+    excludedBranches:
+    - "main"
+    labels:
+    - lgtm
+    - approved
     missingLabels:
     - do-not-merge
     - do-not-merge/hold


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

At current any PR targeting kubevirt/kubevirt repo required approved-vep label. This effectively blocks any PRs targeting release branches.

Since we only want to enforce approved-vep for main branch, we create another config for all other branches without the label.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @fossedihelm @dollierp @xpivarc 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated repository matching rules so branch-specific automation now treats the main branch separately from other branches.
  * Improved targeting for one project’s merge handling to reduce unintended overlap between main and non-main branch rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->