### PR TITLE
fix(grafana-token): use absolute path for GIT_ASKPASS env var

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
@@ -63,6 +63,8 @@ periodics:
       - -ce
       args:
       - |
+        export GIT_ASKPASS=/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
+
         source ./hack/manage-secrets.sh
         decrypt_secrets
         install -Dm400 "${secrets_repo_dir}"/secrets/kubeconfigs/kubevirt-prow-control-plane ~/.kube/config


### PR DESCRIPTION
**What this PR does / why we need it**:

The job [periodic-secrets-rotate-grafana-token](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/periodic-secrets-rotate-grafana-token) failed again this month.

It seems related to the `git-pr.sh` changing its working directory during its execution.

To prevent this error, this PR modifies the `GIT_ASKPASS` env var to use an absolute path instead of a relative one.

Because the `GIT_ASKPASS` env var is defined by the `preset-github-credentials`, the override of this variable needs to be done in the shell scriptlet rather than the env vars of the container.

**Special notes for your reviewer**:

/cc @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the secrets periodic workflow by setting up authentication earlier in the job, helping the secret installation process run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->