### PR TITLE
fix(bootstrap): raise container pids_limit from 4096 to 8192

### DIFF
--- a/images/bootstrap/containers.conf
+++ b/images/bootstrap/containers.conf
@@ -3,7 +3,7 @@ netns="private"
 userns="host"
 ipcns="host"
 cgroupns="host"
-pids_limit=4096
+pids_limit=8192
 log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"


### PR DESCRIPTION
**What this PR does / why we need it**:

Raises the Podman `pids_limit` in the bootstrap container image from 4096 to 8192.

## Context

Unit test jobs (e.g. `pull-kubevirt-unit-test`) run 71+ parallel Ginkgo processes via Bazel. Under the current 4096 PID limit, this exhausts available threads, causing `pthread_create` to fail with `EAGAIN` and crashing test processes during GC / initialization. Example failing build:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18376/pull-kubevirt-unit-test/2074442048357797888

Doubling to 8192 provides sufficient headroom for the parallel test workload while keeping the safety net against runaway forks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This change requires rebuilding and publishing the bootstrap image after merge. The image build process checks out `main`, so the change must merge first.

---
🤖 Assisted by Claude