### PR TITLE
kubevirtci: fix GO_MOD_PATH by using entrypoint.sh and correcting path

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -218,7 +218,7 @@ periodics:
     containers:
     - image: quay.io/kubevirtci/golang:v20260703-61a4923
       command:
-      - "/usr/local/bin/runner.sh"
+      - "/usr/local/bin/entrypoint.sh"
       - "/bin/bash"
       - "-ce"
       - |
@@ -249,7 +249,7 @@ periodics:
         rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
       env:
       - name: GO_MOD_PATH
-        value: go.mod
+        value: cluster-provision/gocli/go.mod
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -32,7 +32,7 @@ postsubmits:
         containers:
         - image: quay.io/kubevirtci/golang:v20260703-61a4923
           command:
-          - "/usr/local/bin/runner.sh"
+          - "/usr/local/bin/entrypoint.sh"
           - "/bin/bash"
           - "-c"
           - |
@@ -48,7 +48,7 @@ postsubmits:
           # docker-in-docker needs privileged mode
           env:
           - name: GO_MOD_PATH
-            value: go.mod
+            value: cluster-provision/gocli/go.mod
           securityContext:
             privileged: true
           volumeMounts:
@@ -125,7 +125,7 @@ postsubmits:
         containers:
         - image: quay.io/kubevirtci/golang:v20260703-61a4923
           command:
-          - "/usr/local/bin/runner.sh"
+          - "/usr/local/bin/entrypoint.sh"
           - "/bin/bash"
           - "-c"
           - |
@@ -169,7 +169,7 @@ postsubmits:
           # docker-in-docker needs privileged mode
           env:
           - name: GO_MOD_PATH
-            value: go.mod
+            value: cluster-provision/gocli/go.mod
           securityContext:
             privileged: true
           volumeMounts:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -429,13 +429,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/bash
         - -c
         - cd cluster-provision/gocli/ && make all container
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         image: quay.io/kubevirtci/golang:v20260703-61a4923
         name: ""
         resources:
@@ -494,7 +494,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -ce
         - |
@@ -502,7 +502,7 @@ presubmits:
           podman run --rm -v $(pwd):/workdir:Z quay.io/kubevirtci/gocli provision-manager --debug
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         image: quay.io/kubevirtci/golang:v20260703-61a4923
         name: ""
         resources:
@@ -524,13 +524,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.32 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: SLIM
           value: "true"
         - name: RUN_KUBEVIRT_CONFORMANCE
@@ -556,13 +556,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.33 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: SLIM
           value: "true"
         - name: RUN_KUBEVIRT_CONFORMANCE
@@ -588,13 +588,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: SLIM
           value: "true"
         - name: RUN_KUBEVIRT_CONFORMANCE
@@ -621,13 +621,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         image: quay.io/kubevirtci/golang:v20260703-61a4923
         name: ""
         resources:
@@ -651,13 +651,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.34 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: PROVISION_CENTOS_VERSION
           value: "10"
         image: quay.io/kubevirtci/golang:v20260703-61a4923
@@ -683,13 +683,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.35 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         image: quay.io/kubevirtci/golang:v20260703-61a4923
         name: ""
         resources:
@@ -713,13 +713,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.35 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: PROVISION_CENTOS_VERSION
           value: "10"
         image: quay.io/kubevirtci/golang:v20260703-61a4923
@@ -744,13 +744,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd $(find ./cluster-provision/k8s -name '1.*' | sort -rV | head -1) && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: PHASES
           value: linux
         - name: BYPASS_PMAN_CHANGE_CHECK
@@ -779,13 +779,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.36 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         image: quay.io/kubevirtci/golang:v20260703-61a4923
         name: ""
         resources:
@@ -809,13 +809,13 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - cd cluster-provision/k8s/1.36 && ../provision.sh
         env:
         - name: GO_MOD_PATH
-          value: go.mod
+          value: cluster-provision/gocli/go.mod
         - name: PROVISION_CENTOS_VERSION
           value: "10"
         image: quay.io/kubevirtci/golang:v20260703-61a4923


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes two bugs introduced by #5227 

- runner.sh - entrypoint.sh: All kubevirtci golang-image jobs were still using runner.sh, which does not read GO_MOD_PATH. Only entrypoint.sh (provided by the golang image) reads it, extracts the Go version,
sets GIMME_GO_VERSION, and then delegates to runner.sh.
- go.mod - cluster-provision/gocli/go.mod: GO_MOD_PATH was set to go.mod but kubevirtci has no go.mod at the repo root.

Jobs were passing because the golang image bakes in GIMME_GO_VERSION=1.26.4.

**Special notes for your reviewer**:
/cc @dhiller @dollierp @brianmcarey 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI jobs to use the correct startup behavior and module location, helping presubmit, periodic, and publish runs execute more reliably.
  * Applied the same fix across multiple job types so checks and release-related runs stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->