### PR TITLE
chore(jobs): enable job decoration globally by default

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
   - name: periodic-publish-kubemacpool-flakefinder-weekly-report
     cron: "50 0 * * *"
-    decorate: true
     cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
@@ -40,7 +39,6 @@ periodics:
     cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20260711-7a66da0
@@ -75,7 +73,6 @@ periodics:
     interval: 168h
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-postsubmits.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: main-kubemacpool
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -28,7 +27,6 @@ postsubmits:
     - name: stable-branch-kubemacpool
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -56,7 +54,6 @@ postsubmits:
     - name: release-kubemacpool
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.20.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-v0.20
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-v0.20
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.21.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-v0.21
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-v0.21
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.26.yaml
@@ -8,7 +8,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.31.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-v0.31
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-v0.31
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.33.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.33.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.33
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.33
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.38.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-v0.38
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-v0.38
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.39.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.39
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.39
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.40.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.40.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.40
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.40
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.41.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.41.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.41
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.41
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.42.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.42
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.42
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.43.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.43
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.43
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.44.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.44
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.44
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.45.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.45.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.45
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.45
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.47.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.47.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.47
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.47
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.49.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.49
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.49
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.50.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.50.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.50
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.50
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.51.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.51.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.51
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.51
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits.yaml
@@ -9,7 +9,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -38,7 +37,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.19.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.19.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.19
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.26.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.26.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.26
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.29.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.29.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.29
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.31.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.31
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.32.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.32.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.32
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.34.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.34
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.36.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits-0.36.yaml
@@ -7,7 +7,6 @@ presubmits:
         - release-0.36
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/ovs-cni/ovs-cni-presubmits.yaml
@@ -9,7 +9,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubernetes-sigs/cluster-api-provider-kubevirt/cluster-api-provider-kubevirt-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-kubevirt:
   - always_run: true
     optional: true
-    decorate: true
     skip_report: true
     cluster: prow-workloads
     decoration_config:
@@ -37,7 +36,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     optional: true
-    decorate: true
     skip_report: true
     cluster: prow-workloads
     decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ansible-kubevirt-modules/ansible-kubevirt-modules-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     cluster: prow-workloads
     decoration_config:
       timeout: 7h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
@@ -9,7 +9,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -47,7 +46,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -84,7 +82,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -122,7 +119,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -161,7 +157,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.1.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.1
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.2.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.2
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.3.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.3
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.4.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.4
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.5.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.5
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.6.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.6
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.7.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.7
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.8.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.8
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -37,7 +36,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-postsubmits.yaml
@@ -3,7 +3,6 @@ postsubmits:
     - name: main-bridge-marker
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -29,7 +28,6 @@ postsubmits:
     - name: release-bridge-marker
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.6.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.6
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits-0.9.1.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.9.1
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/bridge-marker/bridge-marker-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-postsubmits.yaml
@@ -10,7 +10,6 @@ postsubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-gcs-credentials: "true"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-ci-health-test
     run_if_changed: "cmd/.*|e2e/.*|pkg/.*|go\\..*"
     optional: false
-    decorate: true
     cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cloud-provider-kubevirt/cloud-provider-kubevirt-presubmits.yaml
@@ -10,7 +10,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -48,7 +47,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -79,7 +77,6 @@ presubmits:
   - name: pull-kubevirt-cloud-provider-kubevirt-e2e
     always_run: true
     optional: false
-    decorate: true
     cluster: prow-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -6,7 +6,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -28,7 +27,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -50,7 +48,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -67,7 +64,6 @@ periodics:
       - --pr_base_branch=main
 - name: periodic-cnao-workflow-k8s-nightly
   cron: "2 2 * * *"
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -7,7 +7,6 @@ postsubmits:
       - ^release-.*$
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.100.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.100.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.100
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.100
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.101.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.101.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.101
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.101
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.102.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.102.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.102
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.102
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.27
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.27
       always_run: false
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.27
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.27
       always_run: false
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.39
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.39
       always_run: false
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.39
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.39
       always_run: false
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.42.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.42
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 10m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.42
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.42
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -95,7 +92,6 @@ presubmits:
         - release-0.42
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.44
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 10m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.44
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.44
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -95,7 +92,6 @@ presubmits:
         - release-0.44
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -128,7 +124,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -161,7 +156,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -194,7 +188,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -227,7 +220,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -260,7 +252,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.53
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 10m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.53
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.53
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -95,7 +92,6 @@ presubmits:
         - release-0.53
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -128,7 +124,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -161,7 +156,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -194,7 +188,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -227,7 +220,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -260,7 +252,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 10m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -95,7 +92,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -126,7 +122,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -157,7 +152,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -188,7 +182,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -219,7 +212,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -250,7 +242,6 @@ presubmits:
         - release-0.58
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -126,7 +122,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -157,7 +152,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -188,7 +182,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -219,7 +212,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -253,7 +245,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -284,7 +275,6 @@ presubmits:
         - release-0.65
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -126,7 +122,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -157,7 +152,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -188,7 +182,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -219,7 +212,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -250,7 +242,6 @@ presubmits:
         - release-0.76
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.79.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -127,7 +123,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -156,7 +151,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -187,7 +181,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -218,7 +211,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -249,7 +241,6 @@ presubmits:
         - release-0.79
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.85.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -127,7 +123,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -156,7 +151,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -187,7 +181,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -218,7 +211,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -249,7 +241,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -280,7 +271,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -311,7 +301,6 @@ presubmits:
         - release-0.85
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.89.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.89.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -127,7 +123,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -156,7 +151,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -187,7 +181,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -218,7 +211,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -249,7 +241,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -280,7 +271,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -311,7 +301,6 @@ presubmits:
         - release-0.89
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.91.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.91.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -96,7 +93,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -127,7 +123,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -156,7 +151,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -187,7 +181,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -218,7 +211,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -249,7 +241,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -280,7 +271,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -311,7 +301,6 @@ presubmits:
         - release-0.91
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.93.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.93.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.93
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.93
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.95.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.95.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.95
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.95
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.97.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.97.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.97
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.97
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.99.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.99.yaml
@@ -5,7 +5,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -92,7 +89,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -122,7 +118,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -150,7 +145,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -180,7 +174,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -210,7 +203,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -240,7 +232,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -271,7 +262,6 @@ presubmits:
         - release-0.99
       always_run: true
       optional: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -301,7 +291,6 @@ presubmits:
       branches:
         - release-0.99
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 4h
         grace_period: 5m
@@ -40,7 +39,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -72,7 +70,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -103,7 +100,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -135,7 +131,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -168,7 +163,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -199,7 +193,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -232,7 +225,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -265,7 +257,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -298,7 +289,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -330,7 +320,6 @@ presubmits:
       annotations:
         fork-per-release: "true"
       always_run: true
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h
@@ -363,7 +352,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       skip_report: false
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-0.1
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "^common.*yaml"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-0.3
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "^common.*yaml"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.4.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-0.4
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -63,7 +61,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -99,7 +96,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -135,7 +131,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -171,7 +166,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -207,7 +201,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -243,7 +236,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.0.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.0
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -65,7 +63,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -103,7 +100,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -141,7 +137,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -179,7 +174,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -217,7 +211,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -255,7 +248,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -295,7 +287,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.0
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -329,7 +320,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -367,7 +357,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -405,7 +394,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -443,7 +431,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -484,7 +471,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.1
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -65,7 +63,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -103,7 +100,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -141,7 +137,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -179,7 +174,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -217,7 +211,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -255,7 +248,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -293,7 +285,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -331,7 +322,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -371,7 +361,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.1
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -405,7 +394,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -443,7 +431,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -481,7 +468,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -519,7 +505,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -560,7 +545,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.2
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -65,7 +63,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -103,7 +100,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -141,7 +137,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -179,7 +174,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -217,7 +211,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -255,7 +248,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -293,7 +285,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -331,7 +322,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -371,7 +361,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.2
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -405,7 +394,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -443,7 +431,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -481,7 +468,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -519,7 +505,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -560,7 +545,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.3
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -27,7 +26,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -67,7 +65,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -107,7 +104,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -147,7 +143,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -187,7 +182,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -227,7 +221,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -267,7 +260,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -307,7 +299,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -347,7 +338,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*|tests/image/validationos.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -390,7 +380,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -430,7 +419,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -470,7 +458,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -509,7 +496,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.3
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -543,7 +529,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -586,7 +571,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.4
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -28,7 +27,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -68,7 +66,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -108,7 +105,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -144,7 +140,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -184,7 +179,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -224,7 +218,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -264,7 +257,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -304,7 +296,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -344,7 +335,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -384,7 +374,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*|tests/image/validationos.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -427,7 +416,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -467,7 +455,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -507,7 +494,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -546,7 +532,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.4
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -580,7 +565,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -623,7 +607,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.5
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -28,7 +27,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -68,7 +66,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -108,7 +105,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -149,7 +145,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -189,7 +184,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -229,7 +223,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -269,7 +262,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -309,7 +301,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -349,7 +340,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -389,7 +379,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*|tests/image/validationos.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -432,7 +421,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -472,7 +460,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -512,7 +499,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -551,7 +537,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.5
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -585,7 +570,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -628,7 +612,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -4,7 +4,6 @@ presubmits:
       branches:
         - release-1.6
       always_run: true
-      decorate: true
       decoration_config:
         timeout: 3h
       max_concurrency: 5
@@ -28,7 +27,6 @@ presubmits:
       always_run: false
       run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -68,7 +66,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -108,7 +105,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-s390x-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -147,7 +143,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -187,7 +182,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -227,7 +221,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -267,7 +260,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -307,7 +299,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -347,7 +338,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -387,7 +377,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*|tests/image/validationos.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -430,7 +419,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -470,7 +458,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -510,7 +497,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -549,7 +535,6 @@ presubmits:
       run_if_changed: "image/.*"
       branches:
         - release-1.6
-      decorate: true
       decoration_config:
         timeout: 1h
       max_concurrency: 1
