### PR TITLE
Bump performance jobs to 1.36

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1065,7 +1065,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-performance
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-performance
   spec:
     containers:
     - command:
@@ -1085,7 +1085,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.34
+        value: k8s-1.36
       - name: KUBEVIRT_STORAGE
         value: hpp
       - name: KUBEVIRT_MEMORY_SIZE
@@ -1131,7 +1131,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-performance-kwok
   spec:
     containers:
     - command:
@@ -1151,7 +1151,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make kwok-perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.34
+        value: k8s-1.36
       - name: KUBEVIRT_MEMORY_SIZE
         value: 35G
       - name: KUBEVIRT_DEPLOY_KWOK
@@ -1192,7 +1192,7 @@ periodics:
     preset-docker-mirror-proxy: "true"
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok-100
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-performance-kwok-100
   spec:
     containers:
     - command:
@@ -1212,7 +1212,7 @@ periodics:
         FUNC_TEST_ARGS="--no-color --seed=42" make kwok-perftest
       env:
       - name: KUBEVIRT_PROVIDER
-        value: k8s-1.34
+        value: k8s-1.36
       - name: KUBEVIRT_MEMORY_SIZE
         value: 10G
       - name: KUBEVIRT_DEPLOY_KWOK

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 4
-    name: pull-kubevirt-e2e-k8s-1.34-sig-performance
+    name: pull-kubevirt-e2e-k8s-1.36-sig-performance
     run_if_changed: ^cmd/.*|^rpm/.*|^tests/performance/.*|^hack/perftests.sh|^tools/perfscale-audit/.*|^bazel/.*|^third_party/.*|^staging/src/.*|^api/.*|^pkg/virt-.*|^pkg/controller/.*|^pkg/monitoring/.*
     skip_branches:
     - release-\d+\.\d+
@@ -39,7 +39,7 @@ presubmits:
           FUNC_TEST_ARGS="--no-color --seed=42" make perftest
         env:
         - name: KUBEVIRT_PROVIDER
-          value: k8s-1.34
+          value: k8s-1.36
         - name: KUBEVIRT_STORAGE
           value: hpp
         - name: KUBEVIRT_MEMORY_SIZE
@@ -1774,7 +1774,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
-    name: pull-kubevirt-e2e-k8s-1.34-sig-performance-kwok
+    name: pull-kubevirt-e2e-k8s-1.36-sig-performance-kwok
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1794,7 +1794,7 @@ presubmits:
           FUNC_TEST_ARGS="--no-color --seed=42" make kwok-perftest
         env:
         - name: KUBEVIRT_PROVIDER
-          value: k8s-1.34
+          value: k8s-1.36
         - name: KUBEVIRT_MEMORY_SIZE
           value: 35G
         - name: KUBEVIRT_DEPLOY_KWOK
@@ -2382,7 +2382,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 4
-    name: pull-kubevirt-e2e-k8s-1.34-sig-performance-kube-burner
+    name: pull-kubevirt-e2e-k8s-1.36-sig-performance-kube-burner
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -2406,7 +2406,7 @@ presubmits:
           PERFSCALE_KUBE_BURNER=true ./automation/perfscale-test.sh
         env:
         - name: KUBEVIRT_PROVIDER
-          value: k8s-1.34
+          value: k8s-1.36
         - name: KUBEVIRT_MEMORY_SIZE
           value: 35G
         - name: KUBEVIRT_DEPLOY_PROMETHEUS
@@ -2425,7 +2425,7 @@ presubmits:
         - name: PERFAUDIT
           value: "true"
         - name: KUBECONFIG
-          value: kubevirtci/_ci-configs/k8s-1.34/.kubeconfig
+          value: kubevirtci/_ci-configs/k8s-1.36/.kubeconfig
         - name: IMAGE_PULL_POLICY
           value: Always
         - name: KUBE_BURNER_VERSION


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Move sig scale performance lanes to 1.36 provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
