### PR TITLE
fix: vm-file-restore-operator pre/postsubmit jobs release version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
@@ -2,7 +2,7 @@ postsubmits:
   kubevirt/vm-file-restore-operator:
   - name: push-release-vm-file-restore-operator-images
     branches:
-    - release-\d+\.\d+
+    - release-v\d+\.\d+
     cluster: prow-workloads
     always_run: true
     skip_report: true
@@ -42,7 +42,7 @@ postsubmits:
             memory: "8Gi"
   - name: push-release-vm-file-restore-operator-tag
     branches:
-    - release-\d+\.\d+
+    - release-v\d+\.\d+
     cluster: kubevirt-prow-control-plane
     always_run: true
     skip_report: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubevirt/vm-file-restore-operator:
   - name: pull-vm-file-restore-operator-e2e
     skip_branches:
-      - release-\d+\.\d+
+      - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: false
@@ -36,7 +36,7 @@ presubmits:
   - name: pull-vm-file-restore-operator-unit-test
     cluster: kubevirt-prow-control-plane
     skip_branches:
-      - release-\d+\.\d+
+      - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true
@@ -66,7 +66,7 @@ presubmits:
   - name: pull-vm-file-restore-operator-lint
     cluster: kubevirt-prow-control-plane
     skip_branches:
-      - release-\d+\.\d+
+      - release-v\d+\.\d+
     annotations:
       fork-per-release: "true"
     always_run: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing `v` to `release-v\d+\.\d+`

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Updated release branch matching to support the `release-vX.Y` naming format.
  * Adjusted release publishing jobs to run for the correct release branches.
  * Updated presubmit checks to skip applicable release branches consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->