@@ -583,7 +568,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s
@@ -626,7 +610,6 @@ presubmits:
       always_run: false
       run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - release-1.7
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -28,7 +27,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -68,7 +66,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -108,7 +105,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -145,7 +141,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -191,7 +186,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -231,7 +225,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -268,7 +261,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -308,7 +300,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -345,7 +336,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -385,7 +375,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -422,7 +411,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -462,7 +450,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -499,7 +486,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -539,7 +525,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*|tests/image/validationos.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -582,7 +567,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -622,7 +606,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -662,7 +645,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -701,7 +683,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - release-1.7
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -735,7 +716,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -778,7 +758,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
     cron: 0 2 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -43,7 +42,6 @@ periodics:
     cron: 0 2 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -83,7 +81,6 @@ periodics:
     cron: 0 2 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -123,7 +120,6 @@ periodics:
     cron: 0 2 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -163,7 +159,6 @@ periodics:
     cron: 0 2 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -203,7 +198,6 @@ periodics:
     cron: 0 5 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -243,7 +237,6 @@ periodics:
     cron: 0 5 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -283,7 +276,6 @@ periodics:
     cron: 0 4 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -335,7 +327,6 @@ periodics:
     cron: 0 4 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -374,7 +365,6 @@ periodics:
     cron: 0 3 * * *
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
@@ -5,7 +5,6 @@ postsubmits:
       run_if_changed: "image/.*"
       branches:
         - main
-      decorate: true
       decoration_config:
         timeout: 1h
       max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -4,7 +4,6 @@ presubmits:
     branches:
       - main
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 5
@@ -28,7 +27,6 @@ presubmits:
     always_run: false
     run_if_changed: "instancetypes/.*|preferences/.*|scripts/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -68,7 +66,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/rhel/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -108,7 +105,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/rhel/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -148,7 +144,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -188,7 +183,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -225,7 +219,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -271,7 +264,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -311,7 +303,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -348,7 +339,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -388,7 +378,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -425,7 +414,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -465,7 +453,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -502,7 +489,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -542,7 +528,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -579,7 +564,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/leap/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -619,7 +603,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/windows/11/.*|tests/functests/.*|tests/vendor/.*|tests/go.*|tests/image/validationos.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -662,7 +645,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -702,7 +684,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -742,7 +723,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/debian/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -781,7 +761,6 @@ presubmits:
     run_if_changed: "image/.*"
     branches:
       - main
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -815,7 +794,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -858,7 +836,6 @@ presubmits:
     always_run: false
     run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/oraclelinux/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-periodics.yaml
@@ -14,7 +14,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   spec:
     containers:
     - args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-postsubmits.yaml
@@ -14,7 +14,6 @@ postsubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-github-credentials: "true"
-    decorate: true
     spec:
       containers:
       - args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   kubevirt/community:
   - always_run: true
     cluster: kubevirt-prow-control-plane
-    decorate: true
     extra_refs:
     - org: kubevirt
       repo: project-infra
@@ -28,7 +27,6 @@ presubmits:
             memory: "1Gi"
   - always_run: false
     cluster: kubevirt-prow-control-plane
-    decorate: true
     extra_refs:
     - org: kubevirt
       repo: project-infra
@@ -56,7 +54,6 @@ presubmits:
             memory: "1Gi"
   - always_run: false
     cluster: kubevirt-prow-control-plane
-    decorate: true
     extra_refs:
     - org: kubevirt
       repo: project-infra
@@ -79,7 +76,6 @@ presubmits:
             memory: "1Gi"
   - always_run: false
     cluster: kubevirt-prow-control-plane
-    decorate: true
     extra_refs:
     - org: kubevirt
       repo: project-infra

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-periodics.yaml
@@ -4,7 +4,6 @@ periodics:
     testgrid-alert-email: nestor.acuna@ibm.com, ashok.pariya@ibm.com
   cluster: prow-s390x-workloads
   cron: 0 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 7h0m0s
@@ -42,7 +41,6 @@ periodics:
     testgrid-alert-email: fmatouschek@redhat.com, lyarwood@redhat.com
   cluster: prow-workloads
   cron: 0 2 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -30,7 +29,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -55,7 +53,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -88,7 +85,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -121,7 +117,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -155,7 +150,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -189,7 +183,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -222,7 +215,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -256,7 +248,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -289,7 +280,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -323,7 +313,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -356,7 +345,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -390,7 +378,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -423,7 +410,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -457,7 +443,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -490,7 +475,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -6,7 +6,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -28,7 +27,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -50,7 +48,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -70,7 +67,6 @@ periodics:
 # multi-arch manifest
 - name: periodic-containerized-data-importer-push-nightly
   cron: "2 3 * * *"
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 2h
       grace_period: 5m
@@ -45,7 +44,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 2h
       grace_period: 5m
@@ -80,7 +78,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -120,7 +117,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -161,7 +157,6 @@ postsubmits:
     run_if_changed: "hack/build/docker/builder/.*"
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -197,7 +192,6 @@ postsubmits:
     annotations:
       testgrid-create-test-group: "false"
     always_run: true
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.34.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.34.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-v1.34
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
       - release-v1.34
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-v1.38
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -36,7 +35,6 @@ presubmits:
       - release-v1.38
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -69,7 +67,6 @@ presubmits:
     cluster: prow-workloads
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -97,7 +94,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -126,7 +122,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -155,7 +150,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: prow-workloads
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -64,7 +62,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -93,7 +90,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -121,7 +117,6 @@ presubmits:
       - release-v1.43
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -153,7 +148,6 @@ presubmits:
       - release-v1.43
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: prow-workloads
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -64,7 +62,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -93,7 +90,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -121,7 +117,6 @@ presubmits:
       - release-v1.49
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -153,7 +148,6 @@ presubmits:
       - release-v1.49
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -10,7 +10,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -39,7 +38,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -65,7 +63,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -109,7 +106,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -141,7 +137,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -173,7 +168,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -205,7 +199,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -235,7 +228,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -274,7 +266,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -313,7 +304,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: false
     optional: true
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -352,7 +342,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -395,7 +384,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -438,7 +426,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 6h
       grace_period: 10m
@@ -477,7 +464,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 6h
       grace_period: 10m
@@ -550,7 +536,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 10m
@@ -589,7 +574,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -628,7 +612,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -667,7 +650,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -707,7 +689,6 @@ presubmits:
       testgrid-dashboards: kubevirt-containerized-data-importer-presubmits
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/controller-lifecycle-operator-sdk/controller-lifecycle-operator-sdk-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-controller-lifecycle-operator-sdk-e2e
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
       skip_report: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 15m
@@ -45,7 +44,6 @@ postsubmits:
       skip_report: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -10,7 +10,6 @@ presubmits:
       always_run: true
       optional: false
       skip_report: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -46,7 +45,6 @@ presubmits:
       always_run: true
       optional: false
       skip_report: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -82,7 +80,6 @@ presubmits:
       always_run: true
       optional: false
       skip_report: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -118,7 +115,6 @@ presubmits:
       always_run: true
       optional: false
       skip_report: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -156,7 +152,6 @@ presubmits:
       always_run: true
       optional: false
       skip_report: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -194,7 +189,6 @@ presubmits:
       always_run: true
       optional: false
       skip_report: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -231,7 +225,6 @@ presubmits:
       always_run: false
       skip_report: true
       optional: true
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 10m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -49,7 +48,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -88,7 +86,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 15m
@@ -50,7 +49,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 15m
@@ -90,7 +88,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -40,7 +39,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -73,7 +71,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -106,7 +103,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -136,7 +132,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -171,7 +166,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: periodic-hco-push-nightly-build-main
   cron: "2 4 * * *"
-  decorate: true
   annotations:
     testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-periodics
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -5,7 +5,6 @@ postsubmits:
       run_if_changed: "tests/build/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -40,7 +39,6 @@ postsubmits:
       run_if_changed: ^hack/builder/.*|^go\.mod$
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.10.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.10
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -39,7 +38,6 @@ presubmits:
       - release-1.10
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.11.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.11.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.11
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -39,7 +38,6 @@ presubmits:
       - release-1.11
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.12.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.12.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.12
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       - release-1.12
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.13.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.13.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.13
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.14.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.14.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.14
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       - release-1.14
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.15.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.15
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       - release-1.15
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.16.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.16.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.16
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
     - release-1.16
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
@@ -5,7 +5,6 @@ presubmits:
       - release-1.17
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       - release-1.17
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -77,7 +75,6 @@ presubmits:
         - release-1.17
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
@@ -5,7 +5,6 @@ presubmits:
         - release-1.18
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       - release-1.18
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -77,7 +75,6 @@ presubmits:
         - release-1.18
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.2.yaml
@@ -3,7 +3,6 @@ presubmits:
   - always_run: true
     branches:
     - release-1.2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.3.yaml
@@ -3,7 +3,6 @@ presubmits:
   - always_run: true
     branches:
     - release-1.3
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.4.yaml
@@ -5,7 +5,6 @@ presubmits:
     branches:
     - release-1.4
     optional: false
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.5.yaml
@@ -5,7 +5,6 @@ presubmits:
     branches:
     - release-1.5
     optional: false
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -36,7 +35,6 @@ presubmits:
     - release-1.5
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.6.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.6
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.7.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.7
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.8.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.8
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.9.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.9
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
@@ -3,7 +3,6 @@ presubmits:
   - always_run: true
     branches:
     - release-2.3
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -32,7 +31,6 @@ presubmits:
   - always_run: true
     branches:
     - release-2.3
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.4.yaml
@@ -3,7 +3,6 @@ presubmits:
   - always_run: true
     branches:
     - release-2.4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -32,7 +31,6 @@ presubmits:
 #  - always_run: true
 #    branches:
 #    - release-2.4
-#    decorate: true
 #    decoration_config:
 #      grace_period: 5m0s
 #      timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -47,7 +46,6 @@ presubmits:
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 7h
         grace_period: 5m
@@ -85,7 +83,6 @@ presubmits:
       run_if_changed: "tests/build/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -121,7 +118,6 @@ presubmits:
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/iommufd-device-plugin/iommufd-device-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/iommufd-device-plugin/iommufd-device-plugin-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -44,7 +43,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/iommufd-device-plugin/iommufd-device-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/iommufd-device-plugin/iommufd-device-plugin-presubmits.yaml
@@ -10,7 +10,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -48,7 +47,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -86,7 +84,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -124,7 +121,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: periodic-kubectl-virt-plugin-publish
   cron: "0 0 * * *"
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubectl-virt-plugin/kubectl-virt-plugin-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
     always_run: false
     run_if_changed: "scripts/.*"
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-workloads
       decoration_config:
         timeout: 3h
