### PR TITLE
chore(jobs): consolidate GCS credentials preset

### DIFF
--- a/docs/how-to-add-a-prow-cluster.md
+++ b/docs/how-to-add-a-prow-cluster.md
@@ -149,7 +149,7 @@ all is done and close it.
 #### Create secrets that are required for the jobs.
 
 > [!NOTE]
-> Currently there's only the `gcs` secret required.
+> Currently there's only the `gcs-credentials` secret required.
 
 Now we can create Prow job configurations that have the `cluster` field set to the name we provided above.
 

--- a/external-plugins/coverage/plugin/handler/handler_test.go
+++ b/external-plugins/coverage/plugin/handler/handler_test.go
@@ -134,7 +134,7 @@ var _ = Describe("generateCoverageJob", func() {
 				GCS: GCSConfig{
 					Bucket:            "kubevirt-prow",
 					PathStrategy:      "explicit",
-					CredentialsSecret: "gcs",
+					CredentialsSecret: "gcs-credentials",
 				},
 			},
 			Repos: map[string]JobConfig{
@@ -177,7 +177,7 @@ var _ = Describe("generateCoverageJob", func() {
 		Entry("container image", func(j prowapi.ProwJob) string { return j.Spec.PodSpec.Containers[0].Image }, "quay.io/kubevirtci/covreport:latest"),
 		Entry("GCS bucket", func(j prowapi.ProwJob) string { return j.Spec.DecorationConfig.GCSConfiguration.Bucket }, "kubevirt-prow"),
 		Entry("GCS path strategy", func(j prowapi.ProwJob) string { return string(j.Spec.DecorationConfig.GCSConfiguration.PathStrategy) }, string(prowapi.PathStrategyExplicit)),
-		Entry("GCS credentials secret", func(j prowapi.ProwJob) string { return *j.Spec.DecorationConfig.GCSCredentialsSecret }, "gcs"),
+		Entry("GCS credentials secret", func(j prowapi.ProwJob) string { return *j.Spec.DecorationConfig.GCSCredentialsSecret }, "gcs-credentials"),
 		Entry("GO_MOD_PATH env", func(j prowapi.ProwJob) string {
 			for _, env := range j.Spec.PodSpec.Containers[0].Env {
 				if env.Name == "GO_MOD_PATH" {
@@ -286,7 +286,7 @@ var _ = Describe("Handle", func() {
 					Cluster:           "test-cluster",
 					CoverageThreshold: 70,
 					GitHubTokenSecret: "commenter-oauth-token",
-					GCS:               GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+					GCS:               GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs-credentials"},
 					UtilityImages: UtilityImagesConfig{
 						CloneRefs:  "clonerefs:latest",
 						InitUpload: "initupload:latest",
@@ -562,7 +562,7 @@ defaults:
     sidecar: sc
   gcs:
     bucket: test-bucket
-    credentialsSecret: gcs
+    credentialsSecret: gcs-credentials
 repos:
   org/repo:
     testPackages: "./..."
@@ -585,7 +585,7 @@ defaults:
     sidecar: sc
   gcs:
     bucket: test-bucket
-    credentialsSecret: gcs
+    credentialsSecret: gcs-credentials
 repos:
   org/repo:
     testPackages: "./..."
@@ -609,7 +609,7 @@ defaults:
     sidecar: sc
   gcs:
     bucket: test-bucket
-    credentialsSecret: gcs
+    credentialsSecret: gcs-credentials
 repos:
   org/repo:
     testPackages: "./..."
@@ -633,7 +633,7 @@ defaults:
     sidecar: sc
   gcs:
     bucket: test-bucket
-    credentialsSecret: gcs
+    credentialsSecret: gcs-credentials
 repos:
   org/repo:
     testPackages: "./..."
@@ -656,7 +656,7 @@ defaults:
     sidecar: sc
   gcs:
     bucket: test-bucket
-    credentialsSecret: gcs
+    credentialsSecret: gcs-credentials
 repos:
   org/repo:
     testPackages: "./..."

--- a/external-plugins/coverage/plugin/server/eventsserver_test.go
+++ b/external-plugins/coverage/plugin/server/eventsserver_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GitHubEventsServer", func() {
 				Namespace: "test-namespace",
 				Image:     "test-image:latest",
 				Cluster:   "test-cluster",
-				GCS:       handler.GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs"},
+				GCS:       handler.GCSConfig{Bucket: "test-bucket", CredentialsSecret: "gcs-credentials"},
 				UtilityImages: handler.UtilityImagesConfig{
 					CloneRefs:  "clonerefs:latest",
 					InitUpload: "initupload:latest",

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-periodics.yaml
@@ -5,13 +5,11 @@ periodics:
     annotations:
       testgrid-create-test-group: "false"
     labels:
+      preset-gcs-credentials: "true"
       preset-github-credentials: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v202607200935-3862709
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/gcs/service-account.json
           command:
           - /usr/bin/flakefinder
           args:
@@ -23,27 +21,17 @@ periodics:
             - --repo=kubemacpool
             - --skip_results_before_start_of_report=false
             - --pr_base_branch=main
-          volumeMounts:
-            - name: gcs
-              mountPath: /etc/gcs
-              readOnly: true
-      volumes:
-        - name: gcs
-          secret:
-            secretName: gcs
   - name: periodic-publish-kubemacpool-flakefinder-daily-report
     cron: "30 0 * * *"
     cluster: kubevirt-prow-control-plane
     annotations:
       testgrid-create-test-group: "false"
     labels:
+      preset-gcs-credentials: "true"
       preset-github-credentials: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v202607200935-3862709
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/gcs/service-account.json
           command:
           - /usr/bin/flakefinder
           args:
@@ -55,27 +43,17 @@ periodics:
             - --repo=kubemacpool
             - --skip_results_before_start_of_report=false
             - --pr_base_branch=main
-          volumeMounts:
-            - name: gcs
-              mountPath: /etc/gcs
-              readOnly: true
-      volumes:
-        - name: gcs
-          secret:
-            secretName: gcs
   - name: periodic-publish-kubemacpool-flakefinder-four-weekly-report
     interval: 168h
     annotations:
       testgrid-create-test-group: "false"
     labels:
+      preset-gcs-credentials: "true"
       preset-github-credentials: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
         - image: quay.io/kubevirtci/flakefinder:v202607200935-3862709
-          env:
-            - name: GOOGLE_APPLICATION_CREDENTIALS
-              value: /etc/gcs/service-account.json
           command:
           - /usr/bin/flakefinder
           args:
@@ -87,11 +65,3 @@ periodics:
             - --repo=kubemacpool
             - --skip_results_before_start_of_report=false
             - --pr_base_branch=main
-          volumeMounts:
-            - name: gcs
-              mountPath: /etc/gcs
-              readOnly: true
-      volumes:
-        - name: gcs
-          secret:
-            secretName: gcs

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1083,13 +1083,13 @@ periodics:
       - name: CLUSTER_TTL
         value: 30 minutes ago
       - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/virtci-service-account.json
+        value: /etc/gcs-credentials/virtci-service-account.json
       resources:
         requests:
           memory: "300Mi"
       volumeMounts:
       - name: virtci-gcs
-        mountPath: /etc/gcs
+        mountPath: /etc/gcs-credentials
         readOnly: true
     volumes:
     - name: virtci-gcs

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-periodics.yaml
@@ -4,14 +4,12 @@ periodics:
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v202607200935-3862709
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - /usr/bin/flakefinder
       args:
@@ -23,27 +21,17 @@ periodics:
       - --repo=kubernetes-nmstate
       - --skip_results_before_start_of_report=false
       - --pr_base_branch=main
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-publish-knmstate-flakefinder-daily-report
   cron: "45 0 * * *"
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v202607200935-3862709
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - /usr/bin/flakefinder
       args:
@@ -55,27 +43,17 @@ periodics:
       - --repo=kubernetes-nmstate
       - --skip_results_before_start_of_report=false
       - --pr_base_branch=main
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-publish-knmstate-flakefinder-four-weekly-report
   interval: 168h
   annotations:
     testgrid-create-test-group: "false"
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
   spec:
     containers:
     - image: quay.io/kubevirtci/flakefinder:v202607200935-3862709
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       command:
       - /usr/bin/flakefinder
       args:
@@ -87,14 +65,6 @@ periodics:
       - --repo=kubernetes-nmstate
       - --skip_results_before_start_of_report=false
       - --pr_base_branch=main
-      volumeMounts:
-      - name: gcs
-        mountPath: /etc/gcs
-        readOnly: true
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - name: periodic-knmstate-e2e-handler-k8s-latest
   cron: "0 2 * * *"
   annotations:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -909,15 +909,11 @@ presets:
     preset-gcs-credentials: "true"
   env:
   - name: GOOGLE_APPLICATION_CREDENTIALS
-    value: /etc/gcs/service-account.json
-  volumes:
-  - name: gcs
-    secret:
-      secretName: gcs
-      defaultMode: 0400
+    value: /etc/gcs-credentials/service-account.json
   volumeMounts:
-  - name: gcs
-    mountPath: /etc/gcs
+  # Note: `gcs-credentials` volume is defined by default from Job decoration
+  - name: gcs-credentials
+    mountPath: /etc/gcs-credentials
     readOnly: true
 - labels:
     preset-pgp-bot-key: "true"

--- a/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
+++ b/github/ci/prow-deploy/kustom/base/manifests/local/prow-coverage-configmap.yaml
@@ -23,7 +23,7 @@ data:
       gcs:
         bucket: kubevirt-prow
         pathStrategy: explicit
-        credentialsSecret: gcs
+        credentialsSecret: gcs-credentials
     repos:
       kubevirt/project-infra:
         testPackages: "./external-plugins/... ./releng/... ./robots/... ./cmd/... ./pkg/..."

--- a/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/kustomization.yaml
@@ -262,12 +262,6 @@ secretGenerator:
     type: Opaque
   - <<: *gcs_credentials
     namespace: kubevirt-prow-jobs
-  # For backward compatibility
-  - <<: *gcs_credentials
-    name: gcs
-  - <<: *gcs_credentials
-    name: gcs
-    namespace: kubevirt-prow-jobs
   - name: bazel-cache-gcs
     namespace: kubevirt-prow-jobs
     files:

--- a/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/kustomization.yaml
@@ -6,15 +6,11 @@ generatorOptions:
   disableNameSuffixHash: true
 
 secretGenerator:
-  - &gcs_credentials
-    name: gcs-credentials
+  - name: gcs-credentials
     namespace: kubevirt-prow-jobs
     files:
       - secrets/service-account.json
     type: Opaque
-  # For backward compatibility
-  - <<: *gcs_credentials
-    name: gcs
   - name: bazel-cache-gcs
     namespace: kubevirt-prow-jobs
     files:

--- a/github/ci/prow-deploy/kustom/overlays/prow-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-workloads/kustomization.yaml
@@ -39,15 +39,11 @@ secretGenerator:
       - oauth=secrets/github/bot-token
       - token=secrets/github/bot-token
     type: Opaque
-  - &gcs_credentials
-    name: gcs-credentials
+  - name: gcs-credentials
     namespace: kubevirt-prow-jobs
     files:
       - secrets/service-account.json
     type: Opaque
-  # For backward compatibility
-  - <<: *gcs_credentials
-    name: gcs
   - name: bazel-cache-gcs
     namespace: kubevirt-prow-jobs
     files:

--- a/hack/mirror-istioctl.sh
+++ b/hack/mirror-istioctl.sh
@@ -20,5 +20,5 @@ mkdir -p $LOCAL_ISTIOCTL_DIR
     done
 )
 
-gcloud auth activate-service-account --key-file=/etc/gcs/service-account.json
+gcloud auth activate-service-account --key-file=/etc/gcs-credentials/service-account.json
 gsutil rsync -d -r $LOCAL_ISTIOCTL_DIR gs://$BUCKET_DIR

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   cluster: phx-prow
   cron: 5 * * * *
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
@@ -18,27 +19,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 45 0 * * *
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
@@ -53,28 +43,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 25 0 * * *
-  decorate: true
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
@@ -89,27 +67,17 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
     volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   interval: 168h
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
@@ -124,22 +92,10 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -687,6 +643,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
   max_concurrency: 1
@@ -732,8 +689,6 @@ periodics:
         gsutil cp ./_out/commit gs://$bucket_dir/commit
         gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
@@ -742,15 +697,8 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
@@ -765,6 +713,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
   max_concurrency: 1
@@ -810,8 +759,6 @@ periodics:
         gsutil cp ./_out/commit gs://$bucket_dir/commit-arm64
         gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       - name: BUILD_ARCH
@@ -822,15 +769,8 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
@@ -840,6 +780,7 @@ periodics:
     timeout: 1h0m0s
   labels:
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-shared-images: "true"
   max_concurrency: 1
   name: periodic-kubevirt-clean-nightly-build
@@ -858,20 +799,10 @@ periodics:
             gsutil -m rm -r ${nightly_build_dir};
           fi;
         done
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
       resources:
         requests:
           memory: 200Mi
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
@@ -1006,6 +937,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   max_concurrency: 1
   name: bump-kubevirt-rpms-weekly
@@ -1016,22 +948,12 @@ periodics:
       - -c
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
       resources:
         requests:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   cluster: phx-prow
   cron: 5 * * * *
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-kubevirt-flakefinder-hourly-rolling-window-report
   spec:
@@ -18,27 +19,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 45 0 * * *
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-weekly-report
   spec:
@@ -53,27 +43,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   cron: 25 0 * * *
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-daily-report
   spec:
@@ -88,27 +67,16 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: phx-prow
   interval: 168h
   labels:
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   name: periodic-publish-kubevirt-flakefinder-four-weekly-report
   spec:
@@ -123,22 +91,10 @@ periodics:
       - --pr_base_branch=main
       command:
       - /app/robots/cmd/flakefinder/app.binary
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/flakefinder:v20210915-prow-control-plane-v0.1.0-v20210609-402d3ba6b7-229-gf170d8293
-      resources: {}
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-        readOnly: true
     nodeSelector:
       type: vm
       zone: ci
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
@@ -686,6 +642,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
   max_concurrency: 1
@@ -731,8 +688,6 @@ periodics:
         gsutil cp ./_out/commit gs://$bucket_dir/commit
         gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
@@ -741,15 +696,8 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: prow-workloads
@@ -764,6 +712,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-kubevirtci-quay-credential: "true"
     preset-shared-images: "true"
   max_concurrency: 1
@@ -809,8 +758,6 @@ periodics:
         gsutil cp ./_out/commit gs://$bucket_dir/commit-arm64
         gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
       env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
       - name: BUILD_ARCH
@@ -821,15 +768,8 @@ periodics:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
     nodeSelector:
       type: bare-metal-external
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-create-test-group: "false"
   cluster: ibm-prow-jobs
@@ -839,6 +779,7 @@ periodics:
     timeout: 1h0m0s
   labels:
     preset-docker-mirror-proxy: "true"
+    preset-gcs-credentials: "true"
     preset-shared-images: "true"
   max_concurrency: 1
   name: periodic-kubevirt-clean-nightly-build
@@ -857,20 +798,10 @@ periodics:
             gsutil -m rm -r ${nightly_build_dir};
           fi;
         done
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913
       resources:
         requests:
           memory: 200Mi
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
   cluster: prow-workloads
@@ -1005,6 +936,7 @@ periodics:
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
     preset-docker-mirror: "true"
+    preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   max_concurrency: 1
   name: bump-kubevirt-rpms-weekly
@@ -1015,22 +947,12 @@ periodics:
       - -c
       - ../project-infra/hack/git-pr.sh -c "cd ../kubevirt && make rpm-deps" -b bump-rpm-dependencies
         -p ../kubevirt -T main
-      env:
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/gcs/service-account.json
       image: quay.io/kubevirt/builder:2105121048-a05ef0ee1
       resources:
         requests:
           memory: 8Gi
       securityContext:
         privileged: true
-      volumeMounts:
-      - mountPath: /etc/gcs
-        name: gcs
-    volumes:
-    - name: gcs
-      secret:
-        secretName: gcs
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"

--- a/robots/flakefinder/README.md
+++ b/robots/flakefinder/README.md
@@ -95,14 +95,15 @@ See job configurations [here](../../github/ci/prow-deploy/files/jobs/kubevirt/ku
     INFO[0000] Reading...                                    path=/tmp/prowjob.yaml
     INFO[0000] Converting job into docker run command...     job=periodic-publish-flakefinder-xxx-report
     local /etc/github path ("token" mount): /path/to/home/.tokens/etc/github
-    local /etc/gcs path ("gcs" mount): /path/to/home/.gcs/credentials
+    local /etc/gcs-credentials path ("gcs-credentials" mount): /path/to/home/.gcs/credentials
     "docker" "run" "--rm=true" \
      "--name=phaino-24602-1" \
      "--entrypoint=/app/robots/flakefinder/app.binary" \                        
      "-e" \                                                                     
-     "GOOGLE_APPLICATION_CREDENTIALS=/etc/gcs/service-account.json" \
+     "GOOGLE_APPLICATION_CREDENTIALS=/etc/gcs-credentials/service-account.json" \
      "-v" \
      "/path/to/home/.tokens/etc/github:/etc/github" \
+     "/path/to/home/.gcs/credentials:/etc/gcs-credentials" \
      ...
     INFO[0007] Starting job...                               job=periodic-publish-flakefinder-xxx-report
     INFO[0007] Waiting for job to finish...                  container=phaino-24602-1 job=periodic-publish-flakefinder-reports                                                                    


### PR DESCRIPTION
**What this PR does / why we need it**:

Update preset-gcs-credentials to use the secret created during GitHub App migration of Prow core components.

Also update all jobs using GCS to use this preset.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup and “run the job locally” instructions to use the `gcs-credentials` secret and `/etc/gcs-credentials` credentials path.

* **Improvements**
  * Standardized Google Cloud credential handling across coverage, periodic, and maintenance jobs.
  * Jobs now rely on shared credential presets (instead of manually wiring credentials).
  * Updated job/config authentication to use `gcs-credentials` and `/etc/gcs-credentials/service-account.json`.
  * Removed legacy `gcs` compatibility secrets and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->