### PR TITLE
feat(branch-protector): switch to GitHub App credentials

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -406,6 +406,8 @@ tide:
   - labels: [ "kind/bug", "priority/critical-urgent" ]
   - labels: [ "approved-vep" ]
 
+# KubeVirt Prow uses a kubernetes CronJob to reconcile branch protection rules.
+# https://docs.prow.k8s.io/docs/components/optional/branchprotector/
 branch-protection:
   required_status_checks:
     contexts:

--- a/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/branch-protector.yaml
@@ -18,28 +18,42 @@ spec:
               args:
                 - --config-path=/etc/config/config.yaml
                 - --job-config-path=/etc/job-config
-                - --github-token-path=/etc/github/oauth
-                - --confirm
                 - --github-endpoint=http://ghproxy
                 - --github-endpoint=https://api.github.com
+                - --github-app-id=$(GITHUB_APP_ID)
+                - --github-app-private-key-path=/etc/github/cert
+                - --confirm
+              env:
+                - name: GITHUB_APP_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: github-token
+                      key: appid
               volumeMounts:
-                - name: oauth
-                  mountPath: /etc/github
-                  readOnly: true
                 - name: config
                   mountPath: /etc/config
                   readOnly: true
                 - name: job-config
                   mountPath: /etc/job-config
                   readOnly: true
+                - name: github-token
+                  mountPath: /etc/github
+                  readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ALL]
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
           restartPolicy: Never
           volumes:
-            - name: oauth
-              secret:
-                secretName: oauth-token
             - name: config
               configMap:
                 name: config
             - name: job-config
               configMap:
                 name: job-config
+            - name: github-token
+              secret:
+                secretName: github-token


### PR DESCRIPTION
**What this PR does / why we need it**:

Update branch-protector CronJob to use GitHub App credentials instead of Personal Access Token.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated branch protection automation to use GitHub App credentials, improving alignment with current authentication practices.
  * Added helpful notes explaining how branch protection is managed.

* **Security**
  * Hardened the automation container with stricter runtime settings, including non-root execution, reduced privileges, and safer default security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->