### PR TITLE
Add Prow config and branch protection for plugins repo

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -213,6 +213,7 @@ tide:
     kubevirt/redfish-controller: merge
     kubevirt/kubevirt-observability-controller: squash
     kubevirt/vdpa-network-binding-plugin: merge
+    kubevirt/plugins: merge
   queries:
   - repos:
     - kubevirt/dra-pci-driver
@@ -292,6 +293,7 @@ tide:
     - kubevirt/kubevirt-aie
     - kubevirt/kubevirt-aie-webhook
     - kubevirt/kubevirt-observability-controller
+    - kubevirt/plugins
     labels:
     - lgtm
     - approved
@@ -481,6 +483,10 @@ branch-protection:
             release-1.8-aie-nv:
               protect: true
               allow_force_pushes: true
+        plugins:
+          branches:
+            main:
+              protect: true
         project-infra:
           branches:
             main:

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -395,6 +395,15 @@ plugins:
     - release-note
     - trigger
 
+  kubevirt/plugins:
+    plugins:
+    - approve
+    - lgtm
+    - owners-label
+    - release-note
+    - trigger
+    - help
+
   kubevirt/project-infra:
     plugins:
     - approve
@@ -720,6 +729,7 @@ approve:
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller
   - kubevirt/vdpa-network-binding-plugin
+  - kubevirt/plugins
   require_self_approval: true
   lgtm_acts_as_approve: false
   ignore_review_state: true
@@ -868,6 +878,7 @@ lgtm:
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller
   - kubevirt/vdpa-network-binding-plugin
+  - kubevirt/plugins
   review_acts_as_lgtm: true
 
 override:
@@ -935,6 +946,7 @@ triggers:
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller
   - kubevirt/vdpa-network-binding-plugin
+  - kubevirt/plugins
   ignore_ok_to_test: true
 - repos:
   - virtblocks/virtblocks


### PR DESCRIPTION
**What this PR does / why we need it**:

Configures Prow merge automation and branch protection for the `kubevirt/plugins` repository (created in #5280).

- Tide: merge method and query config (with release-note enforcement).
- Branch protection on `main`.
- Prow plugins: approve, lgtm, owners-label, release-note, trigger, help.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prow integration for the `kubevirt/plugins` repository.
  * Enabled automated approval, labeling, merge, release-note, triggering, help, and LGTM workflows.
  * Added branch protection for the repository’s `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->