### PR TITLE
Skip kubevirt-prow bot from release notes contributors

### DIFF
--- a/releng/release-tool/release-tool.go
+++ b/releng/release-tool/release-tool.go
@@ -198,7 +198,8 @@ func (r *releaseData) generateReleaseNotes() error {
 	writeString(fmt.Sprintf("%d people contributed to this release:\n\n", numContributors))
 
 	for _, contributor := range contributorList {
-		if strings.Contains(contributor, "kubevirt-bot") {
+		if strings.Contains(contributor, "kubevirt-bot") ||
+			strings.Contains(contributor, "kubevirt-prow") {
 			// skip the bot
 			continue
 		}

--- a/releng/release-tool/release-tool_test.go
+++ b/releng/release-tool/release-tool_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -458,6 +459,58 @@ func TestNewTag(t *testing.T) {
 		if entry != expectedGitCommands[i] {
 			t.Errorf("expected command %s and got %s", expectedGitCommands[i], entry)
 		}
+	}
+}
+
+func TestGenerateReleaseNotesSkipsBots(t *testing.T) {
+	r := standardSetup()
+	defer standardCleanup(&r)
+
+	r.tag = "v0.2.0"
+	r.tagBranch = "release-0.2"
+	r.previousTag = "v0.1.0"
+
+	err := os.MkdirAll(r.repoDir, 0755)
+	if err != nil {
+		t.Fatalf("failed to create repoDir: %s", err)
+	}
+
+	gitCommand = func(arg ...string) (string, error) {
+		for _, a := range arg {
+			switch a {
+			case "log":
+				return "abc1234 some commit message\n", nil
+			case "shortlog":
+				return "     5\tAlice <alice@example.com>\n     3\tkubevirt-bot <bot@kubevirt.io>\n     2\tBob <bob@example.com>\n     1\tkubevirt-prow <prow@kubevirt.io>\n", nil
+			case "diff":
+				return "10 files changed, 200 insertions(+), 50 deletions(-)", nil
+			}
+		}
+		return "", nil
+	}
+
+	err = r.generateReleaseNotes()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	content, err := os.ReadFile(r.releaseNotesFile)
+	if err != nil {
+		t.Fatalf("failed to read release notes: %s", err)
+	}
+
+	notes := string(content)
+	if strings.Contains(notes, "kubevirt-bot") {
+		t.Error("release notes should not contain kubevirt-bot")
+	}
+	if strings.Contains(notes, "kubevirt-prow") {
+		t.Error("release notes should not contain kubevirt-prow")
+	}
+	if !strings.Contains(notes, "Alice") {
+		t.Error("release notes should contain Alice")
+	}
+	if !strings.Contains(notes, "Bob") {
+		t.Error("release notes should contain Bob")
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
The contributor list in generated release notes already filtered out kubevirt-bot but not kubevirt-prow. Add the missing check and a test covering both bot accounts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release notes no longer list automated bot accounts in the Contributors section.
  * Human contributors continue to be displayed correctly.

* **Tests**
  * Added coverage to verify bot entries are excluded while valid contributors remain included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->