@@ -43,7 +42,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s
@@ -68,7 +66,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -44,7 +43,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie-webhook/kubevirt-aie-webhook-presubmits.yaml
@@ -10,7 +10,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -48,7 +47,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -86,7 +84,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m
@@ -124,7 +121,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
   cron: "0 6 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 1h
   max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: false
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
@@ -4,7 +4,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -32,7 +31,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -63,7 +61,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -93,7 +90,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -123,7 +119,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -150,7 +145,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -196,7 +190,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 15m
@@ -49,7 +48,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -89,7 +87,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 15m
@@ -127,7 +124,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -42,7 +41,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -72,7 +70,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -48,7 +47,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -88,7 +86,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 15m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -42,7 +41,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -72,7 +70,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
@@ -9,7 +9,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -58,7 +57,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -31,7 +30,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -53,7 +51,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/tekton-tasks-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-tekton-tasks/tekton-tasks-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
     cron: 0 2 * * 1
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1
@@ -45,7 +44,6 @@ periodics:
     cron: 0 2 * * 1
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
     max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: periodic-kvp-push-nightly-build-main
   cron: "2 2 * * *"
-  decorate: true
   annotations:
     testgrid-dashboards: kubevirt-velero-plugin-periodics
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -45,7 +44,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -80,7 +78,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-presubmits.yaml
@@ -9,7 +9,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -40,7 +39,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 4h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
   - interval: 24h
     name: kubevirt-io-periodic-link-checker
-    decorate: true
     annotations:
       testgrid-create-test-group: "false"
     extra_refs:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-postsubmits.yaml
@@ -9,7 +9,6 @@ postsubmits:
       preset-shared-images: "true"
     labels:
       preset-github-credentials: "true"
-    decorate: true
     extra_refs:
     - org: kubevirt
       repo: project-infra

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt.github.io/kubevirt-github-io-presubmits.yaml
@@ -1,7 +1,6 @@
 presubmits:
   kubevirt/kubevirt.github.io:
   - name: kubevirt-io-presubmit-link-checker
-    decorate: true
     always_run: true
     skip_report: false
     cluster: kubevirt-prow-control-plane
@@ -18,7 +17,6 @@ presubmits:
     - ^main$
     labels:
       preset-github-credentials: "true"
-    decorate: true
     always_run: true
     cluster: kubevirt-prow-control-plane
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 5 * * * *
-  decorate: true
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
@@ -29,7 +28,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 45 0 * * *
-  decorate: true
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
@@ -58,7 +56,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 25 0 * * *
-  decorate: true
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
@@ -84,7 +81,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 25 1 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -111,7 +107,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 30 3 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -153,7 +148,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 45 3 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -185,7 +179,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: '*/30 * * * *'
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -215,7 +208,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 25 1 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -249,7 +241,6 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   cluster: prow-workloads
   cron: 0 0 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -295,7 +286,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
   cron: 2 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -385,7 +375,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 2 15 */7 * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -421,7 +410,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
   cron: 30 2 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 7h0m0s
@@ -459,7 +447,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
   cron: 0 22, 10 * * *
-  decorate: true
   decoration_config:
     grace_period: 30m0s
     timeout: 4h0m0s
@@ -525,7 +512,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 23 * * 6
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -569,7 +555,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 15 22 * * 0
-  decorate: true
   decoration_config:
     timeout: 1h0m0s
   extra_refs:
@@ -616,7 +601,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 15 22 * * 0
-  decorate: true
   decoration_config:
     timeout: 1h0m0s
   extra_refs:
@@ -664,7 +648,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-arm64-workloads
   cron: 40 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -708,7 +691,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-arm64-workloads
   cron: 40 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -759,7 +741,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 30 4,12,20,00 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -837,7 +818,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-arm64-workloads
   cron: 40 4 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 2h0m0s
@@ -868,7 +848,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-s390x-workloads
   cron: 40 5 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 2h0m0s
@@ -896,7 +875,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: kubevirt-prow-control-plane
   cron: 40 4 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -968,7 +946,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: kubevirt-prow-control-plane
   cron: 40 15 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1051,7 +1028,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 0,8,16 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 6h0m0s
@@ -1117,7 +1093,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 2,10,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1178,7 +1153,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1243,7 +1217,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 0 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -1305,7 +1278,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 30 2,8,14,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1351,7 +1323,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: amd-workloads
   cron: 20 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1393,7 +1364,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 12 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1442,7 +1412,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 6,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1490,7 +1459,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 9,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -1540,7 +1508,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 3,15 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1587,7 +1554,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 5 7 * * 6
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -1632,7 +1598,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 45 6 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -1661,7 +1626,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 45 7 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -1693,7 +1657,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 45 1 * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -1733,7 +1696,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: 45 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -1799,7 +1761,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 0,12 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 3h0m0s
@@ -1845,7 +1806,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 1,7,13,19 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1893,7 +1853,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 25 0,6,12,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1939,7 +1898,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 15 1,7,13,19 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1985,7 +1943,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 0,6,12,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -2035,7 +1992,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 50 0,6,12,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2081,7 +2037,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 55 2,8,14,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2127,7 +2082,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 45 3,9,15,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2173,7 +2127,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 5 2,8,14,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -2223,7 +2176,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 3,9,15,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2269,7 +2221,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: kubevirt-prow-control-plane
   cron: 30 4,12,20,00 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2342,7 +2293,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
   cron: 3 * * * *
-  decorate: true
   extra_refs:
   - base_ref: main
     org: kubevirt
@@ -2384,7 +2334,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 35 4,10,16,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2430,7 +2379,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 25 5,11,17,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2476,7 +2424,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 4,10,16,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -2526,7 +2473,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 5,11,17,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -12,7 +12,6 @@ postsubmits:
       testgrid-days-of-results: "90"
       testgrid-alert-email: push-release-kubevirt-tag@redhat.com
       testgrid-num-failures-to-alert: "1"
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m
@@ -61,7 +60,6 @@ postsubmits:
     always_run: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -97,7 +95,6 @@ postsubmits:
     skip_report: false
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -137,7 +134,6 @@ postsubmits:
       testgrid-create-test-group: "false"
     always_run: true
     skip_report: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 10m
@@ -176,7 +172,6 @@ postsubmits:
     annotations:
       testgrid-create-test-group: "false"
     always_run: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 10m
@@ -213,7 +208,6 @@ postsubmits:
     run_if_changed: "hack/builder/.*"
     branches:
       - main
-    decorate: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
@@ -249,7 +243,6 @@ postsubmits:
     run_if_changed: "hack/builder/.*"
     branches:
       - main
-    decorate: true
     decoration_config:
       timeout: 4h
       grace_period: 5m
