### PR TITLE
Add Whitedyl to ci-maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@ filters:
   ".*":
     reviewers:
       - ci-maintainers
-      - Whitedyl
     approvers:
       - ci-maintainers
       - aglitke

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,6 +3,7 @@ aliases:
   - dhiller
   - dollierp
   - enp0s3
+  - Whitedyl
   - xpivarc
 
   sig-scale-approvers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is my application to get added as a ci-maintainer in OWNERS_ALIASES making me an approver and ability to rehearse. I have spoken with @dhiller about this and he asked me to create this PR. 

Contributions:

- External plugins: Built the coverage plugin end-to-end (#4701), contributed improvements and documentation to rehearse, test-subset, release-blocker, and phased plugins
- Observability: Redesigned the most-flaky-tests report with recency indicators (#5156, #5166), onboarded ci-health to the coverage plugin (#5050), added Grafana prometheus token rotation (#5005), working on cost-per-PR attribution in ci-health
- Infrastructure: Built a CronJob to clean up pods stuck in Terminating state (#5091), managed prow job configuration and CentOS 9 image stability (project-infra + kubevirtci)
- Cluster operations: Regularly creating and running prow jobs on-cluster using mkpj for other contributors
- Bazel cache migration: Currently driving the GCS bazel cache work project-infra side is merged(#5126), kubevirt fix for dockerized builds is open (kubevirt/kubevirt#18152).
- Reviewer: Active reviewer on project-infra since being added to the reviewers list 


**Special notes for your reviewer**:
/cc @dhiller



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership routing by removing one reviewer from the general review list and adding them to the CI maintainers alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->