### PR TITLE
Update jobs using GO_MOD_PATH to use entrypoint.sh instead of runner.sh

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make functest
@@ -54,7 +54,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - /bin/sh
             - -c
             - make functest

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -43,7 +43,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -84,7 +84,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -122,7 +122,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -159,7 +159,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -210,7 +210,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -248,7 +248,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -289,7 +289,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -327,7 +327,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -368,7 +368,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -406,7 +406,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -447,7 +447,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -485,7 +485,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -526,7 +526,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -568,7 +568,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - |
@@ -611,7 +611,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -652,7 +652,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -693,7 +693,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -768,7 +768,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - |
@@ -812,7 +812,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -43,7 +43,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -84,7 +84,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -125,7 +125,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -166,7 +166,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -204,7 +204,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -241,7 +241,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -292,7 +292,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -330,7 +330,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -371,7 +371,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -409,7 +409,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -450,7 +450,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -488,7 +488,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -529,7 +529,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -567,7 +567,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -608,7 +608,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -650,7 +650,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - "/bin/sh"
         - "-c"
         - |
@@ -693,7 +693,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -734,7 +734,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -775,7 +775,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - "make kubevirt-up && make kubevirt-sync && make kubevirt-functest"
@@ -850,7 +850,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - |
@@ -894,7 +894,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - "/bin/sh"
             - "-c"
             - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -20,7 +20,7 @@ periodics:
   spec:
     containers:
     - command:
-      - /usr/local/bin/runner.sh
+      - /usr/local/bin/entrypoint.sh
       - /bin/sh
       - -c
       - ./pipeline-periodic.sh
@@ -61,7 +61,7 @@ periodics:
   spec:
     containers:
     - command:
-      - /usr/local/bin/runner.sh
+      - /usr/local/bin/entrypoint.sh
       - /bin/sh
       - -c
       - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make test
@@ -40,7 +40,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make medius
@@ -69,7 +69,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -102,7 +102,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -137,7 +137,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - /usr/local/bin/runner.sh
+            - /usr/local/bin/entrypoint.sh
             - /bin/sh
             - -c
             - ./pipeline.sh
@@ -172,7 +172,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -206,7 +206,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -241,7 +241,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -275,7 +275,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -310,7 +310,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -344,7 +344,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -379,7 +379,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -413,7 +413,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -448,7 +448,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -482,7 +482,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh
@@ -517,7 +517,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - ./pipeline.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
@@ -21,7 +21,7 @@ presubmits:
         containers:
           - image: quay.io/kubevirtci/golang:v20260417-7427ea2
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/sh"
               - "-c"
               - "export TARGET=k8s-1.34 && automation/test.sh"
@@ -57,7 +57,7 @@ presubmits:
         containers:
           - image: quay.io/kubevirtci/golang:v20260417-7427ea2
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/sh"
               - "-c"
               - "export TARGET=k8s-1.35 && automation/test.sh"
@@ -89,7 +89,7 @@ presubmits:
               - name: GO_MOD_PATH
                 value: "go.mod"
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/sh"
               - "-c"
               - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
         containers:
           - image: quay.io/kubevirtci/golang:v20260707-cacb217
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/sh"
               - "-c"
               - "export TARGET=k8s-1.35 && automation/test.sh"
@@ -63,7 +63,7 @@ presubmits:
         containers:
           - image: quay.io/kubevirtci/golang:v20260707-cacb217
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/sh"
               - "-c"
               - "export TARGET=k8s-1.36 && automation/test.sh"
@@ -99,7 +99,7 @@ presubmits:
               - name: GO_MOD_PATH
                 value: "go.mod"
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/bash"
               - "-c"
               - |
@@ -133,7 +133,7 @@ presubmits:
               - name: GO_MOD_PATH
                 value: "go.mod"
             command:
-              - "/usr/local/bin/runner.sh"
+              - "/usr/local/bin/entrypoint.sh"
               - "/bin/sh"
               - "-c"
               - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.2.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make all
@@ -44,7 +44,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make container-build
@@ -74,7 +74,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make test
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -133,7 +133,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make build-installer build-installer-openshift

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
   spec:
     containers:
     - command:
-      - /usr/local/bin/runner.sh
+      - /usr/local/bin/entrypoint.sh
       - /bin/sh
       - -c
       - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-postsubmits.yaml
@@ -21,7 +21,7 @@ postsubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make all
@@ -44,7 +44,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make container-build
@@ -74,7 +74,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make test
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - "make cluster-up && make cluster-sync && make cluster-functest"
@@ -133,7 +133,7 @@ presubmits:
     spec:
       containers:
       - command:
-        - /usr/local/bin/runner.sh
+        - /usr/local/bin/entrypoint.sh
         - /bin/sh
         - -c
         - make build-installer build-installer-openshift


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up to #5248. Multiple jobs across the repo define `GO_MOD_PATH` but use runner.sh, which does not read it. Only `entrypoint.sh` reads `GO_MOD_PATH`, extracts the Go version from the specified go.mod, and sets `GIMME_GO_VERSION` before triggering `runner.sh`.

This switches all `GO_MOD_PATH` jobs to use `entrypoint.sh`. Without this change, the env var is ignored and the Go version falls back to whatever is baked into the container image.

Affected repos:
- kubevirt/containerdisks
- kubevirt/common-instancetypes
- kubevirt/hyperconverged-cluster-operator
- kubevirt/virt-template
- kubernetes-sigs/cluster-api-provider-kubevirt

**Special notes for your reviewer**:
/cc @dollierp @dhiller 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple CI jobs across several KubeVirt components to start with a new container entrypoint.
  * Applied consistently to presubmit, periodic, and postsubmit jobs, with no changes to test targets, environments, or resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->