### PR TITLE
s390x: disable lanes due to clusters issue

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -70,7 +70,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
       optional: true
       decorate: true
       decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -108,7 +108,8 @@ presubmits:
     branches:
       - release-1.4
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -108,7 +108,8 @@ presubmits:
     branches:
       - release-1.5
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -108,7 +108,8 @@ presubmits:
       branches:
         - release-1.6
       always_run: false
-      run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-s390x-workloads
       decorate: true
       decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -108,7 +108,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -234,7 +235,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -313,7 +315,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -392,7 +395,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -471,7 +475,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -190,7 +190,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -316,7 +317,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -395,7 +397,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -474,7 +477,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -553,7 +557,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -87,7 +87,9 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy
+  - always_run: false
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -191,7 +193,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/centosstream/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/centosstream/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -260,7 +264,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/fedora/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/fedora/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -329,7 +335,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/ubuntu/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/ubuntu/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -398,7 +406,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/opensuse/microos/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/opensuse/microos/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -467,7 +477,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/opensuse/tumbleweed/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/opensuse/tumbleweed/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -37,7 +37,8 @@ presubmits:
     cluster: prow-s390x-workloads
     annotations:
       fork-per-release: "true"
-    always_run: true
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    always_run: false
     optional: true
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
@@ -75,8 +75,9 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.17
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
+      optional: true
       decorate: true
       decoration_config:
         timeout: 2h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
@@ -75,8 +75,9 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.18
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
+      optional: true
       decorate: true
       decoration_config:
         timeout: 2h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -119,8 +119,9 @@ presubmits:
       annotations:
         fork-per-release: "true"
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
+      optional: true
       decorate: true
       decoration_config:
         timeout: 2h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -41,8 +41,9 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy again
+      always_run: false
+      optional: true
       decorate: true
       cluster: prow-s390x-workloads
       decoration_config:
@@ -67,8 +68,9 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy again
+      always_run: false
+      optional: true
       decorate: true
       cluster: prow-s390x-workloads
       decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -395,7 +395,9 @@ presubmits:
             memory: 8Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.4
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -399,7 +399,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.5
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -444,7 +444,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.6
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -496,7 +496,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.7
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -500,7 +500,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.8
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
@@ -533,7 +533,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.9
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -559,7 +559,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -574,7 +574,8 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy
+  - always_run: false
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

s390x clusters are down and jobs are not starting:

=> https://testgrid.k8s.io/kubevirt-project-infra-periodics

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily reduced disruption from unstable s390x CI by making several presubmit jobs optional and disabling automatic runs by default.
  * Updated affected KubeVirt, containerdisks, CDI, hyperconverged-cluster-operator, kubesecondarydns, common-instancetypes, and kubevirtci checks to avoid blocking unrelated changes while the underlying cluster issue is resolved.
  * Added notes indicating these settings will be restored once the s390x workload cluster is healthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->