### PR TITLE
kubevirt,postsubmit: add CPU limits & increase memory requests for push-kubevirt-main

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -124,7 +124,11 @@ postsubmits:
           privileged: true
         resources:
           requests:
-            memory: "8Gi"
+            memory: "24Gi"
+            cpu: "4"
+          limits:
+            memory: "24Gi"
+            cpu: "4"
   - name: push-kubevirt-goveralls
     cluster: kubevirt-prow-control-plane
     branches:


### PR DESCRIPTION
**What this PR does / why we need it**:

push-kubevirt-main has been failing[1] for the last number of merged PRs since https://github.com/kubevirt/kubevirt/commit/aa0302799212a8cac7fc57ef16f040330f3576d2

This appears to be a resource issue - add CPU and memory limits that align with the existing limits on the pull-kubevirt-unit-test job[2]

[1] https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/push-kubevirt-main/2071552634531090432
[2] https://github.com/kubevirt/project-infra/blame/7853029488518961fc3d1c04cbda345d5d1b4862/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml#L846

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @dollierp 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the resource allocation for a CI job, including higher memory and CPU settings.
  * Added matching resource limits to better match the job’s expected usage.
  * This should help improve build reliability and reduce failures caused by insufficient resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->