### PR TITLE
s390x: disable lanes due to clusters being unreachable

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -68,7 +68,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
       optional: true
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -103,7 +103,8 @@ presubmits:
     branches:
       - release-1.4
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -103,7 +103,8 @@ presubmits:
     branches:
       - release-1.5
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -103,7 +103,8 @@ presubmits:
       branches:
         - release-1.6
       always_run: false
-      run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -103,7 +103,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -223,7 +224,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -298,7 +300,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -373,7 +376,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -448,7 +452,8 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -181,7 +181,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -301,7 +302,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -376,7 +378,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -451,7 +454,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -526,7 +530,8 @@ presubmits:
     branches:
       - main
     always_run: false
-    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -81,7 +81,9 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy
+  - always_run: false
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -179,7 +181,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/centosstream/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/centosstream/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -244,7 +248,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/fedora/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/fedora/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -309,7 +315,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/ubuntu/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/ubuntu/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -374,7 +382,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/opensuse/microos/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/opensuse/microos/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -439,7 +449,9 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    run_if_changed: "artifacts/opensuse/tumbleweed/.*"
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    #run_if_changed: "artifacts/opensuse/tumbleweed/.*"
+    optional: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -36,7 +36,8 @@ presubmits:
     cluster: prow-s390x-workloads
     annotations:
       fork-per-release: "true"
-    always_run: true
+    # TODO: revert once the prow-s390x-workloads cluster is healthy
+    always_run: false
     optional: true
     decoration_config:
       timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
@@ -73,8 +73,9 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.17
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
+      optional: true
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
@@ -73,8 +73,9 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.18
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
+      optional: true
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -116,8 +116,9 @@ presubmits:
       annotations:
         fork-per-release: "true"
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy
+      always_run: false
+      optional: true
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -40,8 +40,9 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy again
+      always_run: false
+      optional: true
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s
@@ -64,8 +65,9 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      always_run: true
-      optional: false
+      # TODO: revert once the prow-s390x-workloads cluster is healthy again
+      always_run: false
+      optional: true
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -375,7 +375,9 @@ presubmits:
             memory: 8Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.4
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -379,7 +379,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.5
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -338,7 +338,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.6
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -384,7 +384,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.7
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -384,7 +384,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.8
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
@@ -416,7 +416,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     branches:
     - release-1.9
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -533,7 +533,9 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy again
+  - always_run: false
+    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -546,7 +546,8 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  - always_run: true
+  # TODO: revert once the prow-s390x-workloads cluster is healthy
+  - always_run: false
     cluster: prow-s390x-workloads
     decoration_config:
       timeout: 4h0m0s


### PR DESCRIPTION
**What this PR does / why we need it**:

The s390x clusters are down:

* [prow-s390x-openshift](https://testgrid.k8s.io/kubevirt-project-infra-periodics#periodic-project-infra-prow-s390x-openshift-livez)
* [prow-s390x-secure-execution](https://testgrid.k8s.io/kubevirt-project-infra-periodics#periodic-project-infra-prow-s390x-secure-execution-livez)
* [prow-s390x-workloads](https://testgrid.k8s.io/kubevirt-project-infra-periodics#periodic-project-infra-prow-s390x-workloads-livez)

**Special notes for your reviewer**:

/cc @dhiller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Updates**
  * Updated multiple s390x presubmit checks across KubeVirt components to run only when applicable rather than unconditionally.
  * Marked affected checks as optional where appropriate, so they no longer block changes when unavailable.
  * Disabled several change-based triggers for s390x functional tests.
  * Added temporary reminders to restore the original scheduling once the workload environment is healthy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->