### PR TITLE
fix(rehearse): remove label on closed PRs

### DIFF
--- a/external-plugins/rehearse/plugin/handler/handler.go
+++ b/external-plugins/rehearse/plugin/handler/handler.go
@@ -106,6 +106,7 @@ type githubClient interface {
 	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
 	CreateComment(org, repo string, number int, comment string) error
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	RemoveLabel(org, repo string, number int, label string) error
 }
 
 type repoOwnersClient interface {
@@ -190,7 +191,7 @@ func (h *GitHubEventsHandler) handleIssueComment(log *logrus.Entry, event *githu
 
 func (h *GitHubEventsHandler) shouldActOnPREvent(event *github.PullRequestEvent) bool {
 	switch event.Action {
-	case github.PullRequestActionOpened, github.PullRequestActionSynchronize:
+	case github.PullRequestActionOpened, github.PullRequestActionSynchronize, github.PullRequestActionClosed:
 		return true
 	default:
 		return false
@@ -319,6 +320,26 @@ func (h *GitHubEventsHandler) handlePullRequestUpdateEvent(log *logrus.Entry, ev
 	if err != nil {
 		log.WithError(err).Errorf("Could not get org/repo from the event")
 	}
+
+	// When a pull request is closed and has the OKToRehearse label, remove it
+	if event.Action == github.PullRequestActionClosed {
+		labels, err := h.ghClient.GetIssueLabels(org, repo, event.PullRequest.Number)
+		if err != nil {
+			log.WithError(err).Errorf("could not get labels for PR number %d", event.PullRequest.Number)
+			return
+		}
+		for _, label := range labels {
+			if label.Name == OKToRehearse {
+				err := h.ghClient.RemoveLabel(org, repo, event.PullRequest.Number, label.Name)
+				if err != nil {
+					log.WithError(err).Errorf("could not remove label %s from PR number %d", label.Name, event.PullRequest.Number)
+				}
+				break
+			}
+		}
+		return
+	}
+
 	pr, err := h.ghClient.GetPullRequest(org, repo, event.PullRequest.Number)
 	if err != nil {
 		log.WithError(err).Errorf("Could not get PR number %d", event.PullRequest.Number)

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -296,6 +296,32 @@ periodics:
       - --template
       - --ceiling=10
       - --confirm
+- name: periodic-project-infra-cleanup-ok-to-rehearse
+  interval: 1h
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-test-infra/commenter:v20260729-f66136c16c
+      command:
+      - /ko-app/commenter
+      args:
+      - |-
+        --query=org:kubevirt
+          is:closed
+          is:pr
+          label:ok-to-rehearse
+          is:public
+      - --token=/etc/github/token
+      - |-
+        --comment=/remove-label ok-to-rehearse
+      - --include-closed
+      - --template
+      - --ceiling=10
+      - --confirm
 - name: periodic-project-infra-dependabot-skip-review
   interval: 1h
   annotations:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -310,11 +310,10 @@ periodics:
       - /ko-app/commenter
       args:
       - |-
-        --query=org:kubevirt
+        --query=repo:kubevirt/project-infra
           is:closed
           is:pr
           label:ok-to-rehearse
-          is:public
       - --token=/etc/github/token
       - |-
         --comment=/remove-label ok-to-rehearse

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -816,6 +816,10 @@ label:
       - restricted-labels-kubevirt
       label: approved-vep
 
+    - allowed_users:
+        - kubevirt-bot
+      label: ok-to-rehearse
+
 # https://docs.prow.k8s.io/docs/components/plugins/lgtm/
 lgtm:
 - repos:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The ok-to-rehearse label enables running rehearsals on project-infra PRs. If the label stays there and the PR is reopened a possible attacker that has access to a KubeVirt org member GitHub account can possibly run rehearsals that may leak secrets.

This PR removes the ok-to-rehearse label on any PR that is closed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @dollierp @oshoval 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull-request automation now processes closed pull requests.
  * The `ok-to-rehearse` label is automatically removed when a pull request closes.
  * An hourly cleanup process removes the label from closed pull requests.
  * The automation bot can apply the `ok-to-rehearse` label to pull requests.
  * Label cleanup stops safely when label information cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->