### PR TITLE
don't trigger kubevirtci required lanes on docs-only PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -435,7 +435,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    skip_if_only_changed: '^[^/]+\.md$'
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -560,7 +561,8 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
+    skip_if_only_changed: '^[^/]+\.md$'
     cluster: prow-s390x-workloads
     decorate: true
     decoration_config:
@@ -591,7 +593,8 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  - always_run: true
+  - always_run: false
+    skip_if_only_changed: '^[^/]+\.md$'
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -621,7 +624,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    skip_if_only_changed: '^[^/]+\.md$'
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -681,7 +685,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    skip_if_only_changed: '^[^/]+\.md$'
     cluster: prow-workloads
     decorate: true
     decoration_config:
@@ -774,7 +779,8 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  - always_run: false
+    skip_if_only_changed: '^[^/]+\.md$'
     cluster: prow-workloads
     decorate: true
     decoration_config:


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>
Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>


**What this PR does / why we need it**:
Save CI resources by skipping the required lanes when the PR is a doc-change only PR.
Example: https://github.com/kubevirt/kubevirtci/pull/1765


**Release Note**
```release-note
NONE
```