@@ -289,7 +282,6 @@ postsubmits:
     skip_report: false
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.58.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -42,7 +41,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -79,7 +77,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-nonroot
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -117,7 +114,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network-nonroot
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -155,7 +151,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage-nonroot
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -193,7 +188,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-dv-gc
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -229,7 +223,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -286,7 +279,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator-nonroot
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -324,7 +316,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -362,7 +353,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov-nonroot
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -441,7 +431,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.22-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -517,7 +506,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -587,7 +575,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-nonroot
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -660,7 +647,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -691,7 +677,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -717,7 +702,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -745,7 +729,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -773,7 +756,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -801,7 +783,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -827,7 +808,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -856,7 +836,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -882,7 +861,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-goveralls
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -921,7 +899,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -947,7 +924,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -973,7 +949,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1000,7 +975,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1026,7 +1000,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1052,7 +1025,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1086,7 +1058,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1120,7 +1091,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1154,7 +1124,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1188,7 +1157,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1226,7 +1194,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1264,7 +1231,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-migrations-nonroot
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1306,7 +1272,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1340,7 +1305,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1374,7 +1338,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1451,7 +1414,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1480,7 +1442,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1514,7 +1475,6 @@ presubmits:
     - release-0.58
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1543,7 +1503,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1577,7 +1536,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1611,7 +1569,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1645,7 +1602,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1685,7 +1641,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.22-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1717,7 +1672,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.23-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1762,7 +1716,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1796,7 +1749,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1830,7 +1782,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1864,7 +1815,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1898,7 +1848,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-psa-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1933,7 +1882,6 @@ presubmits:
     - release-0.58
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-psa-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-0.59.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -43,7 +42,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -81,7 +79,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -119,7 +116,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -157,7 +153,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -195,7 +190,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -233,7 +227,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -270,7 +263,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -307,7 +299,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -344,7 +335,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -401,7 +391,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -438,7 +427,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -475,7 +463,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -544,7 +531,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -619,7 +605,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.23-vgpu-root
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -690,7 +675,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -722,7 +706,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -748,7 +731,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -776,7 +758,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -804,7 +785,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -832,7 +812,6 @@ presubmits:
     - release-0.59
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -858,7 +837,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -884,7 +862,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -913,7 +890,6 @@ presubmits:
     - release-0.59
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -939,7 +915,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-goveralls
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -977,7 +952,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1004,7 +978,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1030,7 +1003,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1056,7 +1028,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1082,7 +1053,6 @@ presubmits:
     - release-0.59
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1108,7 +1078,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1143,7 +1112,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1179,7 +1147,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-psa-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1218,7 +1185,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1259,7 +1225,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1298,7 +1263,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1333,7 +1297,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute-realtime-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1370,7 +1333,6 @@ presubmits:
     - release-0.59
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1420,7 +1382,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1449,7 +1410,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1478,7 +1438,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1519,7 +1478,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h30m0s
@@ -1552,7 +1510,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1598,7 +1555,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1633,7 +1589,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1671,7 +1626,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1706,7 +1660,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1741,7 +1694,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.24-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1776,7 +1728,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1814,7 +1765,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-psa-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1852,7 +1802,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1887,7 +1836,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1922,7 +1870,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1957,7 +1904,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1995,7 +1941,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2030,7 +1975,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2067,7 +2011,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2104,7 +2047,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2141,7 +2083,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator-upgrade
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2176,7 +2117,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator-configuration
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2213,7 +2153,6 @@ presubmits:
     - release-0.59
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-psa-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.0.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -43,7 +42,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage-cgroupsv2
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -81,7 +79,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -138,7 +135,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -175,7 +171,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.25-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -244,7 +239,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.27-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -319,7 +313,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -351,7 +344,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -377,7 +369,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -405,7 +396,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -433,7 +423,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -461,7 +450,6 @@ presubmits:
     - release-1.0
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -487,7 +475,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -513,7 +500,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -542,7 +528,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -568,7 +553,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -595,7 +579,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -621,7 +604,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -647,7 +629,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -673,7 +654,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -699,7 +679,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -736,7 +715,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -774,7 +752,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -813,7 +790,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -852,7 +828,6 @@ presubmits:
     - release-1.0
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -903,7 +878,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -932,7 +906,6 @@ presubmits:
     - release-1.0
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -961,7 +934,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1002,7 +974,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1035,7 +1006,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1081,7 +1051,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1116,7 +1085,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1151,7 +1119,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1186,7 +1153,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1224,7 +1190,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1259,7 +1224,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1294,7 +1258,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1329,7 +1292,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1364,7 +1326,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1399,7 +1360,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1434,7 +1394,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1469,7 +1428,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1504,7 +1462,6 @@ presubmits:
     - release-1.0
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.1.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -62,7 +61,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -99,7 +97,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.27-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -168,7 +165,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.27-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -243,7 +239,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -280,7 +275,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -305,7 +299,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -332,7 +325,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -359,7 +351,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -386,7 +377,6 @@ presubmits:
     - release-1.1
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -412,7 +402,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -438,7 +427,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -467,7 +455,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -493,7 +480,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -518,7 +504,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -543,7 +528,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -568,7 +552,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -593,7 +576,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -619,7 +601,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -658,7 +639,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -696,7 +676,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -737,7 +716,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -778,7 +756,6 @@ presubmits:
     - release-1.1
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -828,7 +805,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -857,7 +833,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -885,7 +860,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -926,7 +900,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -961,7 +934,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1007,7 +979,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.25-fips-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1045,7 +1016,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1082,7 +1052,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1117,7 +1086,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1155,7 +1123,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1194,7 +1161,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1236,7 +1202,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.26-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1273,7 +1238,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1310,7 +1274,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1345,7 +1308,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1384,7 +1346,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1421,7 +1382,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1458,7 +1418,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1495,7 +1454,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1530,7 +1488,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1569,7 +1526,6 @@ presubmits:
     - release-1.1
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1606,7 +1562,6 @@ presubmits:
     - release-1.1
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.2.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -62,7 +61,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -101,7 +99,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.27-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -170,7 +167,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -245,7 +241,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -284,7 +279,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -309,7 +303,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -336,7 +329,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -363,7 +355,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -390,7 +381,6 @@ presubmits:
     - release-1.2
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -416,7 +406,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -442,7 +431,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -471,7 +459,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -501,7 +488,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -527,7 +513,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -552,7 +537,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -577,7 +561,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -603,7 +586,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -628,7 +610,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -654,7 +635,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -693,7 +673,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -734,7 +713,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -775,7 +753,6 @@ presubmits:
     - release-1.2
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -825,7 +802,6 @@ presubmits:
     - release-1.2
     cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -891,7 +867,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -920,7 +895,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -948,7 +922,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -988,7 +961,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1023,7 +995,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1069,7 +1040,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1107,7 +1077,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1149,7 +1118,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1188,7 +1156,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1229,7 +1196,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1271,7 +1237,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1311,7 +1276,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.27-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1350,7 +1314,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1389,7 +1352,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1430,7 +1392,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1471,7 +1432,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1510,7 +1470,6 @@ presubmits:
     - release-1.2
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1539,7 +1498,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1578,7 +1536,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1619,7 +1576,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1660,7 +1616,6 @@ presubmits:
     - release-1.2
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.3.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -62,7 +61,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -101,7 +99,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.27-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -170,7 +167,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -245,7 +241,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -284,7 +279,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -309,7 +303,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -336,7 +329,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -363,7 +355,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -390,7 +381,6 @@ presubmits:
     - release-1.3
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -416,7 +406,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -442,7 +431,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -471,7 +459,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -501,7 +488,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -527,7 +513,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -552,7 +537,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -577,7 +561,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -603,7 +586,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -628,7 +610,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -654,7 +635,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -695,7 +675,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -738,7 +717,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -779,7 +757,6 @@ presubmits:
     - release-1.3
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -829,7 +806,6 @@ presubmits:
     - release-1.3
     cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -894,7 +870,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -923,7 +898,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -950,7 +924,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -991,7 +964,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1026,7 +998,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1072,7 +1043,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1110,7 +1080,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1152,7 +1121,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1192,7 +1160,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1233,7 +1200,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1274,7 +1240,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1315,7 +1280,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.28-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1354,7 +1318,6 @@ presubmits:
     - release-1.3
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1383,7 +1346,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1424,7 +1386,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1465,7 +1426,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1506,7 +1466,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1547,7 +1506,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1586,7 +1544,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1627,7 +1584,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1668,7 +1624,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1709,7 +1664,6 @@ presubmits:
     - release-1.3
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -62,7 +61,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -101,7 +99,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.30-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -169,7 +166,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -244,7 +240,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -283,7 +278,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -308,7 +302,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -335,7 +328,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -362,7 +354,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -389,7 +380,6 @@ presubmits:
     - release-1.4
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -414,7 +404,6 @@ presubmits:
     - release-1.4
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -441,7 +430,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -467,7 +455,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -496,7 +483,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -525,7 +511,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -551,7 +536,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -578,7 +562,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -603,7 +586,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -628,7 +610,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -654,7 +635,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -679,7 +659,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -705,7 +684,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -748,7 +726,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -791,7 +768,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -834,7 +810,6 @@ presubmits:
     - release-1.4
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -884,7 +859,6 @@ presubmits:
     - release-1.4
     cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -950,7 +924,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -979,7 +952,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1006,7 +978,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1047,7 +1018,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1082,7 +1052,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1128,7 +1097,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1166,7 +1134,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1208,7 +1175,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1248,7 +1214,6 @@ presubmits:
     - release-1.4
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1277,7 +1242,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1318,7 +1282,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1359,7 +1322,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1400,7 +1362,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1443,7 +1404,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1482,7 +1442,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1525,7 +1484,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1568,7 +1526,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1611,7 +1568,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1652,7 +1608,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1695,7 +1650,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1738,7 +1692,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1781,7 +1734,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1822,7 +1774,6 @@ presubmits:
     - release-1.4
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.29-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -65,7 +64,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -103,7 +101,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.30-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -171,7 +168,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -245,7 +241,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -287,7 +282,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -312,7 +306,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -339,7 +332,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -366,7 +358,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -393,7 +384,6 @@ presubmits:
     - release-1.5
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -418,7 +408,6 @@ presubmits:
     - release-1.5
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -445,7 +434,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -471,7 +459,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -501,7 +488,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -530,7 +516,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -556,7 +541,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -583,7 +567,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -608,7 +591,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -633,7 +615,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -659,7 +640,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -684,7 +664,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -710,7 +689,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -752,7 +730,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -794,7 +771,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -836,7 +812,6 @@ presubmits:
     - release-1.5
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -884,7 +859,6 @@ presubmits:
     - release-1.5
     cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -950,7 +924,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -979,7 +952,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1006,7 +978,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1047,7 +1018,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1081,7 +1051,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1127,7 +1096,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1165,7 +1133,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1206,7 +1173,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1245,7 +1211,6 @@ presubmits:
     - release-1.5
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1274,7 +1239,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1316,7 +1280,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1358,7 +1321,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1400,7 +1362,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1440,7 +1401,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1482,7 +1442,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1524,7 +1483,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1566,7 +1524,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1606,7 +1563,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1657,7 +1613,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1699,7 +1654,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1741,7 +1695,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1783,7 +1736,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1823,7 +1775,6 @@ presubmits:
     - release-1.5
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -65,7 +64,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -103,7 +101,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.30-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -171,7 +168,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -245,7 +241,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -270,7 +265,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -297,7 +291,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -324,7 +317,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -351,7 +343,6 @@ presubmits:
     - release-1.6
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -376,7 +367,6 @@ presubmits:
     - release-1.6
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -403,7 +393,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -429,7 +418,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -459,7 +447,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -488,7 +475,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -514,7 +500,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -541,7 +526,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -566,7 +550,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -591,7 +574,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -617,7 +599,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -642,7 +623,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -668,7 +648,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -706,7 +685,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -746,7 +724,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -782,7 +759,6 @@ presubmits:
     - release-1.6
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -830,7 +806,6 @@ presubmits:
     - release-1.6
     cluster: prow-arm64-workloads
     context: pull-kubevirt-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -896,7 +871,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -925,7 +899,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -952,7 +925,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -993,7 +965,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1025,7 +996,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1071,7 +1041,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1109,7 +1078,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1150,7 +1118,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1187,7 +1154,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1216,7 +1182,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1252,7 +1217,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1288,7 +1252,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1326,7 +1289,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1362,7 +1324,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1413,7 +1374,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1449,7 +1409,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1485,7 +1444,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1523,7 +1481,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1559,7 +1516,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1597,7 +1553,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1633,7 +1588,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1669,7 +1623,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1707,7 +1660,6 @@ presubmits:
     - release-1.6
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -65,7 +64,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -105,7 +103,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.33-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -164,7 +161,6 @@ presubmits:
     - release-1.7
     cluster: amd-workloads
     context: pull-kubevirt-e2e-kind-1.34-sev
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -219,7 +215,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -292,7 +287,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -317,7 +311,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -344,7 +337,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -371,7 +363,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -398,7 +389,6 @@ presubmits:
     - release-1.7
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -423,7 +413,6 @@ presubmits:
     - release-1.7
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -448,7 +437,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -474,7 +462,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -503,7 +490,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -532,7 +518,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -559,7 +544,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -586,7 +570,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -611,7 +594,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -636,7 +618,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -662,7 +643,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -688,7 +668,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -714,7 +693,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -754,7 +732,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-network-with-dnc
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -796,7 +773,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -834,7 +810,6 @@ presubmits:
     - release-1.7
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -878,7 +853,6 @@ presubmits:
     - release-1.7
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -929,7 +903,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -957,7 +930,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -984,7 +956,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1024,7 +995,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1059,7 +1029,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1104,7 +1073,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1145,7 +1113,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1188,7 +1155,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1227,7 +1193,6 @@ presubmits:
     - release-1.7
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1256,7 +1221,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1306,7 +1270,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1341,7 +1304,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1376,7 +1338,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1413,7 +1374,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1448,7 +1408,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1483,7 +1442,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1518,7 +1476,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1555,7 +1512,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1590,7 +1546,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1628,7 +1583,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1666,7 +1620,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1706,7 +1659,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1744,7 +1696,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1784,7 +1735,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1825,7 +1775,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1864,7 +1813,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1903,7 +1851,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1944,7 +1891,6 @@ presubmits:
     - release-1.7
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -65,7 +64,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -105,7 +103,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.35-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -164,7 +161,6 @@ presubmits:
     - release-1.8
     cluster: amd-workloads
     context: pull-kubevirt-e2e-kind-1.34-sev
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -219,7 +215,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -292,7 +287,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -317,7 +311,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -344,7 +337,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -371,7 +363,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -398,7 +389,6 @@ presubmits:
     - release-1.8
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -421,7 +411,6 @@ presubmits:
     - release-1.8
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -446,7 +435,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -472,7 +460,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -501,7 +488,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -530,7 +516,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -557,7 +542,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -584,7 +568,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -609,7 +592,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -634,7 +616,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -660,7 +641,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -686,7 +666,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -712,7 +691,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -752,7 +730,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-network-with-dnc
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -794,7 +771,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -832,7 +808,6 @@ presubmits:
     - release-1.8
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -876,7 +851,6 @@ presubmits:
     - release-1.8
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -927,7 +901,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -955,7 +928,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -982,7 +954,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1022,7 +993,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1057,7 +1027,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1102,7 +1071,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1143,7 +1111,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1186,7 +1153,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1225,7 +1191,6 @@ presubmits:
     - release-1.8
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1254,7 +1219,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1308,7 +1272,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1343,7 +1306,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1378,7 +1340,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1415,7 +1376,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1450,7 +1410,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1488,7 +1447,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1526,7 +1484,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1566,7 +1523,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1604,7 +1560,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1644,7 +1599,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1682,7 +1636,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1720,7 +1673,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1760,7 +1712,6 @@ presubmits:
     - release-1.8
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -65,7 +64,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -105,7 +103,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-1.35-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -164,7 +161,6 @@ presubmits:
     - release-1.9
     cluster: amd-workloads
     context: pull-kubevirt-e2e-kind-1.34-sev
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -219,7 +215,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -293,7 +288,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -318,7 +312,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -345,7 +338,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms-cs10
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -377,7 +369,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -404,7 +395,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -431,7 +421,6 @@ presubmits:
     - release-1.9
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -454,7 +443,6 @@ presubmits:
     - release-1.9
     cluster: prow-arm64-workloads
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -480,7 +468,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -506,7 +493,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -535,7 +521,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -564,7 +549,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-build-cs10
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -596,7 +580,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-build-cs10-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -630,7 +613,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-build-cs10-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -664,7 +646,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -691,7 +672,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -718,7 +698,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -743,7 +722,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -768,7 +746,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -794,7 +771,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -820,7 +796,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -846,7 +821,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -886,7 +860,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-network-with-dnc
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -928,7 +901,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-network-sriov-emulated
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -966,7 +938,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1004,7 +975,6 @@ presubmits:
     - release-1.9
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-kind-1.35-sig-compute-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1045,7 +1015,6 @@ presubmits:
     - release-1.9
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-kind-1.35-sig-compute-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1093,7 +1062,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1121,7 +1089,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: build-kubevirt-builder-cs10
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1149,7 +1116,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1176,7 +1142,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1216,7 +1181,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1251,7 +1215,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.33-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1296,7 +1259,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1337,7 +1299,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1380,7 +1341,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1419,7 +1379,6 @@ presubmits:
     - release-1.9
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1448,7 +1407,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1502,7 +1460,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1540,7 +1497,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1578,7 +1534,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1618,7 +1573,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1656,7 +1610,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1694,7 +1647,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1732,7 +1684,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1772,7 +1723,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.35-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1810,7 +1760,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1848,7 +1797,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1886,7 +1834,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1926,7 +1873,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1966,7 +1912,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.36-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2004,7 +1949,6 @@ presubmits:
     - release-1.9
     cluster: prow-workloads
     context: pull-kubevirt-e2e-k8s-1.34-sig-performance-kube-burner
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -68,7 +67,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -112,7 +110,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -174,7 +171,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: amd-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -230,7 +226,6 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -305,7 +300,6 @@ presubmits:
     annotations:
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -353,7 +347,6 @@ presubmits:
     annotations:
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 36h0m0s
@@ -402,7 +395,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -429,7 +421,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -458,7 +449,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -492,7 +482,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -520,7 +509,6 @@ presubmits:
       fork-per-release: "true"
       rehearsal.allowed: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -550,7 +538,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -575,7 +562,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -602,7 +588,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -630,7 +615,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -661,7 +645,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -692,7 +675,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -726,7 +708,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -762,7 +743,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -799,7 +779,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -829,7 +808,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -858,7 +836,6 @@ presubmits:
     annotations:
       fork-per-release: "false"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -896,7 +873,6 @@ presubmits:
           secretName: kubevirtci-coveralls-token
   - always_run: true
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -934,7 +910,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -961,7 +936,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -988,7 +962,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1016,7 +989,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1044,7 +1016,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1073,7 +1044,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1117,7 +1087,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1162,7 +1131,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1205,7 +1173,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1246,7 +1213,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1289,7 +1255,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1339,7 +1304,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1370,7 +1334,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1400,7 +1363,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1430,7 +1392,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1473,7 +1434,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1511,7 +1471,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1559,7 +1518,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1603,7 +1561,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1649,7 +1606,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1690,7 +1646,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1722,7 +1677,6 @@ presubmits:
       fork-per-release: "false"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1764,7 +1718,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1821,7 +1774,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1863,7 +1815,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1905,7 +1856,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1949,7 +1899,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1991,7 +1940,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2033,7 +1981,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2075,7 +2022,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2119,7 +2065,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2161,7 +2106,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2202,7 +2146,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2243,7 +2186,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2286,7 +2228,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2329,7 +2270,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2370,7 +2310,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -2455,7 +2394,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: periodic-kubevirtci-mirror-crio-repository-weekly
   cron: "25 0 * * 1"
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   decoration_config:
@@ -38,7 +37,6 @@ periodics:
   cron: "0 */12 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 1h
   max_concurrency: 1
