### PR TITLE
chore(jobs): consolidate GitHub credentials preset

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -4,6 +4,8 @@ periodics:
     cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
+    labels:
+      preset-github-credentials: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20260716-ff8cd14
@@ -14,7 +16,7 @@ periodics:
           - /usr/bin/flakefinder
           args:
             - --dry-run=false
-            - --token=/etc/github/oauth
+            - --token=/etc/github/token
             - --merged=168h
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
             - --org=k8snetworkplumbingwg
@@ -22,15 +24,10 @@ periodics:
             - --skip_results_before_start_of_report=false
             - --pr_base_branch=main
           volumeMounts:
-            - name: token
-              mountPath: /etc/github
             - name: gcs
               mountPath: /etc/gcs
               readOnly: true
       volumes:
-        - name: token
-          secret:
-            secretName: oauth-token
         - name: gcs
           secret:
             secretName: gcs
@@ -39,6 +36,8 @@ periodics:
     cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
+    labels:
+      preset-github-credentials: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v20260716-ff8cd14
@@ -49,7 +48,7 @@ periodics:
           - /usr/bin/flakefinder
           args:
             - --dry-run=false
-            - --token=/etc/github/oauth
+            - --token=/etc/github/token
             - --merged=24h
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
             - --org=k8snetworkplumbingwg
@@ -57,15 +56,10 @@ periodics:
             - --skip_results_before_start_of_report=false
             - --pr_base_branch=main
           volumeMounts:
-            - name: token
-              mountPath: /etc/github
             - name: gcs
               mountPath: /etc/gcs
               readOnly: true
       volumes:
-        - name: token
-          secret:
-            secretName: oauth-token
         - name: gcs
           secret:
             secretName: gcs
@@ -73,6 +67,8 @@ periodics:
     interval: 168h
     annotations:
       testgrid-create-test-group: "false"
+    labels:
+      preset-github-credentials: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -84,7 +80,7 @@ periodics:
           - /usr/bin/flakefinder
           args:
             - --dry-run=false
-            - --token=/etc/github/oauth
+            - --token=/etc/github/token
             - --merged=672h
             - --report_output_child_path=k8snetworkplumbingwg/kubemacpool
             - --org=k8snetworkplumbingwg
@@ -92,15 +88,10 @@ periodics:
             - --skip_results_before_start_of_report=false
             - --pr_base_branch=main
           volumeMounts:
-            - name: token
-              mountPath: /etc/github
             - name: gcs
               mountPath: /etc/gcs
               readOnly: true
       volumes:
-        - name: token
-          secret:
-            secretName: oauth-token
         - name: gcs
           secret:
             secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-postsubmits.yaml
@@ -97,7 +97,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/application-aware-quota
         - name: GIT_USER_NAME
@@ -134,7 +134,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/application-aware-quota
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
@@ -99,7 +99,6 @@ presubmits:
       fork-per-release: "true"
     always_run: true
     optional: true
-    decorate: true
     decoration_config:
       timeout: 1h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         - name: GIMME_GO_VERSION
           value: "1.24.3"
         - name: GITHUB_TOKEN_PATH
-          value: "/etc/github/oauth"
+          value: /etc/github/token
         resources:
           requests:
             memory: "1Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=168h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
@@ -35,7 +35,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator
@@ -56,7 +56,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=672h
       - --report_output_child_path=kubevirt/cluster-network-addons-operator
       - --repo=cluster-network-addons-operator

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-postsubmits.yaml
@@ -21,7 +21,7 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/oauth) ./automation/release.sh"
+              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/token) ./automation/release.sh"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -302,24 +302,25 @@ periodics:
           command: ["/bin/bash", "-ce"]
           args:
             - |
-              if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/token; then
-                export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-                latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-                description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
+              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              missing_labels="lgtm,approved,do-not-merge/hold"
 
-                git-pr.sh \
-                  --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                  --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
-                  --repo kubevirt \
-                  --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
-                  --target "${KUBEVIRT_BRANCH}"
-                git-pr.sh \
-                  --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                  --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
-                  --repo ssp-operator \
-                  --branch "update-common-instancetypes-${SSP_BRANCH}" \
-                  --target "${SSP_BRANCH}"
-              fi
+              git-pr.sh \
+                --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
+                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --repo kubevirt \
+                --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
+                --target "${KUBEVIRT_BRANCH}" \
+                --missing-labels "${missing_labels}"
+              git-pr.sh \
+                --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
+                --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
+                --repo ssp-operator \
+                --branch "update-common-instancetypes-${SSP_BRANCH}" \
+                --target "${SSP_BRANCH}" \
+                --missing-labels "${missing_labels}"
           resources:
             requests:
               memory: "200Mi"
@@ -391,24 +392,25 @@ periodics:
           command: ["/bin/bash", "-ce"]
           args:
             - |
-              if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/token; then
-                export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-                latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-                description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
+              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              missing_labels="lgtm,approved,do-not-merge/hold"
 
