### PR TITLE
chore(windows): update job name to match the actual provider version

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -78,7 +78,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 1
-    name: pull-kubevirt-e2e-k8s-1.34-windows2016
+    name: pull-kubevirt-e2e-k8s-1.36-windows2016
     run_before_merge: true
     skip_branches:
     - release-\d+\.\d+


### PR DESCRIPTION
**What this PR does / why we need it**:

The default provider changed to k8s-1.36 in k/kubevirtci and the bump reached the k/kubevirt repository.

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18544/pull-kubevirt-e2e-k8s-1.34-windows2016/2081660008243662848#1:build-log.txt%3A1098-1100

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows 2016 end-to-end presubmit testing target to Kubernetes 1.36.
  * Existing test configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->