### PR TITLE
ci(jobs): add GCS-backed Go test cache for unit test presubmits

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -739,58 +739,101 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+    description: "Runs unit tests and uploads Go test cache for arm64 presubmits"
   cluster: prow-arm64-workloads
-  cron: 40 4 * * *
+  cron: 10 * * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 2h0m0s
   extra_refs:
   - base_ref: main
+    clone_depth: 1
     org: kubevirt
     repo: kubevirt
   labels:
-    preset-bazel-unnested: "false"
+    preset-gcs-credentials: "true"
+    preset-go-test-cache-bucket: "true"
     preset-gomaxprocs-4: "true"
-  max_concurrency: 10
-  name: periodic-kubevirt-unit-test-Arm64
+    preset-podman-in-container-enabled: "true"
+  max_concurrency: 1
+  name: periodic-kubevirt-unit-test-arm64
   spec:
     containers:
     - command:
       - /usr/local/bin/runner.sh
       - /bin/sh
-      - -c
-      - make test
+      - -ce
+      - make go-test-cache-save
       image: quay.io/kubevirtci/bootstrap:v20260830-8316684
       resources:
         requests:
-          memory: 8Gi
+          memory: 12Gi
       securityContext:
         privileged: true
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+    description: "Runs unit tests and uploads Go test cache for s390x presubmits"
   cluster: prow-s390x-workloads
-  cron: 40 5 * * *
+  cron: 30 * * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 2h0m0s
   extra_refs:
   - base_ref: main
+    clone_depth: 1
     org: kubevirt
     repo: kubevirt
-  max_concurrency: 10
+  labels:
+    preset-gcs-credentials: "true"
+    preset-go-test-cache-bucket: "true"
+  max_concurrency: 1
   name: periodic-kubevirt-unit-test-s390x
   spec:
     containers:
     - command:
       - /usr/local/bin/runner.sh
       - /bin/sh
-      - -c
-      - make go-test
+      - -ce
+      - make go-test-cache-save
       image: quay.io/kubevirtci/golang:v20260830-8316684
       resources:
         requests:
-          memory: 8Gi
+          memory: 12Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+    description: "Runs unit tests hourly and uploads Go test cache to GCS for presubmit reuse"
+  cluster: prow-workloads
+  cron: 50 * * * *
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: main
+    clone_depth: 1
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-gcs-credentials: "true"
+    preset-go-test-cache-bucket: "true"
+    preset-podman-in-container-enabled: "true"
+  max_concurrency: 1
+  name: periodic-kubevirt-unit-test
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -ce
+      - make go-test-cache-save
+      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+      resources:
+        requests:
+          cpu: "4"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -808,8 +808,9 @@ periodics:
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+    description: "Runs unit tests and uploads Go test cache for arm64 presubmits"
   cluster: prow-arm64-workloads
-  cron: 40 4 * * *
+  cron: 10 * * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 2h0m0s
@@ -818,28 +819,31 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
-    preset-bazel-unnested: "false"
+    preset-gcs-credentials: "true"
+    preset-go-test-cache-bucket: "true"
     preset-gomaxprocs-4: "true"
-  max_concurrency: 10
-  name: periodic-kubevirt-unit-test-Arm64
+    preset-podman-in-container-enabled: "true"
+  max_concurrency: 1
+  name: periodic-kubevirt-unit-test-arm64
   spec:
     containers:
     - command:
       - /usr/local/bin/runner.sh
       - /bin/sh
-      - -c
-      - make test
+      - -ce
+      - make go-test-cache-save
       image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
       resources:
         requests:
-          memory: 8Gi
+          memory: 12Gi
       securityContext:
         privileged: true
 - annotations:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
+    description: "Runs unit tests and uploads Go test cache for s390x presubmits"
   cluster: prow-s390x-workloads
-  cron: 40 5 * * *
+  cron: 30 * * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 2h0m0s
@@ -847,19 +851,55 @@ periodics:
   - base_ref: main
     org: kubevirt
     repo: kubevirt
-  max_concurrency: 10
+  labels:
+    preset-gcs-credentials: "true"
+    preset-go-test-cache-bucket: "true"
+  max_concurrency: 1
   name: periodic-kubevirt-unit-test-s390x
   spec:
     containers:
     - command:
       - /usr/local/bin/runner.sh
       - /bin/sh
-      - -c
-      - make go-test
+      - -ce
+      - make go-test-cache-save
       image: quay.io/kubevirtci/golang:v20260715-af3e234
       resources:
         requests:
