### PR TITLE
Chore(gsutil): Migrate gsutil to gcloud storage

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/ci-health/ci-health-postsubmits.yaml
@@ -29,7 +29,7 @@ postsubmits:
               for SIG in "${SIGS_TO_REPORT[@]}"; do
                 go run ./cmd/html-report --sig $SIG --results-path ./output/kubevirt/kubevirt/results.json --path /tmp/
               done
-              gsutil cp /tmp/sig*.html gs://kubevirt-prow/reports/sig-failure-reports/
+              gcloud storage cp /tmp/sig*.html gs://kubevirt-prow/reports/sig-failure-reports/
           resources:
             requests:
               memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -129,7 +129,7 @@ periodics:
         go run ./robots/merge-commit-summary \
           --days-in-the-past 7 \
           --output-file "${report_dir}/index.html"
-        gsutil cp "${report_dir}/*" "gs://kubevirt-prow/reports/merge-commit-summary/kubevirt/kubevirt/last-seven-days/"
+        gcloud storage cp "${report_dir}/*" "gs://kubevirt-prow/reports/merge-commit-summary/kubevirt/kubevirt/last-seven-days/"
       command:
       - /usr/local/bin/runner.sh
       - /bin/bash
@@ -165,7 +165,7 @@ periodics:
         report_dir="/tmp/per-test-results/last-six-months"
         mkdir -p "${report_dir}"
         go run ./robots/per-test-execution --months 6 --output-directory "${report_dir}"
-        gsutil cp "${report_dir}/*" "gs://kubevirt-prow/reports/per-test-results/kubevirt/kubevirt/last-six-months/"
+        gcloud storage cp "${report_dir}/*" "gs://kubevirt-prow/reports/per-test-results/kubevirt/kubevirt/last-six-months/"
       command:
       - /usr/local/bin/runner.sh
       - /bin/bash
@@ -194,7 +194,7 @@ periodics:
     - args:
       - |
         go run ./robots/quarantine report --output-file "/tmp/index.html"
-        gsutil cp "/tmp/index.html" "gs://kubevirt-prow/reports/most-flaky-tests/kubevirt/kubevirt/"
+        gcloud storage cp "/tmp/index.html" "gs://kubevirt-prow/reports/most-flaky-tests/kubevirt/kubevirt/"
       command:
       - /usr/local/bin/runner.sh
       - /bin/bash
@@ -344,12 +344,12 @@ periodics:
         git show -s --format=%H > _out/commit
         echo ${build_date} > _out/build_date
         bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
-        gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
-        gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/
-        gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/
-        gsutil cp ./_out/cmd/dump/dump gs://$bucket_dir/testing/dump
-        gsutil cp ./_out/commit gs://$bucket_dir/commit
-        gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
+        gcloud storage cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
+        gcloud storage cp -r ./_out/manifests/testing gs://$bucket_dir/
+        gcloud storage cp ./_out/tests/tests.test gs://$bucket_dir/testing/
+        gcloud storage cp ./_out/cmd/dump/dump gs://$bucket_dir/testing/dump
+        gcloud storage cp ./_out/commit gs://$bucket_dir/commit
+        gcloud storage cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
         unset DOCKER_TAG # we want to publish to main
         export PULL_BASE_REF=main
         export GIT_ASKPASS="$(pwd)/automation/git-askpass.sh"
@@ -394,12 +394,12 @@ periodics:
       - /bin/sh
       - -c
       - |
-        set -e; latest_build=$(gsutil cat gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest); delete_before_seconds=$(date -d "$latest_build - 4 weeks" +%s); for nightly_build_dir in $(gsutil ls gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/ | grep -E '[0-9]+\/$'); do
+        set -e; latest_build=$(gcloud storage cat gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest); delete_before_seconds=$(date -d "$latest_build - 4 weeks" +%s); for nightly_build_dir in $(gcloud storage ls gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/ | grep -E '[0-9]+\/$'); do
           build_date=$(echo "${nightly_build_dir}" | sed -E 's#^.*/([0-9]+)/$#\1#g');
           bd_seconds=$(date -d "$build_date" +%s);
           if [ $bd_seconds -lt $delete_before_seconds ]; then
             echo "Deleting $nightly_build_dir";
-            gsutil -m rm -r ${nightly_build_dir};
+            gcloud storage rm -r ${nightly_build_dir};
           fi;
         done
       image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
