### PR TITLE
Configure kubevirt-observability-controller jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
@@ -1,0 +1,88 @@
+postsubmits:
+  kubevirt/kubevirt-observability-controller:
+  - name: push-release-koc-images
+    branches:
+    # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+    cluster: prow-workloads
+    always_run: true
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-kubevirtci-quay-credential: "true"
+      preset-github-credentials: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        - name: GH_CLI_VERSION
+          value: "1.5.0"
+        - name: GITHUB_TOKEN_PATH
+          value: /etc/github/oauth
+        - name: GITHUB_REPOSITORY
+          value: kubevirt/kubevirt-observability-controller
+        - name: GIT_USER_NAME
+          value: kubevirt-bot
+        - name: GPG_USER_ID
+          value: "0x99F7C0D2E1BB8025"
+        - name: PLATFORMS
+          value: "linux/arm64,linux/amd64,linux/s390x"
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          # Only push images on tags
+          [ -z "$(git tag --points-at HEAD | head -1)" ] ||
+          DOCKER_TAG="$(git tag --points-at HEAD | head -1)" GITHUB_RELEASE=true ./automation/release.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"
+  - name: push-latest-koc-images
+    branches:
+    - main
+    cluster: prow-workloads
+    always_run: true
+    skip_report: true
+    annotations:
+      testgrid-create-test-group: "false"
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-kubevirtci-quay-credential: "true"
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        env:
+        - name: DOCKER_PREFIX
+          value: quay.io/kubevirt
+        - name: PLATFORMS
+          value: "linux/arm64,linux/amd64,linux/s390x"
+        command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io &&
+          DOCKER_TAG="latest" GITHUB_RELEASE=false ./automation/release.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "8Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-presubmits.yaml
@@ -1,0 +1,80 @@
+presubmits:
+  kubevirt/kubevirt-observability-controller:
+  - name: pull-koc-unit-test
+    skip_branches:
+      - release-v\d+\.\d+
+    cluster: kubevirt-prow-control-plane
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make test"
+          resources:
+            requests:
+              memory: "4Gi"
+  - name: pull-koc-generate-verify
+    skip_branches:
+      - release-v\d+\.\d+
+    cluster: kubevirt-prow-control-plane
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "make generate-verify"
+          resources:
+            requests:
+              memory: "4Gi"
+  - name: pull-koc-functest
+    skip_branches:
+      - release-v\d+\.\d+
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    optional: false
+    decorate: true
+    decoration_config:
+      timeout: 5h
+      grace_period: 5m
+    max_concurrency: 6
+    cluster: prow-workloads
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-shared-images: "true"
+    spec:
+      nodeSelector:
+        type: bare-metal-external
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "automation/test.sh"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "52Gi"

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -203,6 +203,7 @@ tide:
     kubevirt/kubevirt-aie-webhook: merge
     kubevirt/ci-health: merge
     kubevirt/redfish-controller: merge
+    kubevirt/kubevirt-observability-controller: squash
   queries:
   - repos:
     - kubevirt/dra-pci-driver
@@ -280,6 +281,7 @@ tide:
     - kubevirt/iommufd-device-plugin
     - kubevirt/kubevirt-aie
     - kubevirt/kubevirt-aie-webhook
+    - kubevirt/kubevirt-observability-controller
     labels:
     - lgtm
     - approved

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -502,7 +502,7 @@ plugins:
     - owners-label
     - release-note
     - trigger
-    
+
   kubevirt/kubevirt-migration-operator:
     plugins:
     - approve
@@ -576,6 +576,15 @@ plugins:
     - lgtm
     - owners-label
     - trigger
+
+  kubevirt/kubevirt-observability-controller:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+    - help
 
 external_plugins:
   libguestfs-appliance:
@@ -698,6 +707,7 @@ approve:
   - kubevirt/kubevirt-aie-webhook
   - kubevirt/ci-health
   - kubevirt/redfish-controller
+  - kubevirt/kubevirt-observability-controller
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -843,6 +853,7 @@ lgtm:
   - kubevirt/vm-file-restore-operator
   - kubevirt/ci-health
   - kubevirt/redfish-controller
+  - kubevirt/kubevirt-observability-controller
   review_acts_as_lgtm: true
 
 override:
@@ -906,6 +917,7 @@ triggers:
   - kubevirt/vm-file-restore-operator
   - kubevirt/ci-health
   - kubevirt/redfish-controller
+  - kubevirt/kubevirt-observability-controller
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks


### PR DESCRIPTION
Add presubmit and postsubmit jobs to kubevirt-observability-controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI / Release Automation**
  * Added presubmit checks for unit tests, generate-verify, and functional testing.
  * Added post-merge workflows to publish versioned release images and a `latest` image.
* **Review & Merge Controls**
  * Updated merge behavior for the repository to use a squash strategy in Tide.
  * Enabled repository-specific approval, LGTM, release-note, and trigger workflows via Prow plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->