@@ -78,7 +76,6 @@ periodics:
   cron: "5 3 * * 4"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 1h
   max_concurrency: 1
@@ -116,7 +113,6 @@ periodics:
   cron: "30 1 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 1h
   max_concurrency: 1
@@ -149,7 +145,6 @@ periodics:
   cron: "0 4 * * 3"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 2h
   max_concurrency: 1
@@ -200,7 +195,6 @@ periodics:
   cron: "0 4 * * 3" #Triggered at same time as x86 job so that both will run on same commit
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 2h
   max_concurrency: 1
@@ -259,7 +253,6 @@ periodics:
   cron: "0 */12 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 1h
   max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -6,7 +6,6 @@ postsubmits:
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         timeout: 6h
       max_concurrency: 1
@@ -63,7 +62,6 @@ postsubmits:
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         timeout: 1h
       max_concurrency: 1
@@ -103,7 +101,6 @@ postsubmits:
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         timeout: 4h
       max_concurrency: 1
@@ -184,7 +181,6 @@ postsubmits:
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         timeout: 1h
       max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -4,7 +4,6 @@ presubmits:
     annotations:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -81,7 +80,6 @@ presubmits:
         name: vfio
   - always_run: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -120,7 +118,6 @@ presubmits:
         name: cgroup
   - always_run: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -160,7 +157,6 @@ presubmits:
         name: cgroup
   - always_run: false
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     max_concurrency: 1
@@ -195,7 +191,6 @@ presubmits:
         name: cgroup
   - always_run: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -235,7 +230,6 @@ presubmits:
         name: cgroup
   - always_run: false
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     max_concurrency: 1
@@ -270,7 +264,6 @@ presubmits:
         name: cgroup
   - always_run: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -310,7 +303,6 @@ presubmits:
         name: cgroup
   - always_run: false
     cluster: prow-arm64-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     max_concurrency: 1
@@ -345,7 +337,6 @@ presubmits:
         name: cgroup
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -411,7 +402,6 @@ presubmits:
         name: vfio
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     labels:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -437,7 +427,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 20m0s
     labels:
@@ -472,7 +461,6 @@ presubmits:
         name: devices
   - always_run: true
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       timeout: 15m0s
     labels:
@@ -500,7 +488,6 @@ presubmits:
           privileged: true
   - always_run: false
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       timeout: 4h0m0s
     labels:
@@ -531,7 +518,6 @@ presubmits:
           privileged: true
   - always_run: false
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       timeout: 4h0m0s
     labels:
@@ -562,7 +548,6 @@ presubmits:
           privileged: true
   - always_run: true
     cluster: prow-s390x-workloads
-    decorate: true
     decoration_config:
       timeout: 4h0m0s
     labels:
@@ -593,7 +578,6 @@ presubmits:
           privileged: true
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -623,7 +607,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -654,7 +637,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -683,7 +665,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -714,7 +695,6 @@ presubmits:
         type: bare-metal-external
   - always_run: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -746,7 +726,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:
@@ -776,7 +755,6 @@ presubmits:
         type: bare-metal-external
   - always_run: true
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 3h0m0s
     labels:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -7,7 +7,6 @@ periodics:
     testgrid-alert-email: afrosi@redhat.com, victortoso@redhat.com
     testgrid-num-failures-to-alert: "1"
     testgrid-alert-stale-results-hours: "1"
-  decorate: true
   decoration_config:
     timeout: 3h
   max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
       - main
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -6,7 +6,6 @@ postsubmits:
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -31,7 +30,6 @@ postsubmits:
       run_if_changed: "^version/version.go"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -45,7 +44,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -80,7 +78,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -120,7 +117,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -160,7 +156,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.1
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.2.yaml
@@ -7,7 +7,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -35,7 +34,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
       - release-v1.2
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -37,7 +36,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -66,7 +64,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 5h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -41,7 +40,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-master.yaml
@@ -10,7 +10,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.10.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.10.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -70,7 +68,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.11.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.11.yaml
@@ -8,7 +8,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -37,7 +36,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.7.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -70,7 +68,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.9.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 7h
       grace_period: 5m
