### PR TITLE
fix(check-presubmits): add missing backslash before newline

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -66,7 +66,7 @@ presubmits:
         - "-ce"
         - |
           go run ./robots/kubevirt check presubmits \
-           --job-config-path-kubevirt-presubmits=github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml 
+           --job-config-path-kubevirt-presubmits=github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml \
            --github-token-path='' \
            --dry-run=false
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add missing backslash before newline so that `--github-token-path` argument is properly forwarded to the command.

The job is currently failing:

```
 + /bin/sh -ce 'go run ./robots/kubevirt check presubmits \
 --job-config-path-kubevirt-presubmits=github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml 
 --github-token-path='\'''\'' \
 --dry-run=false
'
{"error":"version expected to be in form 'v${build_date}-${git_commit}': \"0\"","level":"debug","msg":"Failed to get version timestamp","time":"2026-06-30T15:26:16Z"}
Usage:
  kubevirt check presubmits [flags]
Flags:
  -h, --help                                         help for presubmits
      --job-config-path-kubevirt-presubmits string   The path to the kubevirt presubmit job definitions
Global Flags:
      --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
      --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
      --github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
Error: invalid arguments provided: stat /etc/github/oauth: no such file or directory
Usage:
  kubevirt check presubmits [flags]
Flags:
  -h, --help                                         help for presubmits
      --job-config-path-kubevirt-presubmits string   The path to the kubevirt presubmit job definitions
Global Flags:
      --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
      --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
      --github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
{"level":"fatal","msg":"invalid arguments provided: stat /etc/github/oauth: no such file or directory","robot":"kubevirt","time":"2026-06-30T15:26:16Z"}
```

**Special notes for your reviewer**:

/cc @dhiller
/cc @fossedihelm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a command formatting issue in a presubmit job configuration so multi-line execution continues correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->