### PR TITLE
chore(kubevirt-cs10): bump builder image tag to 2606301559-b9f50e380a

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -630,8 +630,8 @@ periodics:
       args:
       - |
         ../project-infra/hack/git-pr.sh \
-          --command "cd ../kubevirt && KUBEVIRT_CENTOS_STREAM_VERSION=10 KUBEVIRT_CS10_BUILDER_VERSION=2605290816-89fad9a940 make rpm-deps" \
-          --branch bump-rpm-dependencies-cs10 \
+          --command "cd ../kubevirt && KUBEVIRT_CENTOS_STREAM_VERSION=10 KUBEVIRT_CS10_BUILDER_VERSION=2606301559-b9f50e380a make rpm-deps" \
+          --branch bump-cs10-rpm-dependencies \
           --repo-path ../kubevirt \
           --target main \
           --release-note-none \

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -471,7 +471,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2605290816-89fad9a940
+          value: 2606301559-b9f50e380a
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
         resources:
           requests:
@@ -730,7 +730,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2605290816-89fad9a940
+          value: 2606301559-b9f50e380a
         - name: BUILD_ARCH
           value: crossbuild-aarch64
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
@@ -765,7 +765,7 @@ presubmits:
         - name: KUBEVIRT_CENTOS_STREAM_VERSION
           value: "10"
         - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2605290816-89fad9a940
+          value: 2606301559-b9f50e380a
         - name: BUILD_ARCH
           value: crossbuild-s390x
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234


### PR DESCRIPTION
**What this PR does / why we need it**:

This tag updates golang from v1.24.9 to v1.26.4

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

It should fix kubevirt centos10 jobs such as [bump-kubevirt-rpms-cs10-weekly](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/logs/bump-kubevirt-rpms-cs10-weekly).

**Special notes for your reviewer**:

/cc @Whitedyl @lyarwood

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CentOS Stream 10 build and verification jobs to use the latest builder version.
  * Applied the update across dependency bump checks and ARM64 and s390x build validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->