@@ -1637,7 +1637,7 @@ periodics:
       - -ce
       - |
         go run ./robots/test-label-analyzer stats --config-name=quarantine --test-file-path=/home/prow/go/src/github.com/kubevirt/kubevirt/tests --remote-url=https://github.com/kubevirt/kubevirt/%s/tests > /tmp/quarantine.json
-        gsutil cp /tmp/quarantine.json gs://kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/quarantine.json
+        gcloud storage cp /tmp/quarantine.json gs://kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/quarantine.json
       command:
       - /bin/sh
       env:
@@ -1670,13 +1670,13 @@ periodics:
           '--filter-lane-regex=.*-root$' \
           --output-file ${output_file} \
           --overwrite-output-file=true
-        gsutil cp ${output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/
+        gcloud storage cp ${output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/
 
         # generate index page with calendar
         index_output_file=/tmp/flake-stats-14days.html
         go run ./robots/flake-stats-index-page \
           --output-file-path ${index_output_file}
-        gsutil cp ${index_output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/
+        gcloud storage cp ${index_output_file} gs://kubevirt-prow/reports/flakefinder/kubevirt/kubevirt/
       command:
       - /bin/sh
       env:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -80,8 +80,8 @@ postsubmits:
             exit 0
           fi
           make manifests
-          gsutil -m rm -r "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG" || true
-          gsutil cp -r "_out/manifests/testing" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG/manifests/"
+          gcloud storage rm -r "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG" || true
+          gcloud storage cp -r "_out/manifests/testing" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG/manifests/"
         securityContext:
           privileged: true
         resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -147,7 +147,7 @@ periodics:
         # For passing centos image tag to dependent (s390x) prow job
         image_tag=$(cat cluster-provision/k8s/base-image | cut -d ':' -f 2) &&
         echo "$image_tag" > amd64-centos9-$SHORT_SHA &&
-        gsutil cp ./amd64-centos9-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-centos9-$SHORT_SHA
+        gcloud storage cp ./amd64-centos9-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-centos9-$SHORT_SHA
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
@@ -270,7 +270,7 @@ periodics:
         # For passing centos image tag to dependent (s390x) prow job
         image_tag=$(cut -d ':' -f 2 cluster-provision/k8s/base-image-centos10)
         echo "$image_tag" > amd64-centos10-$SHORT_SHA
-        gsutil cp ./amd64-centos10-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-centos10-$SHORT_SHA
+        gcloud storage cp ./amd64-centos10-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-centos10-$SHORT_SHA
       securityContext:
         privileged: true
       resources:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-postsubmits.yaml
@@ -41,9 +41,9 @@ postsubmits:
             # Gets git tag created by above publish.sh run
             KUBEVIRTCI_TAG=$(git tag --points-at HEAD | head -1) &&
             echo "$KUBEVIRTCI_TAG" > latest &&
-            gsutil cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest &&
+            gcloud storage cp ./latest gs://kubevirt-prow/release/kubevirt/kubevirtci/latest &&
             echo "$KUBEVIRTCI_TAG" > amd64-$SHORT_SHA &&
-            gsutil cp ./amd64-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-$SHORT_SHA
+            gcloud storage cp ./amd64-$SHORT_SHA gs://kubevirt-prow/release/kubevirt/kubevirtci/amd64-$SHORT_SHA
           # docker-in-docker needs privileged mode
           env:
           - name: GO_MOD_PATH

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -31,10 +31,10 @@ periodics:
           url=https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/libguestfs-appliance
           bucket_dir="kubevirt-prow/devel/release/kubevirt/libguestfs-appliance"
           ./create-libguestfs-appliance.sh
-          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version-amd64.txt) || gsutil cp ./output/libguestfs-appliance-*amd64.tar.xz gs://$bucket_dir/
-          gsutil cp ./output/latest-version-amd64.txt gs://$bucket_dir/
-          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version-s390x.txt) || gsutil cp ./output/libguestfs-appliance-*s390x.tar.xz gs://$bucket_dir/
-          gsutil cp ./output/latest-version-s390x.txt gs://$bucket_dir/
+          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version-amd64.txt) || gcloud storage cp ./output/libguestfs-appliance-*amd64.tar.xz gs://$bucket_dir/
+          gcloud storage cp ./output/latest-version-amd64.txt gs://$bucket_dir/
+          curl --output /dev/null --silent --head --fail $url/$(cat ./output/latest-version-s390x.txt) || gcloud storage cp ./output/libguestfs-appliance-*s390x.tar.xz gs://$bucket_dir/
+          gcloud storage cp ./output/latest-version-s390x.txt gs://$bucket_dir/
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -831,7 +831,7 @@ postsubmits:
               --github-token-path '' \
               --output-file /tmp/periodics.html
 
