### PR TITLE
chore(monitoring): update lane to k8s-1.36 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -1766,7 +1766,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-monitoring
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-monitoring
   spec:
     containers:
     - command:
@@ -1780,7 +1780,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.34-sig-monitoring
+        value: k8s-1.36-sig-monitoring
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1442,7 +1442,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
-    name: pull-kubevirt-e2e-k8s-1.34-sig-monitoring
+    name: pull-kubevirt-e2e-k8s-1.36-sig-monitoring
     run_if_changed: ^pkg/monitoring/.*|^tests/monitoring/.*|^tests/libmonitoring/.*|^vendor/github.com/machadovilaca/operator-observability/.*
     skip_branches:
     - release-\d+\.\d+
@@ -1455,7 +1455,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.34-sig-monitoring
+          value: k8s-1.36-sig-monitoring
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the k8s provider to version 1.36 in monitoring lanes before the version 1.34 gets removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes monitoring validation to run against Kubernetes 1.36 instead of 1.34.
  * Updated the associated validation job naming to reflect the newer Kubernetes version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->