### PR TITLE
feat(label-sync): switch to GitHub App credentials

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -906,11 +906,13 @@ presubmits:
           requests:
             memory: "200Mi"
         securityContext: *unprivileged_sc
-  - name: pull-prow-kubevirt-labels-update-precheck
+  - &label_sync_job
+    name: pull-prow-kubevirt-labels-update-precheck
     run_if_changed: '^github/ci/prow-deploy/kustom/base/configs/current/labels/labels\.yaml$'
     annotations:
       testgrid-create-test-group: "false"
     labels:
+      preset-github-app-id: "true"
       preset-github-credentials: "true"
     decoration_config:
       timeout: 1h
@@ -919,37 +921,33 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
-      - name: label-sync
+      - &label_sync_container
+        name: label-sync
         image: gcr.io/k8s-staging-test-infra/label_sync:v20260714-c52c557180
         command: [ "/ko-app/label_sync" ]
         args:
         - --config=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+        - --github-endpoint=http://ghproxy.kubevirt-prow.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --confirm=false
         - --orgs=kubevirt
-        - --token=/etc/github/token
+        securityContext: *unprivileged_sc
       restartPolicy: Never
-  - name: pull-prow-nmstate-labels-update-precheck
-    run_if_changed: '^github/ci/prow-deploy/kustom/base/configs/current/labels/labels\.yaml$'
-    annotations:
-      testgrid-create-test-group: "false"
-    labels:
-      preset-github-credentials: "true"
-    decoration_config:
-      timeout: 1h
-      grace_period: 5m
-    cluster: kubevirt-prow-control-plane
-    max_concurrency: 1
+  - <<: *label_sync_job
+    name: pull-prow-nmstate-labels-update-precheck
     spec:
       containers:
-      - name: label-sync
-        image: gcr.io/k8s-staging-test-infra/label_sync:v20260714-c52c557180
-        command: [ "/ko-app/label_sync" ]
+      - <<: *label_sync_container
         args:
         - --config=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+        - --github-endpoint=http://ghproxy.kubevirt-prow.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --confirm=false
         - --only=nmstate/kubernetes-nmstate
-        - --token=/etc/github/token
-      restartPolicy: Never
   - annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-control-plane

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -1,4 +1,8 @@
 ---
+# KubeVirt Prow uses a presubmit ProwJob to validate the labels and a
+# kubernetes CronJob to reconcile them. Both jobs are duplicated to
+# reconcile kubevirt and nmstate organizations separately.
+# https://git.k8s.io/test-infra/label_sync/README.md
 default:
   labels:
     - color: 8fc951

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -33,9 +33,18 @@ spec:
               command: [ "/ko-app/label_sync" ]
               args:
               - --config=/etc/config/labels.yaml
+              - --github-endpoint=http://ghproxy
+              - --github-endpoint=https://api.github.com
+              - --github-app-id=$(GITHUB_APP_ID)
+              - --github-app-private-key-path=/etc/github/cert
               - --confirm=true
               - --orgs=kubevirt
-              - --token=/etc/github/token
+              env:
+                 - name: GITHUB_APP_ID
+                   valueFrom:
+                     secretKeyRef:
+                       name: github-token
+                       key: appid
               volumeMounts:
               - name: config
                 mountPath: /etc/config
@@ -43,6 +52,13 @@ spec:
               - name: github-token
                 mountPath: /etc/github
                 readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ALL]
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
           restartPolicy: Never
           volumes:
           - name: config

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -33,9 +33,18 @@ spec:
               command: [ "/ko-app/label_sync" ]
               args:
               - --config=/etc/config/labels.yaml
+              - --github-endpoint=http://ghproxy
+              - --github-endpoint=https://api.github.com
+              - --github-app-id=$(GITHUB_APP_ID)
+              - --github-app-private-key-path=/etc/github/cert
               - --confirm=true
               - --only=nmstate/kubernetes-nmstate
-              - --token=/etc/github/token
+              env:
+                 - name: GITHUB_APP_ID
+                   valueFrom:
+                     secretKeyRef:
+                       name: github-token
+                       key: appid
               volumeMounts:
               - name: config
                 mountPath: /etc/config
@@ -43,6 +52,13 @@ spec:
               - name: github-token
                 mountPath: /etc/github
                 readOnly: true
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: [ALL]
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
           restartPolicy: Never
           volumes:
           - name: config


### PR DESCRIPTION
**What this PR does / why we need it**:

Switch `label_sync` credentials to [kubevirt-prow](https://github.com/apps/kubevirt-prow) GitHub Application instead of [kubevirt-bot](https://github.com/kubevirt-bot) user token

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label synchronization workflows for both KubeVirt and NMState repositories.
  * Updated label-sync jobs to use GitHub App authentication via the internal GitHub proxy endpoint.
  * Preserved NMState-specific label filtering to limit reconciliation to `nmstate/kubernetes-nmstate`.
* **Security**
  * Hardened label-sync pod security settings (non-root, no privilege escalation, dropped capabilities, default seccomp).
* **Documentation**
  * Added header documentation describing presubmit label validation and scheduled label reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->