### PR TITLE
fix(imagebump): fix case of two tags with same date

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1031,8 +1031,7 @@ periodics:
       - -c
       args:
       - |
-        # TODO: remove dry-run mode once tags sorting order is fixed
-        hack/git-pr.sh --dry-run \
+        hack/git-pr.sh \
           --command "go run ./robots/image-bumper all --repo-root=$(pwd)" \
           --branch project-infra-image-bump \
           --repo project-infra \

--- a/pkg/imagebump/skopeo.go
+++ b/pkg/imagebump/skopeo.go
@@ -25,38 +25,96 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"sort"
+	"strings"
+	"time"
 )
 
 // kubevirtCITagPattern matches tags selected by hack/update-jobs-with-latest-image.sh
 var kubevirtCITagPattern = regexp.MustCompile(`^v?[0-9]+-[a-z0-9]{7,9}$`)
 var ErrNoMatchingTag = errors.New("no tag matching kubevirtci date-hash pattern")
 
-type skopeoListTags struct {
-	Tags []string `json:"Tags"`
-}
+type listTagsCommand func(imageRef string) ([]string, error)
 
-// LatestSkopeoTag returns the last tag in skopeo list-tags order that matches kubevirtCITagPattern
-func LatestSkopeoTag(imageRef string) (string, error) {
+var listTagsCmd = func(imageRef string) ([]string, error) {
 	cmd := exec.Command("skopeo", "list-tags", "docker://"+imageRef)
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("skopeo list-tags docker://%s: %w\n%s", imageRef, err, string(ee.Stderr))
+			return nil, fmt.Errorf("skopeo list-tags docker://%s: %w\n%s", imageRef, err, string(ee.Stderr))
 		}
-		return "", fmt.Errorf("skopeo list-tags docker://%s: %w", imageRef, err)
+		return nil, fmt.Errorf("skopeo list-tags docker://%s: %w", imageRef, err)
+	}
+	type skopeoListTags struct {
+		Tags []string `json:"Tags"`
 	}
 	var parsed skopeoListTags
 	if err := json.Unmarshal(out, &parsed); err != nil {
-		return "", fmt.Errorf("parse skopeo output: %w", err)
+		return nil, fmt.Errorf("parse skopeo output: %w", err)
 	}
