### PR TITLE
docs: add image publishing and label config docs

### DIFF
--- a/docs/labels-management.md
+++ b/docs/labels-management.md
@@ -1,0 +1,40 @@
+# Label Configuration Reference
+
+For how to add a new label and the full label listing, see [labels.md](labels.md).
+
+This document covers the configuration structure of `labels.yaml` and operational details not included in the auto-generated docs.
+
+## Configuration structure
+
+**Config file**: [labels.yaml](https://github.com/kubevirt/project-infra/tree/main/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml)
+
+Two top-level sections:
+- `default.labels` — labels applied to **all** repos in the kubevirt org
+- `repos.<org>/<repo>.labels` — labels specific to a single repository
+
+### Label fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | yes | Label name (e.g. `triage/accepted`) |
+| `color` | yes | Hex color without `#` prefix (e.g. `d455d0`) |
+| `target` | yes | `both` (issues + PRs), `issues`, or `prs` |
+| `description` | no | **Max 100 characters** (GitHub API limit, enforced by `label_sync`) |
+| `prowPlugin` | no | Prow plugin that manages this label (e.g. `label`, `lifecycle`) |
+| `addedBy` | no | Who can add the label (e.g. `anyone`, `org members`, `prow`) |
+| `previously` | no | List of `{name, color}` for label renames/migrations |
+
+### Constraints
+
+- **Label descriptions must not exceed 100 characters.** This is a GitHub API limit enforced by `label_sync`, which will reject labels that exceed it.
+- Label names must be unique (case-insensitive) within each scope.
+
+## Presubmit validation
+
+Any PR touching `labels.yaml` triggers two dry-run presubmit jobs that validate the config without applying it:
+- `pull-prow-kubevirt-labels-update-precheck` (kubevirt org)
+- `pull-prow-nmstate-labels-update-precheck` (nmstate repo)
+
+## Dependency ordering
+
+When a change depends on a new label existing on GitHub (e.g. a job config that applies the label), the label definition PR must merge first **and** the daily CronJob must run before the dependent change will work. Use `/hold` on the dependent PR until the label is available.

--- a/images/README.md
+++ b/images/README.md
@@ -6,7 +6,7 @@ Contains configurations for container images that are used by KubeVirt CI Prow j
 `publish_image.sh`
 ------------------
 
-You can use the above script to build and publish images to `quay.io` (provided you have the quay credentials)
+Builds and publishes a single-arch image to `quay.io` (requires quay credentials).
 
 Example:
 
@@ -14,7 +14,12 @@ Example:
 ./publish_image.sh -b golang quay.io kubevirtci
 ```
 
-builds the image in folder `images/golang` and tags it with `quay.io/kubevirtci/golang:v20211232-abcdefgh` where the tag is calculated from date and current git commit id when building 
+builds the image in folder `images/golang` and tags it with `quay.io/kubevirtci/golang:v20211232-abcdefgh` where the tag is calculated from date and current git commit id when building.
+
+`publish_multiarch_image.sh`
+----------------------------
+
+Builds and publishes multi-architecture images (amd64, arm64, s390x) to `quay.io`. Supports `-a` flag to build amd64 only, `-b` for build-only (no push), and `-l` to use a local base image.
 
 
 Updating published images


### PR DESCRIPTION
## Summary

- Document `publish_multiarch_image.sh` in `images/README.md` (was missing)
- Add `docs/labels-management.md` covering labels.yaml configuration structure, field reference, presubmit validation, and dependency ordering

This information was previously only available in the AGENTS.md file used by AI assistants.

🤖 Assisted by Claude