@@ -41,7 +40,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -70,7 +68,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: periodic-project-infra-retester
   interval: 1h  # Retest at most 1 PR every hour, which should not DOS the queue.
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
@@ -37,7 +36,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -71,7 +69,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -104,7 +101,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -134,7 +130,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -173,7 +168,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -210,7 +204,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -245,7 +238,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -281,7 +273,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -306,7 +297,6 @@ periodics:
   interval: 1h
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -343,7 +333,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   extra_refs:
   - org: kubevirt
     repo: project-infra
@@ -375,7 +364,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-gcs-credentials: "true"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -392,7 +380,6 @@ periodics:
   labels:
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -453,7 +440,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -495,7 +481,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -536,7 +521,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -579,7 +563,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -614,7 +597,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -666,7 +648,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -702,7 +683,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -748,7 +728,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 2h30m
     grace_period: 5m
@@ -791,7 +770,6 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-docker-mirror-proxy: "true"
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -828,7 +806,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 10m
     grace_period: 5m
@@ -866,7 +843,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-docker-mirror-proxy: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -895,7 +871,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -933,7 +908,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -969,7 +943,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -1000,7 +973,6 @@ periodics:
           memory: "200Mi"
 - name: periodic-project-infra-mirror-istioctl
   cron: "25 1 * * 1"
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   decoration_config:
@@ -1039,7 +1011,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -1076,7 +1047,6 @@ periodics:
   max_concurrency: 1
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 4h
     grace_period: 5m
@@ -1116,7 +1086,6 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -1155,7 +1124,6 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m
@@ -1222,7 +1190,6 @@ periodics:
     testgrid-num-failures-to-alert: "1"
     testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
   cluster: kubevirt-prow-control-plane
-  decorate: true
   decoration_config:
     timeout: 5m
     grace_period: 1m
@@ -1350,7 +1317,6 @@ periodics:
     testgrid-num-failures-to-alert: "1"
     testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
   cluster: kubevirt-prow-control-plane
-  decorate: true
   decoration_config:
     timeout: 15m
     grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -7,7 +7,6 @@ postsubmits:
       run_if_changed: "external-plugins/rehearse/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -39,7 +38,6 @@ postsubmits:
       run_if_changed: "external-plugins/coverage/.*|images/covreport/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -71,7 +69,6 @@ postsubmits:
       run_if_changed: "external-plugins/phased/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -103,7 +100,6 @@ postsubmits:
       run_if_changed: "external-plugins/test-subset/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -135,7 +131,6 @@ postsubmits:
       run_if_changed: "^(external-plugins|images)/release-blocker/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -167,7 +162,6 @@ postsubmits:
       run_if_changed: "^(releng|images)/release-tool/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -198,7 +192,6 @@ postsubmits:
       run_if_changed: "^(external-plugins|images)/referee/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -230,7 +223,6 @@ postsubmits:
       run_if_changed: "^(robots|images)/flakefinder/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -263,7 +255,6 @@ postsubmits:
       run_if_changed: "^(robots|images)/ginkgo-tests/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -296,7 +287,6 @@ postsubmits:
       run_if_changed: "images/kubevirt-infra-bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -328,7 +318,6 @@ postsubmits:
       run_if_changed: "images/golang/.*|images/bootstrap/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 5h0m0s
@@ -364,7 +353,6 @@ postsubmits:
       run_if_changed: "images/shared-images-controller/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -395,7 +383,6 @@ postsubmits:
       run_if_changed: "images/kubekins-e2e/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -427,7 +414,6 @@ postsubmits:
       run_if_changed: "images/kubevirt-kubevirt.github.io/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -464,7 +450,6 @@ postsubmits:
       run_if_changed: "images/kubevirt-user-guide/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -496,7 +481,6 @@ postsubmits:
       run_if_changed: "images/prow-deploy/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -527,7 +511,6 @@ postsubmits:
       run_if_changed: "images/autoowners/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -559,7 +542,6 @@ postsubmits:
       run_if_changed: 'images/pr-creator/.*|hack/(git-pr\.sh|git-askpass\.sh)|robots/labels-checker/.*|pkg/.*|go.mod|go.sum'
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -591,7 +573,6 @@ postsubmits:
       run_if_changed: "images/vm-image-builder/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 5h0m0s
@@ -625,7 +606,6 @@ postsubmits:
       run_if_changed: "images/fedora-coreos-kubevirt/.*"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
@@ -657,7 +637,6 @@ postsubmits:
         testgrid-dashboards: kubevirt-project-infra-postsubmits
         testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
         testgrid-num-failures-to-alert: "1"
-      decorate: true
       branches:
       - ^main$
       labels:
@@ -689,7 +668,6 @@ postsubmits:
       always_run: false
       run_if_changed: "github/ci/prow-deploy/kustom/overlays/prow-workloads/.*|github/ci/prow-deploy/kustom/components/.*"
       annotations: *deploy_postsubmit_annotations
-      decorate: true
       branches:
       - ^main$
       labels:
@@ -720,7 +698,6 @@ postsubmits:
     - name: post-project-infra-ci-search-deployment
       always_run: false
       annotations: *deploy_postsubmit_annotations
-      decorate: true
       run_if_changed: "github/ci/services/ci-search/.*"
       branches:
       - ^main$
@@ -753,7 +730,6 @@ postsubmits:
     - name: post-project-infra-grafana-deployment
       always_run: false
       annotations: *deploy_postsubmit_annotations
-      decorate: true
       run_if_changed: "github/ci/services/grafana/.*"
       branches:
       - ^main$
@@ -803,7 +779,6 @@ postsubmits:
         testgrid-create-test-group: "false"
       labels:
         preset-gcs-credentials: "true"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       spec:
         containers:
@@ -828,7 +803,6 @@ postsubmits:
       run_if_changed: "^(robots|images)/test-report/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -860,7 +834,6 @@ postsubmits:
       run_if_changed: "^(robots|images)/test-label-analyzer/.*|pkg/.*|go.mod|go.sum"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
@@ -893,7 +866,6 @@ postsubmits:
       run_if_changed: "hack/mirror-images.sh|hack/images_to_mirror.csv"
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       cluster: kubevirt-prow-control-plane
       labels:
         preset-kubevirtci-quay-credential: "true"
@@ -923,7 +895,6 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       cluster: kubevirt-prow-control-plane
-      decorate: true
       decoration_config:
         grace_period: 5m
         timeout: 1h
@@ -975,7 +946,6 @@ postsubmits:
       annotations:
         testgrid-create-test-group: "false"
       cluster: kubevirt-prow-control-plane
-      decorate: true
       labels:
         preset-github-credentials: "true"
       run_if_changed: "robots/perf-report-creator/shape.yaml"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -4,7 +4,6 @@ presubmits:
     # Check Prow configuration using the `checkconfig` tool:
     # - https://docs.prow.k8s.io/docs/components/cli-tools/checkconfig/
     always_run: true
-    decorate: true
     cluster: kubevirt-prow-control-plane
     labels:
       preset-gcs-credentials: "true"
@@ -32,7 +31,6 @@ presubmits:
   - name: pull-project-infra-test-robots
     run_if_changed: "robots/.*|pkg/.*|go.mod|go.sum"
     optional: false
-    decorate: true
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -55,7 +53,6 @@ presubmits:
             memory: "4Gi"
   - name: pull-project-infra-check-presubmits
     run_if_changed: "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml"
-    decorate: true
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -82,7 +79,6 @@ presubmits:
   - name: pull-project-infra-test-releng
     run_if_changed: "releng/.*|go.mod"
     optional: false
-    decorate: true
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -105,7 +101,6 @@ presubmits:
     run_if_changed: "external-plugins/.*|go.mod"
     cluster: kubevirt-prow-control-plane
     optional: false
-    decorate: true
     spec:
       containers:
       - image: quay.io/kubevirtci/golang:v20260707-cacb217
@@ -126,7 +121,6 @@ presubmits:
   - name: pull-project-infra-test-github-ci-services
     run_if_changed: "github/ci/services/.*|go.mod"
     optional: false
-    decorate: true
     cluster: kubevirt-prow-control-plane
     labels:
       preset-bazel-cache: "true"
@@ -148,7 +142,6 @@ presubmits:
           runAsUser: 0
   - always_run: true
     cluster: kubevirt-prow-control-plane
-    decorate: true
     name: pull-project-infra-lint
     spec:
       containers:
@@ -173,7 +166,6 @@ presubmits:
   - name: build-kubevirt-infra-bootstrap-image
     always_run: false
     run_if_changed: "images/kubevirt-infra-bootstrap/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -197,7 +189,6 @@ presubmits:
   - name: build-bootstrap-image
     always_run: false
     run_if_changed: "images/bootstrap/.*|images/golang/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -224,7 +215,6 @@ presubmits:
   - name: build-shared-images-controller-image
     always_run: false
     run_if_changed: "images/shared-images-controller/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -249,7 +239,6 @@ presubmits:
   - name: build-release-tool-image
     always_run: false
     run_if_changed: "releng/release-tool/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -276,7 +265,6 @@ presubmits:
   - name: build-kubekins-e2e-image
     always_run: false
     run_if_changed: "images/kubekins-e2e/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -302,7 +290,6 @@ presubmits:
   - name: build-kubevirt-kubevirt.github.io-image
     always_run: false
     run_if_changed: "images/kubevirt-kubevirt.github.io/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -333,7 +320,6 @@ presubmits:
   - name: build-kubevirt-user-guide-image
     always_run: false
     run_if_changed: "images/kubevirt-user-guide/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -359,7 +345,6 @@ presubmits:
   - name: build-prow-deploy-image
     always_run: false
     run_if_changed: "images/prow-deploy/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -385,7 +370,6 @@ presubmits:
   - name: build-autoowners-image
     always_run: false
     run_if_changed: "images/autoowners/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -411,7 +395,6 @@ presubmits:
   - name: build-pr-creator-image
     always_run: false
     run_if_changed: 'images/pr-creator/.*|hack/(git-pr\.sh|git-askpass\.sh)|robots/labels-checker/.*|pkg/.*|go.mod|go.sum'
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -437,7 +420,6 @@ presubmits:
   - name: build-vm-image-builder-image
     always_run: false
     run_if_changed: "images/vm-image-builder/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -461,7 +443,6 @@ presubmits:
   - name: build-fedora-coreos-kubevirt-image
     always_run: false
     run_if_changed: "images/fedora-coreos-kubevirt/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -486,7 +467,6 @@ presubmits:
   - name: build-test-report-image
     always_run: false
     run_if_changed: "^(robots|images)/test-report/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -511,7 +491,6 @@ presubmits:
   - name: build-release-blocker-image
     always_run: false
     run_if_changed: "^(robots|images)/release-blocker/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -536,7 +515,6 @@ presubmits:
   - name: build-referee-image
     always_run: false
     run_if_changed: "^(external-plugins|images)/referee/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -563,7 +541,6 @@ presubmits:
     run_if_changed: "^(robots|images)/ginkgo-tests/.*|pkg/.*|go.mod|go.sum"
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     cluster: kubevirt-prow-control-plane
     max_concurrency: 1
     labels:
