### PR TITLE
fix(prow-deploy): skip control-plane deployment for job-only changes (bis)

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -652,7 +652,7 @@ postsubmits:
                 memory: "4Gi"
     - name: post-project-infra-kubevirt-prow-control-plane-deployment
       always_run: false
-      run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+|github/ci/prow-deploy/[^/]+"
+      run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+$|github/ci/prow-deploy/[^/]+$"
       annotations: &deploy_postsubmit_annotations
         testgrid-dashboards: kubevirt-project-infra-postsubmits
         testgrid-alert-email: kubevirt-ci-maintainers@redhat.com

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -766,7 +766,7 @@ presubmits:
               memory: "1Gi"
   - name: pull-project-infra-prow-deploy-test
     always_run: false
-    run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+|github/ci/prow-deploy/[^/]+"
+    run_if_changed: "github/ci/prow-deploy/(defaults|hack|kustom|tasks|templates|vars)/.*|github/ci/prow-deploy/files/[^/]+$|github/ci/prow-deploy/[^/]+$"
     decorate: true
     labels:
       preset-podman-in-container-enabled: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:

Anchor the regexp `[^/]+` to effectively prevent matching job files.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated validation and deployment checks so they run only when the relevant files are changed.
  * Reduced unnecessary CI jobs caused by loosely matching file paths.
  * Preserved expected checks for exact configuration and deployment-related changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->