-                git-pr.sh \
-                  --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                  --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
-                  --repo kubevirt \
-                  --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
-                  --target "${KUBEVIRT_BRANCH}"
-                git-pr.sh \
-                  --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                  --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
-                  --repo ssp-operator \
-                  --branch "update-common-instancetypes-${SSP_BRANCH}" \
-                  --target "${SSP_BRANCH}"
-              fi
+              git-pr.sh \
+                --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
+                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --repo kubevirt \
+                --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
+                --target "${KUBEVIRT_BRANCH}" \
+                --missing-labels "${missing_labels}"
+              git-pr.sh \
+                --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
+                --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
+                --repo ssp-operator \
+                --branch "update-common-instancetypes-${SSP_BRANCH}" \
+                --target "${SSP_BRANCH}" \
+                --missing-labels "${missing_labels}"
           resources:
             requests:
               memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -302,7 +302,7 @@ periodics:
           command: ["/bin/bash", "-ce"]
           args:
             - |
-              if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
+              if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/token; then
                 export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
                 latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
                 description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
@@ -391,7 +391,7 @@ periodics:
           command: ["/bin/bash", "-ce"]
           args:
             - |
-              if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/oauth; then
+              if labels-checker --org=kubevirt --repo=kubevirt --author=kubevirt-bot --branch-name=update-common-instancetypes-${KUBEVIRT_BRANCH} --ensure-labels-missing=lgtm,approved,do-not-merge/hold --github-token-path=/etc/github/token; then
                 export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
                 latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
                 description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/community/community-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/community/community-periodics.yaml
@@ -27,7 +27,7 @@ periodics:
         CONTRIBUTIONS_OUTPUT_FILE_NAME="${ARTIFACTS}/contributions-report.yaml"
 
         go run ./generators/cmd/contributions \
-          --github-token /etc/github/oauth \
+          --github-token /etc/github/token \
           --report-output-file-path ${CONTRIBUTIONS_OUTPUT_FILE_NAME} \
           --months 12
 

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=168h
       - --report_output_child_path=kubevirt/containerized-data-importer
       - --pr_base_branch=main
@@ -35,7 +35,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --report_output_child_path=kubevirt/containerized-data-importer
       - --pr_base_branch=main
@@ -56,7 +56,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=672h
       - --report_output_child_path=kubevirt/containerized-data-importer
       - --pr_base_branch=main

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-postsubmits.yaml
@@ -95,7 +95,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/containerized-data-importer
         - name: GIT_USER_NAME
@@ -134,7 +134,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/containerized-data-importer
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-postsubmits.yaml
@@ -61,7 +61,7 @@ postsubmits:
           - name: GH_CLI_VERSION
             value: "1.5.0"
           - name: GITHUB_TOKEN_PATH
-            value: /etc/github/oauth
+            value: /etc/github/token
           - name: GITHUB_REPOSITORY
             value: kubevirt/csi-driver
           - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-postsubmits.yaml
@@ -103,7 +103,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/hostpath-provisioner-operator
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-postsubmits.yaml
@@ -105,7 +105,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/hostpath-provisioner
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -71,7 +71,6 @@ presubmits:
       fork-per-release: "true"
     always_run: false
     optional: true
-    decorate: true
     decoration_config:
       timeout: 3h
       grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-postsubmits.yaml
@@ -23,7 +23,7 @@ postsubmits:
               - "-c"
               - |
                   cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io && \
-                  GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/oauth) ./hack/build-in-docker.sh
+                  GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/token) ./hack/build-in-docker.sh
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -101,7 +101,7 @@ presubmits:
               - "-c"
               - |
                 cat $QUAY_PASSWORD | docker login --username $(<$QUAY_USER) --password-stdin quay.io && \
-                GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/oauth) PUSH_IMAGE=false ./hack/build-in-docker.sh
+                GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/token) PUSH_IMAGE=false ./hack/build-in-docker.sh
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-postsubmits.yaml
@@ -65,7 +65,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/kubevirt-migration-controller
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/kubevirt-migration-operator
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-observability-controller/kubevirt-observability-controller-postsubmits.yaml
@@ -25,7 +25,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "2.96.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/kubevirt-observability-controller
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-velero-plugin/kubevirt-velero-plugin-postsubmits.yaml
@@ -95,7 +95,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/kubevirt-velero-plugin
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --today=true
       - --report_output_child_path=kubevirt/kubevirt
@@ -39,7 +39,7 @@ periodics:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=168h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -67,7 +67,7 @@ periodics:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -140,8 +140,8 @@ periodics:
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
-            key: oauth
-            name: oauth-token
+            name: github-token
+            key: token
       image: quay.io/kubevirtci/golang:v20260715-af3e234
       resources: {}
 - annotations:
@@ -360,7 +360,7 @@ periodics:
       - name: GIT_USER_NAME
         value: kubevirt-bot
       - name: GITHUB_TOKEN_PATH
