### PR TITLE
coverage: add coverage delta and configurable threshold

### DIFF
--- a/external-plugins/coverage/plugin/handler/handler.go
+++ b/external-plugins/coverage/plugin/handler/handler.go
@@ -45,6 +45,8 @@ type JobConfig struct {
 	GracePeriodSeconds int                 `yaml:"gracePeriodSeconds"`
 	UtilityImages      UtilityImagesConfig `yaml:"utilityImages"`
 	GCS                GCSConfig           `yaml:"gcs"`
+	CoverageThreshold  int                 `yaml:"coverageThreshold"`
+	GitHubTokenSecret  string              `yaml:"githubTokenSecret"`
 }
 
 type Config struct {
@@ -84,6 +86,12 @@ func (c *Config) RepoConfig(repo string) (*JobConfig, bool) {
 	}
 	if repoCfg.GCS != (GCSConfig{}) {
 		merged.GCS = repoCfg.GCS
+	}
+	if repoCfg.CoverageThreshold != 0 {
+		merged.CoverageThreshold = repoCfg.CoverageThreshold
+	}
+	if repoCfg.GitHubTokenSecret != "" {
+		merged.GitHubTokenSecret = repoCfg.GitHubTokenSecret
 	}
 	return &merged, true
 }
@@ -141,6 +149,15 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.Defaults.GracePeriodSeconds == 0 {
 		cfg.Defaults.GracePeriodSeconds = 15
 	}
+	if cfg.Defaults.CoverageThreshold < 0 || cfg.Defaults.CoverageThreshold > 100 {
+		return nil, fmt.Errorf("config: defaults.coverageThreshold must be between 0 and 100")
+	}
+	if cfg.Defaults.CoverageThreshold == 0 {
+		cfg.Defaults.CoverageThreshold = 70
+	}
+	if cfg.Defaults.GitHubTokenSecret == "" {
+		cfg.Defaults.GitHubTokenSecret = "commenter-oauth-token"
+	}
 
 	if len(cfg.Repos) == 0 {
 		return nil, fmt.Errorf("config: at least one repo must be configured")
@@ -154,6 +171,9 @@ func LoadConfig(path string) (*Config, error) {
 		}
 		if repoCfg.GracePeriodSeconds < 0 {
 			return nil, fmt.Errorf("config: repos.%s.gracePeriodSeconds must not be negative", repo)
+		}
+		if repoCfg.CoverageThreshold < 0 || repoCfg.CoverageThreshold > 100 {
+			return nil, fmt.Errorf("config: repos.%s.coverageThreshold must be between 0 and 100", repo)
 		}
 	}
 
@@ -256,10 +276,14 @@ func (h *GitHubEventsHandler) generateCoverageJob(
 		envKeys = append(envKeys, k)
 	}
 	sort.Strings(envKeys)
-	envVars := make([]corev1.EnvVar, 0, len(cfg.Env))
+	envVars := make([]corev1.EnvVar, 0, len(cfg.Env)+1)
 	for _, k := range envKeys {
 		envVars = append(envVars, corev1.EnvVar{Name: k, Value: cfg.Env[k]})
 	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "COVERAGE_THRESHOLD",
+		Value: fmt.Sprintf("%d", cfg.CoverageThreshold),
+	})
 
 	pathStrategy := prowapi.PathStrategyExplicit
 	if cfg.GCS.PathStrategy != "" {
@@ -284,9 +308,26 @@ func (h *GitHubEventsHandler) generateCoverageJob(
 							"-ce",
 						},
 						Args: []string{
-							fmt.Sprintf("go test %s -coverprofile=${ARTIFACTS}/filtered.cov && covreport -i ${ARTIFACTS}/filtered.cov -o ${ARTIFACTS}/filtered.html", cfg.TestPackages),
+							fmt.Sprintf("/usr/local/bin/coverage-report.sh %s", cfg.TestPackages),
 						},
 						Env: envVars,
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "github-token",
+								MountPath: "/etc/github-commenter",
+								ReadOnly:  true,
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "github-token",
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName: cfg.GitHubTokenSecret,
+							},
+						},
 					},
 				},
 			},
