### PR TITLE
kubevirtci: update jobs to use GO_MOD_PATH to allow gocli bump

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -248,8 +248,8 @@ periodics:
         export PROVISION_CENTOS_VERSION=10; export PHASES=linux; export BYPASS_PMAN_CHANGE_CHECK=true; ./publish.sh
         rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
       env:
-      - name: GIMME_GO_VERSION
-        value: "1.24.7"
+      - name: GO_MOD_PATH
+        value: go.mod
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -47,8 +47,8 @@ postsubmits:
             gsutil cp ./amd64-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-$SHORT_SHA
           # docker-in-docker needs privileged mode
           env:
-          - name: GIMME_GO_VERSION
-            value: "1.24.7"
+          - name: GO_MOD_PATH
+            value: go.mod
           securityContext:
             privileged: true
           volumeMounts:
@@ -168,8 +168,8 @@ postsubmits:
             rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
           # docker-in-docker needs privileged mode
           env:
-          - name: GIMME_GO_VERSION
-            value: "1.24.7"
+          - name: GO_MOD_PATH
+            value: go.mod
           securityContext:
             privileged: true
           volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -357,8 +357,8 @@ presubmits:
         - -c
         - cd cluster-provision/gocli/ && make all container
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
         name: ""
         resources:
@@ -424,8 +424,8 @@ presubmits:
           (cd cluster-provision/gocli && make test && make container)
           podman run --rm -v $(pwd):/workdir:Z quay.io/kubevirtci/gocli provision-manager --debug
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
         name: ""
         resources:
@@ -452,8 +452,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.32 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: SLIM
           value: "true"
         - name: RUN_KUBEVIRT_CONFORMANCE
@@ -484,8 +484,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.33 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: SLIM
           value: "true"
         - name: RUN_KUBEVIRT_CONFORMANCE
@@ -516,8 +516,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: SLIM
           value: "true"
         - name: RUN_KUBEVIRT_CONFORMANCE
@@ -549,8 +549,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
         name: ""
         resources:
@@ -579,8 +579,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: PROVISION_CENTOS_VERSION
           value: "10"
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
@@ -611,8 +611,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.35 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
         name: ""
         resources:
@@ -641,8 +641,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.35 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: PROVISION_CENTOS_VERSION
           value: "10"
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
@@ -672,8 +672,8 @@ presubmits:
         - -c
         - cd $(find ./cluster-provision/k8s -name '1.*' | sort -rV | head -1) && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: PHASES
           value: linux
         - name: BYPASS_PMAN_CHANGE_CHECK
@@ -707,8 +707,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.36 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         image: quay.io/kubevirtci/golang:v20260612-73bc71e
         name: ""
         resources:
@@ -737,8 +737,8 @@ presubmits:
         - -c
         - cd cluster-provision/k8s/1.36 && ../provision.sh
         env:
-        - name: GIMME_GO_VERSION
-          value: 1.24.7
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: PROVISION_CENTOS_VERSION
           value: "10"
         image: quay.io/kubevirtci/golang:v20260612-73bc71e


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to properly test updating gocli to go 1.26[1] - the CI jobs need to be updated to use GO_MOD_PATH

[1] https://github.com/kubevirt/kubevirtci/pull/1754

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several CI jobs to use module-based Go configuration for build and test execution.
  * Applied the same environment setting changes across presubmit, postsubmit, and periodic workflows for consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->