### PR TITLE
kubevirt/vdpa-network-binding-plugin: Prow jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/vdpa-network-binding-plugin/vdpa-network-binding-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vdpa-network-binding-plugin/vdpa-network-binding-plugin-periodics.yaml
@@ -1,0 +1,95 @@
+periodics:
+  - name: vdpa-network-binding-plugin-weekly-e2e-k8s-1.35
+    cron: 0 4 * * 1
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    extra_refs:
+      - org: kubevirt
+        repo: vdpa-network-binding-plugin
+        base_ref: main
+    annotations:
+      testgrid-create-test-group: "false"
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -ce
+            - |
+              which go &> /dev/null || dnf install -y golang
+              ./test/automation/setup_and_test.sh
+          env:
+            - name: KUBEVIRT_PROVIDER
+              value: k8s-1.35
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: KUBEVIRT_NUM_NODES
+              value: "3"
+            - name: KUBEVIRT_SYNC_VERSION
+              value: "nightly"
+          image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+          name: ""
+          resources:
+            requests:
+              cpu: "12"
+              memory: 50G
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - name: vdpa-network-binding-plugin-weekly-e2e-k8s-1.36
+    cron: 0 4 * * 1
+    cluster: prow-workloads
+    decorate: true
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    annotations:
+      testgrid-create-test-group: "false"
+    extra_refs:
+      - org: kubevirt
+        repo: vdpa-network-binding-plugin
+        base_ref: main
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/runner.sh
+            - /bin/sh
+            - -ce
+            - |
+              which go &> /dev/null || dnf install -y golang
+              ./test/automation/setup_and_test.sh
+          env:
+            - name: KUBEVIRT_PROVIDER
+              value: k8s-1.36
+            - name: KUBEVIRT_MEMORY_SIZE
+              value: 16G
+            - name: KUBEVIRT_NUM_NODES
+              value: "3"
+            - name: KUBEVIRT_SYNC_VERSION
+              value: "nightly"
+          image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+          name: ""
+          resources:
+            requests:
+              cpu: "12"
+              memory: 50G
+          securityContext:
+            privileged: true
+      nodeSelector:
+        type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vdpa-network-binding-plugin/vdpa-network-binding-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vdpa-network-binding-plugin/vdpa-network-binding-plugin-postsubmits.yaml
@@ -1,0 +1,41 @@
+postsubmits:
+  kubevirt/vdpa-network-binding-plugin:
+    - name: push-release-network-binding-plugin-tag
+      branches:
+        # regex for semver from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      cluster: kubevirt-prow-control-plane
+      always_run: true
+      skip_report: false
+      decorate: true
+      decoration_config:
+        timeout: 1h
+        grace_period: 5m
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-gcs-credentials: "true"
+        preset-github-credentials: "true"
+        preset-kubevirtci-quay-credential: "true"
+        preset-pgp-bot-key: "true"
+      annotations:
+        testgrid-create-test-group: "false"
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260715-af3e234
+            env:
+              - name: IMAGE_REGISTRY
+                value: quay.io/kubevirt
+            command: ["/usr/local/bin/runner.sh", "/bin/sh", "-c"]
+            args:
+              - |
+                set -e
+                export IMAGE_TAG="$(git tag --points-at HEAD | head -1)"
+                [[ ! -z ${IMAGE_TAG} ]] || exit 0
+                export PUSH_REGISTRY=${IMAGE_REGISTRY}
+                make images && make push
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "8Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vdpa-network-binding-plugin/vdpa-network-binding-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vdpa-network-binding-plugin/vdpa-network-binding-plugin-presubmits.yaml
@@ -1,0 +1,88 @@
+presubmits:
+  kubevirt/vdpa-network-binding-plugin:
+    - name: pull-vdpa-network-binding-plugin-e2e-k8s-1.35
+      always_run: true
+      decorate: true
+      cluster: prow-workloads
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-docker-mirror-proxy: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-podman-shared-images: "true"
+        preset-shared-images: "true"
+      max_concurrency: 5
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -ce
+              - |
+                which go &> /dev/null || dnf install -y golang
+                ./test/automation/setup_and_test.sh
+            env:
+              - name: KUBEVIRT_PROVIDER
+                value: k8s-1.35
+              - name: KUBEVIRT_MEMORY_SIZE
+                value: 16G
+              - name: KUBEVIRT_NUM_NODES
+                value: "3"
+              - name: KUBEVIRT_SYNC_VERSION
+                value: "latest"
+            image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+            name: ""
+            resources:
+              requests:
+                cpu: "12"
+                memory: 50G
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external
+    - name: pull-vdpa-network-binding-plugin-e2e-k8s-1.36
+      always_run: true
+      decorate: true
+      cluster: prow-workloads
+      decoration_config:
+        grace_period: 5m0s
+        timeout: 1h0m0s
+      labels:
+        preset-docker-mirror-proxy: "true"
+        preset-podman-in-container-enabled: "true"
+        preset-podman-shared-images: "true"
+        preset-shared-images: "true"
+      max_concurrency: 5
+      skip_branches:
+        - release-\d+\.\d+
+      spec:
+        containers:
+          - command:
+              - /usr/local/bin/runner.sh
+              - /bin/sh
+              - -ce
+              - |
+                which go &> /dev/null || dnf install -y golang
+                ./test/automation/setup_and_test.sh
+            env:
+              - name: KUBEVIRT_PROVIDER
+                value: k8s-1.36
+              - name: KUBEVIRT_MEMORY_SIZE
+                value: 16G
+              - name: KUBEVIRT_NUM_NODES
+                value: "3"
+              - name: KUBEVIRT_SYNC_VERSION
+                value: "latest"
+            image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+            name: ""
+            resources:
+              requests:
+                cpu: "12"
+                memory: 50G
+            securityContext:
+              privileged: true
+        nodeSelector:
+          type: bare-metal-external


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit adds presubmit, postsubmit and periodic jobs targetting the kubevirt/vdpa-network-binding-plugin repository.

- Presubmit jobs run the repository integration tests against k8s-1.35 and k8s-1.36 clusters running the latest stable KubeVirt release available. They do that by running a helper script available in the target repository, test/automation/setup_and_test.sh.
- Postsubmit jobs build relevant images and push them to the quay.io/kubevirt registry when a release is tagged.
- Periodics run every Monday morning at 4AM. These run the integration tests, again against k8s-1.35 and k8s-1.36 clusters, this time running the latest available nightly KubeVirt build. This tries to find integration issues with the latest KubeVirt developments early.

We need it to bring e2e/integration testing to the kubevirt/vdpa-network-binding-plugin repository

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR depends on:
- https://github.com/kubevirt/project-infra/pull/5157: Prow support request for kubevirt/vdpa-network-binding-plugin
- https://github.com/kubevirt/vdpa-network-binding-plugin/pull/5: Test provider implementation and cluster setup.
- https://github.com/kubevirt/vdpa-network-binding-plugin/pull/6: Integration tests.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI automation for the VDPA network binding plugin, including presubmit checks across multiple Kubernetes provider versions.
  * Introduced scheduled weekly periodic end-to-end runs (Mondays) for bare-metal environments with consistent timeout, concurrency, and privileged execution settings.
  * Added a tag-triggered workflow to build and push plugin images/artifacts when release-like version tags are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->