### PR TITLE
Add kubevirt check presubmits command to validate sig-compute TARGET split

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -53,6 +53,32 @@ presubmits:
             memory: "4Gi"
           limits:
             memory: "4Gi"
+  - name: pull-project-infra-check-presubmits
+    run_if_changed: "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml"
+    decorate: true
+    cluster: kubevirt-prow-control-plane
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-ce"
+        - |
+          go run ./robots/kubevirt check presubmits \
+           --job-config-path-kubevirt-presubmits=github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml 
+           --github-token-path='' \
+           --dry-run=false
+        env:
+        - name: GIMME_GO_VERSION
+          value: "1.26.4"
+        - name: GOFLAGS
+          value: "-mod=vendor"
+        resources:
+          requests:
+            memory: "4Gi"
+          limits:
+            memory: "4Gi"
   - name: pull-project-infra-test-releng
     run_if_changed: "releng/.*|go.mod"
     optional: false

--- a/pkg/kubevirt/cmd/check/check.go
+++ b/pkg/kubevirt/cmd/check/check.go
@@ -30,6 +30,7 @@ var checkCommand = &cobra.Command{
 
 func init() {
 	checkCommand.AddCommand(CheckProvidersCommand())
+	checkCommand.AddCommand(CheckPresubmitsCommand())
 }
 
 func CheckCommand() *cobra.Command {

--- a/pkg/kubevirt/cmd/check/presubmits.go
+++ b/pkg/kubevirt/cmd/check/presubmits.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package check
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/prow/pkg/config"
+
+	"kubevirt.io/project-infra/pkg/kubevirt/cmd/flags"
+	"kubevirt.io/project-infra/pkg/kubevirt/prowjobconfigs"
+)
+
+type checkPresubmitsOptions struct {
+	jobConfigPathKubevirtPresubmits string
+}
+
+func (o checkPresubmitsOptions) Validate() error {
+	if _, err := os.Stat(o.jobConfigPathKubevirtPresubmits); os.IsNotExist(err) {
+		return fmt.Errorf("jobConfigPathKubevirtPresubmits is required: %v", err)
+	}
+	return nil
+}
+
+var checkPresubmitsOpts = checkPresubmitsOptions{}
+
+var checkPresubmitsCommand = &cobra.Command{
+	Use:   "presubmits",
+	Short: "kubevirt check presubmits validates the sig-compute TARGET configuration for the latest k8s version",
+	Long: `kubevirt check presubmits validates the sig-compute TARGET configuration for the latest k8s version
+
+For the latest Kubernetes version found in the presubmit job definitions, it checks that
+the sig-compute-serial job has a -serial TARGET and the plain sig-compute job has a -parallel TARGET.`,
+	RunE: runCheckPresubmits,
+}
+
+func CheckPresubmitsCommand() *cobra.Command {
+	return checkPresubmitsCommand
+}
+
+func init() {
+	checkPresubmitsCommand.PersistentFlags().StringVar(&checkPresubmitsOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The path to the kubevirt presubmit job definitions")
+}
+
+func runCheckPresubmits(cmd *cobra.Command, args []string) error {
+	err := flags.ParseFlags(cmd, args, checkPresubmitsOpts)
+	if err != nil {
+		return err
+	}
+
+	jobConfig, err := config.ReadJobConfig(checkPresubmitsOpts.jobConfigPathKubevirtPresubmits)
+	if err != nil {
+		return fmt.Errorf("failed to read jobconfig %s: %v", checkPresubmitsOpts.jobConfigPathKubevirtPresubmits, err)
+	}
+
+	jobs := prowjobconfigs.CollectSigComputeJobs(&jobConfig)
+	if len(jobs) == 0 {
+		return fmt.Errorf("no sig-compute jobs found")
+	}
+
+	latestVersion, err := prowjobconfigs.FindLatestK8sVersionFromJobs(jobs)
+	if err != nil {
+		return err
+	}
+
+	serialJobName := fmt.Sprintf("pull-kubevirt-e2e-k8s-%s-sig-compute-serial", latestVersion)
+	bareJobName := fmt.Sprintf("pull-kubevirt-e2e-k8s-%s-sig-compute", latestVersion)
+	expectedSerialTarget := fmt.Sprintf("k8s-%s-sig-compute-serial", latestVersion)
+	expectedParallelTarget := fmt.Sprintf("k8s-%s-sig-compute-parallel", latestVersion)
+
+	var errs []string
+	for _, job := range jobs {
+		switch job.Name {
+		case serialJobName:
+			if job.Target != expectedSerialTarget {
+				errs = append(errs, fmt.Sprintf("job %q has TARGET %q, expected %q", job.Name, job.Target, expectedSerialTarget))
+			}
+		case bareJobName:
+			if job.Target != expectedParallelTarget {
+				errs = append(errs, fmt.Sprintf("job %q has TARGET %q, expected %q", job.Name, job.Target, expectedParallelTarget))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		for _, e := range errs {
+			fmt.Fprintln(cmd.OutOrStderr(), e)
+		}
+		return fmt.Errorf("sig-compute TARGET validation failed for k8s version %s", latestVersion)
+	}
+
+	return nil
+}

--- a/pkg/kubevirt/prowjobconfigs/presubmits_target.go
+++ b/pkg/kubevirt/prowjobconfigs/presubmits_target.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package prowjobconfigs
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"sigs.k8s.io/prow/pkg/config"
+)
+
+type SigComputeJob struct {
+	Name   string
+	Target string
+}
+
+var (
+	sigComputeJobNameRegex = regexp.MustCompile(`^pull-kubevirt-e2e-k8s-(\d+\.\d+)-sig-compute(-serial)?$`)
+	k8sVersionRegex        = regexp.MustCompile(`k8s-(\d+)\.(\d+)`)
+)
+
+func CollectSigComputeJobs(jobConfig *config.JobConfig) []SigComputeJob {
+	var jobs []SigComputeJob
+	for _, job := range jobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] {
+		if !sigComputeJobNameRegex.MatchString(job.Name) {
+			continue
+		}
+		for _, container := range job.Spec.Containers {
+			for _, env := range container.Env {
+				if env.Name == "TARGET" {
+					jobs = append(jobs, SigComputeJob{Name: job.Name, Target: env.Value})
+				}
+			}
+		}
+	}
+	return jobs
+}
+
+func FindLatestK8sVersionFromJobs(jobs []SigComputeJob) (string, error) {
+	var latestMajor, latestMinor int
+	for _, job := range jobs {
+		matches := k8sVersionRegex.FindStringSubmatch(job.Name)
+		if matches == nil {
+			continue
+		}
+		major, _ := strconv.Atoi(matches[1])
+		minor, _ := strconv.Atoi(matches[2])
+		if major > latestMajor || (major == latestMajor && minor > latestMinor) {
+			latestMajor = major
+			latestMinor = minor
+		}
+	}
+	if latestMajor == 0 {
+		return "", fmt.Errorf("could not determine latest k8s version from sig-compute job names")
+	}
+	return fmt.Sprintf("%d.%d", latestMajor, latestMinor), nil
+}

--- a/robots/kubevirt/README.md
+++ b/robots/kubevirt/README.md
@@ -29,6 +29,28 @@ Global Flags:
 --github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
 ```
 
+### `kubevirt check presubmits`
+
+`kubevirt check presubmits` validates the sig-compute TARGET configuration for the latest k8s version
+
+For the latest Kubernetes version found in the presubmit job definitions, it checks that
+the sig-compute lane is properly split into serial and parallel targets, and that no bare
+sig-compute target exists.
+
+```
+Usage:
+kubevirt check presubmits [flags]
+
+Flags:
+-h, --help                                         help for presubmits
+    --job-config-path-kubevirt-presubmits string   The path to the kubevirt presubmit job definitions
+
+Global Flags:
+    --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
+    --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
+    --github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+```
+
 ### `kubevirt copy jobs`
 
 `kubevirt copy jobs` creates copies of the periodic and presubmit SIG jobs for latest kubevirtci providers


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Ensure that for the latest k8s version in kubevirt-presubmits.yaml, the sig-compute lane uses -serial and -parallel TARGET suffixes instead of a bare sig-compute TARGET. Also trigger the test robots job when kubevirt-presubmits.yaml changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @dhiller @jean-edouard 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation command for checking kubevirt presubmit job definitions.
  * Added automation to run this check in CI when the relevant presubmit config changes.
  * Added a way to verify the latest Kubernetes version is consistently reflected in sig-compute job targets.

* **Documentation**
  * Updated the CLI docs with usage details and available flags for the new validation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->