### PR TITLE
Update kubevirt-observability-controller-postsubmits GH_CLI_VERSION to 2.96.0

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
@@ -24,7 +24,7 @@ postsubmits:
         - name: DOCKER_PREFIX
           value: quay.io/kubevirt
         - name: GH_CLI_VERSION
-          value: "1.5.0"
+          value: "2.96.0"
         - name: GITHUB_TOKEN_PATH
           value: /etc/github/oauth
         - name: GITHUB_REPOSITORY


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub CLI used by the release publishing process to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->