### PR TITLE
Add plugins repo

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -616,6 +616,12 @@ orgs:
         has_projects: true
         has_wiki: true
         has_issues: true
+      plugins:
+        description: SDK and catalog for building KubeVirt plugins
+        default_branch: main
+        has_projects: true
+        has_wiki: true
+        has_issues: true
     teams:
       QE:
         description: ""
@@ -855,6 +861,13 @@ orgs:
         repos:
           kubevirt: admin
           kubevirt-ansible: write
+      plugins-maintainers:
+        description: Maintainers of SDK and catalog for building KubeVirt plugins
+        maintainers:
+          - iholder101
+        privacy: closed
+        repos:
+          plugins: admin
       prow-job-taskforce:
         description: This team is authorized to interact with ProwJobs
         maintainers:


### PR DESCRIPTION
**What this PR does / why we need it**:

Defines the `plugins` repository and a `plugins-maintainers` team in the kubevirt GitHub organization.

The plugins repo will host the SDK and catalog for building KubeVirt plugins, owned by `plugins-maintainers`.

**Release note**:
```release-note
none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `plugins` repository with project tracking, wiki, and issue management enabled.
  * Added a private maintainer team with administrative access to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->