### PR TITLE
Add periodic e2e job for kubevirt-migration-controller

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-periodics.yaml
@@ -1,0 +1,56 @@
+periodics:
+- name: periodic-kubevirt-migration-controller-e2e-latest-kubevirt
+  cron: "10 2 * * *"
+  annotations:
+    testgrid-dashboards: kubevirt-migration-controller-periodics
+    testgrid-alert-email: akalenyu@redhat.com, awels@redhat.com, jpeimer@redhat.com, joscasta@redhat.com
+    testgrid-num-failures-to-alert: "1"
+  decoration_config:
+    timeout: 3h
+    grace_period: 5m
+  max_concurrency: 1
+  labels:
+    preset-podman-in-container-enabled: "true"
+    preset-docker-mirror: "true"
+    preset-shared-images: "true"
+  extra_refs:
+    - org: kubevirt
+      repo: kubevirt-migration-operator
+      base_ref: main
+      workdir: true
+      clone_depth: 1
+    - org: kubevirt
+      repo: kubevirt-migration-controller
+      base_ref: main
+      clone_depth: 1
+  cluster: prow-workloads
+  spec:
+    nodeSelector:
+      type: bare-metal-external
+    containers:
+    - image: quay.io/kubevirtci/golang:v20260612-73bc71e
+      command:
+        - "/usr/local/bin/runner.sh"
+        - "/bin/sh"
+        - "-c"
+        - |
+          export KUBEVIRT_NUM_NODES=2
+          export KUBEVIRT_STORAGE=rook-ceph-default
+
+          # Deploy the migration operator
+          make cluster-up
+          make cluster-sync
+
+          # Sync cluster state to controller repo
+          export KUBECONFIG=$(./cluster-up/kubeconfig.sh)
+          cp -r _ci-configs ../kubevirt-migration-controller/
+          cp -r cluster-up ../kubevirt-migration-controller/
+
+          # Run controller e2e tests
+          cd ../kubevirt-migration-controller
+          ./hack/run-e2e.sh
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          memory: "52Gi"

--- a/github/ci/testgrid/gen-config.yaml
+++ b/github/ci/testgrid/gen-config.yaml
@@ -313,6 +313,7 @@ dashboards:
 - name: kubevirt-velero-plugin-periodics
 - name: kubevirt-csi-driver-presubmits
 - name: kubevirt-containerdisks-periodics
+- name: kubevirt-migration-controller-periodics
 - name: kubevirt-project-infra-periodics
 - name: kubevirt-project-infra-postsubmits
 
@@ -333,6 +334,7 @@ dashboard_groups:
   - kubevirt-velero-plugin-periodics
   - kubevirt-csi-driver-presubmits
   - kubevirt-containerdisks-periodics
+  - kubevirt-migration-controller-periodics
   - kubevirt-project-infra-periodics
   - kubevirt-project-infra-postsubmits
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Deploy the migration operator from its repo and run the controller's
e2e tests against it daily.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new daily automated end-to-end testing job for the KubeVirt migration controller (scheduled daily at 02:10 UTC).
  * The job provisions a two-node environment using the configured storage backend, runs the migration controller E2E suite, and enforces execution limits (single concurrent run with controlled timeout/grace behavior).
  * Updated TestGrid to add a dedicated dashboard for these periodics results, displayed under the existing KubeVirt dashboard group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->