### PR TITLE
fix(prow-workloads): set undefined variable

### DIFF
--- a/github/ci/prow-deploy/vars/prow-workloads/main.yml
+++ b/github/ci/prow-deploy/vars/prow-workloads/main.yml
@@ -1,3 +1,5 @@
+prowUrl: prow.ci.kubevirt.io
+
 testinfra_dir: /tmp/test-infra
 bootstrap_full_config: false
 rescale_pushgateway_deployment: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Set a missing variable to fix the job [post-project-infra-prow-workloads-deployment](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/post-project-infra-prow-workloads-deployment).

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added the Prow service URL `prow.ci.kubevirt.io` to deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->