### PR TITLE
fix(external-plugins): pin images to newest tag and disable bumper

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1060,7 +1060,8 @@ periodics:
       - -c
       args:
       - |
-        hack/git-pr.sh \
+        # TODO: remove dry-run mode once tags sorting order is fixed
+        hack/git-pr.sh --dry-run \
           --command "go run ./robots/image-bumper all --repo-root=$(pwd)" \
           --branch project-infra-image-bump \
           --repo project-infra \

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: coverage
-          image: quay.io/kubevirtci/coverage:v20260716-ff8cd14
+          image: quay.io/kubevirtci/coverage:v20260716-a2b9efe
           imagePullPolicy: IfNotPresent
           args:
             - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-phased-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: phased
-          image: quay.io/kubevirtci/phased:v20260716-ff8cd14
+          image: quay.io/kubevirtci/phased:v20260716-a2b9efe
           imagePullPolicy: IfNotPresent
           args:
             # Not using KubeVirt CI Prow GitHub App Credentials because the

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-rehearse-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: rehearse
-          image: quay.io/kubevirtci/rehearse:v20260716-ff8cd14
+          image: quay.io/kubevirtci/rehearse:v20260716-a2b9efe
           imagePullPolicy: IfNotPresent
           args:
             - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/referee-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/referee-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: referee
-        image: quay.io/kubevirtci/referee:v20260716-ff8cd14
+        image: quay.io/kubevirtci/referee:v20260716-a2b9efe
         args:
         - --dry-run=false
         - --max-no-of-allowed-retest-comments=3

--- a/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/release-blocker_deployment.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: release-blocker
-        image: quay.io/kubevirtci/release-blocker:v20260716-ff8cd14
+        image: quay.io/kubevirtci/release-blocker:v20260716-a2b9efe
         imagePullPolicy: IfNotPresent
         args:
         - --dry-run=false

--- a/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/test-subset-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: test-subset
-          image: quay.io/kubevirtci/test-subset:v20260716-ff8cd14
+          image: quay.io/kubevirtci/test-subset:v20260716-a2b9efe
           imagePullPolicy: IfNotPresent
           args:
             - --github-endpoint=http://ghproxy

--- a/images/publish_image.sh
+++ b/images/publish_image.sh
@@ -81,8 +81,8 @@ EOF
 get_image_tag() {
     local current_commit today
     current_commit="$(git rev-parse HEAD)"
-    today="$(date +%Y%m%d)"
-    echo "v${today}-${current_commit:0:7}"
+    now="$(date +%Y%m%d%H%M)"
+    echo "v${now}-${current_commit:0:7}"
 }
 
 build_image() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Two tags have been built today:
- v20260716-ff8cd14 (older)
- v20260716-a2b9efe (newer which includes github app support)

Unfortunately the bumper use the older one due to alphabetical order.

Pin to the newest tag and disable the bumper temporarly so that the change is not reverted.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several CI service components to newer container image versions.
  * Image tags now include the build time down to the minute, improving version traceability.
* **Bug Fixes**
  * Temporarily enabled dry-run mode for periodic image bump pull requests to prevent incorrect tag ordering from triggering changes.
  * Added a follow-up note to remove this safeguard once tag sorting is corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->