### PR TITLE
chore(istio): bump istio image versions

### DIFF
--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -5,7 +5,6 @@ docker.io,kindest/node:v1.25.2,quay.io/kubevirtci
 docker.io,kindest/node:v1.27.1,quay.io/kubevirtci
 docker.io,grafana/grafana:7.5.4,quay.io/kubevirtci
 docker.io,istio/install-cni:1.30.2,quay.io/kubevirtci
-docker.io,istio/operator:1.30.2,quay.io/kubevirtci
 docker.io,istio/pilot:1.30.2,quay.io/kubevirtci
 docker.io,istio/proxyv2:1.30.2,quay.io/kubevirtci
 docker.io,rpardini/docker-registry-proxy:0.6.2,quay.io/kubevirtci

--- a/hack/images_to_mirror.csv
+++ b/hack/images_to_mirror.csv
@@ -4,8 +4,8 @@ docker.io,kindest/node:v1.23.13,quay.io/kubevirtci
 docker.io,kindest/node:v1.25.2,quay.io/kubevirtci
 docker.io,kindest/node:v1.27.1,quay.io/kubevirtci
 docker.io,grafana/grafana:7.5.4,quay.io/kubevirtci
-docker.io,istio/install-cni:1.15.0,quay.io/kubevirtci
-docker.io,istio/operator:1.15.0,quay.io/kubevirtci
-docker.io,istio/pilot:1.15.0,quay.io/kubevirtci
-docker.io,istio/proxyv2:1.15.0,quay.io/kubevirtci
+docker.io,istio/install-cni:1.30.2,quay.io/kubevirtci
+docker.io,istio/operator:1.30.2,quay.io/kubevirtci
+docker.io,istio/pilot:1.30.2,quay.io/kubevirtci
+docker.io,istio/proxyv2:1.30.2,quay.io/kubevirtci
 docker.io,rpardini/docker-registry-proxy:0.6.2,quay.io/kubevirtci


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

https://github.com/kubevirt/kubevirtci/pull/1757 bumps istio versions in kubevirtci - this bumps the mirroring of the referenced images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
FYI @orelmisan 

/cc @dollierp @Whitedyl 