### PR TITLE
feat(bazel-cache): re-enable GCS remote cache

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -780,12 +780,12 @@ presets:
   env:
     - name: BAZEL_VERSION
       value: "6.5.0"
-    - name: CACHE_HOST
-      value: bazel-cache.kubevirt-prow
-    - name: CACHE_PORT
-      value: "8080"
+    - name: BAZEL_REMOTE_CACHE
+      value: https://storage.googleapis.com/kubevirt-bazel-cache
     - name: BAZEL_REMOTE_CACHE_ENABLED
       value: "true"
+    - name: BAZEL_CACHE_GOOGLE_CREDENTIALS
+      value: /etc/bazel-cache-gcs/bazel-cache-sa.json
   volumes:
     - name: bazel-cache-gcs
       secret:


### PR DESCRIPTION
**What this PR does / why we need it**:
Re-enables the GCS bazel remote cache by switching preset-bazel-cache back from CACHE_HOST/CACHE_PORT (greenhouse) to BAZEL_REMOTE_CACHE (GCS).

This was reverted  because dockerized builds couldn't access the SA credentials. The mount fixes have since merged:
- kubevirt/kubevirt#18152
- kubevirt/containerized-data-importer#4191

**Special notes for your reviewer**:
/cc @dhiller @dollierp 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Bazel caching configuration to use the Google Cloud remote cache.
  * Enabled remote caching and configured the required cache credentials for improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->