@@ -592,7 +569,6 @@ presubmits:
   - name: build-indexpagecreator-image
     always_run: false
     run_if_changed: "^(robots|images)/indexpagecreator/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -617,7 +593,6 @@ presubmits:
   - name: build-flakefinder-image
     always_run: false
     run_if_changed: "^(robots|images)/flakefinder/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -642,7 +617,6 @@ presubmits:
   - name: build-flake-report-creator-image
     always_run: false
     run_if_changed: "^(robots|images)/flake-report-creator/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -667,7 +641,6 @@ presubmits:
   - name: build-rehearse-image
     always_run: false
     run_if_changed: "^(external-plugins|images)/rehearse/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -692,7 +665,6 @@ presubmits:
   - name: build-phased-image
     always_run: false
     run_if_changed: "images/phased/.*|external-plugins/phased/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -717,7 +689,6 @@ presubmits:
   - name: build-test-label-analyzer-image
     always_run: false
     run_if_changed: "images/test-label-analyzer/.*|robots/test-label-analyzer/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -742,7 +713,6 @@ presubmits:
   - name: build-test-subset-image
     always_run: false
     run_if_changed: "images/test-subset/.*|external-plugins/test-subset/.*|pkg/.*|go.mod|go.sum"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -767,7 +737,6 @@ presubmits:
   - name: pull-project-infra-prow-deploy-test
     always_run: false
     run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+$|github/ci/prow-deploy/[^/]+$"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -801,7 +770,6 @@ presubmits:
               memory: "2Gi"
   - name: pull-project-infra-ci-search-deploy-test
     run_if_changed: "github/ci/services/(ci-search|common)/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -838,7 +806,6 @@ presubmits:
   - name: pull-project-infra-grafana-deploy-test
     optional: false
     run_if_changed: "github/ci/services/(grafana|common)/.*"
-    decorate: true
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
@@ -879,7 +846,6 @@ presubmits:
             runAsUser: 0
   - name: pull-project-infra-check-testgrid-config
     run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$|^github/ci/testgrid/gen-config\.yaml$|^github/ci/testgrid/default\.yaml$'
-    decorate: true
     labels:
       preset-bazel-cache: "true"
     annotations:
@@ -907,7 +873,6 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-github-credentials: "true"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -942,7 +907,6 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-github-credentials: "true"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -965,7 +929,6 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-github-credentials: "true"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -985,7 +948,6 @@ presubmits:
   - annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/qe-tools/qe-tools-presubmits.yaml
@@ -2,7 +2,6 @@ presubmits:
   kubevirt/qe-tools:
   - name: pull-qe-tools-make-test
     always_run: true
-    decorate: true
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/redfish-controller/redfish-controller-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/redfish-controller/redfish-controller-periodics.yaml
@@ -1,7 +1,6 @@
 periodics:
 - name: periodic-redfish-controller-push-nightly-main
   cron: "2 4 * * *"
-  decorate: true
   annotations:
     testgrid-create-test-group: "false"
   decoration_config:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/redfish-controller/redfish-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/redfish-controller/redfish-controller-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -39,7 +38,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/redfish-controller/redfish-controller-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/redfish-controller/redfish-controller-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -30,7 +29,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: kubevirt-prow-control-plane
   cron: "50 3 * * *"
-  decorate: true
   decoration_config:
     ssh_key_secrets:
     - prow-kubevirtbot-github-ssh-secret
@@ -41,7 +40,6 @@ periodics:
   labels:
     preset-github-credentials: "true"
     preset-pgp-bot-key: "true"
-  decorate: true
   decoration_config:
     timeout: 1h
     grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/secrets/secrets-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   - always_run: false
     skip_if_only_changed: .*\.md
     cluster: kubevirt-prow-control-plane
-    decorate: true
     decoration_config:
       ssh_key_secrets:
       - prow-kubevirtbot-github-ssh-secret

--- a/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/terraform-provider-kubevirt/terraform-provider-kubevirt-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-terraform-provider-kubevirt-e2e
     always_run: true
     optional: true
-    decorate: true
     skip_report: false
     cluster: prow-workloads
     decoration_config:
@@ -45,7 +44,6 @@ presubmits:
     optional: false
     skip_report: false
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       timeout: 10m
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
@@ -6,7 +6,6 @@ presubmits:
     always_run: true
     optional: true
     skip_report: false
-    decorate: true
     decoration_config:
       timeout: 3h
     max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-postsubmits.yaml
@@ -7,7 +7,6 @@ postsubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-github-credentials: "true"
-    decorate: true
     extra_refs:
     - org: kubevirt
       repo: project-infra

--- a/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/user-guide/user-guide-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: check-links-user-guide
     always_run: false
     skip_report: true
-    decorate: true
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.1.yaml
@@ -8,7 +8,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -34,7 +33,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -63,7 +61,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -93,7 +90,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -122,7 +118,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -152,7 +147,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.2.yaml
@@ -8,7 +8,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -37,7 +36,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -67,7 +65,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -96,7 +93,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -126,7 +122,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
@@ -7,7 +7,6 @@ periodics:
     testgrid-create-test-group: "false"
   labels:
     preset-github-credentials: "true"
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -40,7 +39,6 @@ periodics:
   labels:
     preset-github-credentials: "true"
     preset-podman-in-container-enabled: "true"
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -87,7 +85,6 @@ periodics:
   labels:
     preset-github-credentials: "true"
     preset-podman-in-container-enabled: "true"
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-postsubmits.yaml
@@ -14,7 +14,6 @@ postsubmits:
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
       preset-pgp-bot-key: "true"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 3h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -37,7 +36,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror: "true"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -67,7 +65,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -96,7 +93,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -126,7 +122,6 @@ presubmits:
     cluster: prow-workloads
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
@@ -8,7 +8,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -48,7 +47,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -88,7 +86,6 @@ postsubmits:
     skip_report: true
     annotations:
       testgrid-create-test-group: "false"
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
@@ -7,7 +7,6 @@ presubmits:
       fork-per-release: "true"
     always_run: false
     optional: true
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m
@@ -42,7 +41,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m
@@ -72,7 +70,6 @@ presubmits:
     always_run: true
     skip_report: false
     optional: false
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -3,7 +3,6 @@ presubmits:
   - name: pull-vm-import-operator-e2e-k8s-1.20
     always_run: true
     optional: false
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
   cron: "5 1 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -39,7 +38,6 @@ periodics:
   cron: "45 0 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -75,7 +73,6 @@ periodics:
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -111,7 +108,6 @@ periodics:
   cron: "0 2 * * *"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 3h
     grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -7,7 +7,6 @@ postsubmits:
       always_run: true
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       extra_refs:
       - org: kubevirt
@@ -51,7 +50,6 @@ postsubmits:
     - name: release-kubernetes-nmstate
       annotations:
         testgrid-create-test-group: "false"
-      decorate: true
       max_concurrency: 1
       extra_refs:
       - org: kubevirt

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.15
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.15
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
         - release-0.15
       always_run: false
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -94,7 +91,6 @@ presubmits:
         - release-0.15
       always_run: false
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.31
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.31
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
         - release-0.31
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.35
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.35
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
         - release-0.35
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -94,7 +91,6 @@ presubmits:
         - release-0.35
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.37
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.37
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
         - release-0.37
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -95,7 +92,6 @@ presubmits:
         - release-0.37
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -122,7 +118,6 @@ presubmits:
         - release-0.37
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.43.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.43
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.43
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -61,7 +59,6 @@ presubmits:
         - release-0.43
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -90,7 +87,6 @@ presubmits:
         - release-0.43
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.47.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.47.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.47
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.47
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -61,7 +59,6 @@ presubmits:
         - release-0.47
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.52
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -32,7 +31,6 @@ presubmits:
         - release-0.52
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -63,7 +61,6 @@ presubmits:
         - release-0.52
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
@@ -6,7 +6,6 @@ presubmits:
         - release-0.64
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -34,7 +33,6 @@ presubmits:
         - release-0.64
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -68,7 +66,6 @@ presubmits:
         - release-0.64
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits.yaml
@@ -8,7 +8,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -38,7 +37,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -75,7 +73,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 1h
         grace_period: 5m
@@ -104,7 +101,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: false
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m
@@ -139,7 +135,6 @@ presubmits:
         fork-per-release: "true"
       always_run: true
       optional: true
-      decorate: true
       decoration_config:
         timeout: 3h
         grace_period: 5m

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -6,6 +6,8 @@ prowjob_namespace: kubevirt-prow-jobs
 pod_namespace: kubevirt-prow-jobs
 log_level: debug
 
+decorate_all_jobs: true
+
 # https://docs.prow.k8s.io/docs/components/core/deck/
 # https://pkg.go.dev/sigs.k8s.io/prow/pkg/config#Deck
 deck:

--- a/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/resources/bootstrap.yaml
@@ -26,7 +26,6 @@ data:
     presubmits:
       testorg/testrepo:
         - name: test-job
-          decorate: true
           always_run: true
           skip_report: false
           spec:

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 5 * * * *
-  decorate: true
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
     containers:
@@ -42,7 +41,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 45 0 * * *
-  decorate: true
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
     containers:
@@ -81,7 +79,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 25 0 * * *
-  decorate: true
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
     containers:
