### PR TITLE
chore(kubevirt): add sig lanes for k8s-1.37 provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -184,7 +184,7 @@ periodics:
               latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
               description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
 
-              git-pr.sh \
+              git-pr.sh \
                 --command "cd ../kubevirt && hack/common-instancetypes/bump.sh ${COMMON_INSTANCETYPES_BRANCH}" \
                 --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
                 --repo kubevirt \

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -511,7 +511,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 23 * * 6
+  cron: 0 0 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1342,7 +1342,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 6,18 * * *
+  cron: 0 9,21 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1389,7 +1389,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 9,21 * * *
+  cron: 0 0,12 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -1438,7 +1438,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 3,15 * * *
+  cron: 0 6,18 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1691,7 +1691,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 0,12 * * *
+  cron: 0 3,15 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 3h0m0s
@@ -1783,7 +1783,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 55 2,8,14,20 * * *
+  cron: 25 0,6,12,18 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1828,7 +1828,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 45 3,9,15,21 * * *
+  cron: 15 1,7,13,19 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -1873,7 +1873,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 5 2,8,14,20 * * *
+  cron: 0 0,6,12,18 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -1922,7 +1922,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 20 3,9,15,21 * * *
+  cron: 50 0,6,12,18 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2072,7 +2072,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 35 4,10,16,22 * * *
+  cron: 55 2,8,14,20 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2117,7 +2117,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 25 5,11,17,23 * * *
+  cron: 45 3,9,15,21 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2162,7 +2162,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 10 4,10,16,22 * * *
+  cron: 5 2,8,14,20 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 5h0m0s
@@ -2211,7 +2211,7 @@ periodics:
     testgrid-dashboards: kubevirt-periodics
     testgrid-days-of-results: "60"
   cluster: prow-workloads
-  cron: 0 5,11,17,23 * * *
+  cron: 20 3,9,15,21 * * *
   decoration_config:
     grace_period: 5m0s
     timeout: 4h0m0s
@@ -2244,6 +2244,214 @@ periodics:
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
         value: 1G
+      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 10 4,10,16,22 * * *
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 5h0m0s
+  extra_refs:
+  - base_ref: main
+    clone_depth: 1
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.37-sig-compute
+  spec:
+    containers:
+    - args:
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      command:
+      - /usr/local/bin/runner.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.37-sig-compute
+      - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+        value: --usb 30M --usb 40M
+      - name: KUBEVIRT_FUNC_TEST_GINKGO_TIMEOUT
+        value: 4h45m
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2606301559-b9f50e380a
+      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 35 4,10,16,22 * * *
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    clone_depth: 1
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.37-sig-network
+  spec:
+    containers:
+    - args:
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      command:
+      - /usr/local/bin/runner.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.37-sig-network
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2606301559-b9f50e380a
+      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 0 5,11,17,23 * * *
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    clone_depth: 1
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.37-sig-operator
+  spec:
+    containers:
+    - args:
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      command:
+      - /usr/local/bin/runner.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.37-sig-operator
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2606301559-b9f50e380a
+      image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+      resources:
+        requests:
+          memory: 52Gi
+      securityContext:
+        privileged: true
+    nodeSelector:
+      type: bare-metal-external
+- annotations:
+    testgrid-dashboards: kubevirt-periodics
+    testgrid-days-of-results: "60"
+  cluster: prow-workloads
+  cron: 25 5,11,17,23 * * *
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: main
+    clone_depth: 1
+    org: kubevirt
+    repo: kubevirt
+  labels:
+    preset-bazel-cache: "true"
+    preset-docker-mirror-proxy: "true"
+    preset-podman-in-container-enabled: "true"
+    preset-podman-shared-images: "true"
+    preset-shared-images: "true"
+  name: periodic-kubevirt-e2e-k8s-1.37-sig-storage
+  spec:
+    containers:
+    - args:
+      - /bin/sh
+      - -c
+      - automation/test.sh
+      command:
+      - /usr/local/bin/runner.sh
+      env:
+      - name: KUBEVIRT_E2E_RUN_ALL_SUITES
+        value: "true"
+      - name: KUBEVIRT_QUARANTINE
+        value: "true"
+      - name: TARGET
+        value: k8s-1.37-sig-storage
+      - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+        value: "true"
+      - name: KUBEVIRT_WITH_ETC_CAPACITY
+        value: 1G
+      - name: KUBEVIRT_CENTOS_STREAM_VERSION
+        value: "10"
+      - name: KUBEVIRT_CS10_BUILDER_VERSION
+        value: 2606301559-b9f50e380a
       image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2352,3 +2352,188 @@ presubmits:
             memory: 18Gi
         securityContext:
           privileged: true
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.37-sig-compute
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        command:
+        - /usr/local/bin/runner.sh
+        env:
+        - name: TARGET
+          value: k8s-1.37-sig-compute-parallel
+        - name: KUBEVIRT_PROVIDER_EXTRA_ARGS
+          value: --usb 30M --usb 40M
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2606301559-b9f50e380a
+        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.37-sig-network-smoke
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        command:
+        - /usr/local/bin/runner.sh
+        env:
+        - name: TARGET
+          value: k8s-1.37-sig-network-smoke
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2606301559-b9f50e380a
+        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 7h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.37-sig-operator
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        env:
+        - name: TARGET
+          value: k8s-1.37-sig-operator
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2606301559-b9f50e380a
+        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
+  - always_run: true
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.37-sig-storage
+    optional: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        command:
+        - /usr/local/bin/runner.sh
+        env:
+        - name: TARGET
+          value: k8s-1.37-sig-storage
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        - name: KUBEVIRT_CENTOS_STREAM_VERSION
+          value: "10"
+        - name: KUBEVIRT_CS10_BUILDER_VERSION
+          value: 2606301559-b9f50e380a
+        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -768,7 +768,6 @@ presubmits:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
     name: check-provision-k8s-1.37
-    optional: true
     spec:
       containers:
       - command:

--- a/pkg/kubevirt/cmd/copy/jobs.go
+++ b/pkg/kubevirt/cmd/copy/jobs.go
@@ -37,6 +37,9 @@ import (
 const (
 	shortUse                      = "kubevirt copy jobs creates copies of the periodic and presubmit SIG jobs for latest kubevirtci providers"
 	sourceAndTargetReleaseDoExist = 2
+
+	defaultJobConfigPathKubevirtPresubmits = "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml"
+	defaultJobConfigPathKubevirtPeriodics  = "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml"
 )
 
 type copyJobOptions struct {
@@ -82,8 +85,8 @@ func CopyJobsCommand() *cobra.Command {
 }
 
 func init() {
-	copyJobsCommand.PersistentFlags().StringVar(&copyJobsOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", "", "The path to the kubevirt presubmit job definitions")
-	copyJobsCommand.PersistentFlags().StringVar(&copyJobsOpts.jobConfigPathKubevirtPeriodics, "job-config-path-kubevirt-periodics", "", "The path to the kubevirt periodic job definitions")
+	copyJobsCommand.PersistentFlags().StringVar(&copyJobsOpts.jobConfigPathKubevirtPresubmits, "job-config-path-kubevirt-presubmits", defaultJobConfigPathKubevirtPresubmits, "The path to the kubevirt presubmit job definitions")
+	copyJobsCommand.PersistentFlags().StringVar(&copyJobsOpts.jobConfigPathKubevirtPeriodics, "job-config-path-kubevirt-periodics", defaultJobConfigPathKubevirtPeriodics, "The path to the kubevirt periodic job definitions")
 	copyJobsCommand.PersistentFlags().StringVar(&copyJobsOpts.k8sReleaseSemver, "k8s-release-semver", "", "The semver of the k8s release to create the jobs for, or (as default) empty string to create for latest release")
 }
 
@@ -218,23 +221,24 @@ func copyPresubmitJobsForNewProvider(jobConfig *config.JobConfig, targetProvider
 
 		log.Log().WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Info("Copying source to target job")
 
+		oldJob := allPresubmitJobs[sourceJobName]
 		newJob := config.Presubmit{}
 		newJob.Annotations = make(map[string]string)
-		for k, v := range allPresubmitJobs[sourceJobName].Annotations {
+		for k, v := range oldJob.Annotations {
 			newJob.Annotations[k] = v
 		}
-		newJob.Cluster = allPresubmitJobs[sourceJobName].Cluster
-		newJob.Decorate = allPresubmitJobs[sourceJobName].Decorate
-		newJob.DecorationConfig = allPresubmitJobs[sourceJobName].DecorationConfig.DeepCopy()
-		copy(newJob.ExtraRefs, allPresubmitJobs[sourceJobName].ExtraRefs)
+		newJob.Cluster = oldJob.Cluster
+		newJob.Decorate = oldJob.Decorate
+		newJob.DecorationConfig = oldJob.DecorationConfig.DeepCopy()
+		copy(newJob.ExtraRefs, oldJob.ExtraRefs)
 		newJob.Labels = make(map[string]string)
-		for k, v := range allPresubmitJobs[sourceJobName].Labels {
+		for k, v := range oldJob.Labels {
 			newJob.Labels[k] = v
 		}
-		newJob.MaxConcurrency = allPresubmitJobs[sourceJobName].MaxConcurrency
-		newJob.Spec = allPresubmitJobs[sourceJobName].Spec.DeepCopy()
-		newJob.Brancher.SkipBranches = allPresubmitJobs[sourceJobName].Brancher.SkipBranches
-		newJob.Brancher.Branches = allPresubmitJobs[sourceJobName].Brancher.Branches
+		newJob.MaxConcurrency = oldJob.MaxConcurrency
+		newJob.Spec = oldJob.Spec.DeepCopy()
+		newJob.Brancher.SkipBranches = oldJob.Brancher.SkipBranches
+		newJob.Brancher.Branches = oldJob.Brancher.Branches
 
 		newJob.AlwaysRun = false
 		for index, envVar := range newJob.Spec.Containers[0].Env {
@@ -242,7 +246,7 @@ func copyPresubmitJobsForNewProvider(jobConfig *config.JobConfig, targetProvider
 				continue
 			}
 			newEnvVar := *envVar.DeepCopy()
-			newEnvVar.Value = prowjobconfigs.CreateTargetValue(targetProviderReleaseSemver, sigName)
+			newEnvVar.Value = prowjobconfigs.CreatePresubmitTargetValue(targetProviderReleaseSemver, sigName)
 			newJob.Spec.Containers[0].Env[index] = newEnvVar
 			break
 		}
@@ -279,25 +283,26 @@ func copyPeriodicJobsForNewProvider(jobConfig *config.JobConfig, targetProviderR
 
 		log.Log().WithField("targetJobName", targetJobName).WithField("sourceJobName", sourceJobName).Info("Copying source to target job")
 
+		oldJob := allPeriodicJobs[sourceJobName]
 		newJob := config.Periodic{}
 		newJob.Annotations = make(map[string]string)
-		for k, v := range allPeriodicJobs[sourceJobName].Annotations {
+		for k, v := range oldJob.Annotations {
 			newJob.Annotations[k] = v
 		}
-		newJob.Cluster = allPeriodicJobs[sourceJobName].Cluster
-		newJob.Cron = prowjobconfigs.AdvanceCronExpression(allPeriodicJobs[sourceJobName].Cron)
-		newJob.Decorate = allPeriodicJobs[sourceJobName].Decorate
-		newJob.DecorationConfig = allPeriodicJobs[sourceJobName].DecorationConfig.DeepCopy()
-		copy(newJob.ExtraRefs, allPeriodicJobs[sourceJobName].ExtraRefs)
+		newJob.Cluster = oldJob.Cluster
+		newJob.Cron = prowjobconfigs.AdvanceCronExpression(oldJob.Cron)
+		newJob.Decorate = oldJob.Decorate
+		newJob.DecorationConfig = oldJob.DecorationConfig.DeepCopy()
+		copy(newJob.ExtraRefs, oldJob.ExtraRefs)
 		newJob.Labels = make(map[string]string)
-		for k, v := range allPeriodicJobs[sourceJobName].Labels {
+		for k, v := range oldJob.Labels {
 			newJob.Labels[k] = v
 		}
-		newJob.MaxConcurrency = allPeriodicJobs[sourceJobName].MaxConcurrency
-		newJob.ReporterConfig = allPeriodicJobs[sourceJobName].ReporterConfig.DeepCopy()
-		newJob.Spec = allPeriodicJobs[sourceJobName].Spec.DeepCopy()
+		newJob.MaxConcurrency = oldJob.MaxConcurrency
+		newJob.ReporterConfig = oldJob.ReporterConfig.DeepCopy()
+		newJob.Spec = oldJob.Spec.DeepCopy()
 
-		newJob.UtilityConfig.ExtraRefs = append(newJob.UtilityConfig.ExtraRefs, allPeriodicJobs[sourceJobName].UtilityConfig.ExtraRefs...)
+		newJob.UtilityConfig.ExtraRefs = append(newJob.UtilityConfig.ExtraRefs, oldJob.UtilityConfig.ExtraRefs...)
 
 		for containerIndex, container := range newJob.Spec.Containers {
 			for envVarIndex, envVar := range container.Env {
@@ -305,7 +310,7 @@ func copyPeriodicJobsForNewProvider(jobConfig *config.JobConfig, targetProviderR
 					continue
 				}
 				newEnvVar := *envVar.DeepCopy()
-				newEnvVar.Value = prowjobconfigs.CreateTargetValue(targetProviderReleaseSemver, sigName)
+				newEnvVar.Value = prowjobconfigs.CreatePeriodicTargetValue(targetProviderReleaseSemver, sigName)
 				newJob.Spec.Containers[containerIndex].Env[envVarIndex] = newEnvVar
 				break
 			}

--- a/pkg/kubevirt/cmd/copy/jobs_test.go
+++ b/pkg/kubevirt/cmd/copy/jobs_test.go
@@ -810,7 +810,7 @@ func createPresubmitJobForRelease(semver *querier.SemVer, sigName string, always
 							},
 							{
 								Name:  "TARGET",
-								Value: prowjobconfigs.CreateTargetValue(semver, sigName),
+								Value: prowjobconfigs.CreatePresubmitTargetValue(semver, sigName),
 							},
 						},
 					},

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-presubmits.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.21-sig-network
+    name: pull-kubevirt-e2e-k8s-1.21-sig-network-smoke
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -27,7 +27,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.21-sig-network
+          value: k8s-1.21-sig-network-smoke
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -99,7 +99,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.21-sig-compute
+          value: k8s-1.21-sig-compute-parallel
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -197,7 +197,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.20-sig-network
+    name: pull-kubevirt-e2e-k8s-1.20-sig-network-smoke
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -209,7 +209,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-network
+          value: k8s-1.20-sig-network-smoke
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -282,7 +282,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-compute
+          value: k8s-1.20-sig-compute-parallel
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -1391,7 +1391,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-network
+    name: pull-kubevirt-e2e-k8s-1.22-sig-network-smoke
     spec:
       containers:
       - command:
@@ -1401,7 +1401,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-network
+          value: k8s-1.22-sig-network-smoke
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -1469,7 +1469,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-compute
+          value: k8s-1.22-sig-compute-parallel
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-presubmits.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.21-sig-network
+    name: pull-kubevirt-e2e-k8s-1.21-sig-network-smoke
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -27,7 +27,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.21-sig-network
+          value: k8s-1.21-sig-network-smoke
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -99,7 +99,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.21-sig-compute
+          value: k8s-1.21-sig-compute-parallel
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -197,7 +197,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.20-sig-network
+    name: pull-kubevirt-e2e-k8s-1.20-sig-network-smoke
     skip_branches:
     - release-\d+\.\d+
     spec:
@@ -209,7 +209,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-network
+          value: k8s-1.20-sig-network-smoke
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -282,7 +282,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.20-sig-compute
+          value: k8s-1.20-sig-compute-parallel
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -1391,7 +1391,7 @@ presubmits:
       preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.22-sig-network
+    name: pull-kubevirt-e2e-k8s-1.22-sig-network-smoke
     optional: true
     spec:
       containers:
@@ -1402,7 +1402,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-network
+          value: k8s-1.22-sig-network-smoke
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:
@@ -1472,7 +1472,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.22-sig-compute
+          value: k8s-1.22-sig-compute-parallel
         image: quay.io/kubevirtci/bootstrap:v20210906-994b913
         resources:
           requests:

--- a/pkg/kubevirt/prowjobconfigs/jobconfig.go
+++ b/pkg/kubevirt/prowjobconfigs/jobconfig.go
@@ -27,10 +27,10 @@ import (
 const OrgAndRepoForJobConfig = "kubevirt/kubevirt"
 
 var SigNames = []string{
-	"sig-network",
-	"sig-storage",
 	"sig-compute",
+	"sig-network",
 	"sig-operator",
+	"sig-storage",
 }
 
 var cronRegex *regexp.Regexp
@@ -44,14 +44,30 @@ func init() {
 }
 
 func CreatePresubmitJobName(latestReleaseSemver *querier.SemVer, sigName string) string {
+	switch sigName {
+	case "sig-network":
+		sigName += "-smoke"
+	}
+
 	return fmt.Sprintf("pull-kubevirt-e2e-k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
+}
+
+func CreatePresubmitTargetValue(latestReleaseSemver *querier.SemVer, sigName string) string {
+	switch sigName {
+	case "sig-compute":
+		sigName += "-parallel"
+	case "sig-network":
+		sigName += "-smoke"
+	}
+
+	return fmt.Sprintf("k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
 }
 
 func CreatePeriodicJobName(latestReleaseSemver *querier.SemVer, sigName string) string {
 	return fmt.Sprintf("periodic-kubevirt-e2e-k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
 }
 
-func CreateTargetValue(latestReleaseSemver *querier.SemVer, sigName string) string {
+func CreatePeriodicTargetValue(latestReleaseSemver *querier.SemVer, sigName string) string {
 	return fmt.Sprintf("k8s-%s.%s-%s", latestReleaseSemver.Major, latestReleaseSemver.Minor, sigName)
 }
 

--- a/pkg/kubevirt/prowjobconfigs/presubmits_target.go
+++ b/pkg/kubevirt/prowjobconfigs/presubmits_target.go
@@ -28,7 +28,7 @@ type SigComputeJob struct {
 }
 
 var (
-	sigComputeJobNameRegex = regexp.MustCompile(`^pull-kubevirt-e2e-k8s-(\d+\.\d+)-sig-compute(-serial)?$`)
+	sigComputeJobNameRegex = regexp.MustCompile(`^pull-kubevirt-e2e-k8s-(\d+\.\d+)-sig-compute(-(migrations|serial))?$`)
 	k8sVersionRegex        = regexp.MustCompile(`k8s-(\d+)\.(\d+)`)
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add presubmit and periodic job definitions for k8s 1.37 by copying from the previous version.

New presubmits are optional until the provider is stabilized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added periodic and presubmit testing for Kubernetes 1.37 across compute, network, operator, and storage areas.
  * Added CentOS Stream 10 support for the new testing jobs.
  * Added parallel and smoke-test naming for applicable presubmit jobs.

* **Bug Fixes**
  * Updated job scheduling and target handling for more consistent test execution.
  * The Kubernetes 1.37 provisioning check now runs as a required presubmit.
  * Improved recognition of migration and serial compute test variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->