### PR TITLE
chore(prow): add prow config for vhostuser-network-binding-plugin repo

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -215,6 +215,7 @@ tide:
     kubevirt/redfish-controller: merge
     kubevirt/kubevirt-observability-controller: squash
     kubevirt/vdpa-network-binding-plugin: merge
+    kubevirt/vhostuser-network-binding-plugin: merge
     kubevirt/plugins: merge
   queries:
   - repos:
@@ -246,6 +247,7 @@ tide:
     - kubevirt/ci-health
     - kubevirt/redfish-controller
     - kubevirt/vdpa-network-binding-plugin
+    - kubevirt/vhostuser-network-binding-plugin
     labels:
     - lgtm
     - approved
@@ -651,6 +653,10 @@ branch-protection:
             main:
               protect: true
         vdpa-network-binding-plugin:
+          branches:
+            main:
+              protect: true
+        vhostuser-network-binding-plugin:
           branches:
             main:
               protect: true

--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -604,6 +604,12 @@ plugins:
     - lgtm
     - trigger
 
+  kubevirt/vhostuser-network-binding-plugin:
+    plugins:
+    - approve
+    - lgtm
+    - trigger
+
 # https://docs.prow.k8s.io/docs/components/plugins/#external-plugins
 external_plugins:
   libguestfs-appliance:
@@ -730,6 +736,7 @@ approve:
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller
   - kubevirt/vdpa-network-binding-plugin
+  - kubevirt/vhostuser-network-binding-plugin
   - kubevirt/plugins
   require_self_approval: true
   lgtm_acts_as_approve: false
@@ -884,6 +891,7 @@ lgtm:
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller
   - kubevirt/vdpa-network-binding-plugin
+  - kubevirt/vhostuser-network-binding-plugin
   - kubevirt/plugins
   review_acts_as_lgtm: true
 
@@ -953,6 +961,7 @@ triggers:
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller
   - kubevirt/vdpa-network-binding-plugin
+  - kubevirt/vhostuser-network-binding-plugin
   - kubevirt/plugins
   ignore_ok_to_test: true
 - repos:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Prow configuration for `vhostuser-network-binding-plugin` repository.

It is a copy/paste of the `vdpa-network-binding-plugin` config.

**Special notes for your reviewer**:

/cc @Whitedyl @orelmisan @mcoquelin 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for automated merge management and repository queries.
  * Enabled approval, review, and pull request trigger workflows.
  * Added branch protection for the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->