### PR TITLE
feat(kubevirtci): add presubmit jobs for k8s-1.37 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -521,66 +521,6 @@ presubmits:
             memory: 1Gi
         securityContext:
           privileged: true
-  - always_run: false
-    cluster: prow-s390x-workloads
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-kubevirtci-check-provision-env: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
-    name: check-provision-k8s-1.32-s390x
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/entrypoint.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.32 && ../provision.sh
-        env:
-        - name: GO_MOD_PATH
-          value: cluster-provision/gocli/go.mod
-        - name: SLIM
-          value: "true"
-        - name: RUN_KUBEVIRT_CONFORMANCE
-          value: "false"
-        image: quay.io/kubevirtci/golang:v20260715-af3e234
-        resources:
-          requests:
-            memory: 16Gi
-        securityContext:
-          privileged: true
-  - always_run: false
-    cluster: prow-s390x-workloads
-    decoration_config:
-      timeout: 4h0m0s
-    labels:
-      preset-kubevirtci-check-provision-env: "true"
-      preset-podman-in-container-enabled: "true"
-    max_concurrency: 3
-    name: check-provision-k8s-1.33-s390x
-    optional: true
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/entrypoint.sh
-        - /bin/sh
-        - -c
-        - cd cluster-provision/k8s/1.33 && ../provision.sh
-        env:
-        - name: GO_MOD_PATH
-          value: cluster-provision/gocli/go.mod
-        - name: SLIM
-          value: "true"
-        - name: RUN_KUBEVIRT_CONFORMANCE
-          value: "false"
-        image: quay.io/kubevirtci/golang:v20260715-af3e234
-        resources:
-          requests:
-            memory: 16Gi
-        securityContext:
-          privileged: true
   - always_run: true
     cluster: prow-s390x-workloads
     decoration_config:
@@ -818,3 +758,68 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: true
+    cluster: prow-workloads
+    decoration_config:
+      timeout: 3h30m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-kubevirtci-check-provision-env: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-provision-k8s-1.37
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint.sh
+        args:
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.37 && ../provision.sh
+        env:
+        - name: GO_MOD_PATH
+          value: cluster-provision/gocli/go.mod
+        - name: PROVISION_CENTOS_VERSION
+          value: "10"
+        image: quay.io/kubevirtci/golang:v20260715-af3e234
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    cluster: prow-s390x-workloads
+    decoration_config:
+      timeout: 4h0m0s
+    labels:
+      preset-kubevirtci-check-provision-env: "true"
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: check-provision-k8s-1.37-s390x
+    optional: true
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint.sh
+        args:
+        - /bin/sh
+        - -c
+        - cd cluster-provision/k8s/1.37 && ../provision.sh
+        env:
+        - name: GO_MOD_PATH
+          value: cluster-provision/gocli/go.mod
+        - name: PROVISION_CENTOS_VERSION
+          value: "10"
+        - name: SLIM
+          value: "true"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "false"
+        image: quay.io/kubevirtci/golang:v20260715-af3e234
+        resources:
+          requests:
+            memory: 16Gi
+        securityContext:
+          privileged: true

--- a/robots/kubevirtci-presubmit-creator/main.go
+++ b/robots/kubevirtci-presubmit-creator/main.go
@@ -183,7 +183,7 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 		JobBase: config.JobBase{
 			UtilityConfig: config.UtilityConfig{
 				DecorationConfig: &prowjobs.DecorationConfig{
-					Timeout: &prowjobs.Duration{Duration: 3 * time.Hour},
+					Timeout: &prowjobs.Duration{Duration: 3*time.Hour + 30*time.Minute},
 				},
 			},
 			Name:           fmt.Sprintf("check-provision-k8s-%s.%s", semver.Major, semver.Minor),
@@ -202,15 +202,21 @@ func CreatePresubmitJobForRelease(semver *querier.SemVer) config.Presubmit {
 					{
 						Image: golangImage,
 						Command: []string{
-							"/usr/local/bin/runner.sh",
+							"/usr/local/bin/entrypoint.sh",
+						},
+						Args: []string{
 							"/bin/sh",
 							"-c",
 							fmt.Sprintf("cd cluster-provision/k8s/%s.%s && ../provision.sh", semver.Major, semver.Minor),
 						},
 						Env: []v1.EnvVar{
 							{
-								Name:  "GIMME_GO_VERSION",
-								Value: "1.24.7",
+								Name:  "GO_MOD_PATH",
+								Value: "cluster-provision/gocli/go.mod",
+							},
+							{
+								Name:  "PROVISION_CENTOS_VERSION",
+								Value: "10",
 							},
 						},
 						SecurityContext: &v1.SecurityContext{

--- a/robots/kubevirtci-presubmit-creator/main_test.go
+++ b/robots/kubevirtci-presubmit-creator/main_test.go
@@ -28,7 +28,9 @@ func TestCreateBumpedJobForRelease(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Command: []string{
-										"/usr/local/bin/runner.sh",
+										"/usr/local/bin/entrypoint.sh",
+									},
+									Args: []string{
 										"/bin/sh",
 										"-c",
 										"cd cluster-provision/k8s/1.37 && ../provision.sh",
@@ -53,7 +55,9 @@ func TestCreateBumpedJobForRelease(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Command: []string{
-										"/usr/local/bin/runner.sh",
+										"/usr/local/bin/entrypoint.sh",
+									},
+									Args: []string{
 										"/bin/sh",
 										"-c",
 										"cd cluster-provision/k8s/1.42 && ../provision.sh",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the required jobs to build the k8s-1.37 kubevirtci provider introduced by https://github.com/kubevirt/kubevirtci/pull/1807.

This provider is CentOS 10 only.

Also remove obsolete providers k8s-1.32-s390x and k8s-1.33-s390x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added presubmit coverage for Kubernetes versions 1.34 through 1.37 across workload and s390x clusters.
  * Added CentOS 10 job variants, including slim-mode and dynamic CentOS-base validation.

* **Improvements**
  * Updated generated presubmit jobs to use the current execution entrypoint and Go module configuration.
  * Extended the presubmit timeout to 3 hours 30 minutes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->