### PR TITLE
feat(prow): add status event subscription and phase annotations for phased plugin

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -401,6 +401,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -491,6 +492,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
@@ -548,6 +550,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-s390x-workloads
     decorate: true
@@ -573,6 +576,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
     decorate: true
@@ -601,6 +605,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -629,6 +634,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -660,6 +666,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -797,6 +804,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true
@@ -933,6 +941,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
@@ -960,6 +969,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
@@ -987,6 +997,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
@@ -1043,6 +1054,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: kubevirt-prow-control-plane
     decorate: true
     decoration_config:
@@ -1200,9 +1212,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true
@@ -1241,9 +1254,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-arm64-workloads
     decorate: true
@@ -1399,6 +1413,7 @@ presubmits:
   - always_run: true
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "0"
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -2156,9 +2171,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true
@@ -2197,9 +2213,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true
@@ -2238,9 +2255,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true
@@ -2281,9 +2299,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true
@@ -2324,9 +2343,10 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
     annotations:
       fork-per-release: "true"
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -301,8 +301,9 @@ presubmits:
           path: /dev/vfio/
           type: Directory
         name: vfio
-  - always_run: true
+  - always_run: false
     annotations:
+      phased.kubevirt.io/phase: "1"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-workloads
     decorate: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -645,6 +645,7 @@ external_plugins:
     endpoint: http://prow-phased:9900
     events:
       - pull_request
+      - status
   - name: referee
     endpoint: http://referee:9900
     events:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the Prow config changes required by #5046 (N-phase support for the phased plugin):

1. Subscribes the phased external plugin to `status` webhook events (in addition to `pull_request`)
2. Adds `phased.kubevirt.io/phase` annotations to kubevirt/kubevirt presubmit jobs

**Phase assignment:**

- **Phase 0** (13 jobs): build, lint, unit tests, generate — auto-triggered by Prow (`always_run: true`)
- **Phase 1** (8 jobs): 1.36 e2e sig tests, check-tests-for-flakes — triggered by the phased plugin after phase 0 completes (`always_run: false`)

Phase 1 jobs are changed from `always_run: true` to `always_run: false` so they are no longer auto-triggered by Prow. Instead, the phased plugin posts `/test` comments when all phase 0 jobs succeed.

Optional and special-purpose jobs (fuzz, goveralls, fossa, sev) are not annotated.

**Which issue(s) this PR fixes**:

Companion config for #5046

**Special notes for your reviewer**:

This PR only modifies Prow config YAML — no code changes. The plugin code changes are in #5046.

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phased handling for multiple presubmit checks, using phased annotations to control execution.
  * Updated selected end-to-end jobs to run only when triggered in phased mode instead of always running.
  * Extended phased event handling to include `status` events in addition to pull request activity, improving CI visibility and gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->