### PR TITLE
Add periodic Prow job for CI cost-per-PR report

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-periodics.yaml
@@ -1,0 +1,41 @@
+periodics:
+- name: periodic-ci-health-cost-report
+  cron: "0 6 * * *"
+  max_concurrency: 1
+  decorate: true
+  decoration_config:
+    timeout: 30m
+    grace_period: 5m
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-gcs-credentials: "true"
+  cluster: prow-workloads
+  extra_refs:
+  - org: kubevirt
+    repo: ci-health
+    base_ref: main
+    workdir: true
+  spec:
+    containers:
+      - image: quay.io/kubevirtci/golang:v20260707-cacb217
+        command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        args:
+          - |
+            go run ./cmd/cost/ \
+              --thanos-url https://thanos-querier.openshift-monitoring.svc:9091 \
+              --bearer-token-path /var/run/secrets/kubernetes.io/serviceaccount/token \
+              --insecure-skip-tls-verify \
+              --namespace kubevirt-prow-jobs \
+              --node-selector "kubevirt-worker-.*" \
+              --data-days 7 \
+              --path /tmp/output
+
+            gsutil cp /tmp/output/kubevirt/kubevirt/cost-report.html gs://kubevirt-prow/reports/cost-per-pr/cost-per-pr.html
+            gsutil cp /tmp/output/kubevirt/kubevirt/cost-results.json gs://kubevirt-prow/reports/cost-per-pr/cost-results.json
+        resources:
+          requests:
+            memory: "500Mi"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a daily Prow periodic job that generates a CI resource usage report per PR and uploads it to GCS.
  
The job runs the `cmd/cost` tool from kubevirt/ci-health#161, which queries Thanos on the prow-workloads cluster for Prow job pod CPU and memory usage, calculates each PR's consumption as a percentage of total cluster capacity, and outputs an HTML report.

**Special notes for your reviewer**:
/cc @dhiller @dollierp 
I will add a hold to this PR and remove when kubevirt/ci-health#161 is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily automated cost report for CI workloads.
  * Reports include an HTML summary and JSON results, which are uploaded for access through existing CI reporting infrastructure.
  * The report analyzes the previous seven days of usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->