### PR TITLE
fix(jobs): drop stray quote breaking knmstate release job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-postsubmits.yaml
@@ -77,7 +77,7 @@ postsubmits:
               - |
                 export GIT_ASKPASS=/home/prow/go/src/github.com/kubevirt/project-infra/hack/git-askpass.sh
 
-                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_TOKEN=$(cat /etc/github/token) ./automation/release.sh"
+                cat $QUAY_PASSWORD | docker login --username $(cat $QUAY_USER) --password-stdin=true quay.io && GITHUB_TOKEN=$(cat /etc/github/token) ./automation/release.sh
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:

The `release-kubernetes-nmstate` postsubmit cannot publish releases, it dies before running anything:

```
/bin/bash: -c: line 3: unexpected EOF while looking for matching `"'
```

5a548bb7a (#5303) moved the command from a quoted `command:` string into a `|` block scalar under `args:` and dropped the leading `"` but not the trailing one. In a block scalar that quote is literal shell input, hence the parse error. This PR removes it.

Failing build: https://storage.googleapis.com/kubevirt-prow/logs/release-kubernetes-nmstate/2082127492130279424/build-log.txt

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

`publish-kubernetes-nmstate` got the same conversion without the typo, and the release job only triggers on `^v\d+\.\d+\.\d+$` branches, so this stayed dormant until the next release attempt. I grepped the other files touched by 5a548bb7a and this was the only occurrence. Verified by extracting both jobs' `args[0]` and running `bash -n`.

/cc @dollierp