### PR TITLE
Append version suffix to presubmit job names in forkProwJobs

### DIFF
--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -449,6 +449,12 @@ func (r *releaseData) forkProwJobs() error {
 			return err
 		}
 
+		err = appendVersionSuffixToJobNames(fullOutputConfig, version)
+		if err != nil {
+			log.Printf("ERROR: appending version suffix to job names failed: %s", err)
+			return err
+		}
+
 		_, err = gitCommand("-C", r.infraDir, "add", outputConfig)
 		if err != nil {
 			return err
@@ -532,6 +538,24 @@ func configureReleaseJob(configPath string, outputPath string) error {
 		return err
 	}
 	return nil
+}
+
+func appendVersionSuffixToJobNames(configPath string, version string) error {
+	jobConfig, err := config.ReadJobConfig(configPath)
+	if err != nil {
+		return err
+	}
+	for key, presubmits := range jobConfig.PresubmitsStatic {
+		for i := range presubmits {
+			presubmits[i].Name = presubmits[i].Name + "-" + version
+		}
+		jobConfig.PresubmitsStatic[key] = presubmits
+	}
+	marshalled, err := yaml.Marshal(&jobConfig)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, marshalled, os.ModePerm)
 }
 
 func (r *releaseData) cutNewBranch(skipProw bool) error {

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -499,5 +500,45 @@ func TestConfigureReleaseJob(t *testing.T) {
 	}
 	if err != nil {
 		t.Errorf("got unexpected error %s", err)
+	}
+}
+
+func TestAppendVersionSuffixToJobNames(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "appendVersionSuffix-*")
+	if err != nil {
+		t.Fatalf("got unexpected error %s", err)
+	}
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			log.Warnf("failed to remove temp dir %s", tempDir)
+		}
+	}(tempDir)
+
+	tempFile := filepath.Join(tempDir, "kubevirt-presubmits-1.6.yaml")
+	input, err := os.ReadFile("testdata/jobconfig/kubevirt-presubmits-1.6.yaml")
+	if err != nil {
+		t.Fatalf("got unexpected error %s", err)
+	}
+	err = os.WriteFile(tempFile, input, os.ModePerm)
+	if err != nil {
+		t.Fatalf("got unexpected error %s", err)
+	}
+
+	err = appendVersionSuffixToJobNames(tempFile, "1.6")
+	if err != nil {
+		t.Fatalf("got unexpected error %s", err)
+	}
+
+	jobConfig, err := config.ReadJobConfig(tempFile)
+	if err != nil {
+		t.Fatalf("got unexpected error %s", err)
+	}
+	for _, presubmits := range jobConfig.PresubmitsStatic {
+		for _, presubmit := range presubmits {
+			if !strings.HasSuffix(presubmit.Name, "-1.6") {
+				t.Errorf("expected job name %q to have suffix -1.6", presubmit.Name)
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
`config-forker` does not add a version suffix to presubmit job names, only to periodics and postsubmits. Add `appendVersionSuffixToJobNames` as a separate post-processing step in forkProwJobs to append the release version (e.g. -1.9) to each presubmit name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Append version suffix to presubmit job names during config fork
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release-branch job configs now automatically add the release version to presubmit job names.
  * This helps keep job names unique and easier to identify across release branches.

* **Tests**
  * Added coverage to verify that generated presubmit job names include the expected version suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->