### PR TITLE
fix(prow-deploy): skip control-plane deployment for job-only changes

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -652,7 +652,7 @@ postsubmits:
                 memory: "4Gi"
     - name: post-project-infra-kubevirt-prow-control-plane-deployment
       always_run: false
-      run_if_changed: "github/ci/prow-deploy/.*"
+      run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+|github/ci/prow-deploy/[^/]+"
       annotations: &deploy_postsubmit_annotations
         testgrid-dashboards: kubevirt-project-infra-postsubmits
         testgrid-alert-email: kubevirt-ci-maintainers@redhat.com

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -766,7 +766,7 @@ presubmits:
               memory: "1Gi"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
-    run_if_changed: "github/ci/prow-deploy/.*"
+    run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+|github/ci/prow-deploy/[^/]+"
     decorate: true
     labels:
       preset-podman-in-container-enabled: "true"


### PR DESCRIPTION
## Summary

- Narrow `run_if_changed` for the control-plane deployment postsubmit and the prow-deploy-test presubmit to exclude `github/ci/prow-deploy/files/jobs/`
- Prow does not allow `run_if_changed` and `skip_if_only_changed` on the same job, so the regex is narrowed instead

## Context

The broad `run_if_changed: "github/ci/prow-deploy/.*"` matches everything under `github/ci/prow-deploy/`, including job definition YAMLs under `files/jobs/`. This caused PRs like #5182 (which only rename/add job lanes) to trigger a full prow control-plane deployment and deploy test, even though no deployment-related files changed.

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined CI test and deployment triggers so they run only for relevant changes within the deployment configuration.
  * Prevented unrelated file updates from unnecessarily triggering presubmit and postsubmit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->