### PR TITLE
perf-report-creator: fix weekly data gaps in performance benchmarks

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1170,7 +1170,7 @@ periodics:
     repo: project-infra
     base_ref: main
     workdir: true
-  interval: 168h
+  cron: "0 20 * * 1"
   labels:
     preset-bazel-cache: "true"
     preset-gcs-credentials: "true"

--- a/robots/perf-report-creator/main.go
+++ b/robots/perf-report-creator/main.go
@@ -404,16 +404,9 @@ func getWeeklyVMResults(results *Collection) (map[YearWeek][]ResultWithDate, err
 }
 
 func getMondayOfWeekDate(year, week int) string {
-	// Get the first Monday of the Year
-	firstDayOfYear := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)
-	daysUntilFirstMonday := int(time.Monday - firstDayOfYear.Weekday())
-	if daysUntilFirstMonday < 0 {
-		daysUntilFirstMonday += 7
-	}
-
-	// create a time.Time object representing the Monday of the ISO Week
-	weekMonday := firstDayOfYear.AddDate(0, 0, daysUntilFirstMonday+((week-1)*7))
-
-	// print the Monday in ISO format
+	// Jan 4 is always in ISO week 1. Find that week's Monday, then offset by week-1.
+	jan4 := time.Date(year, time.January, 4, 0, 0, 0, 0, time.UTC)
+	week1Monday := jan4.AddDate(0, 0, -int((jan4.Weekday()+6)%7))
+	weekMonday := week1Monday.AddDate(0, 0, (week-1)*7)
 	return weekMonday.Format("2006-01-02")
 }

--- a/robots/perf-report-creator/record.go
+++ b/robots/perf-report-creator/record.go
@@ -39,6 +39,59 @@ func NewRecordDateWithAverage(rdps []RecordDataPoint) RecordData {
 	return r
 }
 
+func readRecord(path string) (*Record, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var record Record
+	if err := json.NewDecoder(f).Decode(&record); err != nil {
+		return nil, err
+	}
+	return &record, nil
+}
+
+func dataPointKey(dp RecordDataPoint) string {
+	if dp.Date == nil {
+		return ""
+	}
+	return dp.Date.UTC().Format(time.RFC3339Nano)
+}
+
+func mergeDataPoints(existing, incoming []RecordDataPoint) []RecordDataPoint {
+	byDate := map[string]RecordDataPoint{}
+	order := make([]string, 0, len(existing)+len(incoming))
+
+	add := func(dp RecordDataPoint) {
+		key := dataPointKey(dp)
+		if key == "" {
+			return
+		}
+		if _, ok := byDate[key]; !ok {
+			order = append(order, key)
+		}
+		byDate[key] = dp
+	}
+
+	for _, dp := range existing {
+		add(dp)
+	}
+	for _, dp := range incoming {
+		add(dp)
+	}
+
+	merged := make([]RecordDataPoint, 0, len(order))
+	for _, key := range order {
+		merged = append(merged, byDate[key])
+	}
+	return merged
+}
+
 func calculateAVGAndWriteOutput(results map[YearWeek][]ResultWithDate, objType string, outputDir string, metrics ...string) error {
 	for _, metric := range metrics {
 		for yw := range results {
@@ -61,6 +114,15 @@ func calculateAVGAndWriteOutput(results map[YearWeek][]ResultWithDate, objType s
 					Date:  result.Date,
 				})
 			}
+
+			existing, err := readRecord(outputPath)
+			if err != nil {
+				return err
+			}
+			if existing != nil {
+				rdp = mergeDataPoints(existing.Data.DataPoints, rdp)
+			}
+
 			record.NumberOfDays = 7
 			record.Data = NewRecordDateWithAverage(rdp)
 			f, err := os.Create(outputPath)
@@ -70,8 +132,12 @@ func calculateAVGAndWriteOutput(results map[YearWeek][]ResultWithDate, objType s
 			e := json.NewEncoder(f)
 			e.SetIndent("", "  ")
 			err = e.Encode(&record)
+			closeErr := f.Close()
 			if err != nil {
 				return err
+			}
+			if closeErr != nil {
+				return closeErr
 			}
 		}
 	}

