### PR TITLE
fix(ginkgo-tests): provide go toolchain

### DIFF
--- a/images/ginkgo-tests/Containerfile
+++ b/images/ginkgo-tests/Containerfile
@@ -1,9 +1,6 @@
-FROM quay.io/kubevirtci/golang:v20260707-cacb217 as builder
+# Not using a staged build here as ginkgo-tests internally calls ginkgo which in
+# turn compiles the test suite. This requires the full Go toolchain
+FROM quay.io/kubevirtci/golang:v20260707-cacb217
 RUN cd /project-infra && \
     /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/ginkgo-tests ./robots/ginkgo-tests"
-RUN dnf install -y \
-    ripgrep
-FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
-COPY --from=builder /go/bin/ginkgo-tests /usr/bin/ginkgo-tests
-COPY --from=builder /usr/bin/rg /usr/bin/rg
-ENTRYPOINT ["/usr/bin/ginkgo-tests"]
+ENTRYPOINT ["/usr/local/bin/runner.sh", "/go/bin/ginkgo-tests"]

--- a/images/ginkgo-tests/Containerfile
+++ b/images/ginkgo-tests/Containerfile
@@ -3,4 +3,4 @@
 FROM quay.io/kubevirtci/golang:v20260707-cacb217
 RUN cd /project-infra && \
     /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/ginkgo-tests ./robots/ginkgo-tests"
-ENTRYPOINT ["/usr/local/bin/runner.sh", "/go/bin/ginkgo-tests"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "/go/bin/ginkgo-tests"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since ginkgo-tests calls ginkgo internally which in turn compiles the test suite, we base the image on the golang image instead.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
- Partially addresses https://github.com/kubevirt/kubevirt/issues/18393

**Special notes for your reviewer**:
/cc @dollierp @Whitedyl 

Tested together locally with https://github.com/kubevirt/kubevirt/pull/18394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the test container setup to build and run the test binary directly from a single Go image.
  * Removed an extra image build step and unrelated bundled tooling, reducing container complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->