-        value: /etc/github/oauth
+        value: /etc/github/token
       - name: BUILD_ARCH
         value: amd64,crossbuild-s390x,crossbuild-aarch64
       image: quay.io/kubevirtci/golang:v20260715-af3e234
@@ -754,6 +754,7 @@ periodics:
   labels:
     preset-bazel-cache: "true"
     preset-docker-mirror-proxy: "true"
+    preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-pgp-bot-key: "true"
     preset-podman-in-container-enabled: "true"
@@ -796,23 +797,14 @@ periodics:
         value: Always
       - name: BUILD_ARCH
         value: crossbuild-s390x
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
       resources:
         requests:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/github
-        name: token
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -1732,7 +1724,7 @@ periodics:
             --org kubevirt \
             --repo kubevirt \
             --path-to-repository $kubevirt_dir \
-            --github-token-file /etc/github/oauth
+            --github-token-file /etc/github/token
         cd ${sig_release_dir}
         git add upcoming-changes.md
         if git diff --name-only --exit-code HEAD; then
@@ -2234,6 +2226,7 @@ periodics:
   labels:
     preset-bazel-cache: "true"
     preset-docker-mirror-proxy: "true"
+    preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-pgp-bot-key: "true"
     preset-podman-in-container-enabled: "true"
@@ -2273,21 +2266,12 @@ periodics:
         value: Always
       - name: BUILD_ARCH
         value: amd64,crossbuild-s390x
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
       resources:
         requests:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/github
-        name: token
-    volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
 - annotations:
     testgrid-alert-email: kubevirt-ci-maintainers@redhat.com
     testgrid-dashboards: kubevirt-periodics

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -31,7 +31,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "2.52.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/kubevirt
         - name: GIT_USER_NAME
@@ -113,7 +113,7 @@ postsubmits:
         - name: GIT_USER_NAME
           value: kubevirt-bot
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         command: [ "/usr/local/bin/runner.sh", "/bin/sh", "-c" ]
         args:
         - ./automation/postsubmit-main.sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -145,7 +145,6 @@ periodics:
   cron: "0 4 * * 2"
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 2h
   max_concurrency: 1
@@ -196,7 +195,6 @@ periodics:
   cron: "0 4 * * 2" #Triggered at same time as x86 job so that both will run on same commit
   annotations:
     testgrid-create-test-group: "false"
-  decorate: true
   decoration_config:
     timeout: 2h
   max_concurrency: 1
@@ -298,7 +296,7 @@ periodics:
         cat $QUAY_PASSWORD | podman login --username $(<$QUAY_USER) --password-stdin quay.io
         PROVISION_CENTOS_VERSION=10 ./hack/bump-centos-version.sh
         SHORT_SHA=$(git rev-parse --short HEAD)
-        GIT_ASKPASS=../project-infra/hack/git-askpass.sh ../project-infra/hack/git-pr.sh \
+        ../project-infra/hack/git-pr.sh \
         --command "PROVISION_CENTOS_VERSION=10 PHASES=linux BYPASS_PMAN_CHANGE_CHECK=true ./publish.sh" \
         --repo kubevirtci \
         --branch bump-centos10-stream \

--- a/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/macvtap-cni/macvtap-cni-postsubmits.yaml
@@ -47,7 +47,7 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/oauth) ./automation/release.sh"
+              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_USER=kubevirt-bot GITHUB_TOKEN=$(cat /etc/github/token) ./automation/release.sh"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-postsubmits.yaml
@@ -95,7 +95,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/managed-tenant-quota
         - name: GIT_USER_NAME
@@ -134,7 +134,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/managed-tenant-quota
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
       - "-ce"
       - >
         go run ./robots/retester
-        --token=/etc/github/oauth
+        --token=/etc/github/token
         --ceiling=1
         --confirm
       env:
@@ -30,6 +30,9 @@ periodics:
     - name: token
       secret:
         secretName:  commenter-oauth-token
+        items:
+        - key: oauth
+          path: token
 - name: periodic-project-infra-stale-issues
   interval: 1h
   annotations:
@@ -51,7 +54,7 @@ periodics:
           -label:lifecycle/rotten
           is:public
       - --updated=2160h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=Issues go stale after 90d of inactivity.
         Mark the issue as fresh with `/remove-lifecycle stale`.
@@ -83,7 +86,7 @@ periodics:
           label:lifecycle/stale
           -label:lifecycle/rotten
       - --updated=720h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=Stale issues rot after 30d of inactivity.
         Mark the issue as fresh with `/remove-lifecycle rotten`.
@@ -114,7 +117,7 @@ periodics:
           -label:lifecycle/frozen
           label:lifecycle/rotten
       - --updated=720h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=Rotten issues close after 30d of inactivity.
         Reopen the issue with `/reopen`.