-	var last string
-	for _, t := range parsed.Tags {
+	return parsed.Tags, nil
+}
+
+type inspectCommand func(fullImageRef string) (time.Time, error)
+
+var inspectCmd = func(fullImageRef string) (time.Time, error) {
+	cmd := exec.Command("skopeo", "inspect", "docker://"+fullImageRef)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return time.Time{}, fmt.Errorf("skopeo inspect docker://%s: %w\n%s", fullImageRef, err, string(ee.Stderr))
+		}
+		return time.Time{}, fmt.Errorf("skopeo inspect docker://%s: %w", fullImageRef, err)
+	}
+	type skopeoInspect struct {
+		Created time.Time `json:"Created"`
+	}
+	var parsed skopeoInspect
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		return time.Time{}, fmt.Errorf("parse skopeo inspect output: %w", err)
+	}
+	return parsed.Created, nil
+}
+
+// LatestSkopeoTag returns the last tag in skopeo list-tags order that matches kubevirtCITagPattern
+// after sorting by the date part first - if that doesn't work, i.e. if the date part is the same for
+// two tags, then it resorts to calling skopeo inspect, and comparing the Created entry
+func LatestSkopeoTag(imageRef string) (string, error) {
+	tags, err := listTagsCmd(imageRef)
+	if err != nil {
+		return "", fmt.Errorf("listTagsCmd for %s: %w", imageRef, err)
+	}
+	var allMatching []string
+	for _, t := range tags {
 		if kubevirtCITagPattern.MatchString(t) {
-			last = t
+			allMatching = append(allMatching, t)
 		}
 	}
-	if last == "" {
+	if len(allMatching) == 0 {
 		return "", fmt.Errorf("%w for %s (pattern %s)", ErrNoMatchingTag, imageRef, kubevirtCITagPattern.String())
 	}
-	return last, nil
+
+	var sortErrs []error
+	sort.Slice(allMatching, func(i, j int) bool {
+		iDateTime, jDateTime := strings.Split(allMatching[i], "-")[0], strings.Split(allMatching[j], "-")[0]
+		if iDateTime != jDateTime {
+			return iDateTime < jDateTime
+		}
+		iCreated, err := inspectCmd(fmt.Sprintf("%s:%s", imageRef, allMatching[i]))
+		if err != nil {
+			sortErrs = append(sortErrs, err)
+			return false
+		}
+		jCreated, err := inspectCmd(fmt.Sprintf("%s:%s", imageRef, allMatching[j]))
+		if err != nil {
+			sortErrs = append(sortErrs, err)
+			return false
+		}
+		return iCreated.Before(jCreated)
+	})
+	if len(sortErrs) > 0 {
+		return "", fmt.Errorf("errors when sorting tags: %w", errors.Join(sortErrs...))
+	}
+
+	return allMatching[len(allMatching)-1], nil
 }

--- a/pkg/imagebump/skopeo.go
+++ b/pkg/imagebump/skopeo.go
@@ -25,9 +25,12 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // kubevirtCITagPattern matches tags selected by hack/update-jobs-with-latest-image.sh
@@ -37,6 +40,8 @@ var ErrNoMatchingTag = errors.New("no tag matching kubevirtci date-hash pattern"
 type listTagsCommand func(imageRef string) ([]string, error)
 
 var listTagsCmd = func(imageRef string) ([]string, error) {
+	logEntry := log.WithField("command", fmt.Sprintf("%s %s %s", "skopeo", "list-tags", "docker://"+imageRef))
+	logEntry.Debug("running")
 	cmd := exec.Command("skopeo", "list-tags", "docker://"+imageRef)
 	out, err := cmd.Output()
 	if err != nil {
@@ -52,12 +57,15 @@ var listTagsCmd = func(imageRef string) ([]string, error) {
 	if err := json.Unmarshal(out, &parsed); err != nil {
 		return nil, fmt.Errorf("parse skopeo output: %w", err)
 	}
+	logEntry.WithField("parsed", parsed).Debug("done")
 	return parsed.Tags, nil
 }
 
 type inspectCommand func(fullImageRef string) (time.Time, error)
 
 var inspectCmd = func(fullImageRef string) (time.Time, error) {
+	logEntry := log.WithField("command", fmt.Sprintf("%s %s %s", "skopeo", "inspect", "docker://"+fullImageRef))
+	logEntry.Debug("running")
 	cmd := exec.Command("skopeo", "inspect", "docker://"+fullImageRef)
 	out, err := cmd.Output()
 	if err != nil {
@@ -73,6 +81,7 @@ var inspectCmd = func(fullImageRef string) (time.Time, error) {
 	if err := json.Unmarshal(out, &parsed); err != nil {
 		return time.Time{}, fmt.Errorf("parse skopeo inspect output: %w", err)
 	}
+	logEntry.WithField("parsed", parsed).Debug("done")
 	return parsed.Created, nil
 }
 
@@ -94,18 +103,35 @@ func LatestSkopeoTag(imageRef string) (string, error) {
 		return "", fmt.Errorf("%w for %s (pattern %s)", ErrNoMatchingTag, imageRef, kubevirtCITagPattern.String())
 	}
 
-	var sortErrs []error
-	sort.Slice(allMatching, func(i, j int) bool {
-		iDateTime, jDateTime := strings.Split(allMatching[i], "-")[0], strings.Split(allMatching[j], "-")[0]
-		if iDateTime != jDateTime {
-			return iDateTime < jDateTime
+	// First pass, reverse sort, so newest elements should be at the start
+	slices.Reverse(allMatching)
+
+	// Now reduce to the subset of the latest candidates, i.e. remove all that don't have the date component of the last
+	// entry
+	dateComponent := strings.Split(allMatching[0], "-")[0]
+	var candidates []string
+	for _, c := range allMatching {
+		if !strings.HasPrefix(c, dateComponent) {
+			continue
 		}
-		iCreated, err := inspectCmd(fmt.Sprintf("%s:%s", imageRef, allMatching[i]))
+		candidates = append(candidates, c)
+	}
+
+	// Only one left, done
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+
+	// Now sort the candidates again, using skopeo inspect to look up the Created date
+	// This time the most recent tag will show up at the bottom
+	var sortErrs []error
+	sort.Slice(candidates, func(i, j int) bool {
+		iCreated, err := inspectCmd(fmt.Sprintf("%s:%s", imageRef, candidates[i]))
 		if err != nil {
 			sortErrs = append(sortErrs, err)
 			return false
 		}
-		jCreated, err := inspectCmd(fmt.Sprintf("%s:%s", imageRef, allMatching[j]))
+		jCreated, err := inspectCmd(fmt.Sprintf("%s:%s", imageRef, candidates[j]))
 		if err != nil {
 			sortErrs = append(sortErrs, err)
 			return false
@@ -116,5 +142,5 @@ func LatestSkopeoTag(imageRef string) (string, error) {
 		return "", fmt.Errorf("errors when sorting tags: %w", errors.Join(sortErrs...))
 	}
 
-	return allMatching[len(allMatching)-1], nil
+	return allMatching[len(candidates)-1], nil
 }

--- a/pkg/imagebump/skopeo.go
+++ b/pkg/imagebump/skopeo.go
@@ -40,22 +40,24 @@ var ErrNoMatchingTag = errors.New("no tag matching kubevirtci date-hash pattern"
 type listTagsCommand func(imageRef string) ([]string, error)
 
 var listTagsCmd = func(imageRef string) ([]string, error) {
-	logEntry := log.WithField("command", fmt.Sprintf("%s %s %s", "skopeo", "list-tags", "docker://"+imageRef))
+	cmdArgs := []string{"list-tags", "docker://" + imageRef}
+	fullCommand := "skopeo " + strings.Join(cmdArgs, " ")
+	logEntry := log.WithField("command", fullCommand)
 	logEntry.Debug("running")
-	cmd := exec.Command("skopeo", "list-tags", "docker://"+imageRef)
+	cmd := exec.Command("skopeo", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("skopeo list-tags docker://%s: %w\n%s", imageRef, err, string(ee.Stderr))
+			return nil, fmt.Errorf("%s: %w\n%s", fullCommand, err, string(ee.Stderr))
 		}
-		return nil, fmt.Errorf("skopeo list-tags docker://%s: %w", imageRef, err)
+		return nil, fmt.Errorf("%s: %w", fullCommand, err)
 	}
 	type skopeoListTags struct {
 		Tags []string `json:"Tags"`
 	}
 	var parsed skopeoListTags
 	if err := json.Unmarshal(out, &parsed); err != nil {
-		return nil, fmt.Errorf("parse skopeo output: %w", err)
+		return nil, fmt.Errorf("parse %s output: %w", fullCommand, err)
 	}
 	logEntry.WithField("parsed", parsed).Debug("done")
 	return parsed.Tags, nil
@@ -64,25 +66,26 @@ var listTagsCmd = func(imageRef string) ([]string, error) {
 type inspectCommand func(fullImageRef string) (time.Time, error)
 
 var inspectCmd = func(fullImageRef string) (time.Time, error) {
-	logEntry := log.WithField("command", fmt.Sprintf("%s %s %s", "skopeo", "inspect", "docker://"+fullImageRef))
+	const dateTimeFormat string = "2006-01-02T15:04:05Z"
+	cmdArgs := []string{"inspect", "--no-tags", fmt.Sprintf(`--format={{.Created.Format "%s"}}`, dateTimeFormat), "docker://" + fullImageRef}
+	fullCommand := "skopeo " + strings.Join(cmdArgs, " ")
+	logEntry := log.WithField("command", fullCommand)
 	logEntry.Debug("running")
-	cmd := exec.Command("skopeo", "inspect", "docker://"+fullImageRef)
+	cmd := exec.Command("skopeo", cmdArgs...)
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			return time.Time{}, fmt.Errorf("skopeo inspect docker://%s: %w\n%s", fullImageRef, err, string(ee.Stderr))
+			return time.Time{}, fmt.Errorf("%s: %w\n%s", fullCommand, err, string(ee.Stderr))
 		}
-		return time.Time{}, fmt.Errorf("skopeo inspect docker://%s: %w", fullImageRef, err)
+		return time.Time{}, fmt.Errorf("%s: %w", fullCommand, err)
 	}
-	type skopeoInspect struct {
-		Created time.Time `json:"Created"`
-	}
-	var parsed skopeoInspect
-	if err := json.Unmarshal(out, &parsed); err != nil {
-		return time.Time{}, fmt.Errorf("parse skopeo inspect output: %w", err)
+	before, _ := strings.CutSuffix(string(out), "\n")
+	parsed, err := time.Parse(dateTimeFormat, before)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse %s output: %w\n%v", fullCommand, err, out)
 	}
 	logEntry.WithField("parsed", parsed).Debug("done")
-	return parsed.Created, nil
+	return parsed, nil
 }
 
 // LatestSkopeoTag returns the last tag in skopeo list-tags order that matches kubevirtCITagPattern

--- a/pkg/imagebump/skopeo_test.go
+++ b/pkg/imagebump/skopeo_test.go
@@ -1,0 +1,97 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package imagebump
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("skopeo", func() {
+	Context("listTags", func() {
+		var oldlistTagsCommand listTagsCommand
+		var oldinspectCommand inspectCommand
+		BeforeEach(func() {
+			oldlistTagsCommand = listTagsCmd
+			oldinspectCommand = inspectCmd
+		})
+		AfterEach(func() {
+			listTagsCmd = oldlistTagsCommand
+			inspectCmd = oldinspectCommand
+		})
+		DescribeTable("sorts",
+			func(imageRef string, listTagsOutput []string, expectedTag string, expectsListTagsErr bool, inspectCreatedByFullImageRef map[string]time.Time) {
+				listTagsCmd = newListTagsCommand(listTagsOutput)
+				inspectCmd = newInspectCommand(inspectCreatedByFullImageRef)
+				tag, err := LatestSkopeoTag(imageRef)
+				if expectsListTagsErr {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(tag, err).To(BeEquivalentTo(expectedTag))
+					Expect(err).ToNot(HaveOccurred())
+				}
+			},
+			Entry("none",
+				"quay.io/kubevirtci/ginkgo-tests",
+				[]string{},
+				"",
+				true,
+				map[string]time.Time{},
+			),
+			Entry("different by day",
+				"quay.io/kubevirtci/ginkgo-tests",
+				[]string{
+					"v20260711-7a66da0",
+					"v20260716-a2b9efe",
+				},
+				"v20260716-a2b9efe",
+				false,
+				map[string]time.Time{},
+			),
+			Entry("different by hour",
+				"quay.io/kubevirtci/ginkgo-tests",
+				[]string{
+					"v20260711-7a66da0",
+					"v20260716-a2b9efe",
+					"v20260716-ff8cd14",
+				},
+				"v20260716-a2b9efe",
+				false,
+				map[string]time.Time{
+					"quay.io/kubevirtci/ginkgo-tests:v20260716-a2b9efe": time.Date(2026, 07, 16, 10, 0, 0, 0, time.UTC),
+					"quay.io/kubevirtci/ginkgo-tests:v20260716-ff8cd14": time.Date(2026, 07, 16, 1, 0, 0, 0, time.UTC)},
+			),
+		)
+	})
+})
+
+func newListTagsCommand(output []string) listTagsCommand {
+	return func(imageRef string) ([]string, error) {
+		return output, nil
+	}
+}
+
+func newInspectCommand(inspectCreatedByFullImageRef map[string]time.Time) inspectCommand {
+	return func(fullImageRef string) (time.Time, error) {
+		return inspectCreatedByFullImageRef[fullImageRef], nil
+	}
+}

--- a/pkg/imagebump/test_suite_test.go
+++ b/pkg/imagebump/test_suite_test.go
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package imagebump
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestImageBump(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ImageBump Main Suite")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

In case of images being bumped twice in one day, both images receive the same first part in their tag. Quay seems to return the list of tags in it's list-tag command response as sorted by tag alphabetically. However it is possible that a tag with the second part (an abbreviation of the commit hash) maybe sorted earlier, even though it has been pushed later in the day.

Example:
```bash
❯ skopeo list-tags docker://quay.io/kubevirtci/flakefinder
{
	"Repository": "quay.io/kubevirtci/flakefinder",
	"Tags": [
		"latest",
		...
		"v20260711-7a66da0",
		"v20260716-a2b9efe",
		"v20260716-ff8cd14"
	]
}
❯ skopeo inspect docker://quay.io/kubevirtci/flakefinder:v20260716-ff8cd14 | jq '.Created'
"2026-07-16T01:22:31Z"
❯ skopeo inspect docker://quay.io/kubevirtci/flakefinder:v20260716-a2b9efe | jq '.Created'
"2026-07-16T10:18:43Z"
```

This change adds a call to `skopeo inspect` fetching the `Created` date of the image as a fallback in case two images have the same first part.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image tag selection to consistently identify the newest matching tag.
  * Added timestamp-based tie-breaking when multiple tags share the same date.
  * Enhanced error reporting when tag or image metadata cannot be retrieved.

* **Tests**
  * Added coverage for empty tag lists, date-based selection, and timestamp-based tie-breaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->