### PR TITLE
orgs: Add vhostuser-network-binding-plugin repo

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -508,6 +508,8 @@ orgs:
         has_wiki: false
       vdpa-network-binding-plugin:
         description: KubeVirt network binding plugin providing network vhost-vdpa interface support to VMs.
+      vhostuser-network-binding-plugin:
+        description: KubeVirt network binding plugin providing network vhost-user interface support to VMs.
       virt-template:
         description: A KubeVirt add-on providing native, user-friendly templating workflows for KubeVirt virtual machines.
         has_projects: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the repository `vhostuser-network-binding-plugin` to the KubeVirt organization.

**Why this repository is needed**:

This repository implements the vhostuser network binding plugin, which brings support to [vhost-user network interfaces](https://libvirt.org/formatdomain.html#vhost-user-connection).

Given the dynamic nature of vhost-user sockets, this network binding plugin assumes the vhost-user socket directory is provided by a DRA driver. The current target is to support OVS-DPDK DRA Driver (https://github.com/amorenoz/dra-driver-ovsdpdk which will soon move to the [NPWG](https://github.com/k8snetworkplumbingwg/) org).

This project is still in early phases of development.

The repository admin/maintainer configuration was split into a separate PR: https://github.com/kubevirt/project-infra/pull/5275

**Which licensing model the repository is using or planning to use**:
Apache-2.0

**Maintainers who sponsor this repository**:
- @orelmisan 

**New GitHub team[^1] within KubeVirt org for new repository**:
GitHub team:
- vhostuser-network-binding-plugin-maintainers

Repo maintainers:

- @amorenoz

Repo users:

- @

[^1]: See [GitHub teams docs](https://docs.github.com/en/organizations/organizing-members-into-teams/about-teams)

**CI support is planned for**:

- [ ] tide [^2]
- [ ] prow jobs [^3]


**Note: Using [GitHub actions](https://docs.github.com/en/actions) might be an option if prow support is not available. However¸ KubeVirt CI maintainers will only support GitHub actions to the extent possible.**

[^2]:
See [merge automation](https://github.com/kubevirt/community/blob/main/docs/add-merge-automation-to-your-repository.md)
[^3]:
See [How to onboard a repository to Prow](https://github.com/kubevirt/project-infra/blob/main/docs/how-to-onboard-a-repository.md)

CI maintainer sponsoring:

<!--
    A CI maintainer from [CI maintainers](../../OWNERS_ALIASES) is required to sponsor the repository PR if CI support is required.
-->

- @

**KubeVirt mailing list announcement**:
- https://groups.google.com/g/kubevirt-dev/c/psaJGONf-ts

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close
the issue(s) when PR gets merged)*:
Fixes #

### Special notes for your reviewer
- Current repository and source code: https://github.com/amorenoz/vhostuser-network-binding-plugin
- Admin/maintainership configuration PR: https://github.com/kubevirt/project-infra/pull/5275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the vhostuser-network-binding-plugin repository to the project repository catalog.
  * Included a description highlighting support for vhost-user network interfaces in virtual machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->