### PR TITLE
fix(branch-protection): protect only main on kubernetes-nmstate

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -674,7 +674,13 @@ branch-protection:
     nmstate:
       repos:
         kubernetes-nmstate:
-          protect: true
+          # Protect only main: repo-level "protect: true" stamps every
+          # branch, including bot-managed PR head branches (copilot/*,
+          # dependabot/*, ...), locking the bots out of their own branches
+          # since required status checks reject any direct push.
+          branches:
+            main:
+              protect: true
 
 push_gateway:
   endpoint: pushgateway


### PR DESCRIPTION
**What this PR does / why we need it**:

The repo-level `protect: true` for `nmstate/kubernetes-nmstate` makes branchprotector stamp a classic branch protection rule (required status checks: `dco` + prow presubmits) onto **every** branch of the repo, including PR head branches owned by bots (`copilot/*`, `dependabot/*`, `snyk-security`, `revert-*`, ...).

This locks the bots out of their own branches:

- Required status checks reject any direct push with `GH006: Protected branch update failed` — a freshly created commit can never have passing checks at push time.
- There is no bypass available to them: classic protection rules only exempt admins, and GitHub Copilot's coding agent cannot be added as a bypass actor (that only exists for rulesets) nor work from a fork.
- dependabot needs force-pushes to rebase its branches, which the stamped rules also block.

Concrete case: in nmstate/kubernetes-nmstate#1547 the Copilot coding agent can no longer push to its own PR branch after branchprotector protected `copilot/takeover-pr-1545` (the rule was stamped after the agent's initial pushes, mid-PR).

Per review feedback, this protects only `main` instead of the whole repo, matching the convention used by the other repos in this config file. Supporting facts:

- Release branches are dormant — the last PR merged into a `release-*` branch was in Nov 2023; releases are cut from `main` now.
- PR merge gating is unaffected: Tide enforces the required presubmits + `dco` independently of branch protection. Branch protection only adds direct-push blocking.
- `gh-pages` is pushed directly by `kubevirt-bot` (docs publishing) and should not carry presubmit contexts at all.

**Which issue(s) this PR fixes**:
None (see nmstate/kubernetes-nmstate#1547 for the affected PR)

**Special notes for your reviewer**:

branchprotector does not remove rules it already created for branches it no longer manages — it just skips them. The stale rules already stamped on the other branches of kubernetes-nmstate will be cleaned up manually by a repo admin.

---
*This change was prepared with AI assistance (claude-fable-5).*