--- a/robots/perf-report-creator/record.go
+++ b/robots/perf-report-creator/record.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -39,21 +40,30 @@ func NewRecordDateWithAverage(rdps []RecordDataPoint) RecordData {
 	return r
 }
 
-func readRecord(path string) (*Record, error) {
+func readRecord(path string) (record *Record, err error) {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			closeErr := fmt.Errorf("close %s: %w", path, cerr)
+			if err != nil {
+				err = errors.Join(err, closeErr)
+			} else {
+				err = closeErr
+			}
+		}
+	}()
 
-	var record Record
-	if err := json.NewDecoder(f).Decode(&record); err != nil {
-		return nil, err
+	var decoded Record
+	if err = json.NewDecoder(f).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
 	}
-	return &record, nil
+	return &decoded, nil
 }
 
 func dataPointKey(dp RecordDataPoint) string {
@@ -102,7 +112,7 @@ func calculateAVGAndWriteOutput(results map[YearWeek][]ResultWithDate, objType s
 			outputDirPath := filepath.Join(outputDir, objType, metric, getMondayOfWeekDate(yw.Year, yw.Week), "data")
 			err := os.MkdirAll(outputDirPath, 0755)
 			if err != nil {
-				return err
+				return fmt.Errorf("mkdir %s: %w", outputDirPath, err)
 			}
 			outputPath := filepath.Join(outputDirPath, "results.json")
 			fmt.Println("writing output to", outputPath)
@@ -127,17 +137,23 @@ func calculateAVGAndWriteOutput(results map[YearWeek][]ResultWithDate, objType s
 			record.Data = NewRecordDateWithAverage(rdp)
 			f, err := os.Create(outputPath)
 			if err != nil {
-				return err
+				return fmt.Errorf("create %s: %w", outputPath, err)
 			}
 			e := json.NewEncoder(f)
 			e.SetIndent("", "  ")
 			err = e.Encode(&record)
 			closeErr := f.Close()
+			if err != nil && closeErr != nil {
+				return errors.Join(
+					fmt.Errorf("encode %s: %w", outputPath, err),
+					fmt.Errorf("close %s: %w", outputPath, closeErr),
+				)
+			}
 			if err != nil {
-				return err
+				return fmt.Errorf("encode %s: %w", outputPath, err)
 			}
 			if closeErr != nil {
-				return closeErr
+				return fmt.Errorf("close %s: %w", outputPath, closeErr)
 			}
 		}
 	}

--- a/robots/perf-report-creator/record_test.go
+++ b/robots/perf-report-creator/record_test.go
@@ -93,7 +93,9 @@ func TestCalculateAVGAndWriteOutputMergesExisting(t *testing.T) {
 	if err := json.NewEncoder(f).Encode(&existing); err != nil {
 		t.Fatal(err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	incomingDate := time.Date(2026, 7, 10, 8, 0, 0, 0, time.UTC)
 	results := map[YearWeek][]ResultWithDate{

--- a/robots/perf-report-creator/record_test.go
+++ b/robots/perf-report-creator/record_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestGetMondayOfWeekDate(t *testing.T) {
+	tests := []struct {
+		year, week int
+		want       string
+	}{
+		{2026, 1, "2025-12-29"},
+		{2026, 27, "2026-06-29"},
+		{2026, 28, "2026-07-06"},
+		{2026, 29, "2026-07-13"},
+		{2024, 1, "2024-01-01"},
+		{2025, 1, "2024-12-30"},
+	}
+
+	for _, tc := range tests {
+		got := getMondayOfWeekDate(tc.year, tc.week)
+		if got != tc.want {
+			t.Fatalf("getMondayOfWeekDate(%d, %d)=%q, want %q", tc.year, tc.week, got, tc.want)
+		}
+
+		parsed, err := time.Parse("2006-01-02", got)
+		if err != nil {
+			t.Fatalf("parse monday: %v", err)
+		}
+		if parsed.Weekday() != time.Monday {
+			t.Fatalf("expected Monday for %q, got %s", got, parsed.Weekday())
+		}
+		year, week := parsed.ISOWeek()
+		if year != tc.year || week != tc.week {
+			t.Fatalf("ISOWeek(%q)=(%d,%d), want (%d,%d)", got, year, week, tc.year, tc.week)
+		}
+	}
+}
+
+func TestMergeDataPoints(t *testing.T) {
+	t1 := time.Date(2026, 7, 6, 1, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 7, 7, 1, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 7, 8, 1, 0, 0, 0, time.UTC)
+
+	existing := []RecordDataPoint{
+		{Value: 10, Date: &t1},
+		{Value: 11, Date: &t2},
+	}
+	incoming := []RecordDataPoint{
+		{Value: 21, Date: &t2},
+		{Value: 12, Date: &t3},
+	}
+
+	merged := mergeDataPoints(existing, incoming)
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 points, got %d", len(merged))
+	}
+	if merged[0].Value != 10 || !merged[0].Date.Equal(t1) {
+		t.Fatalf("unexpected first point: %+v", merged[0])
+	}
+	if merged[1].Value != 21 || !merged[1].Date.Equal(t2) {
+		t.Fatalf("expected incoming to replace same-timestamp point: %+v", merged[1])
+	}
+	if merged[2].Value != 12 || !merged[2].Date.Equal(t3) {
+		t.Fatalf("unexpected third point: %+v", merged[2])
+	}
+}
+
+func TestCalculateAVGAndWriteOutputMergesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	monday := getMondayOfWeekDate(2026, 28)
+	outputPath := filepath.Join(tmp, "vmi", "vmiCreationToRunningSecondsP50", monday, "data", "results.json")
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	existingDate := time.Date(2026, 7, 6, 8, 0, 0, 0, time.UTC)
+	existing := Record{
+		StartDate:    monday,
+		NumberOfDays: 7,
+		Data: NewRecordDateWithAverage([]RecordDataPoint{
+			{Value: 10, Date: &existingDate},
+		}),
+	}
+	f, err := os.Create(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewEncoder(f).Encode(&existing); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	incomingDate := time.Date(2026, 7, 10, 8, 0, 0, 0, time.UTC)
+	results := map[YearWeek][]ResultWithDate{
+		{Year: 2026, Week: 28}: {
+			{
+				Date: &incomingDate,
+				Values: map[ResultType]ResultValue{
+					"vmiCreationToRunningSecondsP50": {Value: 20},
+				},
+			},
+		},
+	}
+
+	if err := calculateAVGAndWriteOutput(results, "vmi", tmp, "vmiCreationToRunningSecondsP50"); err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := readRecord(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged == nil {
+		t.Fatal("expected merged record")
+	}
+	if len(merged.Data.DataPoints) != 2 {
+		t.Fatalf("expected 2 merged points, got %d", len(merged.Data.DataPoints))
+	}
+	if merged.Data.Average != 15 {
+		t.Fatalf("expected average 15, got %v", merged.Data.Average)
+	}
+}

--- a/robots/perf-report-creator/scrape.sh
+++ b/robots/perf-report-creator/scrape.sh
@@ -16,6 +16,13 @@ perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir 
 # scrape kwok density test results
 perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance-kwok
 
+# Seed weekly output with already published data so weekly-report can merge
+# instead of overwriting earlier days in the same ISO week.
+if [ -d "${BENCHMARKS_DIR}/weekly" ]; then
+  mkdir -p "${OUTPUT_DIR}/weekly"
+  cp -a "${BENCHMARKS_DIR}/weekly/." "${OUTPUT_DIR}/weekly/"
+fi
+
 # aggregate sig-performance ${KUBEVIRT_PROVIDER} results in weekly directory
 perf-report-creator weekly-report --output-dir=${OUTPUT_DIR}/weekly/periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance \
   --results-dir=${OUTPUT_DIR}/results/periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance \

--- a/robots/perf-report-creator/scrape.sh
+++ b/robots/perf-report-creator/scrape.sh
@@ -1,3 +1,5 @@
+set -euo pipefail
+
 CREDENTIALS_FILE=${1}
 BENCHMARKS_DIR=${2}
 OUTPUT_DIR=${3:-output}
@@ -9,12 +11,17 @@ if [ -z "${KUBEVIRT_PROVIDER}" ]; then
     exit 1
 fi
 
+# The scrape window overlaps the previous ISO week so that late artifact
+# uploads and job start time drift are still picked up. Overlapping runs are
+# deduplicated when weekly-report merges into the published data.
+SINCE=${SINCE:-192h0s}
+
 # scrape sig-performance ${KUBEVIRT_PROVIDER} results
-perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance
+perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since ${SINCE} --performance-job-name periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance
 # scrape 100 density test results
-perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-performance-cluster-100-density-test
+perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since ${SINCE} --performance-job-name periodic-kubevirt-performance-cluster-100-density-test
 # scrape kwok density test results
-perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since 168h0s --performance-job-name periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance-kwok
+perf-report-creator results --credentials-file=${CREDENTIALS_FILE} --output-dir ${OUTPUT_DIR}/results --since ${SINCE} --performance-job-name periodic-kubevirt-e2e-${KUBEVIRT_PROVIDER}-sig-performance-kwok
 
 # Seed weekly output with already published data so weekly-report can merge
 # instead of overwriting earlier days in the same ISO week.


### PR DESCRIPTION
## Summary
- Fix recurring gaps in the weekly performance benchmark graphs (e.g. `periodic-kubevirt-e2e-k8s-1.34-sig-performance` dropping days like Jul 6-9).
- Root cause: `weekly-report` overwrote each ISO week's `results.json` with only the runs in the current scrape window, and `getMondayOfWeekDate` was off by one week so data landed in the wrong week folder.

## Changes
- `record.go`: merge new datapoints into the existing weekly `results.json` (dedup by run timestamp) instead of overwriting, and recompute the average over the merged set.
- `main.go`: fix `getMondayOfWeekDate` to derive the ISO week Monday from Jan 4 (always ISO week 1).
- `scrape.sh`: seed the weekly output from the already published benchmarks repo so the merge has prior data, and widen the scrape window to `192h` (overridable via `SINCE`) to catch late artifact uploads.
- `project-infra-periodics.yaml`: run `periodic-project-infra-perf-report-creator` on a fixed Monday cron (`0 20 * * 1`) instead of a drifting `168h` interval, so each run covers a completed ISO week.
- `record_test.go`: unit tests for the ISO Monday calculation, datapoint merge, and merge-on-write path.

## Test plan
- [x] `go test ./robots/perf-report-creator/`
- [ ] Confirm prow config validation passes
- [ ] After merge, verify the next weekly publish keeps all days of the ISO week

Note: this stops future data loss. Backfilling the already-lost historical days in `kubevirt/ci-performance-benchmarks` is a separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly performance reports preserve existing benchmark data while incorporating new results.
  * Scraping supports a configurable time window, defaulting to eight days.
* **Bug Fixes**
  * Corrected ISO week calculations, including year boundaries.
  * Duplicate data points are merged by timestamp, with updated values replacing older entries.
  * Report averages are recalculated after combining historical and new data.
* **Maintenance**
  * Performance report generation now runs every Monday at 20:00.
  * Improved error reporting and reliability during report collection and generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->