### PR TITLE
kubevirt-aie: add branch prefix to image tags and 1.9 sync-nv-rpms periodic

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
@@ -32,3 +32,36 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-kubevirt-aie-sync-nv-rpms-1.9
+  cron: "0 7 * * *"
+  annotations:
+    testgrid-create-test-group: "false"
+  decoration_config:
+    timeout: 1h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt-aie
+    base_ref: release-1.9-aie-nv
+    workdir: true
+  labels:
+    preset-github-credentials: "true"
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260728-f2d39b9
+      command: ["/bin/sh", "-c"]
+      args:
+      - |
+        export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+        git-pr.sh \
+          --command "./hack/sync-nv-rpms.sh" \
+          --summary "Sync el10nv RPMs for libvirt and qemu-kvm" \
+          --release-note-none \
+          --repo kubevirt-aie \
+          --branch sync-nv-rpms-1.9 \
+          --target release-1.9-aie-nv \
+          --missing-labels lgtm,approved,do-not-merge/hold
+      resources:
+        requests:
+          memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-aie-periodics.yaml
@@ -32,3 +32,37 @@ periodics:
       resources:
         requests:
           memory: "200Mi"
+- name: periodic-kubevirt-aie-sync-nv-rpms-1.9
+  cron: "0 7 * * *"
+  annotations:
+    testgrid-create-test-group: "false"
+  decoration_config:
+    timeout: 1h
+  max_concurrency: 1
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt-aie
+    base_ref: release-1.9-aie-nv
+    clone_depth: 1
+    workdir: true
+  labels:
+    preset-github-credentials: "true"
+  cluster: kubevirt-prow-control-plane
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260728-f2d39b9
+      command: ["/bin/sh", "-c"]
+      args:
+      - |
+        export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+        git-pr.sh \
+          --command "./hack/sync-nv-rpms.sh" \
+          --summary "Sync el10nv RPMs for libvirt and qemu-kvm" \
+          --release-note-none \
+          --repo kubevirt-aie \
+          --branch sync-nv-rpms-1.9 \
+          --target release-1.9-aie-nv \
+          --missing-labels lgtm,approved,do-not-merge/hold
+      resources:
+        requests:
+          memory: "200Mi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
         - |
           cat "$QUAY_PASSWORD" | podman login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
           cp /etc/bazel.bazelrc ./ci.bazelrc
-          DOCKER_TAG="$(date +%Y%m%d)_$(git rev-parse --short=10 HEAD)" \
+          DOCKER_TAG="1.8-aie-nv_$(date +%Y%m%d)_$(git rev-parse --short=10 HEAD)" \
             BUILD_ARCH=amd64,crossbuild-aarch64 \
             PUSH_TARGETS=virt-launcher \
             make bazel-push-images

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-postsubmits.yaml
@@ -35,7 +35,7 @@ postsubmits:
         - |
           cat "$QUAY_PASSWORD" | podman login --username "$(cat "$QUAY_USER")" --password-stdin=true quay.io
           cp /etc/bazel.bazelrc ./ci.bazelrc
-          DOCKER_TAG="$(date +%Y%m%d)_$(git rev-parse --short=10 HEAD)" \
+          DOCKER_TAG="1.9-aie-nv_$(date +%Y%m%d)_$(git rev-parse --short=10 HEAD)" \
             BUILD_ARCH=amd64,crossbuild-aarch64 \
             PUSH_TARGETS=virt-launcher \
             make bazel-push-images


### PR DESCRIPTION
## Summary

- **CNV-94693**: Add branch prefix to postsubmit virt-launcher image tags so images from `release-1.8-aie-nv` and `release-1.9-aie-nv` can be distinguished in `quay.io/kubevirt/kubevirt-aie`. Tags change from `YYYYMMDD_sha` to `1.8-aie-nv_YYYYMMDD_sha` / `1.9-aie-nv_YYYYMMDD_sha`.
- **CNV-94694**: Add `periodic-kubevirt-aie-sync-nv-rpms-1.9` periodic job mirroring the existing 1.8 RPM sync job but targeting `release-1.9-aie-nv`. Cron offset to 07:00 UTC to avoid concurrent runs with the 1.8 job. Uses `sync-nv-rpms-1.9` as the PR branch name to avoid collisions.
- Bump `KUBEVIRT_CS10_BUILDER_VERSION` from `2605290816-89fad9a940` (May 2026) to `2606301559-b9f50e380a` in the `pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv` presubmit, aligning it with the version already used elsewhere in this repo. The old builder was causing the e2e job to run with a stale toolchain; the primary fix for the associated CI failure (missing `libwsman1` for libvirt 12.5.0) is in https://github.com/kubevirt/kubevirt-aie/pull/73.

## Test plan

- [ ] Verify postsubmit job definitions parse correctly in Prow
- [ ] Confirm next merge to `release-1.8-aie-nv` produces a tag with `1.8-aie-nv_` prefix in quay
- [ ] Confirm next merge to `release-1.9-aie-nv` produces a tag with `1.9-aie-nv_` prefix in quay
- [ ] Confirm `periodic-kubevirt-aie-sync-nv-rpms-1.9` fires at 07:00 UTC and opens a PR against `release-1.9-aie-nv`
- [ ] Confirm `pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv` picks up the new builder on next run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily synchronization job for EL10 NVIDIA RPMs on the 1.9 AIE-NV release branch.

* **Bug Fixes**
  * Improved image tag naming by including the release identifier for 1.8 and 1.9 AIE-NV builds.
  * Updated the ARM64 Kubernetes presubmit environment to use a newer CentOS Stream 10 builder image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->