### PR TITLE
s390x: re-enable lanes after clusters issue is fixed

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits.yaml
@@ -68,8 +68,7 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
+      always_run: true
       optional: true
       decoration_config:
         timeout: 3h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -103,8 +103,7 @@ presubmits:
     branches:
       - release-1.4
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -103,8 +103,7 @@ presubmits:
     branches:
       - release-1.5
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -103,8 +103,7 @@ presubmits:
       branches:
         - release-1.6
       always_run: false
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+      run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -103,8 +103,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -224,8 +223,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -300,8 +298,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -376,8 +373,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -452,8 +448,7 @@ presubmits:
     branches:
       - release-1.7
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -181,8 +181,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/linux/.*|preferences/linux-efi/.*|preferences/fedora/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -302,8 +301,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -378,8 +376,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/centos/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -454,8 +451,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/ubuntu/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s
@@ -530,8 +526,7 @@ presubmits:
     branches:
       - main
     always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
+    run_if_changed: "preferences/base/.*|preferences/components/.*|preferences/opensuse/tumbleweed/.*|tests/functests/.*|tests/vendor/.*|tests/go.*"
     cluster: prow-s390x-workloads
     decoration_config:
       grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -81,9 +81,7 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
-  # TODO: revert once the prow-s390x-workloads cluster is healthy
-  - always_run: false
-    optional: true
+  - always_run: true
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -181,9 +179,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/centosstream/.*"
-    optional: true
+    run_if_changed: "artifacts/centosstream/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -248,9 +244,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/fedora/.*"
-    optional: true
+    run_if_changed: "artifacts/fedora/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -315,9 +309,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/ubuntu/.*"
-    optional: true
+    run_if_changed: "artifacts/ubuntu/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -382,9 +374,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/opensuse/microos/.*"
-    optional: true
+    run_if_changed: "artifacts/opensuse/microos/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads
@@ -449,9 +439,7 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    #run_if_changed: "artifacts/opensuse/tumbleweed/.*"
-    optional: true
+    run_if_changed: "artifacts/opensuse/tumbleweed/.*"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -36,8 +36,7 @@ presubmits:
     cluster: prow-s390x-workloads
     annotations:
       fork-per-release: "true"
-    # TODO: revert once the prow-s390x-workloads cluster is healthy
-    always_run: false
+    always_run: true
     optional: true
     decoration_config:
       timeout: 1h

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.17.yaml
@@ -73,9 +73,8 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.17
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.18.yaml
@@ -73,9 +73,8 @@ presubmits:
     - name: pull-hyperconverged-cluster-operator-unit-test-s390x
       branches:
         - release-1.18
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits.yaml
@@ -116,9 +116,8 @@ presubmits:
       annotations:
         fork-per-release: "true"
         testgrid-dashboards: kubevirt-hyperconverged-cluster-operator-presubmits
-      # TODO: revert once the prow-s390x-workloads cluster is healthy
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       decoration_config:
         timeout: 2h
         grace_period: 5m

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubesecondarydns/kubesecondarydns-presubmits.yaml
@@ -40,9 +40,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      # TODO: revert once the prow-s390x-workloads cluster is healthy again
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s
@@ -65,9 +64,8 @@ presubmits:
         - release-\d+\.\d+
       annotations:
         fork-per-release: "true"
-      # TODO: revert once the prow-s390x-workloads cluster is healthy again
-      always_run: false
-      optional: true
+      always_run: true
+      optional: false
       cluster: prow-s390x-workloads
       decoration_config:
         grace_period: 5m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.4.yaml
@@ -375,9 +375,7 @@ presubmits:
             memory: 8Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.4
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.5.yaml
@@ -379,9 +379,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.5
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.6.yaml
@@ -338,9 +338,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.6
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.7.yaml
@@ -384,9 +384,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.7
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.8.yaml
@@ -384,9 +384,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.8
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits-1.9.yaml
@@ -416,9 +416,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     branches:
     - release-1.9
     cluster: prow-s390x-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -533,9 +533,7 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy again
-  - always_run: false
-    optional: true
+  - always_run: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -546,8 +546,7 @@ presubmits:
             memory: 16Gi
         securityContext:
           privileged: true
-  # TODO: revert once the prow-s390x-workloads cluster is healthy
-  - always_run: false
+  - always_run: true
     cluster: prow-s390x-workloads
     decoration_config:
       timeout: 4h0m0s


### PR DESCRIPTION
**What this PR does / why we need it**:

Hardware have been replaced and s390x clusters are healthy again:

=> https://prow.ci.kubevirt.io/?type=periodic&job=periodic-project-infra-prow-s390x-*-livez

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * S390x unit, build, and functional presubmit checks now run as required checks instead of optional jobs.
  * Several checks now run automatically for every change, improving validation coverage.
  * Functional tests now trigger when relevant preferences, artifact, or test files are modified.
  * Updated coverage applies across multiple KubeVirt components, operating systems, and supported release branches.

* **Chores**
  * Refined automated change-detection rules for more accurate presubmit scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->