-            gsutil cp /tmp/presubmits*.html /tmp/periodics.html gs://kubevirt-prow/reports/e2ejobs/kubevirt/kubevirt
+            gcloud storage cp /tmp/presubmits*.html /tmp/periodics.html gs://kubevirt-prow/reports/e2ejobs/kubevirt/kubevirt
           resources:
             requests:
               memory: "200Mi"

--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -50,4 +50,4 @@ do
     mirror_crio_repo_for_version $i
 done
 
-gsutil rsync -d -r $LOCAL_MIRROR_DIR gs://$BUCKET_DIR
+gcloud storage rsync --delete-unmatched-destination-objects -r "$LOCAL_MIRROR_DIR" "gs://$BUCKET_DIR"

--- a/hack/mirror-istioctl.sh
+++ b/hack/mirror-istioctl.sh
@@ -21,4 +21,4 @@ mkdir -p $LOCAL_ISTIOCTL_DIR
 )
 
 gcloud auth activate-service-account --key-file=/etc/gcs-credentials/service-account.json
-gsutil rsync -d -r $LOCAL_ISTIOCTL_DIR gs://$BUCKET_DIR
+gcloud storage rsync --delete-unmatched-destination-objects -r "$LOCAL_ISTIOCTL_DIR" "gs://$BUCKET_DIR"

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
@@ -683,11 +683,11 @@ periodics:
         git show -s --format=%H > _out/commit
         echo ${build_date} > _out/build_date
         bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
-        gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
-        gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/
-        gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/
-        gsutil cp ./_out/commit gs://$bucket_dir/commit
-        gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
+        gcloud storage cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
+        gcloud storage cp -r ./_out/manifests/testing gs://$bucket_dir/
+        gcloud storage cp ./_out/tests/tests.test gs://$bucket_dir/testing/
+        gcloud storage cp ./_out/commit gs://$bucket_dir/commit
+        gcloud storage cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
@@ -753,11 +753,11 @@ periodics:
         git show -s --format=%H > _out/commit
         echo ${build_date} > _out/build_date
         bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
-        gsutil cp ./_out/manifests/release/kubevirt-operator.yaml gs://$bucket_dir/kubevirt-operator-arm64.yaml
-        gsutil cp ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/kubevirt-cr-arm64.yaml
-        gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/testing-arm64
-        gsutil cp ./_out/commit gs://$bucket_dir/commit-arm64
-        gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
+        gcloud storage cp ./_out/manifests/release/kubevirt-operator.yaml gs://$bucket_dir/kubevirt-operator-arm64.yaml
+        gcloud storage cp ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/kubevirt-cr-arm64.yaml
+        gcloud storage cp -r ./_out/manifests/testing gs://$bucket_dir/testing-arm64
+        gcloud storage cp ./_out/commit gs://$bucket_dir/commit-arm64
+        gcloud storage cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
@@ -791,12 +791,12 @@ periodics:
       - /bin/sh
       - -c
       - |
-        set -e; latest_build=$(gsutil cat gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest); delete_before_seconds=$(date -d "$latest_build - 4 weeks" +%s); for nightly_build_dir in $(gsutil ls gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/ | grep -E '[0-9]+\/$'); do
+        set -e; latest_build=$(gcloud storage cat gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest); delete_before_seconds=$(date -d "$latest_build - 4 weeks" +%s); for nightly_build_dir in $(gcloud storage ls gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/ | grep -E '[0-9]+\/$'); do
           build_date=$(echo "${nightly_build_dir}" | sed -E 's#^.*/([0-9]+)/$#\1#g');
           bd_seconds=$(date -d "$build_date" +%s);
           if [ $bd_seconds -lt $delete_before_seconds ]; then
             echo "Deleting $nightly_build_dir";
