### PR TITLE
kubevirt, network: Promote 1.37 to be the latest gating provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -526,7 +526,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.36-sig-network-sriov-emulated
+  name: periodic-kubevirt-e2e-k8s-1.37-sig-network-sriov-emulated
   spec:
     containers:
     - command:
@@ -538,7 +538,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.36-emulated-igb
+        value: k8s-1.37-emulated-igb
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -1210,7 +1210,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.36-sig-network-with-dnc
+  name: periodic-kubevirt-e2e-k8s-1.37-sig-network-with-dnc
   spec:
     containers:
     - command:
@@ -1227,7 +1227,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.36-sig-network
+        value: k8s-1.37-sig-network
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -1652,7 +1652,7 @@ periodics:
     preset-podman-in-container-enabled: "true"
     preset-podman-shared-images: "true"
     preset-shared-images: "true"
-  name: periodic-kubevirt-e2e-k8s-1.36-ipv6-sig-network
+  name: periodic-kubevirt-e2e-k8s-1.37-ipv6-sig-network
   spec:
     containers:
     - command:
@@ -1666,7 +1666,7 @@ periodics:
       - name: KUBEVIRT_QUARANTINE
         value: "true"
       - name: TARGET
-        value: k8s-1.36-sig-network
+        value: k8s-1.37-sig-network
       - name: KUBEVIRT_SINGLE_STACK
         value: "true"
       - name: KUBEVIRT_WITH_ETC_IN_MEMORY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1909,46 +1909,6 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.36-sig-network-smoke
-    skip_branches:
-    - release-\d+\.\d+
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/runner.sh
-        - /bin/sh
-        - -c
-        - automation/test.sh
-        env:
-        - name: TARGET
-          value: k8s-1.36-sig-network-smoke
-        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
-          value: "true"
-        - name: KUBEVIRT_WITH_ETC_CAPACITY
-          value: 1G
-        image: quay.io/kubevirtci/bootstrap:v20260830-8316684
-        resources:
-          requests:
-            memory: 52Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external
-  - always_run: true
-    annotations:
-      fork-per-release: "true"
-      testgrid-dashboards: kubevirt-presubmits
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 4h0m0s
-    labels:
-      preset-bazel-cache: "true"
-      preset-docker-mirror-proxy: "true"
-      preset-podman-in-container-enabled: "true"
-      preset-podman-shared-images: "true"
-      preset-shared-images: "true"
-    max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.36-sig-storage
     skip_branches:
     - release-\d+\.\d+
@@ -2422,7 +2382,6 @@ presubmits:
       preset-shared-images: "true"
     max_concurrency: 11
     name: pull-kubevirt-e2e-k8s-1.37-sig-network-smoke
-    optional: true
     skip_branches:
     - release-\d+\.\d+
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1882,8 +1882,6 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.36-sig-network
-        - name: SKIP_SMOKE
-          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
@@ -2394,6 +2392,8 @@ presubmits:
         env:
         - name: TARGET
           value: k8s-1.37-sig-network
+        - name: SKIP_SMOKE
+          value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2364,6 +2364,48 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    annotations:
+      fork-per-release: "true"
+      testgrid-dashboards: kubevirt-presubmits
+    cluster: prow-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 4h0m0s
+    labels:
+      preset-bazel-cache: "true"
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      preset-podman-shared-images: "true"
+      preset-shared-images: "true"
+    max_concurrency: 11
+    name: pull-kubevirt-e2e-k8s-1.37-sig-network
+    run_before_merge: true
+    skip_branches:
+    - release-\d+\.\d+
+    spec:
+      containers:
+      - args:
+        - /bin/sh
+        - -c
+        - automation/test.sh
+        command:
+        - /usr/local/bin/runner.sh
+        env:
+        - name: TARGET
+          value: k8s-1.37-sig-network
+        - name: KUBEVIRT_WITH_ETC_IN_MEMORY
+          value: "true"
+        - name: KUBEVIRT_WITH_ETC_CAPACITY
+          value: 1G
+        image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external
   - always_run: true
     annotations:
       fork-per-release: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -978,7 +978,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.36-ipv6-sig-network
+    name: pull-kubevirt-e2e-k8s-1.37-ipv6-sig-network
     run_before_merge: true
     skip_branches:
     - release-\d+\.\d+
@@ -991,7 +991,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.36-sig-network
+          value: k8s-1.37-sig-network
         - name: KUBEVIRT_SINGLE_STACK
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1022,7 +1022,7 @@ presubmits:
       preset-shared-images: "true"
       rehearsal.allowed: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.36-sig-network-with-dnc
+    name: pull-kubevirt-e2e-k8s-1.37-sig-network-with-dnc
     optional: true
     skip_branches:
     - release-\d+\.\d+
@@ -1035,7 +1035,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.36-sig-network
+          value: k8s-1.37-sig-network
         - name: KUBEVIRT_WITH_DYN_NET_CTRL
           value: "true"
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
@@ -1065,7 +1065,7 @@ presubmits:
       preset-podman-shared-images: "true"
       preset-shared-images: "true"
     max_concurrency: 11
-    name: pull-kubevirt-e2e-k8s-1.36-sig-network-sriov-emulated
+    name: pull-kubevirt-e2e-k8s-1.37-sig-network-sriov-emulated
     run_before_merge: true
     skip_branches:
     - release-\d+\.\d+
@@ -1078,7 +1078,7 @@ presubmits:
         - automation/test.sh
         env:
         - name: TARGET
-          value: k8s-1.36-emulated-igb
+          value: k8s-1.37-emulated-igb
         - name: KUBEVIRT_WITH_ETC_IN_MEMORY
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Each stable / preview k8s provider carries two sig-network presubmit lanes: 
1. a smoke lane (a lightweight subset that runs on every PR)
2. a full sig-network lane (the complete suite). 

When 1.37 was introduced, only the smoke presubmit was added.
The full sig-network presubmit was intentionally left out until the smoke lane proved stable (see https://github.com/kubevirt/project-infra/pull/5370).
The full target was already running as a periodic, just not per-PR.

Now that the smoke lane is green, 
we can promote 1.37 to be the latest gating provider by doing the following:

1. Add the full pull-kubevirt-e2e-k8s-1.37-sig-network presubmit, as phase 2 gating.
2. Makes the 1.37 smoke phase 1 gating, dropping the 1.36 smoke - only the latest gating requires it.
3. Promote the DNC, IPv6, and SR-IOV to 1.37 (both for presubmit and periodics).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
None
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI and Testing**
  - Updated IPv6, dynamic networking, and emulated SR-IOV validation jobs to Kubernetes 1.37.
  - Updated corresponding periodic networking tests to use Kubernetes 1.37.
  - Added a Kubernetes 1.37 network presubmit job.
  - Made the Kubernetes 1.37 network smoke test required.
  - Removed the outdated Kubernetes 1.36 network smoke job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->