### PR TITLE
improve error reporting in gcs_restapi.sh stat and cat functions

### DIFF
--- a/images/bootstrap/gcs_restapi.sh
+++ b/images/bootstrap/gcs_restapi.sh
@@ -97,15 +97,31 @@ stat_gcs_file() {
 
     auth_header=$(get_auth_header "$auth") || exit 1
 
-    stat_response=$(curl -s -X GET \
+    local http_code
+    local stat_response
+    stat_response=$(curl -s --write-out '\n%{http_code}' -X GET \
       ${auth_header:+-H "$auth_header"} \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
+    local curl_exit=$?
 
-    if echo "$stat_response" | jq -e '.error' > /dev/null; then
+    if [ "$curl_exit" -ne 0 ]; then
+        echo "Warning: curl failed with exit code $curl_exit for $2" >&2
         return 1
-    else
-        return 0
     fi
+
+    http_code=$(echo "$stat_response" | tail -1)
+    stat_response=$(echo "$stat_response" | sed '$d')
+
+    if [ "$http_code" != "200" ]; then
+        return 1
+    fi
+
+    if ! echo "$stat_response" | jq -e '.name' > /dev/null 2>&1; then
+        echo "Warning: stat got HTTP 200 but invalid JSON for $2" >&2
+        return 1
+    fi
+
+    return 0
 }
 
 # Function to read the content of a file from GCS
@@ -116,18 +132,38 @@ cat_gcs_file() {
 
     auth_header=$(get_auth_header "$auth") || exit 1
 
-    file_content=$(curl --silent --fail -X GET \
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    local http_code
+    http_code=$(curl --silent --output "$tmpfile" --write-out '%{http_code}' -X GET \
       ${auth_header:+-H "$auth_header"} \
       -H "Cache-Control: no-cache" \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path?alt=media&ignoreCache=1")
+    local curl_exit=$?
 
-    if [ -z "$file_content" ]; then
-        echo "Error: No content received"
+    if [ "$curl_exit" -ne 0 ]; then
+        echo "Error: curl failed with exit code $curl_exit for $2" >&2
+        rm -f "$tmpfile"
         return 1
-    else
-        echo "$file_content"
-        return 0
     fi
+
+    if [ "$http_code" != "200" ]; then
+        echo "Error: HTTP $http_code for $2" >&2
+        echo "Response body: $(cat "$tmpfile")" >&2
+        rm -f "$tmpfile"
+        return 1
+    fi
+
+    if [ ! -s "$tmpfile" ]; then
+        echo "Error: HTTP 200 but empty body for $2" >&2
+        rm -f "$tmpfile"
+        return 1
+    fi
+
+    cat "$tmpfile"
+    rm -f "$tmpfile"
+    return 0
 }
 
 # Function to delete a file from GCS

--- a/images/bootstrap/gcs_restapi.sh
+++ b/images/bootstrap/gcs_restapi.sh
@@ -97,15 +97,22 @@ stat_gcs_file() {
 
     auth_header=$(get_auth_header "$auth") || exit 1
 
-    stat_response=$(curl -s -X GET \
+    local stat_response
+    stat_response=$(curl --silent --show-error --fail-with-body -X GET \
       ${auth_header:+-H "$auth_header"} \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path")
+    local curl_exit=$?
 
-    if echo "$stat_response" | jq -e '.error' > /dev/null; then
+    if [ "$curl_exit" -ne 0 ]; then
         return 1
-    else
-        return 0
     fi
+
+    if ! echo "$stat_response" | jq -e '.name' > /dev/null 2>&1; then
+        echo "Warning: stat succeeded but response has no .name for $2: $stat_response" >&2
+        return 1
+    fi
+
+    return 0
 }
 
 # Function to read the content of a file from GCS
@@ -116,18 +123,35 @@ cat_gcs_file() {
 
     auth_header=$(get_auth_header "$auth") || exit 1
 
-    file_content=$(curl --silent --fail -X GET \
+    local tmpfile
+    tmpfile=$(mktemp) || { echo "Error: mktemp failed" >&2; return 1; }
+
+    local http_code
+    http_code=$(curl --silent --show-error --fail-with-body --output "$tmpfile" --write-out '%{http_code}' -X GET \
       ${auth_header:+-H "$auth_header"} \
       -H "Cache-Control: no-cache" \
       "${BASE_URL}/storage/v1/b/$bucket_name/o/$gcs_file_path?alt=media&ignoreCache=1")
+    local curl_exit=$?
 
-    if [ -z "$file_content" ]; then
-        echo "Error: No content received"
+    if [ "$curl_exit" -ne 0 ]; then
+        echo "Error: HTTP ${http_code:-?} for $2 (curl exit $curl_exit)" >&2
+        if [ -s "$tmpfile" ]; then
+            echo "Response body: $(cat "$tmpfile")" >&2
+        fi
+        rm -f "$tmpfile"
         return 1
-    else
-        echo "$file_content"
-        return 0
     fi
+
+    if [ ! -s "$tmpfile" ]; then
+        echo "Error: HTTP 200 but empty body for $2" >&2
+        rm -f "$tmpfile"
+        return 1
+    fi
+
+    local cat_exit=0
+    cat "$tmpfile" || cat_exit=$?
+    rm -f "$tmpfile"
+    return "$cat_exit"
 }
 
 # Function to delete a file from GCS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The `cat_gcs_file` function in `gcs_restapi.sh` uses `curl --fail --silent`, which silently discards the HTTP status code and response body on failure making it hard to debug failures like [these](https://testgrid.k8s.io/kubevirt-containerdisks-periodics#periodic-containerdisks-s390x-verify-nightly)

Also`stat_gcs_file` uses `jq -e '.error'` to detect failures, which only catches responses that contain an explicit `.error` JSON key, this can generate false positives

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Reporting exmaple before on failure:
```bash
File release/kubevirt/kubevirtci/amd64-c3d11ec0 is now available.
Error: No content received          # or nothing useful
Failed to fetch KUBEVIRTCI_TAG (attempt 1/5). Retrying in 5 seconds...
```

Reporting after this:
```bash
File release/kubevirt/kubevirtci/amd64-c3d11ec0 is now available.
Error: HTTP 403 for release/kubevirt/kubevirtci/amd64-c3d11ec0
Response body: {
  "error": {
    "code": 403,
    "message": "..."
  }
}
Failed to fetch KUBEVIRTCI_TAG (attempt 1/5). Retrying in 5 seconds...
```

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved Google Cloud Storage request handling by reporting connection and HTTP errors clearly.
* Added validation to ensure file metadata responses are valid and include a file name.
* Improved file downloads by detecting empty or unsuccessful responses and displaying relevant error details.
* Preserved command status when displaying downloaded file contents.
* Ensured temporary download files are cleaned up after successful or failed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->