@@ -145,7 +148,7 @@ periodics:
           -label:lifecycle/rotten
           is:public
       - --updated=1080h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=There has been no activity on this PR for 45 days.
         To protect limited CI resources, it has been automatically labelled 'stale'.
@@ -182,7 +185,7 @@ periodics:
           label:lifecycle/stale
           -label:lifecycle/rotten
       - --updated=336h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=There has been no activity on this PR for 59 days and it has been stale for 14 days.
         To protect limited CI resources, it has been automatically labelled 'rotten' and will be closed in 7 days.
@@ -217,7 +220,7 @@ periodics:
           -label:lifecycle/frozen
           label:lifecycle/rotten
       - --updated=168h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=There has been no activity on this PR for 66 days and it has been rotten for 7 days.
         To protect limited CI resources, it has been automatically closed.
@@ -256,7 +259,7 @@ periodics:
           -review:changes-requested
           is:public
       - --updated=168h
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=Pull requests that are marked with `lgtm` should receive a review
         from an approver within 1 week.
@@ -286,7 +289,7 @@ periodics:
           is:pr
           label:needs-approver-review
           is:public
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=/remove-label needs-approver-review
       - --include-closed
@@ -310,7 +313,7 @@ periodics:
           is:pr
           author:app/dependabot
           -label:skip-review
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - |-
         --comment=Dependabot PRs are automatically labeled for merge
         once all required presubmit tests pass.
@@ -327,6 +330,9 @@ periodics:
     - name: token
       secret:
         secretName: commenter-oauth-token
+        items:
+        - key: oauth
+          path: token
 - name: periodic-project-infra-autoowners
   interval: 24h
   annotations:
@@ -356,7 +362,7 @@ periodics:
       - --target-dir=.
       - --target-subdir=github/ci/prow-deploy/files
       - --config-subdir=jobs
-      - --github-token-path=/etc/github/oauth
+      - --github-token-path=/etc/github/token
       - --git-signoff=true
 - name: periodic-update-flakefinder-indexpage
   interval: 24h
@@ -749,7 +755,7 @@ periodics:
       - --github-endpoint=http://ghproxy
       - --github-endpoint=https://api.github.com
       - --config-path=github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
-      - --github-token-path=/etc/github/oauth
+      - --github-token-path=/etc/github/token
       - --fix-org=true
       - --fix-org-members=true
       - --fix-repos=true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -956,7 +956,7 @@ postsubmits:
           - name: TARGET_GITHUB_REPO
             value: kubevirt/ci-performance-benchmarks
           - name: GITHUB_TOKEN_PATH
-            value: /etc/github/oauth
+            value: /etc/github/token
           command:
           - /usr/local/bin/runner.sh
           - /bin/sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -889,7 +889,7 @@ presubmits:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --config-path=github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
-        - --github-token-path=/etc/github/oauth
+        - --github-token-path=/etc/github/token
         - --fix-org=true
         - --fix-org-members=true
         - --fix-repos=true
@@ -921,7 +921,7 @@ presubmits:
         - --config=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
         - --confirm=false
         - --orgs=kubevirt
-        - --token=/etc/github/oauth
+        - --token=/etc/github/token
       restartPolicy: Never
   - name: pull-prow-nmstate-labels-update-precheck
     run_if_changed: '^github/ci/prow-deploy/kustom/base/configs/current/labels/labels\.yaml$'
@@ -943,7 +943,7 @@ presubmits:
         - --config=github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
         - --confirm=false
         - --only=nmstate/kubernetes-nmstate
-        - --token=/etc/github/oauth
+        - --token=/etc/github/token
       restartPolicy: Never
   - annotations:
       testgrid-create-test-group: "false"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-postsubmits.yaml
@@ -64,7 +64,7 @@ postsubmits:
         - name: GH_CLI_VERSION
           value: "1.5.0"
         - name: GITHUB_TOKEN_PATH
-          value: /etc/github/oauth
+          value: /etc/github/token
         - name: GITHUB_REPOSITORY
           value: kubevirt/vm-file-restore-operator
         - name: GIT_USER_NAME

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -3,6 +3,8 @@ periodics:
   cron: "5 1 * * *"
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -14,7 +16,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=168h
       - --report_output_child_path=nmstate/kubernetes-nmstate
       - --org=nmstate
@@ -22,15 +24,10 @@ periodics:
       - --skip_results_before_start_of_report=false
       - --pr_base_branch=main
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -38,6 +35,8 @@ periodics:
   cron: "45 0 * * *"
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -49,7 +48,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --report_output_child_path=nmstate/kubernetes-nmstate
       - --org=nmstate
@@ -57,15 +56,10 @@ periodics:
       - --skip_results_before_start_of_report=false
       - --pr_base_branch=main
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -73,6 +67,8 @@ periodics:
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
@@ -84,7 +80,7 @@ periodics:
       - /usr/bin/flakefinder
       args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=672h
       - --report_output_child_path=nmstate/kubernetes-nmstate
       - --org=nmstate