-          memory: 8Gi
+          memory: 12Gi
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+    description: "Runs unit tests hourly and uploads Go test cache to GCS for presubmit reuse"
+  cluster: prow-workloads
+  cron: 50 * * * *
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - base_ref: main
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-gcs-credentials: "true"
+    preset-go-test-cache-bucket: "true"
+    preset-podman-in-container-enabled: "true"
+  max_concurrency: 1
+  name: periodic-kubevirt-unit-test
+  spec:
+    containers:
+    - command:
+      - /usr/local/bin/runner.sh
+      - /bin/sh
+      - -ce
+      - make go-test-cache-save
+      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+      resources:
+        requests:
+          cpu: "4"
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -541,6 +541,9 @@ presubmits:
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
+    labels:
+      preset-gcs-credentials: "true"
+      preset-go-test-cache-bucket: "true"
     name: pull-kubevirt-unit-test-s390x
     skip_branches:
     - release-\d+\.\d+
@@ -549,7 +552,7 @@ presubmits:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
-        - -c
+        - -ce
         - make go-test
         image: quay.io/kubevirtci/golang:v20260715-af3e234
         resources:
@@ -566,6 +569,8 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
+      preset-gcs-credentials: "true"
+      preset-go-test-cache-bucket: "true"
       preset-gomaxprocs-4: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
@@ -576,8 +581,8 @@ presubmits:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
-        - -c
-        - make test
+        - -ce
+        - make go-test
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
         resources:
           requests:
@@ -785,6 +790,8 @@ presubmits:
     labels:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
+      preset-go-test-cache-bucket: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test
     skip_branches:
@@ -794,8 +801,8 @@ presubmits:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
-        - -c
-        - make test
+        - -ce
+        - make go-test
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
         resources:
           requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -465,6 +465,9 @@ presubmits:
     decoration_config:
       grace_period: 5m0s
       timeout: 2h0m0s
+    labels:
+      preset-gcs-credentials: "true"
+      preset-go-test-cache-bucket: "true"
     name: pull-kubevirt-unit-test-s390x
     skip_branches:
     - release-\d+\.\d+
@@ -473,7 +476,7 @@ presubmits:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
-        - -c
+        - -ce
         - make go-test
         image: quay.io/kubevirtci/golang:v20260830-8316684
         resources:
@@ -490,6 +493,8 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
+      preset-gcs-credentials: "true"
+      preset-go-test-cache-bucket: "true"
       preset-gomaxprocs-4: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test-arm64
@@ -500,8 +505,8 @@ presubmits:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
-        - -c
-        - make test
+        - -ce
+        - make go-test
         image: quay.io/kubevirtci/bootstrap:v20260830-8316684
         resources:
           requests:
@@ -709,6 +714,8 @@ presubmits:
     labels:
       preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
+      preset-gcs-credentials: "true"
+      preset-go-test-cache-bucket: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-unit-test
     skip_branches:
@@ -718,8 +725,8 @@ presubmits:
       - command:
         - /usr/local/bin/runner.sh
         - /bin/sh
-        - -c
-        - make test
+        - -ce
+        - make go-test
         image: quay.io/kubevirtci/bootstrap:v20260830-8316684
         resources:
           requests:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -925,6 +925,11 @@ presets:
     mountPath: /etc/gcs-credentials
     readOnly: true
 - labels:
+    preset-go-test-cache-bucket: "true"
+  env:
+  - name: GO_TEST_CACHE_BUCKET
+    value: gs://kubevirt-go-cache/go-test-cache
+- labels:
     preset-pgp-bot-key: "true"
   volumeMounts:
   - mountPath: /etc/pgp

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -916,6 +916,11 @@ presets:
     mountPath: /etc/gcs-credentials
     readOnly: true
 - labels:
+    preset-go-test-cache-bucket: "true"
+  env:
+  - name: GO_TEST_CACHE_BUCKET
+    value: gs://kubevirt-prow/cache/go-test-cache
+- labels:
     preset-pgp-bot-key: "true"
   volumeMounts:
   - mountPath: /etc/pgp


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Replace periodic-kubevirt-unit-test-{Arm64,s390x} with hourly cache-producing periodic jobs (periodic-kubevirt-go-test-cache-build, -arm64, -s390x) that run `make go-test-cache-save`, which executes the full unit test suite and uploads the resulting Go test cache to GCS keyed by architecture.
Presubmit unit test jobs (pull-kubevirt-unit-test, -arm64, -s390x) now restore this shared cache before running tests, significantly reducing wall-clock time when source hasn't changed.
Inspired by: https://github.com/kubernetes/test-infra/pull/16623

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to this #https://github.com/kubevirt/kubevirt/pull/18645

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    None.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved Go test times by enabling shared cloud-backed test caching for presubmit checks.
  * Added dedicated cache-building jobs for Arm64, s390x, and general unit tests.
  * Introduced hourly cache refreshes and shallow clones to streamline test execution.

* **CI Improvements**
  * Updated unit-test checks to use shared Go test caching.
  * Standardized scheduling, serialized execution, authentication, and resource settings across architectures.
  * Replaced older general test configurations with focused unit-test jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->