### PR TITLE
fix(sync-manifests): revamp filtering to get latest tag

### DIFF
--- a/github/ci/prow-deploy/hack/sync-manifests.sh
+++ b/github/ci/prow-deploy/hack/sync-manifests.sh
@@ -41,9 +41,12 @@ latest_prow_version=$(
     curl https://us-docker.pkg.dev/v2/k8s-infra-prow/images/prow-controller-manager/tags/list \
         | yq -r '
             .manifest | to_entries
-            | map(.value) | sort_by(.timeUploadedMs)
-            | .[-1].tag[]
-            | select(test("^(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10})$"))
+            # List all existing tags sorted by upload timestamp in ascending order
+            | map(.value) | sort_by(.timeUploadedMs) | map(.tag) | flatten
+            # Filter out tags not matching a release pattern (e.g: SBOM)
+            | map(select(test("^(v?\d{8}-(?:v\d(?:[.-]\d+)*-g)?[0-9a-f]{6,10})$")))
+            # Return the newest matching tag
+            | .[-1]
           '
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prow started publishing manifests for SBOM artifacts which do not match the release pattern and break the filtering algorithm returning an empty latest tag.

This change improve the algorithm to not assume that the latest published manifest always contains a release tag.

**Which issue(s) this PR fixes**:

Fixes the Prow job [periodic-project-infra-prow-manifests](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/periodic-project-infra-prow-manifests).

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release manifest selection by choosing the newest matching release tag.
  * Excluded non-release tags and ensured tag values are processed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->