### PR TITLE
robots/quarantine: log info, not warning, for already-quarantined unmatched tests

### DIFF
--- a/robots/quarantine/cmd/auto-quarantine.go
+++ b/robots/quarantine/cmd/auto-quarantine.go
@@ -187,7 +187,11 @@ func determineTestsForQuarantine(topXTests flakestats.TopXTests, reports []types
 		// Prepare to find the required data to modify the Test
 		matchingSpecReport := ginkgo.GetSpecReportByTestName(reports, topXTest.Name)
 		if matchingSpecReport == nil {
-			log.Warnf("could not find file for %q by name", topXTest.Name)
+			if topXTest.NoteHasBeenQuarantined {
+				log.Infof("could not find file for %q by name, but test is already quarantined", topXTest.Name)
+			} else {
+				log.Warnf("could not find file for %q by name", topXTest.Name)
+			}
 			continue
 		}
 

--- a/robots/quarantine/cmd/auto-quarantine_test.go
+++ b/robots/quarantine/cmd/auto-quarantine_test.go
@@ -27,9 +27,23 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
 	flakestats "kubevirt.io/project-infra/pkg/flake-stats"
 	"kubevirt.io/project-infra/pkg/searchci"
 )
+
+// entryRecordingHook records the last log entry fired against the logger it is attached to,
+// so that tests can assert on the level a given code path logged at.
+type entryRecordingHook struct {
+	lastEntry *log.Entry
+}
+
+func (h *entryRecordingHook) Levels() []log.Level { return log.AllLevels }
+
+func (h *entryRecordingHook) Fire(entry *log.Entry) error {
+	h.lastEntry = entry
+	return nil
+}
 
 var _ = Describe("auto-quarantine", func() {
 	When("Writing pr description", func() {
@@ -458,6 +472,58 @@ to contain
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(BeEmpty())
+		})
+
+		It("logs at warning level for unmatched tests that are not quarantined", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10),
+			})
+			hook := &entryRecordingHook{}
+			originalHooks := log.StandardLogger().Hooks
+			log.AddHook(hook)
+			defer log.StandardLogger().ReplaceHooks(originalHooks)
+
+			test := newTopXTest(testName)
+			test.NoteHasBeenQuarantined = false
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{test},
+				reportsContaining("completely different test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+			entry := hook.lastEntry
+			Expect(entry).ToNot(BeNil())
+			Expect(entry.Level).To(Equal(log.WarnLevel))
+			Expect(entry.Message).To(ContainSubstring("could not find file for"))
+		})
+
+		It("logs at info level for unmatched tests that are already quarantined", func() {
+			stubCandidate([]searchci.Impact{
+				newImpact(requiredLane, 10),
+			})
+			hook := &entryRecordingHook{}
+			originalHooks := log.StandardLogger().Hooks
+			log.AddHook(hook)
+			defer log.StandardLogger().ReplaceHooks(originalHooks)
+
+			test := newTopXTest(testName)
+			test.NoteHasBeenQuarantined = true
+
+			result, err := determineTestsForQuarantine(
+				flakestats.TopXTests{test},
+				reportsContaining("completely different test"),
+				map[string]struct{}{requiredLane: {}},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+			entry := hook.lastEntry
+			Expect(entry).ToNot(BeNil())
+			Expect(entry.Level).To(Equal(log.InfoLevel))
+			Expect(entry.Message).To(ContainSubstring("could not find file for"))
 		})
 
 		It("propagates error from getQuarantineCandidate", func() {


### PR DESCRIPTION
Motivation:
auto-quarantine determines which flaky tests to quarantine by
dry-running ginkgo and matching flake-stats test names against the
resulting spec reports. When a test cannot be matched to a source
file, it logs `could not find file for %q by name` at warning level
and skips it. The periodic auto-quarantine job build log showed this
warning for tests that were in fact already quarantined (their name
carries a `[QUARANTINE]` decorator), which made auto-quarantine
falsely appear broken on the most-flaky-test report even though the
underlying quarantine-selection logic behaved correctly. A maintainer
confirmed in the issue thread that the fix is to check whether the
test is already known to be quarantined before logging at warning
level.

Approach:
flake-stats already tracks per-test whether it was seen carrying the
`[QUARANTINE]` marker during the aggregation window via
TopXTest.NoteHasBeenQuarantined, but determineTestsForQuarantine
never consulted it. determineTestsForQuarantine now logs at info
level (with a clarifying suffix) instead of warning when
topXTest.NoteHasBeenQuarantined is true. The control flow is
unchanged: an unmatched test is still skipped either way; only the
log level and message for the already-quarantined case change, so
this reduces log noise/false-positive warnings rather than altering
quarantine behavior.

Validation:
Ran `go build ./external-plugins/... ./releng/... ./robots/...
./github/ci/services/... ./cmd/... ./pkg/...` (the repo's documented
build target) and `go test ./robots/... ./pkg/...` (a superset of the
documented test target), both passing. Added two unit tests to
auto-quarantine_test.go that register a log hook and assert on the
emitted log level: one confirms a test with
NoteHasBeenQuarantined=false still logs at warning level (unchanged
behavior), the other confirms a test with
NoteHasBeenQuarantined=true now logs at info level. Verified by
temporarily reverting the conditional that the new info-level test
fails without the fix, then restored it.

Report: https://github.com/kubevirt/project-infra/issues/5305
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #5305

```release-note
robots/quarantine: log info, not warning, for already-quarantined unmatched tests
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quarantine discovery messages when test reports are unavailable.
  * Tests already in quarantine now generate informational messages instead of warnings.
  * Unmatched tests that are not quarantined continue to generate warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->