### PR TITLE
Add kubevirt-aie release-1.9-aie-nv CI jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
@@ -33,3 +33,37 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-kubevirt-aie-sync-nv-rpms-1.9
+  cron: "0 6 * * *"
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 1h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt-aie
+    base_ref: release-1.9-aie-nv
+    workdir: true
+  labels:
+    preset-github-credentials: "true"
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260624-f0a9591
+      command: ["/bin/sh", "-c"]
+      args:
+      - |
+        export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+        git-pr.sh \
+          --command "./hack/sync-nv-rpms.sh" \
+          --summary "Sync el10nv RPMs for libvirt and qemu-kvm" \
+          --release-note-none \
+          --repo kubevirt-aie \
+          --branch sync-nv-rpms-1.9 \
+          --target release-1.9-aie-nv \
+          --missing-labels lgtm,approved,do-not-merge/hold
+      resources:
+        requests:
+          memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-postsubmits.yaml
@@ -1,0 +1,46 @@
+postsubmits:
+  kubevirt/kubevirt-aie:
+  - name: push-kubevirt-aie-virt-launcher-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    cluster: prow-workloads
+    always_run: true
+    skip_report: false
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    max_concurrency: 1
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt/kubevirt-aie
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: "2602251001-25ce1ccb15"
+        command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          cat "$QUAY_PASSWORD" | podman login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
+          cp /etc/bazel.bazelrc ./ci.bazelrc
+          DOCKER_TAG="$(date +%Y%m%d)_$(git rev-parse --short=10 HEAD)" \
+            BUILD_ARCH=amd64,crossbuild-aarch64 \
+            PUSH_TARGETS=virt-launcher \
+            make bazel-push-images
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: 12Gi

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
@@ -1,0 +1,253 @@
+presubmits:
+  kubevirt/kubevirt-aie:
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-aie-build-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-aie-build-arm64-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - cp /etc/bazel.bazelrc ./ci.bazelrc && make && make build-verify
+        env:
+        - name: BUILD_ARCH
+          value: crossbuild-aarch64
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 8Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-aie-code-lint-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - |
+          make lint
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-aie-unit-test-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make test
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            cpu: "4"
+            memory: 24Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 2h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+    name: pull-kubevirt-aie-unit-test-arm64-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - make test
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 4
+    name: pull-kubevirt-aie-kind-1.36-sig-compute-arm64-1.9-aie-nv
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/test.sh
+        env:
+        - name: TARGET
+          value: kind-1.36-wg-arm64
+        - name: KUBEVIRT_NUM_NODES
+          value: "2"
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: "2602231621-e36f1c7568"
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-arm64-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 2
+    name: pull-kubevirt-aie-kind-1.36-conformance-arm64-1.9-aie-nv
+    optional: true
+    branches:
+    - release-1.9-aie-nv
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -ce
+        - |
+          automation/conformance.sh
+        env:
+        - name: TARGET
+          value: kind-1.36-wg-arm64
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.36
+        - name: KUBEVIRT_NUM_NODES
+          value: "3"
+        - name: IPFAMILY
+          value: dual
+        - name: RUN_ON_ARM64_INFRA
+          value: "true"
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: "2602231621-e36f1c7568"
+        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        name: ""
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -459,6 +459,9 @@ branch-protection:
             release-1.8-aie-nv:
               protect: true
               allow_force_pushes: true
+            release-1.9-aie-nv:
+              protect: true
+              allow_force_pushes: true
         project-infra:
           branches:
             main:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds presubmit, postsubmit, and periodic CI jobs for the kubevirt-aie `release-1.9-aie-nv` branch, mirroring the existing `release-1.8-aie-nv` jobs. Also adds branch protection for the new branch.

Changes:
- **Presubmits** (`kubevirt-release-1.9-aie-nv-presubmits.yaml`): build (x86_64 + arm64), lint, unit test (x86_64 + arm64), kind-1.36 sig-compute arm64, kind-1.36 conformance arm64 (optional)
- **Postsubmit** (`kubevirt-release-1.9-aie-nv-postsubmits.yaml`): push virt-launcher image to `quay.io/kubevirt/kubevirt-aie`
- **Periodic** (`kubevirt-aie-periodics.yaml`): daily `sync-nv-rpms` targeting `release-1.9-aie-nv` (alongside existing 1.8 periodic)
- **Branch protection** (`config.yaml`): `release-1.9-aie-nv` with `protect: true` and `allow_force_pushes: true`

Kind version bumped from 1.35 to 1.36 for the 1.9 jobs.

**Which issue(s) this PR fixes**:
Related to kubevirt/kubevirt-aie#56

**Special notes for your reviewer**:

Job definitions are a mechanical copy of the 1.8 jobs with `1.8-aie-nv` → `1.9-aie-nv` and `kind-1.35` → `kind-1.36`. Bootstrap image and CS10 builder versions are kept the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI jobs for the new `release-1.9-aie-nv` branch, including periodic sync, presubmit checks, and postsubmit publishing.
  * Enabled build, lint, unit test, and arm64/kind test coverage for the new release stream.
* **Chores**
  * Added branch protection for `release-1.9-aie-nv` to support the new release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->