@@ -92,15 +88,10 @@ periodics:
       - --skip_results_before_start_of_report=false
       - --pr_base_branch=main
       volumeMounts:
-      - name: token
-        mountPath: /etc/github
       - name: gcs
         mountPath: /etc/gcs
         readOnly: true
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -15,6 +15,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
+        preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
       branches:
         - main
@@ -23,8 +24,6 @@ postsubmits:
         containers:
           - image: quay.io/kubevirtci/golang:v20260715-af3e234
             env:
-            - name: GIT_ASKPASS
-              value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
             - name: GITHUB_USER
               value: kubevirt-bot
             - name: GITHUB_EMAIL
@@ -35,17 +34,14 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && ./automation/publish.sh"
+            args:
+              - |
+                export GIT_ASKPASS=/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
+
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && ./automation/publish.sh
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
-            volumeMounts:
-              - name: github-token
-                mountPath: /etc/github
-        volumes:
-          - name: github-token
-            secret:
-              secretName: oauth-token
 
     - name: release-kubernetes-nmstate
       annotations:
@@ -58,6 +54,7 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror-proxy: "true"
+        preset-github-credentials: "true"
         preset-kubevirtci-quay-credential: "true"
       branches:
         - ^v\d+\.\d+\.\d+$
@@ -66,8 +63,6 @@ postsubmits:
         containers:
           - image: quay.io/kubevirtci/golang:v20260715-af3e234
             env:
-            - name: GIT_ASKPASS
-              value: "/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh"
             - name: GITHUB_USER
               value: kubevirt-bot
             - name: GITHUB_EMAIL
@@ -78,14 +73,11 @@ postsubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/bash"
               - "-c"
-              - "cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_TOKEN=$(cat /etc/github/oauth) ./automation/release.sh"
+            args:
+              - |
+                export GIT_ASKPASS=/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
+
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_TOKEN=$(cat /etc/github/token) ./automation/release.sh"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true
-            volumeMounts:
-              - name: github-token
-                mountPath: /etc/github
-        volumes:
-          - name: github-token
-            secret:
-              secretName: oauth-token

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -894,7 +894,7 @@ presets:
   volumes:
   - name: github-token
     secret:
-      secretName: oauth-token
+      secretName: github-token
       defaultMode: 0400
   volumeMounts:
     - name: github-token

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-kubevirt.yaml
@@ -35,19 +35,19 @@ spec:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               - --orgs=kubevirt
-              - --token=/etc/github/oauth
+              - --token=/etc/github/token
               volumeMounts:
-              - name: oauth
-                mountPath: /etc/github
-                readOnly: true
               - name: config
                 mountPath: /etc/config
                 readOnly: true
+              - name: github-token
+                mountPath: /etc/github
+                readOnly: true
           restartPolicy: Never
           volumes:
-          - name: oauth
-            secret:
-              secretName: oauth-token
           - name: config
             configMap:
               name: label-config
+          - name: github-token
+            secret:
+              secretName: github-token

--- a/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/label-sync-nmstate.yaml
@@ -35,19 +35,19 @@ spec:
               - --config=/etc/config/labels.yaml
               - --confirm=true
               - --only=nmstate/kubernetes-nmstate
-              - --token=/etc/github/oauth
+              - --token=/etc/github/token
               volumeMounts:
-              - name: oauth
-                mountPath: /etc/github
-                readOnly: true
               - name: config
                 mountPath: /etc/config
                 readOnly: true
+              - name: github-token
+                mountPath: /etc/github
+                readOnly: true
           restartPolicy: Never
           volumes:
-          - name: oauth
-            secret:
-              secretName: oauth-token
           - name: config
             configMap:
               name: label-config
+          - name: github-token
+            secret:
+              secretName: github-token

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -255,13 +255,6 @@ secretGenerator:
     type: Opaque
   - <<: *github_token
     namespace: kubevirt-prow-jobs
-  - &oauth_token
-    name: oauth-token
-    files:
-      - oauth=secrets/github/bot-token
-    type: Opaque
-  - <<: *oauth_token
-    namespace: kubevirt-prow-jobs
   - &gcs_credentials
     name: gcs-credentials
     files:

--- a/github/ci/prow-deploy/kustom/overlays/prow-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-workloads/kustomization.yaml
@@ -39,16 +39,6 @@ secretGenerator:
       - oauth=secrets/github/bot-token
       - token=secrets/github/bot-token
     type: Opaque
-  - name: oauth-token
-    namespace: kubevirt-prow-jobs
-    files:
-      - oauth=secrets/github/bot-token
-    type: Opaque
-  - name: unprivileged-oauth-token
-    namespace: kubevirt-prow-jobs
-    files:
-      - oauth=secrets/unprivileged-oauth-token
-    type: Opaque
   - &gcs_credentials
     name: gcs-credentials
     namespace: kubevirt-prow-jobs