-            gsutil -m rm -r ${nightly_build_dir};
+            gcloud storage rm -r ${nightly_build_dir};
           fi;
         done
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
@@ -682,11 +682,11 @@ periodics:
         git show -s --format=%H > _out/commit
         echo ${build_date} > _out/build_date
         bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
-        gsutil cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
-        gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/
-        gsutil cp ./_out/tests/tests.test gs://$bucket_dir/testing/
-        gsutil cp ./_out/commit gs://$bucket_dir/commit
-        gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
+        gcloud storage cp ./_out/manifests/release/kubevirt-operator.yaml ./_out/manifests/release/kubevirt-cr.yaml _out/manifests/release/conformance.yaml gs://$bucket_dir/
+        gcloud storage cp -r ./_out/manifests/testing gs://$bucket_dir/
+        gcloud storage cp ./_out/tests/tests.test gs://$bucket_dir/testing/
+        gcloud storage cp ./_out/commit gs://$bucket_dir/commit
+        gcloud storage cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
@@ -752,11 +752,11 @@ periodics:
         git show -s --format=%H > _out/commit
         echo ${build_date} > _out/build_date
         bucket_dir="kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${build_date}"
-        gsutil cp ./_out/manifests/release/kubevirt-operator.yaml gs://$bucket_dir/kubevirt-operator-arm64.yaml
-        gsutil cp ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/kubevirt-cr-arm64.yaml
-        gsutil cp -r ./_out/manifests/testing gs://$bucket_dir/testing-arm64
-        gsutil cp ./_out/commit gs://$bucket_dir/commit-arm64
-        gsutil cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
+        gcloud storage cp ./_out/manifests/release/kubevirt-operator.yaml gs://$bucket_dir/kubevirt-operator-arm64.yaml
+        gcloud storage cp ./_out/manifests/release/kubevirt-cr.yaml gs://$bucket_dir/kubevirt-cr-arm64.yaml
+        gcloud storage cp -r ./_out/manifests/testing gs://$bucket_dir/testing-arm64
+        gcloud storage cp ./_out/commit gs://$bucket_dir/commit-arm64
+        gcloud storage cp ./_out/build_date gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest-arm64
       env:
       - name: DOCKER_PREFIX
         value: quay.io/kubevirt
@@ -790,12 +790,12 @@ periodics:
       - /bin/sh
       - -c
       - |
-        set -e; latest_build=$(gsutil cat gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest); delete_before_seconds=$(date -d "$latest_build - 4 weeks" +%s); for nightly_build_dir in $(gsutil ls gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/ | grep -E '[0-9]+\/$'); do
+        set -e; latest_build=$(gcloud storage cat gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest); delete_before_seconds=$(date -d "$latest_build - 4 weeks" +%s); for nightly_build_dir in $(gcloud storage ls gs://kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/ | grep -E '[0-9]+\/$'); do
           build_date=$(echo "${nightly_build_dir}" | sed -E 's#^.*/([0-9]+)/$#\1#g');
           bd_seconds=$(date -d "$build_date" +%s);
           if [ $bd_seconds -lt $delete_before_seconds ]; then
             echo "Deleting $nightly_build_dir";
-            gsutil -m rm -r ${nightly_build_dir};
+            gcloud storage rm -r ${nightly_build_dir};
           fi;
         done
       image: quay.io/kubevirtci/bootstrap:v20210906-994b913


### PR DESCRIPTION
**What this PR does / why we need it**:

- Migrate all `gsutil` commands to `gcloud storage` equivalents across Prow job definitions and mirror scripts
- `gsutil` is deprecated and will be removed from the Google Cloud SDK in March 2025
- The `-m` flag is dropped as `gcloud storage` handles parallel operations by default
- `gcloud storage` is already available in the bootstrap image via the installed `google-cloud-sdk`, so no image changes are needed

Migration reference
https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud

**Special notes for your reviewer**:
/cc @dhiller @dollierp 
After this PR is merged and verified to be working I will move onto the other repo's affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated automated report, artifact, manifest, and appliance publishing workflows to use the current Google Cloud Storage command-line interface.
  * Updated repository mirroring tasks to use the modern storage synchronization command.
  * Preserved existing upload destinations, naming conventions, and synchronization behavior.
  * Nightly cleanup continues removing outdated directories, with equivalent storage cleanup commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->