### PR TITLE
Fix slice aliasing bug in expandPaths for nested DescribeTable

### DIFF
--- a/robots/ginkgo-tests/cmd/extract-changed.go
+++ b/robots/ginkgo-tests/cmd/extract-changed.go
@@ -401,12 +401,13 @@ func (m *OutlineMapper) GetPathsForLines(lines ...int) ([][]*ginkgo.Node, error)
 
 func expandPaths(parents []*ginkgo.Node, children []*ginkgo.Node) (paths [][]*ginkgo.Node) {
 	for _, child := range children {
+		parentsCopy := make([]*ginkgo.Node, len(parents), len(parents)+1)
+		copy(parentsCopy, parents)
 		if len(child.Nodes) > 0 {
-			newParents := append(parents, child.CloneWithoutNodes())
-			nodes := expandPaths(newParents, child.Nodes)
+			nodes := expandPaths(append(parentsCopy, child.CloneWithoutNodes()), child.Nodes)
 			paths = append(paths, nodes...)
 		} else {
-			paths = append(paths, append(parents, child))
+			paths = append(paths, append(parentsCopy, child))
 		}
 	}
 	return

--- a/robots/ginkgo-tests/cmd/extract-changed_test.go
+++ b/robots/ginkgo-tests/cmd/extract-changed_test.go
@@ -253,7 +253,83 @@ var _ = Describe("extract testnames", func() {
 		})
 
 		It("should contain final test name", func() {
-			Expect(slices.Contains(changedTestNames, "whatever description of describe description of it")).To(BeTrue())
+			Expect(slices.Contains(changedTestNames, "nested describe nested context nested table entry1")).To(BeTrue())
+		})
+
+	})
+
+	When("a line within a deeply nested DescribeTable body is changed", Ordered, func() {
+
+		const (
+			fakeCommitHash = "abc1234567890"
+			testFile       = "testdata/simple_test.go"
+		)
+
+		var (
+			testPaths        [][]*ginkgo.Node
+			changedTestNames []string
+		)
+
+		BeforeAll(func() {
+			var outline []*ginkgo.Node
+
+			file, err := os.Open("testdata/simple_test_outline.json")
+			Expect(err).ToNot(HaveOccurred())
+			err = json.NewDecoder(file).Decode(&outline)
+			Expect(err).ToNot(HaveOccurred())
+
+			testfileContent, err := os.ReadFile(testFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			commits := []*git.LogCommit{
+				{
+					Hash: fakeCommitHash,
+					FileChanges: []*git.FileChange{
+						{ChangeType: git.Modified, Filename: testFile},
+					},
+				},
+			}
+			outlines := map[string][]*ginkgo.Node{
+				testFile: outline,
+			}
+			// line 80 is inside the nested DescribeTable function body (Describe > Context > DescribeTable),
+			// outside any Entry
+			blameLines := map[string][]*git.BlameLine{
+				testFile: {
+					{CommitID: fakeCommitHash[:11], LineNo: 80},
+				},
+			}
+			testfileContents := map[string]string{
+				testFile: string(testfileContent),
+			}
+
+			testPaths = extractChangedTestPaths(commits, outlines, blameLines, testfileContents)
+
+			absTestPath, err := filepath.Abs("testdata")
+			Expect(err).ToNot(HaveOccurred())
+			changedTestNames, err = generateTestNames(testPaths, absTestPath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return paths for all entries in the table", func() {
+			Expect(testPaths).To(HaveLen(4))
+		})
+
+		It("should return distinct paths for each entry", func() {
+			uniqueLeafTexts := map[string]struct{}{}
+			for _, path := range testPaths {
+				leafNode := path[len(path)-1]
+				uniqueLeafTexts[leafNode.Text] = struct{}{}
+			}
+			Expect(uniqueLeafTexts).To(HaveLen(4))
+		})
+
+		It("should contain test name for each entry", func() {
+			Expect(changedTestNames).To(HaveLen(4))
+			Expect(slices.Contains(changedTestNames, "nested describe nested context nested table entry1")).To(BeTrue())
+			Expect(slices.Contains(changedTestNames, "nested describe nested context nested table entry2")).To(BeTrue())
+			Expect(slices.Contains(changedTestNames, "nested describe nested context nested table entry3")).To(BeTrue())
+			Expect(slices.Contains(changedTestNames, "nested describe nested context nested table entry4")).To(BeTrue())
 		})
 
 	})

--- a/robots/ginkgo-tests/cmd/testdata/simple_test.go
+++ b/robots/ginkgo-tests/cmd/testdata/simple_test.go
@@ -72,3 +72,17 @@ var _ = Describe(ExtendArgs("description of describe", func() {
 func ExtendArgs(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
 	return "whatever " + text, args
 }
+
+var _ = Describe("nested describe", func() {
+	Context("nested context", func() {
+		DescribeTable("nested table",
+			func(val string) {
+				Expect(val).ToNot(BeEmpty())
+			},
+			Entry("entry1", "a"),
+			Entry("entry2", "b"),
+			Entry("entry3", "c"),
+			Entry("entry4", "d"),
+		)
+	})
+})

--- a/robots/ginkgo-tests/cmd/testdata/simple_test_outline.json
+++ b/robots/ginkgo-tests/cmd/testdata/simple_test_outline.json
@@ -1,116 +1,219 @@
 [
-  {
-    "name": "Describe",
-    "text": "simple",
-    "start": 745,
-    "end": 1508,
-    "spec": false,
-    "focused": false,
-    "pending": false,
-    "labels": [],
-    "nodes": [
-      {
-        "name": "Context",
-        "text": "was previously part of the latter node",
-        "start": 775,
-        "end": 936,
+    {
+        "name": "Describe",
+        "text": "simple",
+        "start": 747,
+        "end": 1510,
         "spec": false,
         "focused": false,
         "pending": false,
         "labels": [],
         "nodes": [
-          {
-            "name": "It",
-            "text": "[test_id:1742]is still found",
-            "start": 837,
-            "end": 931,
-            "spec": true,
-            "focused": false,
-            "pending": false,
-            "labels": [],
-            "nodes": []
-          }
+            {
+                "name": "Context",
+                "text": "was previously part of the latter node",
+                "start": 777,
+                "end": 938,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                    {
+                        "name": "It",
+                        "text": "[test_id:1742]is still found",
+                        "start": 839,
+                        "end": 933,
+                        "spec": true,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": []
+                    }
+                ]
+            },
+            {
+                "name": "When",
+                "text": "does something is executed",
+                "start": 941,
+                "end": 1278,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                    {
+                        "name": "It",
+                        "text": "does not return an error",
+                        "start": 988,
+                        "end": 1076,
+                        "spec": true,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": []
+                    },
+                    {
+                        "name": "It",
+                        "text": "does return an error",
+                        "start": 1080,
+                        "end": 1166,
+                        "spec": true,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": []
+                    },
+                    {
+                        "name": "It",
+                        "text": "[vendor:cnv-qe]does do something else",
+                        "start": 1170,
+                        "end": 1273,
+                        "spec": true,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": []
+                    }
+                ]
+            },
+            {
+                "name": "DescribeTable",
+                "text": "is a table",
+                "start": 1281,
+                "end": 1506,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                    {
+                        "name": "Entry",
+                        "text": "first testcase",
+                        "start": 1416,
+                        "end": 1451,
+                        "spec": true,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": []
+                    },
+                    {
+                        "name": "Entry",
+                        "text": "[test_id:8976]2nd testcase",
+                        "start": 1455,
+                        "end": 1502,
+                        "spec": true,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": []
+                    }
+                ]
+            }
         ]
-      },
-      {
-        "name": "When",
-        "text": "does something is executed",
-        "start": 939,
-        "end": 1276,
+    },
+    {
+        "name": "Describe",
+        "text": "undefined",
+        "start": 1520,
+        "end": 1662,
         "spec": false,
         "focused": false,
         "pending": false,
         "labels": [],
         "nodes": [
-          {
-            "name": "It",
-            "text": "does not return an error",
-            "start": 986,
-            "end": 1074,
-            "spec": true,
-            "focused": false,
-            "pending": false,
-            "labels": [],
-            "nodes": []
-          },
-          {
-            "name": "It",
-            "text": "does return an error",
-            "start": 1078,
-            "end": 1164,
-            "spec": true,
-            "focused": false,
-            "pending": false,
-            "labels": [],
-            "nodes": []
-          },
-          {
-            "name": "It",
-            "text": "[vendor:cnv-qe]does do something else",
-            "start": 1168,
-            "end": 1271,
-            "spec": true,
-            "focused": false,
-            "pending": false,
-            "labels": [],
-            "nodes": []
-          }
+            {
+                "name": "It",
+                "text": "description of it",
+                "start": 1578,
+                "end": 1657,
+                "spec": true,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": []
+            }
         ]
-      },
-      {
-        "name": "DescribeTable",
-        "text": "is a table",
-        "start": 1279,
-        "end": 1504,
+    },
+    {
+        "name": "Describe",
+        "text": "nested describe",
+        "start": 1805,
+        "end": 2081,
         "spec": false,
         "focused": false,
         "pending": false,
         "labels": [],
         "nodes": [
-          {
-            "name": "Entry",
-            "text": "first testcase",
-            "start": 1414,
-            "end": 1449,
-            "spec": true,
-            "focused": false,
-            "pending": false,
-            "labels": [],
-            "nodes": []
-          },
-          {
-            "name": "Entry",
-            "text": "[test_id:8976]2nd testcase",
-            "start": 1453,
-            "end": 1500,
-            "spec": true,
-            "focused": false,
-            "pending": false,
-            "labels": [],
-            "nodes": []
-          }
+            {
+                "name": "Context",
+                "text": "nested context",
+                "start": 1843,
+                "end": 2078,
+                "spec": false,
+                "focused": false,
+                "pending": false,
+                "labels": [],
+                "nodes": [
+                    {
+                        "name": "DescribeTable",
+                        "text": "nested table",
+                        "start": 1880,
+                        "end": 2074,
+                        "spec": false,
+                        "focused": false,
+                        "pending": false,
+                        "labels": [],
+                        "nodes": [
+                            {
+                                "name": "Entry",
+                                "text": "entry1",
+                                "start": 1974,
+                                "end": 1994,
+                                "spec": true,
+                                "focused": false,
+                                "pending": false,
+                                "labels": [],
+                                "nodes": []
+                            },
+                            {
+                                "name": "Entry",
+                                "text": "entry2",
+                                "start": 1999,
+                                "end": 2019,
+                                "spec": true,
+                                "focused": false,
+                                "pending": false,
+                                "labels": [],
+                                "nodes": []
+                            },
+                            {
+                                "name": "Entry",
+                                "text": "entry3",
+                                "start": 2024,
+                                "end": 2044,
+                                "spec": true,
+                                "focused": false,
+                                "pending": false,
+                                "labels": [],
+                                "nodes": []
+                            },
+                            {
+                                "name": "Entry",
+                                "text": "entry4",
+                                "start": 2049,
+                                "end": 2069,
+                                "spec": true,
+                                "focused": false,
+                                "pending": false,
+                                "labels": [],
+                                "nodes": []
+                            }
+                        ]
+                    }
+                ]
+            }
         ]
-      }
-    ]
-  }
+    }
 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
expandPaths reused the parents slice across loop iterations. When Go's append had spare capacity (3+ nesting levels), all paths ended up pointing to the last Entry. Copy the slice each iteration to ensure independent backing arrays.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @dhiller 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of changed tests in deeply nested table-based test structures, with more accurate generated test names for each entry.
* **Tests**
  * Added coverage for nested table scenarios and updated test fixtures to reflect the new nesting layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->