### PR TITLE
add members to wg-arch-s390x github team in prow config

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -49,7 +49,7 @@ orgs:
       - dankenigsberg
       - dasionov
       - davidvossel
-      - davo911
+      - Davo911
       - dominikholler
       - Dsanatar
       - EdDev
@@ -974,6 +974,15 @@ orgs:
           Ref: https://github.com/kubevirt/community/blob/main/wg-arch-s390x/charter.md
         maintainers:
           - chandramerla
+        members:
+          - ashokpariya0
+          - Davo911
+          - HarshithaMS005
+          - jschintag
+          - laxmi-333
+          - nekkunti
+          - nestoracunablanco
+          - vamsikrishna-siddu
         privacy: closed
       community-team:
         description: "Maintainers of KubeVirt community and websites"


### PR DESCRIPTION
Add the following members to the `wg-arch-s390x` github team to re-run s390x jobs:

- ashokpariya0
- Davo911
- HarshithaMS005
- jschintag
- laxmi-333
- nekkunti
- nestoracunablanco
- vamsikrishna-siddu

The `wg-arch-s390x` github team was created in #5183. This PR adds members to that github team.

**What this PR does / why we need it**:
To allow s390x team members to be able to re-run jobs on prow-s390x-cluster https://github.com/kubevirt/project-infra/pull/5181

**Special notes for your reviewer**:
@dollierp 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the GitHub username capitalization in the kubevirt organization members entry (`davo911` → `Davo911`).
  * Updated the `wg-arch-s390x` team configuration by adding an explicit members list with additional participants, while preserving existing maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->