### PR TITLE
fix(kubevirt-unit-tests-1.9): use image with increased pid_limits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
@@ -443,7 +443,7 @@ presubmits:
         - /bin/sh
         - -c
         - make go-test
-        image: quay.io/kubevirtci/golang:v20260612-73bc71e
+        image: quay.io/kubevirtci/golang:v20260707-cacb217
         resources:
           requests:
             memory: 8Gi
@@ -469,7 +469,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        image: quay.io/kubevirtci/bootstrap:v20260707-cacb217
         resources:
           requests:
             memory: 12Gi
@@ -679,7 +679,7 @@ presubmits:
         - /bin/sh
         - -c
         - make test
-        image: quay.io/kubevirtci/bootstrap:v20260612-73bc71e
+        image: quay.io/kubevirtci/bootstrap:v20260707-cacb217
         resources:
           requests:
             cpu: "4"


### PR DESCRIPTION
**What this PR does / why we need it**:

Update to container images with increased pid_limits in KubeVirt unit tests jobs for the release-1.9 branch.

Note that the golang image also bumps the Golang version from v1.24.9 to v1.26.4 which shouldn't be a problem because release-1.9 branch was cut off after the Golang bump on KubeVirt.

**Special notes for your reviewer**:

/cc @dhiller @fossedihelm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and test environments for s390x, arm64, and generic unit test jobs.
  * Ensured CI jobs use the latest approved container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->