### PR TITLE
chore(coderabbit): replace vendor exclusion with path instruction

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,14 +9,20 @@ reviews:
       enabled: true
     shellcheck:
       enabled: true
-  path_filters:
-    - "!vendor/**"
   path_instructions:
     - path: "**"
       instructions: |
         Comment severity: prefix style, naming, or minor improvement suggestions with "nit:" — these must not block merging.
         Correctness issues, logic errors, security concerns, or contract violations must state the problem and why it matters.
         When a review contains only nits, approve rather than request changes.
+
+    - path: "vendor/**"
+      instructions: |
+        Vendored Go dependencies — do not review for style, logic, or correctness.
+        Only verify:
+        - Changes are consistent with go.mod and go.sum (no manual edits).
+        - No non-vendored files (scripts, configs, documentation) are added inside vendor/.
+        - The vendor/modules.txt file is present and updated.
 
     - path: "**/*.go"
       instructions: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the blanket `!vendor/**` path filter with a `path_instructions` entry so that CodeRabbit lightly reviews vendor changes instead of ignoring them entirely. The instruction limits review to consistency checks: go.mod/go.sum match, no stray non-vendored files, and vendor/modules.txt presence.

**Which issue(s) this PR fixes**:
Follow-up to #5246

**Special notes for your reviewer**:
Config-only change — no functional code modified.

---
🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review guidance for vendored dependencies.
  * Review checks now focus on dependency consistency and required vendor metadata, while avoiding unnecessary style or logic review of vendored code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->