### PR TITLE
chore(kubevirt): remove sig lanes for k8s-1.34 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -140,8 +140,8 @@ periodics:
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:
-            name: github-token
             key: token
+            name: github-token
       image: quay.io/kubevirtci/golang:v20260715-af3e234
       resources: {}
 - annotations:
@@ -517,9 +517,9 @@ periodics:
     timeout: 4h0m0s
   extra_refs:
   - base_ref: main
+    clone_depth: 1
     org: kubevirt
     repo: kubevirt
-    clone_depth: 1
   labels:
     preset-bazel-cache: "true"
     preset-docker-mirror-proxy: "true"
@@ -577,11 +577,7 @@ periodics:
       report: true
   spec:
     containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/bash
-      - -ceu
-      args:
+    - args:
       - |
         ../project-infra/hack/git-pr.sh \
           --command "cd ../kubevirt && make rpm-deps" \
@@ -591,6 +587,10 @@ periodics:
           --release-note-none \
           --labels skip-review \
           --body $'Run of `cd ../kubevirt && make rpm-deps`\n\n/release-blocker main'
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -ceu
       image: quay.io/kubevirtci/pr-creator:v20260809-12a13ee
       resources:
         requests:
@@ -623,11 +623,7 @@ periodics:
       report: true
   spec:
     containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/bash
-      - -ceu
-      args:
+    - args:
       - |
         ../project-infra/hack/git-pr.sh \
           --command "cd ../kubevirt && KUBEVIRT_CENTOS_STREAM_VERSION=10 KUBEVIRT_CS10_BUILDER_VERSION=2606301559-b9f50e380a make rpm-deps" \
@@ -637,6 +633,10 @@ periodics:
           --release-note-none \
           --labels skip-review \
           --body $'Run of `cd ../kubevirt && KUBEVIRT_CENTOS_STREAM_VERSION=10 make rpm-deps`\n\n/release-blocker main'
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -ceu
       image: quay.io/kubevirtci/pr-creator:v20260809-12a13ee
       resources:
         requests:
@@ -1208,67 +1208,6 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 0 * * *
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 1h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    ci.kubevirt.io/prometheus: ""
-    preset-bazel-cache: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.32-sig-performance-realtime
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - |
-        # Create k8s cluster
-        make cluster-up
-
-        # Push and deploy kubevirt
-        make cluster-sync
-
-        FUNC_TEST_ARGS="--no-color --seed=42" make realtime-perftest
-      env:
-      - name: KUBEVIRT_PROVIDER
-        value: k8s-1.32
-      - name: KUBEVIRT_STORAGE
-        value: rook-ceph-default
-      - name: KUBEVIRT_MEMORY_SIZE
-        value: 9G
-      - name: KUBEVIRT_NUM_NODES
-        value: "2"
-      - name: KUBEVIRT_E2E_REALTIME_PERF_TEST
-        value: "true"
-      - name: KUBEVIRT_E2E_CYCLIC_DURATION_IN_SECONDS
-        value: "60"
-      - name: KUBEVIRT_E2E_REALTIME_LATENCY_THRESHOLD_IN_MICROSECONDS
-        value: "40"
-      - name: KUBEVIRT_HUGEPAGES_2M
-        value: "512"
-      - name: KUBEVIRT_REALTIME_SCHEDULER
-        value: "true"
-      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-      resources:
-        requests:
-          cpu: "10"
-          memory: 26Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
   cron: 30 2,8,14,20 * * *
   decoration_config:
     grace_period: 5m0s
@@ -1417,7 +1356,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-storage-root
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-storage-root
   spec:
     containers:
     - command:
@@ -1431,7 +1370,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.34-sig-storage
+        value: k8s-1.36-sig-storage
       - name: FEATURE_GATES
         value: Root
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1513,7 +1452,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-operator-root
+  name: periodic-kubevirt-e2e-k8s-1.36-sig-operator-root
   spec:
     containers:
     - command:
