### PR TITLE
feat(tide): allow critical bug PRs to merge on kubevirt/kubevirt main

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -292,6 +292,7 @@ tide:
     - do-not-merge/invalid-commit-message
     - needs-rebase
     - "dco-signoff: no"
+    # BEGIN kubevirt/kubevirt section
   - repos:
     - kubevirt/kubevirt
     includedBranches:
@@ -300,6 +301,24 @@ tide:
     - lgtm
     - approved
     - approved-vep
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/invalid-commit-message
+    - needs-rebase
+    - "dco-signoff: no"
+  - repos:
+    - kubevirt/kubevirt
+    includedBranches:
+    - "main"
+    labels:
+    - lgtm
+    - approved
+    - kind/bug
+    - priority/critical-urgent
     missingLabels:
     - do-not-merge
     - do-not-merge/hold
@@ -325,6 +344,7 @@ tide:
     - do-not-merge/invalid-commit-message
     - needs-rebase
     - "dco-signoff: no"
+    # END kubevirt/kubevirt section
   # dependabot PRs that have been labeled skip-review by the commenter periodic
   - author: dependabot[bot]
     repos:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Add a separate tide merge query for kubevirt/kubevirt main branch
that accepts PRs labeled kind/bug and priority/critical-urgent
without requiring approved-vep.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @xpivarc @dollierp 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated review/query rules for one project so it now matches the intended branch and label criteria more accurately.
  * Replaced an outdated label requirement with a more relevant bug-related label, which should improve how changes are routed and handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->