### PR TITLE
feat(external-plugins): switch to GitHub App credentials

### DIFF
--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-deployment.yaml
@@ -23,10 +23,17 @@ spec:
           args:
             - --dry-run=false
             - --config=/etc/coverage/config.yaml
-            - --github-token-path=/etc/github/oauth
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-app-id=$(GITHUB_APP_ID)
+            - --github-app-private-key-path=/etc/github/cert
             - --hmac-secret-file=/etc/webhook/hmac
+          env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: appid
           ports:
             - name: http
               containerPort: 9901
@@ -34,19 +41,26 @@ spec:
             - name: hmac
               mountPath: /etc/webhook
               readOnly: true
-            - name: oauth
+            - name: github-token
               mountPath: /etc/github
               readOnly: true
             - name: config
               mountPath: /etc/coverage
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: hmac
           secret:
             secretName: hmac-token
-        - name: oauth
+        - name: github-token
           secret:
-            secretName: oauth-token
+            secretName: github-token
         - name: config
           configMap:
             name: prow-coverage-config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
@@ -20,7 +20,9 @@ spec:
           image: quay.io/kubevirtci/phased:v20260716-ff8cd14
           imagePullPolicy: IfNotPresent
           args:
-            - --github-token-path=/etc/github/oauth
+            # Not using KubeVirt CI Prow GitHub App Credentials because the
+            # trigger plugin ignore comments from its own bot user.
+            - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --cache-dir=/var/run/cache
@@ -34,7 +36,7 @@ spec:
             - name: hmac
               mountPath: /etc/webhook
               readOnly: true
-            - name: oauth
+            - name: github-token
               mountPath: /etc/github
               readOnly: true
             - name: plugins
@@ -43,13 +45,23 @@ spec:
             - name: cache
               mountPath: /var/run/cache
               readOnly: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: hmac
           secret:
             secretName: hmac-token
-        - name: oauth
+        - name: github-token
           secret:
             secretName: commenter-oauth-token
+            items:
+              - key: oauth
+                path: token
         - name: plugins
           configMap:
             name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -22,13 +22,20 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - --dry-run=false
-            - --github-token-path=/etc/github/oauth
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-app-id=$(GITHUB_APP_ID)
+            - --github-app-private-key-path=/etc/github/cert
             - --cache-dir=/var/run/cache
             - --jobs-config-base=github/ci/prow-deploy/files/jobs
             - --prow-config-path=github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
             - --always-run=false
+          env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: appid
           ports:
             - name: http
               containerPort: 9900
@@ -36,7 +43,7 @@ spec:
             - name: hmac
               mountPath: /etc/webhook
               readOnly: true
-            - name: oauth
+            - name: github-token
               mountPath: /etc/github
               readOnly: true
             - name: plugins
@@ -45,13 +52,20 @@ spec:
             - name: cache
               mountPath: /var/run/cache
               readOnly: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: hmac
           secret:
             secretName: hmac-token
-        - name: oauth
+        - name: github-token
           secret:
-            secretName: oauth-token
+            secretName: github-token
         - name: plugins
           configMap:
             name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/local/referee-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/referee-deployment.yaml
@@ -23,7 +23,9 @@ spec:
         - --dry-run=false
         - --max-no-of-allowed-retest-comments=3
         - --port=9900
-        - --github-token-path=/etc/github/oauth
+        # Not using KubeVirt CI Prow GitHub App Credentials because the
+        # trigger plugin ignore comments from its own bot user.
+        - --github-token-path=/etc/github/token
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         ports:
@@ -33,7 +35,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: plugins
@@ -42,13 +44,23 @@ spec:
         - name: cache
           mountPath: /var/run/cache
           readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: hmac
         secret:
           secretName: hmac-token
-      - name: oauth
+      - name: github-token
         secret:
           secretName: commenter-oauth-token
+          items:
+            - key: oauth
+              path: token
       - name: plugins
         configMap:
           name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
@@ -23,7 +23,14 @@ spec:
         - --dry-run=false
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
+        env:
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: appid
         ports:
           - name: http
             containerPort: 8888
@@ -31,19 +38,26 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: github-token
           mountPath: /etc/github
           readOnly: true
         - name: plugins
           mountPath: /etc/plugins
           readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: hmac
         secret:
           secretName: hmac-token
-      - name: oauth
+      - name: github-token
         secret:
-          secretName: oauth-token
+          secretName: github-token
       - name: plugins
         configMap:
           name: plugins

--- a/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
@@ -21,13 +21,20 @@ spec:
           image: quay.io/kubevirtci/test-subset:v20260716-ff8cd14
           imagePullPolicy: IfNotPresent
           args:
-            - --github-token-path=/etc/github/oauth
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-app-id=$(GITHUB_APP_ID)
+            - --github-app-private-key-path=/etc/github/cert
             - --cache-dir=/var/run/cache
             - --jobs-config-base=github/ci/prow-deploy/files/jobs
             - --prow-config-path=github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
             - --prow-location=https://raw.githubusercontent.com/kubevirt/project-infra/main
+          env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-token
+                  key: appid
           ports:
             - name: http
               containerPort: 9900
@@ -35,7 +42,7 @@ spec:
             - name: hmac
               mountPath: /etc/webhook
               readOnly: true
-            - name: oauth
+            - name: github-token
               mountPath: /etc/github
               readOnly: true
             - name: plugins
@@ -44,13 +51,20 @@ spec:
             - name: cache
               mountPath: /var/run/cache
               readOnly: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: hmac
           secret:
             secretName: hmac-token
-        - name: oauth
+        - name: github-token
           secret:
-            secretName: oauth-token
+            secretName: github-token
         - name: plugins
           configMap:
             name: plugins

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/cherrypicker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/patches/JsonRFC6902/cherrypicker_deployment.yaml
@@ -2,7 +2,6 @@
 - op: replace
   path: /spec/template/spec/volumes/2/secret
   value:
-    secretName: oauth-token
-    items:
-      - key: oauth
-        path: token
+    # Not using KubeVirt CI Prow GitHub App Credentials because the
+    # cherry-picker plugin requires a user to create forks.
+    secretName: github-token


### PR DESCRIPTION
**What this PR does / why we need it**:

Update KubeVirt Prow in-house external plugins deployment manifests to use GitHub App credentials instead of Personal Access Token.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened several deployment containers by enforcing non-root execution, disabling privilege escalation, dropping capabilities, and applying the default seccomp profile.

* **Authentication**
  * Updated CI services to use GitHub App credentials or standardized GitHub token mounts.
  * Updated credential secret and volume mappings across coverage, phased, rehearse, referee, release-blocker, test-subset, and cherry-picker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->