@@ -1527,7 +1466,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.34-sig-operator
+        value: k8s-1.36-sig-operator
       - name: FEATURE_GATES
         value: Root
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1836,190 +1775,6 @@ periodics:
       resources:
         requests:
           memory: 29Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 25 0,6,12,18 * * *
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-network
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.34-sig-network
-      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-        value: "true"
-      - name: KUBEVIRT_WITH_ETC_CAPACITY
-        value: 1G
-      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-      resources:
-        requests:
-          memory: 52Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 15 1,7,13,19 * * *
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-storage
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.34-sig-storage
-      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-        value: "true"
-      - name: KUBEVIRT_WITH_ETC_CAPACITY
-        value: 1G
-      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-      resources:
-        requests:
-          memory: 52Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 0 0,6,12,18 * * *
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 5h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-compute
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.34-sig-compute
-      - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
-        value: --usb 30M --usb 40M
-      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
-        value: 4h45m
-      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-        value: "true"
-      - name: KUBEVIRT_WITH_ETC_CAPACITY
-        value: 1G
-      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-      resources:
-        requests:
-          memory: 52Gi
-      securityContext:
-        privileged: true
-    nodeSelector:
-      type: bare-metal-external
-- annotations:
-    testgrid-dashboards: kubevirt-periodics
-    testgrid-days-of-results: "60"
-  cluster: prow-workloads
-  cron: 50 0,6,12,18 * * *
-  decoration_config:
-    grace_period: 5m0s
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: main
-    org: kubevirt
-    repo: kubevirt
-  labels:
-    preset-bazel-cache: "true"
-    preset-docker-mirror-proxy: "true"
-    preset-podman-in-container-enabled: "true"
-    preset-podman-shared-images: "true"
-    preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.34-sig-operator
-  spec:
-    containers:
-    - command:
-      - /usr/local/bin/runner.sh
-      - /bin/sh
-      - -c
-      - automation/test.sh
-      env:
-      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
-        value: "true"
-      - name: KUBEVIRT_QUARANTINE
-        value: "true"
-      - name: TARGET
-        value: k8s-1.34-sig-operator
-      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-        value: "true"
-      - name: KUBEVIRT_WITH_ETC_CAPACITY
-        value: 1G
-      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-      resources:
-        requests:
-          memory: 52Gi
       securityContext:
         privileged: true
     nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1142,7 +1142,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.36-sig-network-sriov-emulated
-    optional: false
     run_before_merge: true
     skip_branches:
     - release-\d+\.\d+
@@ -1520,49 +1519,6 @@ presubmits:
     cluster: prow-workloads
     decoration_config:
       grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.34-sig-storage-root
-    optional: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.34-sig-storage
-        - name: FEATURE_GATES
-          value: Root
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_CAPACITY
-          value: 1G
-        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-        resources:
-          requests:
-            memory: 52Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
       timeout: 7h0m0s
     labels:
       preset-bazel-cache: "true"
@@ -1765,172 +1721,6 @@ presubmits:
           requests:
             cpu: "12"
             memory: 73Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.34-sig-network
-    run_before_merge: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.34-sig-network
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_CAPACITY
-          value: 1G
-        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-        resources:
-          requests:
-            memory: 52Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.34-sig-storage
-    run_before_merge: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.34-sig-storage
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_CAPACITY
-          value: 1G
-        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-        resources:
-          requests:
-            memory: 52Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.34-sig-compute
-    run_before_merge: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.34-sig-compute-parallel
-        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
-          value: --usb 30M --usb 40M
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_CAPACITY
-          value: 1G
-        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-        resources:
-          requests:
-            memory: 52Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: false
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 7h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.34-sig-operator
-    run_before_merge: true
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.34-sig-operator
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_CAPACITY
-          value: 1G
-        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-        resources:
-          requests:
-            memory: 52Gi
         securityContext:
           privileged: true
       nodeSelector:
@@ -2364,10 +2154,10 @@ presubmits:
     max_concurrency: 4
     name: pull-kubevirt-e2e-k8s-1.36-sig-performance-kube-burner
     optional: true
-    skip_branches:
-    - release-\d+\.\d+
     reporter_config:
       slack: {}
+    skip_branches:
+    - release-\d+\.\d+
     spec:
       containers:
       - command:
@@ -2430,7 +2220,6 @@ presubmits:
       nodeSelector:
         type: bare-metal-external
   - always_run: false
-    optional: true
     annotations:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
@@ -2446,6 +2235,7 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.36-sig-compute-dra
+    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -2457,7 +2247,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: "k8s-1.36-sig-compute-dra-gpu"
+          value: k8s-1.36-sig-compute-dra-gpu
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2479,7 +2269,6 @@ presubmits:
       fork-per-release: "true"
       testgrid-dashboards: kubevirt-presubmits
     cluster: prow-hyperv-workloads
-    decorate: true
     decoration_config:
       grace_period: 5m0s
       timeout: 7h0m0s
@@ -2558,7 +2347,6 @@ presubmits:
         - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
           value: "8h"
         image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
-        name: ""
         resources:
           requests:
             memory: 18Gi


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the target for the next release is 1.37, 1.36, 1.35, we are removing the 1.34 lanes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated validation by removing obsolete and redundant CI jobs.
  * Updated selected storage and operator test coverage to Kubernetes 1.36.
  * Refined job scheduling and execution settings for more consistent validation.
  * Adjusted optional test classifications and removed outdated configuration fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->