### PR TITLE
images: update bootstrap image base to Fedora 44

### DIFF
--- a/images/bootstrap/Containerfile
+++ b/images/bootstrap/Containerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
-FROM fedora:42
+FROM fedora:44
 
 WORKDIR /workspace
 RUN mkdir -p /workspace
@@ -43,7 +43,7 @@ RUN dnf install -y \
     glibc-devel \
     glibc-static \
     iproute \
-    java-21-openjdk-devel \
+    java-25-openjdk-devel \
     jq \
     libstdc++-static \
     libvirt-devel \


### PR DESCRIPTION
**What this PR does / why we need it**:

With the release of Fedora 44 - 42 has reached end of life.

F44 moved to java 25 - update openjdk-devel to stop container build failure

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #4624 

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bootstrap environment to use Fedora 44.
  * Upgraded the installed Java development tools to Java 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->