### PR TITLE
chore(kubevirtci): disable auto-bump of the QEMU runner

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -72,43 +72,6 @@ periodics:
       resources:
         requests:
           memory: "8Gi"
-- name: periodic-kubevirtci-bump-fedora-provision-image
-  cron: "5 3 * * 4"
-  annotations:
-    testgrid-create-test-group: "false"
-  decoration_config:
-    timeout: 1h
-  max_concurrency: 1
-  extra_refs:
-  - org: kubevirt
-    repo: project-infra
-    base_ref: main
-    workdir: true
-  - org: kubevirt
-    repo: kubevirtci
-    base_ref: main
-  labels:
-    preset-github-credentials: "true"
-  cluster: kubevirt-prow-control-plane
-  spec:
-    containers:
-    - image: quay.io/kubevirtci/pr-creator:v20260723-ca75c4e
-      command: ["/bin/sh", "-ce"]
-      args:
-      - |
-        git-pr.sh \
-          --command "./hack/bump-fedora-images-version.sh ../kubevirtci/cluster-provision/centos9/Dockerfile ../kubevirtci/cluster-provision/centos10/Dockerfile" \
-          --description-command "echo 'Bump fedora provisioning base to latest version'" \
-          --branch bump-fedora-provision \
-          --repo-path ../kubevirtci \
-          --repo kubevirtci \
-          --target main \
-          --missing-labels lgtm,approved,do-not-merge/hold
-      securityContext:
-        privileged: true
-      resources:
-        requests:
-          memory: "200Mi"
 - name: periodic-kubevirtci-bump-cdi
   cron: "30 1 * * *"
   annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -1,5 +1,40 @@
 presubmits:
   kubevirt/kubevirtci:
+  - name: pull-kubevirtci-bump-fedora-provision-image
+    always_run: false
+    annotations:
+      testgrid-create-test-group: "false"
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 1
+    extra_refs:
+    - org: kubevirt
+      repo: project-infra
+      base_ref: main
+      clone_depth: 1
+      workdir: true
+    labels:
+      preset-github-credentials: "true"
+    cluster: kubevirt-prow-control-plane
+    spec:
+      containers:
+      - image: quay.io/kubevirtci/pr-creator:v20260723-ca75c4e
+        command: ["/bin/sh", "-ce"]
+        args:
+        - |
+          git-pr.sh \
+            --command "./hack/bump-fedora-images-version.sh ../kubevirtci/cluster-provision/centos9/Dockerfile ../kubevirtci/cluster-provision/centos10/Dockerfile" \
+            --description-command "echo 'Bump fedora provisioning base to latest version'" \
+            --branch bump-fedora-provision \
+            --repo-path ../kubevirtci \
+            --repo kubevirtci \
+            --target main \
+            --missing-labels lgtm,approved,do-not-merge/hold
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "200Mi"
   - always_run: false
     annotations:
       k8s.v1.cni.cncf.io/networks: default/sriov-passthrough-cni,default/sriov-passthrough-cni


### PR DESCRIPTION
**What this PR does / why we need it**:

The QEMU runner should be updated very sparsely to limit the drift between the user space if the containerized QEMU and the kernel space of the nodes of the Prow workloads cluster (RHCOS 9).

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the scheduled automation that periodically created updates for Fedora provisioning image versions.
  * Added a new presubmit job to bump Fedora provisioning base image versions on pull requests targeting the main branch.
  * Other periodic and presubmit maintenance jobs continue to run as configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->