--- a/github/ci/prow-deploy/prow-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-autobump-config.yaml
@@ -1,5 +1,5 @@
 ---
-gitHubToken: "/etc/github/oauth"
+gitHubToken: "/etc/github/token"
 includedConfigPaths:
   - "/config/github/ci/prow-deploy/kustom/base/configs/current/config"
   - "/config/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/resources"

--- a/github/ci/prow-deploy/prow-job-autobump-config.yaml
+++ b/github/ci/prow-deploy/prow-job-autobump-config.yaml
@@ -1,5 +1,5 @@
 ---
-gitHubToken: "/etc/github/oauth"
+gitHubToken: "/etc/github/token"
 includedConfigPaths:
   - "/config/github/ci/prow-deploy/files/jobs"
   - "/config/github/ci/prow-deploy/kustom/base/manifests/local"

--- a/github/ci/prow-deploy/tasks/secrets.yml
+++ b/github/ci/prow-deploy/tasks/secrets.yml
@@ -4,11 +4,6 @@
     path: '{{ secrets_dir }}'
     state: directory
 
-- name: Create unprivileged github token secret
-  copy:
-    content: '{{ githubUnprivileged.token }}'
-    dest: '{{ secrets_dir }}/unprivileged-oauth-token'
-
 - name: set gcs service account
   set_fact:
     gcsServiceAccount: '{{ lookup("env", "GOOGLE_APPLICATION_CREDENTIALS") }}'

--- a/hack/checkconfig.sh
+++ b/hack/checkconfig.sh
@@ -30,4 +30,6 @@ podman run --rm \
     --config-path /project-infra/github/ci/prow-deploy/files/config.yaml \
     --job-config-path /project-infra/github/ci/prow-deploy/files/jobs \
     --plugin-config /project-infra/github/ci/prow-deploy/files/plugins.yaml \
-    --strict
+    --strict \
+    --include-default-warnings \
+    --warnings unknown-fields-all

--- a/hack/contributions.sh
+++ b/hack/contributions.sh
@@ -22,10 +22,10 @@ set -euo pipefail
 
 function usage() {
     cat <<EOF
-usage: $0 <path-to-oauth-token> [<arg-1>...<arg-n>]
+usage: $0 <path-to-github-token> [<arg-1>...<arg-n>]
        $0 --help
 
-       Example: $0 /path/to/github/oauth --username dhiller --repo project-infra --months 12
+       Example: $0 /path/to/github/token --username dhiller --repo project-infra --months 12
 EOF
 }
 
@@ -42,8 +42,8 @@ if [[ "$1" == "--help" ]]; then
     exit 1
 fi
 
-oauth_token="$1"
-if [[ ! -f "${oauth_token}" ]]; then
+github_token="$1"
+if [[ ! -f "${github_token}" ]]; then
     usage
     exit 1
 fi
@@ -55,11 +55,11 @@ temp_dir=$(mktemp -d /tmp/contributions-XXXXXX)
 
 podman run \
     -v "${temp_dir}:/tmp:z" \
-    -v "$(dirname "${oauth_token}"):/etc/github:Z" \
+    -v "$(dirname "${github_token}"):/etc/github:Z" \
     -v "${project_infra_dir}:/project-infra:z" \
     --rm \
     quay.io/kubevirtci/contributions:v20250417-cd6921f \
-    --github-token "/etc/github/$(basename "${oauth_token}")" \
+    --github-token "/etc/github/$(basename "${github_token}")" \
     --orgs-file-path "/project-infra/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml" \
     "$@" 2>&1 | tee "${temp_dir}/output.txt"
 report_file=$(grep -oE '[^/]*\.yaml' "${temp_dir}/output.txt" | head -n1)

--- a/hack/git-askpass.sh
+++ b/hack/git-askpass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-GITHUB_TOKEN=${GITHUB_TOKEN:-/etc/github/oauth}
+GITHUB_TOKEN=${GITHUB_TOKEN:-/etc/github/token}
 
 cat $GITHUB_TOKEN

--- a/hack/git-pr.sh
+++ b/hack/git-pr.sh
@@ -43,7 +43,7 @@ repo_path=${PWD}
 summary=
 targetbranch=master
 title=
