### PR TITLE
kubevirtci: update bump fedora automation to also update Centos10 provision base image

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -100,7 +100,7 @@ periodics:
       args:
       - |
         git-pr.sh \
-          --command "./hack/bump-fedora-images-version.sh ../kubevirtci/cluster-provision/centos9/Dockerfile" \
+          --command "./hack/bump-fedora-images-version.sh ../kubevirtci/cluster-provision/centos9/Dockerfile ../kubevirtci/cluster-provision/centos10/Dockerfile" \
           --description-command "echo 'Bump fedora provisioning base to latest version'" \
           --branch bump-fedora-provision \
           --repo-path ../kubevirtci \

--- a/hack/bump-fedora-images-version.sh
+++ b/hack/bump-fedora-images-version.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 function usage {
     cat <<EOF
-usage: $0 <Containerfile/Dockerfile>
+usage: $0 <Containerfile/Dockerfile> [Containerfile/Dockerfile ...]
 
     Bump a fedora based container to the latest available fedora version
 
@@ -13,20 +13,20 @@ EOF
 }
 
 
-if [ ! "$#" -eq 1 ]; then
+if [ ! "$#" -ge 1 ]; then
     usage
     exit 1
 fi
 
-BUILD_FILE=$1
-
-if [ ! -f "$BUILD_FILE" ];  then
-    echo "Containerfile not found at $BUILD_FILE"
-    exit 1
-fi
+for BUILD_FILE in "$@"; do
+    if [ ! -f "$BUILD_FILE" ];  then
+        echo "Containerfile not found at $BUILD_FILE"
+        exit 1
+    fi
+done
 
 # Get latest version of Fedora available
 
 LATEST_FEDORA=$(curl -s -L https://fedoraproject.org/releases.json | jq -r '[.[].version|select(test("^[0-9]+$"))]|max')
 
-sed -i s"/fedora:[0-9][0-9]/fedora:$LATEST_FEDORA/"  $BUILD_FILE
+sed -i s"/fedora:[0-9][0-9]/fedora:$LATEST_FEDORA/" "$@"


### PR DESCRIPTION

**What this PR does / why we need it**:

The CentOS 10 based provider did not exist when this automation was introduced. Include the CentOS 10 Containerfile in the bump automation to ensure that they stay in sync as currently they are not consistent.[1]

Update the bump script to take multiple Containerfiles at once.

[1] https://github.com/kubevirt/kubevirtci/blob/95e13d4a8cc165ef07ce1b2f87d2437e2c6b2267/cluster-provision/centos10/Dockerfile#L1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Fedora image version updates now apply consistently across multiple container build files in a single run.
  * Automated update checks now include both CentOS 9 and CentOS 10 build definitions.
  * Improved validation of provided build file paths and clearer usage when no build files are specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->