### PR TITLE
s390x: re-enable lanes after the cluster issue is fixed

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -70,8 +70,7 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
+      always_run: true
       optional: true
       decorate: true
       decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -108,8 +108,7 @@ presubmits:
     branches:
       - release-1.4
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -108,8 +108,7 @@ presubmits:
     branches:
       - release-1.5
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -108,8 +108,7 @@ presubmits:
       branches:
         - release-1.6
       always_run: false
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+      run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-s390x-workloads
       decorate: true
       decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -108,8 +108,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -235,8 +234,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -315,8 +313,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -395,8 +392,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -475,8 +471,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -190,8 +190,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -317,8 +316,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -397,8 +395,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -477,8 +474,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -557,8 +553,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -87,9 +87,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  # TODO: revert once the prow-s390x-workloads cluster is healthy
-  - always_run: false
-    optional: true
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -193,9 +191,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/centosstream/.*"
-    optional: true
+    run_if_changed: "artifacts/centosstream/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -264,9 +260,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/fedora/.*"
-    optional: true
+    run_if_changed: "artifacts/fedora/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -335,9 +329,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/ubuntu/.*"
-    optional: true
+    run_if_changed: "artifacts/ubuntu/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -406,9 +398,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/opensuse/microos/.*"
-    optional: true
+    run_if_changed: "artifacts/opensuse/microos/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -477,9 +467,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/opensuse/tumbleweed/.*"
-    optional: true
+    run_if_changed: "artifacts/opensuse/tumbleweed/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -37,8 +37,7 @@ presubmits:
     cluster: prow-s390x-workloads
     annotations:
       fork-per-release: "true"
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
@@ -75,9 +75,8 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.17
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decorate: true
       decoration_config:
         timeout: 2h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
@@ -75,9 +75,8 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.18
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decorate: true
       decoration_config:
         timeout: 2h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -119,9 +119,8 @@ presubmits:
       annotations:
         fork-per-release: "true"
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decorate: true
       decoration_config:
         timeout: 2h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -41,9 +41,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      # TODO: revert once the prow-s390x-workloads cluster is healthy again
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decorate: true
       cluster: prow-s390x-workloads
       decoration_config:
@@ -68,9 +67,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      # TODO: revert once the prow-s390x-workloads cluster is healthy again
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decorate: true
       cluster: prow-s390x-workloads
       decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -395,9 +395,7 @@ presubmits:
             memory: 8Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.4
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -399,9 +399,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.5
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -444,9 +444,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.6
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -496,9 +496,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.7
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -500,9 +500,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.8
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
@@ -533,9 +533,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.9
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -559,9 +559,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -574,8 +574,7 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy
-  - always_run: false
+  - always_run: true
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

s390x clusters are healthy again:

=> https://prow.ci.kubevirt.io/?type=periodic&job=periodic-project-infra-prow-s390x-*-livez

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded and enabled several presubmit checks so more s390x-related changes now trigger the appropriate validation jobs automatically.
* **Bug Fixes**
  * Multiple previously optional or disabled CI jobs now run by default, improving test coverage and making build/test feedback more consistent.
  * Updated trigger rules for several jobs to run only when relevant files change, reducing unnecessary checks while preserving coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->