-token=/etc/github/oauth
+token=/etc/github/token
 user=kubevirt-bot
 
 usage() {

--- a/hack/migratestatus.sh
+++ b/hack/migratestatus.sh
@@ -33,14 +33,13 @@ function main() {
         exit 1
     fi
 
-    oauth_token_dir="$(realpath $(dirname $1))"
-    oauth_file_name="$(basename $1)"
+    github_token_path="$1"
     shift
 
     podman run \
-        -v "$oauth_token_dir:/etc/tokens:z" \
+        -v "${github_token_path%/*}:/etc/github:Z" \
         --rm quay.io/kubevirtci/migratestatus:v20250326-66cd380 \
-        --github-token-path "/etc/tokens/$oauth_file_name" $@
+        --github-token-path "/etc/github/${github_token_path##*/}" $@
 }
 
 main "$@"

--- a/hack/migratestatus.sh
+++ b/hack/migratestatus.sh
@@ -34,12 +34,15 @@ function main() {
     fi
 
     github_token_path="$1"
+    github_token_dir="${github_token_path%/*}"
+    github_token_file="${github_token_path##*/}"
+
     shift
 
     podman run \
-        -v "${github_token_path%/*}:/etc/github:Z" \
+        -v "${github_token_dir}:/etc/github:Z" \
         --rm quay.io/kubevirtci/migratestatus:v20250326-66cd380 \
-        --github-token-path "/etc/github/${github_token_path##*/}" $@
+        --github-token-path "/etc/github/${github_token_file##*/}" "$@"
 }
 
 main "$@"

--- a/pkg/kubevirt/cmd/flags/flags.go
+++ b/pkg/kubevirt/cmd/flags/flags.go
@@ -54,7 +54,7 @@ func (o GlobalOptions) Validate() error {
 
 func AddPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&Options.DryRun, FlagDryRun, true, "Whether the file should get modified or just modifications printed to stdout.")
-	cmd.PersistentFlags().StringVar(&Options.GitHubTokenPath, FlagGitHubTokenPath, "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	cmd.PersistentFlags().StringVar(&Options.GitHubTokenPath, FlagGitHubTokenPath, "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	cmd.PersistentFlags().StringVar(&Options.GitHubEndPoint, FlagGitHubEndpoint, "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 }
 

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
@@ -3,12 +3,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 5 * * * *
+  labels:
+    preset-github-credentials: "true"
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --today=true
       - --report_output_child_path=kubevirt/kubevirt
@@ -22,8 +24,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -31,9 +31,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -41,12 +38,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 45 0 * * *
+  labels:
+    preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=168h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -60,8 +59,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -69,9 +66,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -79,12 +73,15 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 25 0 * * *
+  decorate: true
+  labels:
+    preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -98,8 +95,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -107,9 +102,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -117,12 +109,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   interval: 168h
+  labels:
+    preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=672h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -136,8 +130,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -145,9 +137,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -1017,6 +1006,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-github-credentials: "true"
   max_concurrency: 1
   name: bump-kubevirt-rpms-weekly
   spec:
@@ -1027,8 +1017,6 @@ periodics:
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main
       env:
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
       image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
@@ -1038,14 +1026,9 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -1069,6 +1052,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
     preset-pgp-bot-key: "true"
@@ -1115,23 +1099,14 @@ periodics:
         value: crossbuild-aarch64
       - name: KUBEVIRT_E2E_FOCUS
         value: test_id:1464
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
       resources:
         requests:
           memory: 29Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/github
-        name: token
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
@@ -3,12 +3,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 5 * * * *
+  labels:
+    preset-github-credentials: "true"
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --today=true
       - --report_output_child_path=kubevirt/kubevirt
@@ -22,8 +24,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -31,9 +31,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -41,12 +38,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 45 0 * * *
+  labels:
+    preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=168h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -60,8 +59,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -69,9 +66,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -79,12 +73,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 25 0 * * *
+  labels:
+    preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=24h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -98,8 +94,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -107,9 +101,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -117,12 +108,14 @@ periodics:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   interval: 168h
+  labels:
+    preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
     containers:
     - args:
       - --dry-run=false
-      - --token=/etc/github/oauth
+      - --token=/etc/github/token
       - --merged=672h
       - --report_output_child_path=kubevirt/kubevirt
       - --skip_results_before_start_of_report=false
@@ -136,8 +129,6 @@ periodics:
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
       resources: {}
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
         readOnly: true
@@ -145,9 +136,6 @@ periodics:
       type: vm
       zone: ci
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -1017,6 +1005,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-github-credentials: "true"
   max_concurrency: 1
   name: bump-kubevirt-rpms-weekly
   spec:
@@ -1027,8 +1016,6 @@ periodics:
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main
       env:
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/gcs/service-account.json
       image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
@@ -1038,14 +1025,9 @@ periodics:
       securityContext:
         privileged: true
       volumeMounts:
-      - mountPath: /etc/github
-        name: token
       - mountPath: /etc/gcs
         name: gcs
     volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
     - name: gcs
       secret:
         secretName: gcs
@@ -1069,6 +1051,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-github-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
     preset-pgp-bot-key: "true"
@@ -1115,23 +1098,14 @@ periodics:
         value: crossbuild-aarch64
       - name: KUBEVIRT_E2E_FOCUS
         value: test_id:1464
-      - name: GIT_ASKPASS
-        value: ../project-infra/hack/git-askpass.sh
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
       resources:
         requests:
           memory: 29Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/github
-        name: token
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: token
-      secret:
-        secretName: oauth-token
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/robots/kubevirt/README.md
+++ b/robots/kubevirt/README.md
@@ -26,7 +26,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt check presubmits`
@@ -48,7 +48,7 @@ Flags:
 Global Flags:
     --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
     --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
-    --github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+    --github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt copy jobs`
@@ -80,7 +80,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt get periodics`
@@ -103,7 +103,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt get presubmits` 
@@ -127,7 +127,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt remove always_run`
@@ -163,7 +163,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt remove jobs`
@@ -200,7 +200,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 ### `kubevirt require presubmits` 
@@ -235,7 +235,7 @@ Flags:
 Global Flags:
 --dry-run                    Whether the file should get modified or just modifications printed to stdout. (default true)
 --github-endpoint string     GitHub's API endpoint (may differ for enterprise). (default "https://api.github.com/")
---github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/oauth")
+--github-token-path string   Path to the file containing the GitHub OAuth secret. (default "/etc/github/token")
 ```
 
 Building

--- a/robots/kubevirtci-bumper/main.go
+++ b/robots/kubevirtci-bumper/main.go
@@ -73,7 +73,7 @@ func (o *options) Validate() error {
 func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.BoolVar(&o.ensureLatest, "ensure-latest", false, "Ensure that we have a provider for the latest k8s release")
 	fs.StringVar(&o.forceTargetMajorMinor, "force-target-major-minor", "", `when using ensure-latest, override latest k8s release to use given target major.minor (i.e. "1.28"`)

--- a/robots/kubevirtci-presubmit-creator/main.go
+++ b/robots/kubevirtci-presubmit-creator/main.go
@@ -57,7 +57,7 @@ func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether the file should get modified or just modifications printed to stdout.")
-	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.jobConfigPathKubevirtciPresubmit, "job-config-path-kubevirtci-presubmit", "", "The directory of the k8s providers")
 	fs.StringVar(&o.k8sReleaseSemver, "k8s-release-semver", "", "The semver of the k8s release to create a presubmit for")

--- a/robots/kubevirtci-presubmit-remover/main.go
+++ b/robots/kubevirtci-presubmit-remover/main.go
@@ -50,7 +50,7 @@ func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether the file should get modified or just modifications printed to stdout.")
-	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.jobConfigPathKubevirtciPresubmit, "job-config-path-kubevirtci-presubmit", "", "The directory of the k8s providers")
 	err := fs.Parse(os.Args[1:])

--- a/robots/labels-checker/main.go
+++ b/robots/labels-checker/main.go
@@ -65,7 +65,7 @@ func (o *options) getEnsureLabelsMissing() []string {
 var o = options{}
 
 func init() {
-	flag.StringVar(&o.tokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	flag.StringVar(&o.tokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	flag.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	flag.StringVar(&o.org, "org", "", "The org for the PR.")
 	flag.StringVar(&o.repo, "repo", "", "The repo for the PR.")

--- a/robots/org-access-check/main.go
+++ b/robots/org-access-check/main.go
@@ -60,7 +60,7 @@ type AccessPermissionsToRepositoriesToCollaborators map[string]RepositoriesToCol
 
 func (o *options) Validate() error {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&o.tokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.tokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.org, "org", "kubevirt", "The GitHub org")
 	fs.BoolVar(&o.debugLogging, "v", false, "verbose aka debug logging")

--- a/robots/release-querier/main.go
+++ b/robots/release-querier/main.go
@@ -77,7 +77,7 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.StringVar(&o.org, "org", "kubevirt", "Organization")
 	fs.StringVar(&o.repo, "repo", "kubevirt", "Organization")
-	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/oauth", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.TokenPath, "github-token-path", "/etc/github/token", "Path to the file containing the GitHub OAuth secret.")
 	fs.StringVar(&o.endpoint, "github-endpoint", "https://api.github.com/", "GitHub's API endpoint (may differ for enterprise).")
 	fs.BoolVar(&o.latest, "latest", false, "Query for the latest release")
 	fs.StringVar(&o.latestThreeMinor, "last-three-minor-of", "", "Query for the last three minor releases of a given release (e.g. v1 or 2)")


### PR DESCRIPTION
**What this PR does / why we need it**:

Update `preset-github-credentials` to use the secret created during GitHub App migration of Prow core components.

It is a unified secret which contains both GitHub App credentials (keys: `appid`, `cert`) and kubevirt-bit user token (key: `token`).

This is a pre-requisite to switch some commands to use GitHub App credentials in Prow jobs.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized GitHub credential handling across automated builds, releases, reporting, and maintenance tasks.
  - Improved reliability of workflows that publish reports, create pull requests, synchronize labels, and manage releases.
  - Updated selected validation jobs to run as optional checks where appropriate.

- **Chores**
  - Consolidated credential configuration and removed obsolete token setup.
  - Enhanced configuration validation to report a broader range of warnings.

- **Documentation**
  - Updated command usage examples and default credential-path documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->