@@ -312,7 +353,7 @@ func (h *GitHubEventsHandler) generateCoverageJob(
 		},
 		Reporter: config.Reporter{
 			Context:    "coverage-auto",
-			SkipReport: false,
+			SkipReport: true,
 		},
 	}
 	return pjutil.NewPresubmit(*pr, pr.Base.SHA, presubmit, eventGUID, nil)

--- a/external-plugins/coverage/plugin/handler/handler.go
+++ b/external-plugins/coverage/plugin/handler/handler.go
@@ -22,6 +22,13 @@ import (
 	"sigs.k8s.io/prow/pkg/pjutil"
 )
 
+const (
+	defaultCoverageThreshold  = 70
+	defaultGitHubTokenSecret  = "commenter-oauth-token"
+	defaultTimeoutMinutes     = 120
+	defaultGracePeriodSeconds = 15
+)
+
 type UtilityImagesConfig struct {
 	CloneRefs  string `yaml:"cloneRefs"`
 	InitUpload string `yaml:"initUpload"`
@@ -144,19 +151,19 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, fmt.Errorf("config: defaults.gracePeriodSeconds must not be negative")
 	}
 	if cfg.Defaults.TimeoutMinutes == 0 {
-		cfg.Defaults.TimeoutMinutes = 120
+		cfg.Defaults.TimeoutMinutes = defaultTimeoutMinutes
 	}
 	if cfg.Defaults.GracePeriodSeconds == 0 {
-		cfg.Defaults.GracePeriodSeconds = 15
+		cfg.Defaults.GracePeriodSeconds = defaultGracePeriodSeconds
 	}
 	if cfg.Defaults.CoverageThreshold < 0 || cfg.Defaults.CoverageThreshold > 100 {
 		return nil, fmt.Errorf("config: defaults.coverageThreshold must be between 0 and 100")
 	}
 	if cfg.Defaults.CoverageThreshold == 0 {
-		cfg.Defaults.CoverageThreshold = 70
+		cfg.Defaults.CoverageThreshold = defaultCoverageThreshold
 	}
 	if cfg.Defaults.GitHubTokenSecret == "" {
-		cfg.Defaults.GitHubTokenSecret = "commenter-oauth-token"
+		cfg.Defaults.GitHubTokenSecret = defaultGitHubTokenSecret
 	}
 
 	if len(cfg.Repos) == 0 {

--- a/external-plugins/coverage/plugin/handler/handler_test.go
+++ b/external-plugins/coverage/plugin/handler/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -122,6 +123,8 @@ var _ = Describe("generateCoverageJob", func() {
 				},
 				TimeoutMinutes:     120,
 				GracePeriodSeconds: 15,
+				CoverageThreshold:  70,
+				GitHubTokenSecret:  "commenter-oauth-token",
 				UtilityImages: UtilityImagesConfig{
 					CloneRefs:  "us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20260401-f6cc3990c",
 					InitUpload: "us-docker.pkg.dev/k8s-infra-prow/images/initupload:v20260401-f6cc3990c",
@@ -191,7 +194,21 @@ var _ = Describe("generateCoverageJob", func() {
 			}
 			return ""
 		}, "local"),
+		Entry("COVERAGE_THRESHOLD env", func(j prowapi.ProwJob) string {
+			for _, env := range j.Spec.PodSpec.Containers[0].Env {
+				if env.Name == "COVERAGE_THRESHOLD" {
+					return env.Value
+				}
+			}
+			return ""
+		}, "70"),
 	)
+
+	It("Should use coverage-report.sh entrypoint", func() {
+		args := job.Spec.PodSpec.Containers[0].Args
+		Expect(args).To(HaveLen(1))
+		Expect(args[0]).To(HavePrefix("/usr/local/bin/coverage-report.sh"))
+	})
 
 	DescribeTable("Should include specific coverage targets",
 		func(target string) {
@@ -211,7 +228,7 @@ var _ = Describe("generateCoverageJob", func() {
 			args := job.Spec.PodSpec.Containers[0].Args
 			Expect(args[0]).NotTo(ContainSubstring(target))
 		},
-		Entry("should not run all tests", "go test ./..."),
+		Entry("should not run all tests", "/usr/local/bin/coverage-report.sh ./..."),
 		Entry("should not include github/ci/services e2e tests", "./github/ci/services/..."),
 	)
 
@@ -225,11 +242,17 @@ var _ = Describe("generateCoverageJob", func() {
 		Entry("sidecar", func(j prowapi.ProwJob) string { return j.Spec.DecorationConfig.UtilityImages.Sidecar }),
 	)
 
-	It("Should output coverage artifacts matching Spyglass config", func() {
-		args := job.Spec.PodSpec.Containers[0].Args
-		Expect(args).To(HaveLen(1))
-		Expect(args[0]).To(ContainSubstring("-coverprofile=${ARTIFACTS}/filtered.cov"))
-		Expect(args[0]).To(ContainSubstring("-o ${ARTIFACTS}/filtered.html"))
+	It("Should mount the GitHub token secret", func() {
+		volumeMounts := job.Spec.PodSpec.Containers[0].VolumeMounts
+		Expect(volumeMounts).To(HaveLen(1))
+		Expect(volumeMounts[0].Name).To(Equal("github-token"))
+		Expect(volumeMounts[0].MountPath).To(Equal("/etc/github-commenter"))
+		Expect(volumeMounts[0].ReadOnly).To(BeTrue())
+
+		volumes := job.Spec.PodSpec.Volumes
+		Expect(volumes).To(HaveLen(1))
+		Expect(volumes[0].Name).To(Equal("github-token"))
+		Expect(volumes[0].VolumeSource.Secret.SecretName).To(Equal("commenter-oauth-token"))
 	})
 })
 
@@ -258,10 +281,12 @@ var _ = Describe("Handle", func() {
 			prowJobClient: fakeProwClient.ProwJobs("test-namespace"),
 			config: &Config{
 				Defaults: JobConfig{
-					Namespace: "test-namespace",
-					Image:     "test-image:latest",
-					Cluster:   "test-cluster",
-					GCS:       GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+					Namespace:         "test-namespace",
+					Image:             "test-image:latest",
+					Cluster:           "test-cluster",
+					CoverageThreshold: 70,
+					GitHubTokenSecret: "commenter-oauth-token",
+					GCS:               GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
 					UtilityImages: UtilityImagesConfig{
 						CloneRefs:  "clonerefs:latest",
 						InitUpload: "initupload:latest",
@@ -504,5 +529,182 @@ var _ = Describe("Handle", func() {
 
 			Expect(fakeProwClient.Actions()).To(BeEmpty())
 		})
+	})
+})
+
+var _ = Describe("LoadConfig", func() {
+	var writeConfig func(content string) string
+
+	BeforeEach(func() {
+		writeConfig = func(content string) string {
+			f, err := os.CreateTemp("", "coverage-config-*.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				Expect(os.Remove(f.Name())).To(Succeed())
+			})
+			_, err = f.WriteString(content)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(f.Close()).To(Succeed())
+			return f.Name()
+		}
+	})
+
+	It("Should default coverageThreshold to 70 when not set", func() {
+		path := writeConfig(`
+defaults:
+  namespace: test-ns
+  image: test-image
+  cluster: test-cluster
+  utilityImages:
+    cloneRefs: cr
+    initUpload: iu
+    entrypoint: ep
+    sidecar: sc
+  gcs:
+    bucket: test-bucket
+    credentialsSecret: gcs
+repos:
+  org/repo:
+    testPackages: "./..."
+`)
+		cfg, err := LoadConfig(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Defaults.CoverageThreshold).To(Equal(70))
+	})
+
+	It("Should default githubTokenSecret to commenter-oauth-token when not set", func() {
+		path := writeConfig(`
+defaults:
+  namespace: test-ns
+  image: test-image
+  cluster: test-cluster
+  utilityImages:
+    cloneRefs: cr
+    initUpload: iu
+    entrypoint: ep
+    sidecar: sc
+  gcs:
+    bucket: test-bucket
+    credentialsSecret: gcs
+repos:
+  org/repo:
+    testPackages: "./..."
+`)
+		cfg, err := LoadConfig(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Defaults.GitHubTokenSecret).To(Equal("commenter-oauth-token"))
+	})
+
+	It("Should accept a custom coverageThreshold", func() {
+		path := writeConfig(`
+defaults:
+  namespace: test-ns
+  image: test-image
+  cluster: test-cluster
+  coverageThreshold: 50
+  utilityImages:
+    cloneRefs: cr
+    initUpload: iu
+    entrypoint: ep
+    sidecar: sc
+  gcs:
+    bucket: test-bucket
+    credentialsSecret: gcs
+repos:
+  org/repo:
+    testPackages: "./..."
+`)
+		cfg, err := LoadConfig(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Defaults.CoverageThreshold).To(Equal(50))
+	})
+
+	It("Should reject coverageThreshold greater than 100", func() {
+		path := writeConfig(`
+defaults:
+  namespace: test-ns
+  image: test-image
+  cluster: test-cluster
+  coverageThreshold: 101
+  utilityImages:
+    cloneRefs: cr
+    initUpload: iu
+    entrypoint: ep
+    sidecar: sc
+  gcs:
+    bucket: test-bucket
+    credentialsSecret: gcs
+repos:
+  org/repo:
+    testPackages: "./..."
+`)
+		_, err := LoadConfig(path)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("coverageThreshold must be between 0 and 100"))
+	})
+
+	It("Should reject negative repo coverageThreshold", func() {
+		path := writeConfig(`
+defaults:
+  namespace: test-ns
+  image: test-image
+  cluster: test-cluster
+  utilityImages:
+    cloneRefs: cr
+    initUpload: iu
+    entrypoint: ep
+    sidecar: sc
+  gcs:
+    bucket: test-bucket
+    credentialsSecret: gcs
+repos:
+  org/repo:
+    testPackages: "./..."
+    coverageThreshold: -1
+`)
+		_, err := LoadConfig(path)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("coverageThreshold must be between 0 and 100"))
+	})
+})
+
+var _ = Describe("RepoConfig", func() {
+	It("Should override coverageThreshold per repo", func() {
+		cfg := &Config{
+			Defaults: JobConfig{
+				Namespace:         "ns",
+				CoverageThreshold: 70,
+				GitHubTokenSecret: "default-token",
+			},
+			Repos: map[string]JobConfig{
+				"org/repo": {
+					TestPackages:      "./...",
+					CoverageThreshold: 50,
+				},
+			},
+		}
+
+		repoCfg, ok := cfg.RepoConfig("org/repo")
+		Expect(ok).To(BeTrue())
+		Expect(repoCfg.CoverageThreshold).To(Equal(50))
+		Expect(repoCfg.GitHubTokenSecret).To(Equal("default-token"))
+	})
+
+	It("Should inherit default coverageThreshold when repo does not set one", func() {
+		cfg := &Config{
+			Defaults: JobConfig{
+				Namespace:         "ns",
+				CoverageThreshold: 70,
+			},
+			Repos: map[string]JobConfig{
+				"org/repo": {
+					TestPackages: "./...",
+				},
+			},
+		}
+
+		repoCfg, ok := cfg.RepoConfig("org/repo")
+		Expect(ok).To(BeTrue())
+		Expect(repoCfg.CoverageThreshold).To(Equal(70))
 	})
 })

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
@@ -27,5 +27,6 @@ data:
     repos:
       kubevirt/project-infra:
         testPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/..."
+        coverageThreshold: 25
       kubevirt/ci-health:
         testPackages: "./pkg/... ./cmd/..."

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
@@ -8,6 +8,8 @@ data:
       namespace: kubevirt-prow-jobs
       image: "quay.io/kubevirtci/covreport:latest"
       cluster: kubevirt-prow-control-plane
+      coverageThreshold: 70
+      githubTokenSecret: commenter-oauth-token
       env:
         GO_MOD_PATH: go.mod
         GOTOOLCHAIN: local

--- a/images/covreport/Containerfile
+++ b/images/covreport/Containerfile
@@ -1,5 +1,4 @@
 FROM quay.io/kubevirtci/golang:v20260707-cacb217
 RUN /usr/local/bin/entrypoint.sh /bin/sh -ce "GOBIN=/usr/local/bin go install github.com/cancue/covreport@v0.5.0"
-COPY coverage-report.sh /usr/local/bin/coverage-report.sh
-RUN chmod +x /usr/local/bin/coverage-report.sh
+COPY --chmod=755 coverage-report.sh /usr/local/bin/coverage-report.sh
 

--- a/images/covreport/Containerfile
+++ b/images/covreport/Containerfile
@@ -1,3 +1,5 @@
 FROM quay.io/kubevirtci/golang:v20260707-cacb217
 RUN /usr/local/bin/entrypoint.sh /bin/sh -ce "GOBIN=/usr/local/bin go install github.com/cancue/covreport@v0.5.0"
+COPY coverage-report.sh /usr/local/bin/coverage-report.sh
+RUN chmod +x /usr/local/bin/coverage-report.sh
 

--- a/images/covreport/coverage-report.sh
+++ b/images/covreport/coverage-report.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TEST_PACKAGES="${*}"
+THRESHOLD="${COVERAGE_THRESHOLD:-70}"
+GITHUB_TOKEN_FILE="/etc/github-commenter/oauth"
+GITHUB_API="https://api.github.com"
+STATUS_CONTEXT="coverage-auto"
+SPYGLASS_BASE="https://prow.ci.kubevirt.io/view/gs/kubevirt-prow"
+
+spyglass_url() {
+    echo "${SPYGLASS_BASE}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/"
+}
+
+post_github_status() {
+    local state="$1"
+    local description="$2"
+    local target_url="${3:-}"
+
+    if [[ ! -f "${GITHUB_TOKEN_FILE}" ]]; then
+        echo "WARNING: GitHub token not found, skipping status update"
+        return
+    fi
+
+    local payload
+    payload=$(jq -n \
+        --arg state "${state}" \
+        --arg description "${description}" \
+        --arg context "${STATUS_CONTEXT}" \
+        --arg target_url "${target_url}" \
+        '{state: $state, description: $description, context: $context, target_url: $target_url}')
+
+    curl -s -X POST \
+        -H "Authorization: token $(cat "${GITHUB_TOKEN_FILE}")" \
+        -H "Accept: application/vnd.github.v3+json" \
+        "${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${PULL_PULL_SHA}" \
+        -d "${payload}" > /dev/null || echo "WARNING: Failed to post GitHub commit status"
+}
+
+extract_total_coverage() {
+    local covfile="$1"
+    if [[ ! -f "${covfile}" ]]; then
+        echo "0"
+        return
+    fi
+    go tool cover -func="${covfile}" | awk '/^total:/ { gsub(/%/, "", $NF); print $NF }'
+}
+
+post_github_status "pending" "Running coverage..." "$(spyglass_url)"
+trap 'post_github_status "error" "Coverage script failed" "$(spyglass_url)"' ERR
+
+# Run coverage on PR code
+TEST_EXIT=0
+go test ${TEST_PACKAGES} -coverprofile="${ARTIFACTS}/pr.cov" || TEST_EXIT=$?
+
+if [[ ${TEST_EXIT} -ne 0 ]]; then
+    echo "WARNING: go test exited with ${TEST_EXIT}, coverage profile may be partial"
+fi
+
+if [[ -f "${ARTIFACTS}/pr.cov" ]]; then
+    covreport -i "${ARTIFACTS}/pr.cov" -o "${ARTIFACTS}/filtered.html"
+fi
+
+PR_COVERAGE=$(extract_total_coverage "${ARTIFACTS}/pr.cov")
+echo "PR coverage: ${PR_COVERAGE}%"
+
+# Run coverage on base branch
+BASE_COVERAGE="0"
+CURRENT_HEAD=$(git rev-parse HEAD)
+
+git fetch origin "${PULL_BASE_SHA}" --depth=1 2>/dev/null || true
+if git checkout "${PULL_BASE_SHA}" 2>/dev/null; then
+    if go test ${TEST_PACKAGES} -coverprofile="${ARTIFACTS}/base.cov" 2>/dev/null; then
+        BASE_COVERAGE=$(extract_total_coverage "${ARTIFACTS}/base.cov")
+    else
+        echo "WARNING: Tests failed on base branch, using 0% as base coverage"
+    fi
+    git checkout "${CURRENT_HEAD}" 2>/dev/null || true
+else
+    echo "WARNING: Could not checkout base SHA ${PULL_BASE_SHA}, using 0% as base coverage"
+fi
+echo "Base coverage: ${BASE_COVERAGE}%"
+
+# Compute delta
+DELTA=$(awk "BEGIN { printf \"%.1f\", ${PR_COVERAGE} - ${BASE_COVERAGE} }")
+echo "Coverage delta: ${DELTA}%"
+
+cat > "${ARTIFACTS}/coverage-summary.json" <<EOJSON
+{
+  "pr_coverage": ${PR_COVERAGE},
+  "base_coverage": ${BASE_COVERAGE},
+  "delta": ${DELTA},
+  "threshold": ${THRESHOLD}
+}
+EOJSON
+
+# Post final status
+trap - ERR
+
+DELTA_DISPLAY="${DELTA}"
+if awk "BEGIN { exit !(${DELTA} > 0) }"; then
+    DELTA_DISPLAY="+${DELTA}"
+fi
+
+BELOW_THRESHOLD=false
+if awk "BEGIN { exit !(${PR_COVERAGE} < ${THRESHOLD}) }"; then
+    BELOW_THRESHOLD=true
+fi
+
+TARGET_URL="$(spyglass_url)"
+
+if [[ ${TEST_EXIT} -ne 0 ]]; then
+    post_github_status "error" "${PR_COVERAGE}% (${DELTA_DISPLAY}%) -- tests failed" "${TARGET_URL}"
+elif [[ "${BELOW_THRESHOLD}" == "true" ]]; then
+    post_github_status "failure" "${PR_COVERAGE}% (${DELTA_DISPLAY}%) -- below threshold ${THRESHOLD}%" "${TARGET_URL}"
+else
+    post_github_status "success" "${PR_COVERAGE}% (${DELTA_DISPLAY}%) | threshold: ${THRESHOLD}%" "${TARGET_URL}"
+fi
+
+if [[ -f "${ARTIFACTS}/pr.cov" ]]; then
+    cp "${ARTIFACTS}/pr.cov" "${ARTIFACTS}/filtered.cov"
+fi
+
+if [[ ${TEST_EXIT} -ne 0 ]]; then
+    echo "FAIL: go test failed with exit code ${TEST_EXIT}"
+    exit ${TEST_EXIT}
+fi
+
+if [[ "${BELOW_THRESHOLD}" == "true" ]]; then
+    echo "FAIL: Coverage ${PR_COVERAGE}% is below threshold ${THRESHOLD}%"
+    exit 1
+fi
+
+echo "PASS: Coverage ${PR_COVERAGE}% meets threshold ${THRESHOLD}%"

--- a/images/covreport/coverage-report.sh
+++ b/images/covreport/coverage-report.sh
@@ -21,7 +21,7 @@ post_github_status() {
     local target_url="${3:-}"
 
     if [[ ! -f "${GITHUB_TOKEN_FILE}" ]]; then
-        echo "WARNING: GitHub token not found, skipping status update"
+        echo "WARNING: GitHub token not found, skipping status update" >&2
         return
     fi
 
@@ -37,7 +37,7 @@ post_github_status() {
         -H "Authorization: token $(cat "${GITHUB_TOKEN_FILE}")" \
         -H "Accept: application/vnd.github.v3+json" \
         "${GITHUB_API}/repos/${REPO_OWNER}/${REPO_NAME}/statuses/${PULL_PULL_SHA}" \
-        -d "${payload}" > /dev/null || echo "WARNING: Failed to post GitHub commit status"
+        -d "${payload}" > /dev/null || echo "WARNING: Failed to post GitHub commit status" >&2
 }
 
 extract_total_coverage() {
@@ -57,7 +57,7 @@ TEST_EXIT=0
 go test ${TEST_PACKAGES} -coverprofile="${ARTIFACTS}/pr.cov" || TEST_EXIT=$?
 
 if [[ ${TEST_EXIT} -ne 0 ]]; then
-    echo "WARNING: go test exited with ${TEST_EXIT}, coverage profile may be partial"
+    echo "WARNING: go test exited with ${TEST_EXIT}, coverage profile may be partial" >&2
 fi
 
 if [[ -f "${ARTIFACTS}/pr.cov" ]]; then
@@ -76,11 +76,11 @@ if git checkout "${PULL_BASE_SHA}" 2>/dev/null; then
     if go test ${TEST_PACKAGES} -coverprofile="${ARTIFACTS}/base.cov" 2>/dev/null; then
         BASE_COVERAGE=$(extract_total_coverage "${ARTIFACTS}/base.cov")
     else
-        echo "WARNING: Tests failed on base branch, using 0% as base coverage"
+        echo "WARNING: Tests failed on base branch, using 0% as base coverage" >&2
     fi
     git checkout "${CURRENT_HEAD}" 2>/dev/null || true
 else
-    echo "WARNING: Could not checkout base SHA ${PULL_BASE_SHA}, using 0% as base coverage"
+    echo "WARNING: Could not checkout base SHA ${PULL_BASE_SHA}, using 0% as base coverage" >&2
 fi
 echo "Base coverage: ${BASE_COVERAGE}%"
 
@@ -125,12 +125,12 @@ if [[ -f "${ARTIFACTS}/pr.cov" ]]; then
 fi
 
 if [[ ${TEST_EXIT} -ne 0 ]]; then
-    echo "FAIL: go test failed with exit code ${TEST_EXIT}"
+    echo "FAIL: go test failed with exit code ${TEST_EXIT}" >&2
     exit ${TEST_EXIT}
 fi
 
 if [[ "${BELOW_THRESHOLD}" == "true" ]]; then
-    echo "FAIL: Coverage ${PR_COVERAGE}% is below threshold ${THRESHOLD}%"
+    echo "FAIL: Coverage ${PR_COVERAGE}% is below threshold ${THRESHOLD}%" >&2
     exit 1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds coverage delta computation and a configurable per-repo coverage threshold to the coverage external plugin. When a PR with Go file changes is opened, the coverage job now compares PR coverage against the base branch and posts the result as a GitHub commit status (see below`). If coverage drops below the configured threshold, the job fails.

Previously the plugin only ran coverage on the PR code with no baseline comparison and no minimum enforcement.

The coverage threshold is configurable per repo in the ConfigMap (`coverageThreshold`, default 70%). Repos can override it to match their current baseline.


**Special notes for your reviewer**:
/cc @dhiller @dollierp 
I've created a rehearsal in the git status to show what it will look like. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable coverage acceptance thresholds with sensible defaults.
  * Added support for selecting the GitHub token secret used by coverage reporting.
  * Coverage reporting now produces richer artifacts (including a coverage summary) and automatically posts GitHub commit statuses (pending/success/failure/error).
* **Bug Fixes**
  * Improved validation for coverage threshold values (including per-repo overrides) to prevent invalid settings.
  * Fixed repo-level configuration inheritance/override so defaults and overrides behave consistently.
  * Updated the coverage job to mount and use the configured GitHub token secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->