### PR TITLE
feat(needs-rebase): switch to GitHub App credentials

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -1,4 +1,7 @@
-# source https://github.com/kubernetes-sigs/prow/blob/8cd4af136cc0eeb9ee7ab9fc11cd99f7adba663e/pkg/plugins/config.go#L52
+# Source:
+# - https://docs.prow.k8s.io/docs/components/plugins/
+# - https://sigs.k8s.io/prow/pkg/plugins/plugin-config-documented.yaml
+# - https://pkg.go.dev/sigs.k8s.io/prow/pkg/plugins#Configuration
 # let's keep the order in the same way as it's defined in above configuration
 
 plugins:
@@ -586,6 +589,7 @@ plugins:
     - trigger
     - help
 
+# https://docs.prow.k8s.io/docs/components/plugins/#external-plugins
 external_plugins:
   libguestfs-appliance:
   - name: needs-rebase
@@ -645,6 +649,7 @@ external_plugins:
     events:
       - issue_comment
 
+# https://docs.prow.k8s.io/docs/components/plugins/approve/approvers/
 approve:
 - repos:
   - kubevirt/project-infra
@@ -793,6 +798,7 @@ label:
       - restricted-labels-kubevirt
       label: approved-vep
 
+# https://docs.prow.k8s.io/docs/components/plugins/lgtm/
 lgtm:
 - repos:
   - kubevirt/machine-remediation-operator
@@ -862,6 +868,8 @@ override:
     kubevirt:
       - prow-job-taskforce
 
+# Note: the trigger plugin ignore comments from its own bot user:
+# - https://sigs.k8s.io/prow/pkg/plugins/trigger/generic-comment.go#handleGenericComment()#L50-L59
 triggers:
 - repos:
   - kubevirt/project-infra

--- a/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/test_infra/current/needs-rebase_deployment.yaml
@@ -38,8 +38,15 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
-        - --update-period=6h
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        - --update-period=3h
+        env:
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: appid
         ports:
           - name: http
             containerPort: 8888
@@ -47,7 +54,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: plugins
@@ -57,9 +64,9 @@ spec:
       - name: hmac
         secret:
           secretName: hmac-token
-      - name: oauth
+      - name: github-token
         secret:
-          secretName: oauth-token
+          secretName: github-token
       - name: plugins
         configMap:
           name: plugins


### PR DESCRIPTION
**What this PR does / why we need it**:

Update needs-rebase external plugin deployment manifests to use GitHub App credentials instead of Personal Access Token.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Prow plugin configuration reference comments, adding a top “Source” guidance block and URL anchor notes above key plugin sections.
  * Clarified trigger behavior regarding comments from its own bot user.
* **Chores**
  * Updated the needs-rebase deployment to use GitHub App credentials instead of an OAuth token.
  * Increased the needs-rebase reconciliation/update frequency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->