@@ -119,7 +116,6 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
-  decorate: true
   interval: 168h
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
@@ -160,7 +156,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 1,9,17 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -206,7 +201,6 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   cluster: prow-workloads
   cron: 0 0 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -251,7 +245,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 2,10,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -296,7 +289,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 3,11,19 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -341,7 +333,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -386,7 +377,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -431,7 +421,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 30 6,14,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -476,7 +465,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -523,7 +511,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -568,7 +555,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 50 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -613,7 +599,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 6,14,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -658,7 +643,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -704,7 +688,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
   cron: 2 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -783,7 +766,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
   cron: 2 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -864,7 +846,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
   cron: 2 15 */7 * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -906,7 +887,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
   cron: 30 2 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 7h0m0s
@@ -943,7 +923,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 22,10 * * *
-  decorate: true
   decoration_config:
     grace_period: 30m0s
     timeout: 4h0m0s
@@ -1024,7 +1003,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 15 22 * * 0
-  decorate: true
   decoration_config:
     timeout: 1h0m0s
   extra_refs:
@@ -1076,7 +1054,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1160,7 +1137,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1219,7 +1195,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 50 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1264,7 +1239,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 6,14,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1309,7 +1283,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1354,7 +1327,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 0,8,16 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1401,7 +1373,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cron: "0 9,17,0 * * *"
-  decorate: true
   decoration_config:
     timeout: 7h
     grace_period: 5m

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-presubmits.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -42,7 +41,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -79,7 +77,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -116,7 +113,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -152,7 +148,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -192,7 +187,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -229,7 +223,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -267,7 +260,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -304,7 +296,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -341,7 +332,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -383,7 +373,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -424,7 +413,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -466,7 +454,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -508,7 +495,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -549,7 +535,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -586,7 +571,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -624,7 +608,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -661,7 +644,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -698,7 +680,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -736,7 +717,6 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -820,7 +800,6 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -899,7 +878,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -958,7 +936,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -990,7 +967,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1018,7 +994,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1048,7 +1023,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1079,7 +1053,6 @@ presubmits:
       fork-per-release: "true"
       rehearsal.allowed: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1109,7 +1082,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1137,7 +1109,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1169,7 +1140,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1197,7 +1167,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -1236,7 +1205,6 @@ presubmits:
           secretName: kubevirtci-coveralls-token
   - always_run: true
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -1276,7 +1244,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1304,7 +1271,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1332,7 +1298,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1361,7 +1326,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1389,7 +1353,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1418,7 +1381,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1453,7 +1415,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1488,7 +1449,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1523,7 +1483,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
@@ -3,7 +3,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 5 * * * *
-  decorate: true
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
     containers:
@@ -42,7 +41,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 45 0 * * *
-  decorate: true
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
     containers:
@@ -81,7 +79,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 25 0 * * *
-  decorate: true
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
     containers:
@@ -119,7 +116,6 @@ periodics:
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
-  decorate: true
   interval: 168h
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
@@ -160,7 +156,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 1,9,17 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -206,7 +201,6 @@ periodics:
     testgrid-num-failures-to-alert: "1"
   cluster: prow-workloads
   cron: 0 0 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -251,7 +245,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 2,10,18 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -296,7 +289,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 3,11,19 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -341,7 +333,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -386,7 +377,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -431,7 +421,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 30 6,14,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -476,7 +465,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -523,7 +511,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -568,7 +555,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 50 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -613,7 +599,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 6,14,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -658,7 +643,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -704,7 +688,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
   cron: 2 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -783,7 +766,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
   cron: 2 1 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -864,7 +846,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
   cron: 2 15 */7 * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 1h0m0s
@@ -906,7 +887,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
   cron: 30 2 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 7h0m0s
@@ -943,7 +923,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 22,10 * * *
-  decorate: true
   decoration_config:
     grace_period: 30m0s
     timeout: 4h0m0s
@@ -1024,7 +1003,6 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 15 22 * * 0
-  decorate: true
   decoration_config:
     timeout: 1h0m0s
   extra_refs:
@@ -1076,7 +1054,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 4,12,20 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1160,7 +1137,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 40 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1219,7 +1195,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 50 5,13,21 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1264,7 +1239,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 0 6,14,22 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1309,7 +1283,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 10 7,15,23 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1354,7 +1327,6 @@ periodics:
     testgrid-days-of-results: "60"
   cluster: prow-workloads
   cron: 20 0,8,16 * * *
-  decorate: true
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1401,7 +1373,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cron: "0 9,17,0 * * *"
-  decorate: true
   decoration_config:
     timeout: 7h
     grace_period: 5m

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-presubmits.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -42,7 +41,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -79,7 +77,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -116,7 +113,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -152,7 +148,6 @@ presubmits:
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -192,7 +187,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -229,7 +223,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -267,7 +260,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -304,7 +296,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -341,7 +332,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -383,7 +373,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -424,7 +413,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -466,7 +454,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -508,7 +495,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -549,7 +535,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -586,7 +571,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -624,7 +608,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -661,7 +644,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -698,7 +680,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -736,7 +717,6 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -820,7 +800,6 @@ presubmits:
       k8s.v1.cni.cncf.io/networks: multus-cni-ns/sriov-passthrough-cni,multus-cni-ns/sriov-passthrough-cni
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -899,7 +878,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -958,7 +936,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -990,7 +967,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1018,7 +994,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1048,7 +1023,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1079,7 +1053,6 @@ presubmits:
       fork-per-release: "true"
       rehearsal.allowed: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1109,7 +1082,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1137,7 +1109,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1169,7 +1140,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1197,7 +1167,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -1236,7 +1205,6 @@ presubmits:
           secretName: kubevirtci-coveralls-token
   - always_run: true
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 10m0s
       timeout: 1h0m0s
@@ -1276,7 +1244,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1304,7 +1271,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1332,7 +1298,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1361,7 +1326,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1389,7 +1353,6 @@ presubmits:
     annotations:
       fork-per-release: "true"
     cluster: ibm-prow-jobs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1418,7 +1381,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1454,7 +1416,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1490,7 +1451,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1526,7 +1486,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/releng/release-tool/testdata/jobconfig/kubevirt-presubmits-1.6.yaml
+++ b/releng/release-tool/testdata/jobconfig/kubevirt-presubmits-1.6.yaml
@@ -5,7 +5,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-performance
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -66,7 +65,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-windows2016
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -106,7 +104,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-1.30-vgpu
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -175,7 +172,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-kind-sriov
-    decorate: true
     decoration_config:
       grace_period: 30m0s
       timeout: 4h0m0s
@@ -250,7 +246,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-check-tests-for-flakes
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -292,7 +287,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-generate
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -318,7 +312,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-rpms
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -346,7 +339,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-verify-go-mod
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -374,7 +366,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-gosec
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -402,7 +393,6 @@ presubmits:
     - release-1.6
     cluster: prow-s390x-workloads
     context: pull-kubevirt-unit-test-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -427,7 +417,6 @@ presubmits:
     - release-1.6
     cluster: prow-arm64-workloads-2
     context: pull-kubevirt-unit-test-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -454,7 +443,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -481,7 +469,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -511,7 +498,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-build-s390x
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -541,7 +527,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-unit-test
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -568,7 +553,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-fuzz
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -596,7 +580,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-apidocs
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -622,7 +605,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-client-python
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -648,7 +630,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-manifests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -674,7 +655,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-prom-rules-verify
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -700,7 +680,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-check-unassigned-tests
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -727,7 +706,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-ipv6-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -771,7 +749,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network-multus-v4
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -814,7 +791,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-migrations
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -857,7 +833,6 @@ presubmits:
     - release-1.6
     cluster: prow-arm64-workloads
     context: pull-kubevirt-e2e-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -906,7 +881,6 @@ presubmits:
     - release-1.6
     cluster: prow-arm64-workloads-2
     context: pull-kubevirt-conformance-arm64
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -972,7 +946,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: build-kubevirt-builder
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1002,7 +975,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-code-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1030,7 +1002,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-swap-enabled
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1072,7 +1043,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-monitoring
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
@@ -1107,7 +1077,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-single-node
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1154,7 +1123,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1193,7 +1161,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute-root
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1235,7 +1202,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-realtime
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1275,7 +1241,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-control-plane
     context: pull-kubevirt-metrics-lint
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s
@@ -1305,7 +1270,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1349,7 +1313,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1393,7 +1356,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1437,7 +1399,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.30-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1479,7 +1440,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1523,7 +1483,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1567,7 +1526,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1611,7 +1569,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.31-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1653,7 +1610,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-performance-kwok
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1705,7 +1661,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-network
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1748,7 +1703,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-storage
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 4h0m0s
@@ -1791,7 +1745,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1834,7 +1787,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-operator
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -1875,7 +1827,6 @@ presubmits:
     - release-1.6
     cluster: kubevirt-prow-workloads
     context: pull-kubevirt-e2e-k8s-1.32-sig-compute-serial
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s

--- a/robots/kubevirtci-presubmit-creator/main.go
+++ b/robots/kubevirtci-presubmit-creator/main.go
@@ -182,7 +182,6 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 		Optional:  true,
 		JobBase: config.JobBase{
 			UtilityConfig: config.UtilityConfig{
-				Decorate: &yes,
 				DecorationConfig: &prowjobs.DecorationConfig{
 					Timeout: &prowjobs.Duration{Duration: 3 * time.Hour},
 				},

--- a/robots/retester/testdata/kubevirt/non-required-presubmits.yaml
+++ b/robots/retester/testdata/kubevirt/non-required-presubmits.yaml
@@ -5,7 +5,6 @@ presubmits:
         fork-per-release: "true"
         testgrid-dashboards: kubevirt-presubmits
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 5m0s
         timeout: 1h0m0s

--- a/robots/retester/testdata/kubevirt/required-presubmits.yaml
+++ b/robots/retester/testdata/kubevirt/required-presubmits.yaml
@@ -6,7 +6,6 @@ presubmits:
         k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni
         testgrid-dashboards: kubevirt-presubmits
       cluster: prow-workloads
-      decorate: true
       decoration_config:
         grace_period: 30m0s
         timeout: 4h0m0s


### PR DESCRIPTION
**What this PR does / why we need it**:

Set `decorate_all_jobs: true` in Prow's global configuration file so that it can be removed from individual job definitions.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl 