### PR TITLE
kubevirt, presubmits: Add SKIP_SMOKE validation

### DIFF
--- a/pkg/kubevirt/cmd/check/presubmits.go
+++ b/pkg/kubevirt/cmd/check/presubmits.go
@@ -17,6 +17,7 @@ package check
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/prow/pkg/config"
@@ -40,11 +41,12 @@ var checkPresubmitsOpts = checkPresubmitsOptions{}
 
 var checkPresubmitsCommand = &cobra.Command{
 	Use:   "presubmits",
-	Short: "kubevirt check presubmits validates the sig-compute TARGET configuration for the latest k8s version",
-	Long: `kubevirt check presubmits validates the sig-compute TARGET configuration for the latest k8s version
+	Short: "kubevirt check presubmits validates sig-compute and sig-network presubmit invariants",
+	Long: `kubevirt check presubmits validates sig-compute and sig-network presubmit invariants
 
-For the latest Kubernetes version found in the presubmit job definitions, it checks that
-the sig-compute-serial job has a -serial TARGET and the plain sig-compute job has a -parallel TARGET.`,
+For the latest Kubernetes version found in the presubmit job definitions it checks that
+the sig-compute-serial job has a -serial TARGET and the plain sig-compute job has a -parallel TARGET.
+It also checks that the latest stable sig-network lane configuration stays coherent with the sig-network-smoke lane.`,
 	RunE: runCheckPresubmits,
 }
 
@@ -67,14 +69,26 @@ func runCheckPresubmits(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to read jobconfig %s: %v", checkPresubmitsOpts.jobConfigPathKubevirtPresubmits, err)
 	}
 
-	jobs := prowjobconfigs.CollectSigComputeJobs(&jobConfig)
+	var errs []string
+	errs = append(errs, validateSigComputeTargets(&jobConfig)...)
+	errs = append(errs, validateSigNetworkSkipSmokeEnv(&jobConfig)...)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("presubmit validation failed:\n%s", strings.Join(errs, "\n"))
+	}
+
+	return nil
+}
+
+func validateSigComputeTargets(jobConfig *config.JobConfig) []string {
+	jobs := prowjobconfigs.CollectSigComputeJobs(jobConfig)
 	if len(jobs) == 0 {
-		return fmt.Errorf("no sig-compute jobs found")
+		return []string{"no sig-compute jobs found"}
 	}
 
 	latestVersion, err := prowjobconfigs.FindLatestK8sVersionFromJobs(jobs)
 	if err != nil {
-		return err
+		return []string{err.Error()}
 	}
 
 	serialJobName := fmt.Sprintf("pull-kubevirt-e2e-k8s-%s-sig-compute-serial", latestVersion)
@@ -96,12 +110,52 @@ func runCheckPresubmits(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(errs) > 0 {
-		for _, e := range errs {
-			fmt.Fprintln(cmd.OutOrStderr(), e)
-		}
-		return fmt.Errorf("sig-compute TARGET validation failed for k8s version %s", latestVersion)
+	return errs
+}
+
+func validateSigNetworkSkipSmokeEnv(jobConfig *config.JobConfig) []string {
+	jobs := prowjobconfigs.CollectSigNetworkJobs(jobConfig)
+	if len(jobs) == 0 {
+		return []string{"no sig-network jobs found"}
 	}
 
-	return nil
+	var errs []string
+	var smokeVersion string
+	var skipSmokeVersions []string
+
+	for _, job := range jobs {
+		if job.IsSmoke {
+			if smokeVersion != "" {
+				errs = append(errs, fmt.Sprintf("multiple sig-network-smoke jobs found: %q and k8s-%s", job.Name, smokeVersion))
+				continue
+			}
+			smokeVersion = job.K8sVersion
+			continue
+		}
+
+		if job.SkipSmokeEnv == "true" {
+			skipSmokeVersions = append(skipSmokeVersions, job.K8sVersion)
+			continue
+		}
+		if job.SkipSmokeEnv != "" {
+			errs = append(errs, fmt.Sprintf("job %q has SKIP_SMOKE=%q, expected \"true\"", job.Name, job.SkipSmokeEnv))
+		}
+	}
+
+	if smokeVersion == "" {
+		errs = append(errs, "no sig-network-smoke job found")
+	}
+
+	switch len(skipSmokeVersions) {
+	case 0:
+		errs = append(errs, "no plain sig-network job has SKIP_SMOKE=true")
+	case 1:
+		if smokeVersion != "" && skipSmokeVersions[0] != smokeVersion {
+			errs = append(errs, fmt.Sprintf("sig-network-smoke runs on k8s-%s, but SKIP_SMOKE=true is set on sig-network k8s-%s", smokeVersion, skipSmokeVersions[0]))
+		}
+	default:
+		errs = append(errs, fmt.Sprintf("multiple plain sig-network jobs have SKIP_SMOKE=true: %v", skipSmokeVersions))
+	}
+
+	return errs
 }

--- a/pkg/kubevirt/cmd/check/presubmits_test.go
+++ b/pkg/kubevirt/cmd/check/presubmits_test.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 The KubeVirt Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package check
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/prow/pkg/config"
+
+	"kubevirt.io/project-infra/pkg/kubevirt/prowjobconfigs"
+)
+
+func TestPresubmits(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "check presubmits suite")
+}
+
+var _ = Describe("presubmit checks", func() {
+	DescribeTable("validateSigNetworkSkipSmokeEnv",
+		func(jobs []config.Presubmit, expectedErrs ...string) {
+			errs := validateSigNetworkSkipSmokeEnv(&config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					prowjobconfigs.OrgAndRepoForJobConfig: jobs,
+				},
+			})
+
+			if len(expectedErrs) == 0 {
+				Expect(errs).To(BeEmpty())
+				return
+			}
+
+			for _, expectedErr := range expectedErrs {
+				Expect(errs).To(ContainElement(ContainSubstring(expectedErr)))
+			}
+		},
+		Entry("smoke version matches env lane", []config.Presubmit{
+			newSigNetworkJob("1.35", false, ""),
+			newSigNetworkJob("1.36", false, "true"),
+			newSigNetworkJob("1.36", true, ""),
+		}),
+		Entry("fails when env lane is missing", []config.Presubmit{
+			newSigNetworkJob("1.35", false, ""),
+			newSigNetworkJob("1.36", false, ""),
+			newSigNetworkJob("1.36", true, ""),
+		}, "no plain sig-network job has SKIP_SMOKE=true"),
+		Entry("fails when smoke version mismatches env lane", []config.Presubmit{
+			newSigNetworkJob("1.35", false, "true"),
+			newSigNetworkJob("1.36", false, ""),
+			newSigNetworkJob("1.36", true, ""),
+		}, "sig-network-smoke runs on k8s-1.36, but SKIP_SMOKE=true is set on sig-network k8s-1.35"),
+		Entry("fails when multiple env lanes exist", []config.Presubmit{
+			newSigNetworkJob("1.35", false, "true"),
+			newSigNetworkJob("1.36", false, "true"),
+			newSigNetworkJob("1.36", true, ""),
+		}, "multiple plain sig-network jobs have SKIP_SMOKE=true"),
+		Entry("fails when env var is set to unexpected value", []config.Presubmit{
+			newSigNetworkJob("1.36", false, "false"),
+			newSigNetworkJob("1.36", true, ""),
+		}, "job \"pull-kubevirt-e2e-k8s-1.36-sig-network\" has SKIP_SMOKE=\"false\", expected \"true\""),
+		Entry("ignores optional extra smoke lane", []config.Presubmit{
+			newSigNetworkJob("1.35", false, ""),
+			newSigNetworkJob("1.36", false, "true"),
+			newSigNetworkJob("1.36", true, ""),
+			optionalPresubmit(newSigNetworkJob("1.37", true, "")),
+		}),
+		Entry("ignores optional SKIP_SMOKE on another version", []config.Presubmit{
+			newSigNetworkJob("1.35", false, ""),
+			newSigNetworkJob("1.36", false, "true"),
+			newSigNetworkJob("1.36", true, ""),
+			optionalPresubmit(newSigNetworkJob("1.37", false, "true")),
+		}),
+	)
+
+	DescribeTable("validateSigComputeTargets",
+		func(jobs []config.Presubmit, expectedErrs ...string) {
+			errs := validateSigComputeTargets(&config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{
+					prowjobconfigs.OrgAndRepoForJobConfig: jobs,
+				},
+			})
+
+			if len(expectedErrs) == 0 {
+				Expect(errs).To(BeEmpty())
+				return
+			}
+
+			for _, expectedErr := range expectedErrs {
+				Expect(errs).To(ContainElement(ContainSubstring(expectedErr)))
+			}
+		},
+		Entry("accepts aligned latest jobs", []config.Presubmit{
+			newSigComputeJob("1.35", false, "k8s-1.35-sig-compute-parallel"),
+			newSigComputeJob("1.36", false, "k8s-1.36-sig-compute-parallel"),
+			newSigComputeJob("1.36", true, "k8s-1.36-sig-compute-serial"),
+		}),
+		Entry("fails when latest parallel TARGET is wrong", []config.Presubmit{
+			newSigComputeJob("1.36", false, "k8s-1.36-sig-compute"),
+			newSigComputeJob("1.36", true, "k8s-1.36-sig-compute-serial"),
+		}, "job \"pull-kubevirt-e2e-k8s-1.36-sig-compute\" has TARGET \"k8s-1.36-sig-compute\", expected \"k8s-1.36-sig-compute-parallel\""),
+		Entry("fails when latest serial TARGET is wrong", []config.Presubmit{
+			newSigComputeJob("1.36", false, "k8s-1.36-sig-compute-parallel"),
+			newSigComputeJob("1.36", true, "k8s-1.36-sig-compute-parallel"),
+		}, "job \"pull-kubevirt-e2e-k8s-1.36-sig-compute-serial\" has TARGET \"k8s-1.36-sig-compute-parallel\", expected \"k8s-1.36-sig-compute-serial\""),
+	)
+})
+
+func newSigNetworkJob(version string, smoke bool, skipSmokeEnv string) config.Presubmit {
+	name := "pull-kubevirt-e2e-k8s-" + version + "-sig-network"
+	if smoke {
+		name += "-smoke"
+	}
+
+	env := []v1.EnvVar{{
+		Name:  "TARGET",
+		Value: "k8s-" + version + "-sig-network",
+	}}
+	if smoke {
+		env[0].Value += "-smoke"
+	}
+	if skipSmokeEnv != "" {
+		env = append(env, v1.EnvVar{Name: "SKIP_SMOKE", Value: skipSmokeEnv})
+	}
+
+	return config.Presubmit{
+		JobBase: config.JobBase{
+			Name: name,
+			Spec: &v1.PodSpec{
+				Containers: []v1.Container{{
+					Env: env,
+				}},
+			},
+		},
+	}
+}
+
+func optionalPresubmit(job config.Presubmit) config.Presubmit {
+	job.Optional = true
+	return job
+}
+
+func newSigComputeJob(version string, serial bool, target string) config.Presubmit {
+	name := "pull-kubevirt-e2e-k8s-" + version + "-sig-compute"
+	if serial {
+		name += "-serial"
+	}
+
+	return config.Presubmit{
+		JobBase: config.JobBase{
+			Name: name,
+			Spec: &v1.PodSpec{
+				Containers: []v1.Container{{
+					Env: []v1.EnvVar{{
+						Name:  "TARGET",
+						Value: target,
+					}},
+				}},
+			},
+		},
+	}
+}

--- a/pkg/kubevirt/prowjobconfigs/presubmits_target.go
+++ b/pkg/kubevirt/prowjobconfigs/presubmits_target.go
@@ -27,8 +27,16 @@ type SigComputeJob struct {
 	Target string
 }
 
+type SigNetworkJob struct {
+	Name         string
+	K8sVersion   string
+	IsSmoke      bool
+	SkipSmokeEnv string
+}
+
 var (
 	sigComputeJobNameRegex = regexp.MustCompile(`^pull-kubevirt-e2e-k8s-(\d+\.\d+)-sig-compute(-(migrations|serial))?$`)
+	sigNetworkJobNameRegex = regexp.MustCompile(`^pull-kubevirt-e2e-k8s-(\d+\.\d+)-sig-network(-smoke)?$`)
 	k8sVersionRegex        = regexp.MustCompile(`k8s-(\d+)\.(\d+)`)
 )
 
@@ -47,6 +55,34 @@ func CollectSigComputeJobs(jobConfig *config.JobConfig) []SigComputeJob {
 		}
 	}
 	return jobs
+}
+
+func CollectSigNetworkJobs(jobConfig *config.JobConfig) []SigNetworkJob {
+	var jobs []SigNetworkJob
+	for _, job := range jobConfig.PresubmitsStatic[OrgAndRepoForJobConfig] {
+		matches := sigNetworkJobNameRegex.FindStringSubmatch(job.Name)
+		if job.Optional || matches == nil {
+			continue
+		}
+		jobs = append(jobs, SigNetworkJob{
+			Name:         job.Name,
+			K8sVersion:   matches[1],
+			IsSmoke:      matches[2] == "-smoke",
+			SkipSmokeEnv: GetEnvValue(job, "SKIP_SMOKE"),
+		})
+	}
+	return jobs
+}
+
+func GetEnvValue(job config.Presubmit, envName string) string {
+	for _, container := range job.Spec.Containers {
+		for _, env := range container.Env {
+			if env.Name == envName {
+				return env.Value
+			}
+		}
+	}
+	return ""
 }
 
 func FindLatestK8sVersionFromJobs(jobs []SigComputeJob) (string, error) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

We introduced the `SKIP_SMOKE` var, which skips conformance tests, it should be enabled only on 
one gating sig-network lane, and the k8s version of this lane should be the same of the gating smoke lane, so this what this PR enforce. 
Reason is that we move the var manually, when bumping the lanes, so it is a guard to make sure we didn't forget / left unbalanced state.

Validate that there is exactly one gating sig-network-smoke.
Validate that exactly one gating sig-network job sets `SKIP_SMOKE`,
that the value is true, and that it matches the gating sig-network-smoke k8s version.

Since this PR touches also sig-compute validation functions, add unit tests for both sig-compute,
and the new sig-network validation logic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Presubmit checks now validate SIG Network smoke jobs, `SKIP_SMOKE` settings, required lanes, and Kubernetes-version alignment.
  * SIG Compute checks now recognize parallel, serial, and migration job targets.
  * Validation reports all detected issues together for easier troubleshooting.

* **Tests**
  * Added coverage for valid and invalid SIG Network and SIG Compute presubmit configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->