### PR TITLE
jobs(kubevirt-aie): fix kind-1.35 arm64 e2e job for release-1.9-aie-nv

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-postsubmits.yaml
@@ -27,7 +27,7 @@ postsubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: "2605290816-89fad9a940"
+          value: "2606301559-b9f50e380a"
         command:
         - /usr/local/bin/runner.sh
         - /bin/sh

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
@@ -160,7 +160,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
@@ -160,7 +160,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
-      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
@@ -160,6 +160,8 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv
@@ -181,7 +183,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: "2605290816-89fad9a940"
+          value: "2606301559-b9f50e380a"
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
         name: ""
         resources:


### PR DESCRIPTION
## Summary

The `pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv` job has been consistently failing to bring up KubeVirt. Two root causes identified:

**1. Stale `KUBEVIRT_CS10_BUILDER_VERSION`**

The job was pinned to `2605290816-89fad9a940` (built 2026-05-29), which predates the `Dockerfile.cs10` update on 2026-06-27 that bumped Go to 1.26.4 and updated golangci-lint to v2.12.4. This causes the e2e job to build virt-handler inside an old builder container with a mismatched toolchain. Updated to `2606301559-b9f50e380a` (built 2026-06-30) — the latest published `builder-cs10` image that includes the Go 1.26.4 update.

**2. Missing `preset-bazel-cache` and `preset-docker-mirror-proxy` labels**

Every other job in this presubmit file carries both labels, but the kind e2e job was missing them. Without `preset-bazel-cache`, the job has no Bazel remote cache and must re-download all dependencies from scratch — triggering the CentOS Stream 10 mirror 404 errors visible in the build logs. Without `preset-docker-mirror-proxy`, image pulls go directly to public registries.

The same `KUBEVIRT_CS10_BUILDER_VERSION` bump is applied to the postsubmit.

## Test plan

- [ ] Re-run `pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv` on kubevirt/kubevirt-aie PR #73 after this merges to confirm KubeVirt reaches `Available`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the builder version used by KubeVirt 1.9 AIE NV validation and post-submit jobs.
  * Enabled Docker mirror proxy support for the ARM64 kind pre-submit job.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->