### PR TITLE
chore(sev): update lanes to kind-1.36 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1361,7 +1361,7 @@ periodics:
     repo: kubevirt
   labels:
     preset-podman-in-container-enabled: "true"
-  name: periodic-kubevirt-e2e-kind-1.34-sev
+  name: periodic-kubevirt-e2e-kind-1.36-sev
   spec:
     containers:
     - command:
@@ -1379,9 +1379,9 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: kind-1.34-sev
+        value: kind-1.36-sev
       - name: KUBEVIRT_PROVIDER
-        value: kind-1.34
+        value: kind-1.36
       image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -181,7 +181,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 5
-    name: pull-kubevirt-e2e-kind-1.34-sev
+    name: pull-kubevirt-e2e-kind-1.36-sev
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -197,9 +197,9 @@ presubmits:
           automation/test.sh
         env:
         - name: TARGET
-          value: kind-1.34-sev
+          value: kind-1.36-sev
         - name: KUBEVIRT_PROVIDER
-          value: kind-1.34
+          value: kind-1.36
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the Kind provider to version 1.36 in SEV lanes before the version 1.34 gets removed.

**Special notes for your reviewer**:

/cc @alancaldelas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated periodic and presubmit end-to-end test jobs to use Kind 1.36 instead of Kind 1.34.
  * Updated job names and test configuration to reflect the newer Kind version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->