### PR TITLE
Use golang images in kubevirt-observability-controller postsubmits jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
@@ -19,7 +19,7 @@ postsubmits:
       preset-github-credentials: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20260703-61a4923
+      - image: quay.io/kubevirtci/golang:v20260703-61a4923
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
@@ -67,7 +67,7 @@ postsubmits:
       preset-kubevirtci-quay-credential: "true"
     spec:
       containers:
-      - image: quay.io/kubevirtci/bootstrap:v20260703-61a4923
+      - image: quay.io/kubevirtci/golang:v20260703-61a4923
         env:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container image used by the two postsubmit release jobs to a newer Golang-based image.
  * Left existing job configuration, environment variables, and release commands unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->