### PR TITLE
feat: re-enable CentOS 9 Stream automatic bump jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -263,7 +263,7 @@ periodics:
         rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
       env:
       - name: GIMME_GO_VERSION
-        value: "1.24.7"
+        value: "1.26.0"
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -145,6 +145,130 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-kubevirtci-bump-centos-base
+  cron: "0 4 * * 2"
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
+    workdir: true
+  - org: kubevirt
+    repo: project-infra
+    base_ref: main
+  labels:
+    preset-docker-mirror-proxy: "true"
+    preset-github-credentials: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-kubevirtci-quay-credential: "true"
+    preset-gcs-credentials: "true"
+  cluster: prow-workloads
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260519-5bbee81
+      command:
+      - "/usr/local/bin/runner.sh"
+      - "/bin/bash"
+      - "-c"
+      - |
+        cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+        ./hack/bump-centos-version.sh &&
+        SHORT_SHA=$(git rev-parse --short HEAD) &&
+        GIT_ASKPASS=../project-infra/hack/git-askpass.sh ../project-infra/hack/git-pr.sh \
+          --command "PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh" \
+          --repo kubevirtci \
+          --branch bump-centos-stream \
+          --target main \
+          --summary "Automatic bump of CentOS Stream to latest" \
+          --labels skip-review &&
+        # For passing centos image tag to dependent (s390x) prow job
+        image_tag=$(cat cluster-provision/k8s/base-image | cut -d ':' -f 2) &&
+        echo "$image_tag" > amd64-centos9-$SHORT_SHA &&
+        gsutil cp ./amd64-centos9-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-centos9-$SHORT_SHA
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "52Gi"
+- name: periodic-kubevirtci-bump-centos-base-s390x
+  cron: "0 4 * * 2" #Triggered at same time as x86 job so that both will run on same commit
+  annotations:
+    testgrid-create-test-group: "false"
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirtci
+    base_ref: main
+    workdir: true
+  labels:
+    preset-podman-in-container-enabled: "true"
+    preset-kubevirtci-quay-credential: "true"
+    preset-gcs-credentials: "true"
+  cluster: prow-s390x-workloads
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/golang:v20260417-7427ea2
+      command:
+      - "/usr/local/bin/runner.sh"
+      - "/bin/bash"
+      - "-c"
+      - |
+        # For getting centos image tag from amd64 prow job and use same for s390x and manifest-list images
+        SHORT_SHA=$(git rev-parse --short HEAD) &&
+        GCS_FILE_PATH=release/kubevirt/kubevirtci/amd64-centos9-$SHORT_SHA &&
+        CHECK_INTERVAL=30 &&
+        source /usr/local/bin/gcs_restapi.sh &&
+        while true; do
+            if stat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false"; then
+                echo "File $GCS_FILE_PATH is now available."
+                break
+            else
+                echo "File $GCS_FILE_PATH not found. Checking again in $CHECK_INTERVAL seconds."
+                sleep $CHECK_INTERVAL
+            fi
+        done
+        # Add retry mechanism for reading file content to handle GCS eventual consistency
+        MAX_RETRIES=5
+        RETRY_COUNT=0
+        RETRY_INTERVAL=5
+        while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            KUBEVIRTCI_TAG=$(cat_gcs_file kubevirt-prow "$GCS_FILE_PATH" "false")
+            if [ $? -eq 0 ] && [ -n "$KUBEVIRTCI_TAG" ]; then
+                echo "Successfully fetched KUBEVIRTCI_TAG: $KUBEVIRTCI_TAG"
+                break
+            else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                    echo "Failed to fetch KUBEVIRTCI_TAG (attempt $RETRY_COUNT/$MAX_RETRIES). Retrying in $RETRY_INTERVAL seconds..."
+                    sleep $RETRY_INTERVAL
+                else
+                    echo "Failed to fetch KUBEVIRTCI_TAG after $MAX_RETRIES attempts"
+                    exit 1
+                fi
+            fi
+        done
+        export KUBEVIRTCI_TAG &&
+        cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io &&
+        ./hack/bump-centos-version.sh &&
+        export PHASES=linux; export BYPASS_PMAN_CHANGE_CHECK=true; ./publish.sh &&
+        rm_gcs_file kubevirt-prow "$GCS_FILE_PATH"
+      env:
+      - name: GIMME_GO_VERSION
+        value: "1.24.7"
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "52Gi"
 - name: periodic-kubevirtci-bump-centos10-base
   cron: "0 4 * * 3"
   annotations:


### PR DESCRIPTION
## Summary

Re-enables the periodic CentOS 9 Stream base image bump jobs (`periodic-kubevirtci-bump-centos-base` and `periodic-kubevirtci-bump-centos-base-s390x`) that were removed in #5095 due to the boot hang described in #5098.

## Dependency

**Do not merge until https://github.com/kubevirt/kubevirtci/pull/1767 is merged.** That PR fixes the root cause — the QEMU `-serial pty` backend stalling guest boot under CPU contention when the newer CentOS 9 kernel produces more boot output. Without the fix, the auto-bumped images will intermittently fail to boot during `publish-kubevirtci`.

## Root cause (from #5098 investigation)

The CentOS 9 Stream image was never broken. When `-serial pty` is used and nobody reads from the PTY (always the case in CI), the QEMU PTY backend can stall guest execution. The kernel jump from `5.14.0-691` to `5.14.0-721` (~30 releases) produces more boot messages on `console=ttyS0`, crossing the threshold that triggers the stall. kubevirtci#1767 switches the serial backend to `-serial file:/dev/stderr` in CI, which eliminates the hang.

## Changes

Reverts the removal from #5095, restoring:
- `periodic-kubevirtci-bump-centos-base` (x86_64, weekly on Tuesdays at 04:00)
- `periodic-kubevirtci-bump-centos-base-s390x` (s390x, same schedule)

## Test plan

- [ ] kubevirtci#1767 merged and serial backend fix deployed
- [ ] First auto-bump run succeeds (next Tuesday after merge)

/kind bug

🤖 Assisted by Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated periodic jobs to update CentOS base images for amd64 and s390x builds.
  * Added coordination between architectures to ensure consistent image tags.
  * Added automated publishing of updated images and cleanup of temporary release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->