### PR TITLE
Remove CS10 builder version from k8s-1.37 jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -2197,10 +2197,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
         value: 1G
-      - name: KUBEVIRT_CENTOS_STREAM_VERSION
-        value: "10"
-      - name: KUBEVIRT_CS10_BUILDER_VERSION
-        value: 2606301559-b9f50e380a
       image: quay.io/kubevirtci/bootstrap:v20260830-8316684
       resources:
         requests:
@@ -2248,10 +2244,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
         value: 1G
-      - name: KUBEVIRT_CENTOS_STREAM_VERSION
-        value: "10"
-      - name: KUBEVIRT_CS10_BUILDER_VERSION
-        value: 2606301559-b9f50e380a
       image: quay.io/kubevirtci/bootstrap:v20260830-8316684
       resources:
         requests:
@@ -2298,10 +2290,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
         value: 1G
-      - name: KUBEVIRT_CENTOS_STREAM_VERSION
-        value: "10"
-      - name: KUBEVIRT_CS10_BUILDER_VERSION
-        value: 2606301559-b9f50e380a
       image: quay.io/kubevirtci/bootstrap:v20260830-8316684
       resources:
         requests:
@@ -2349,10 +2337,6 @@ periodics:
         value: "true"
       - name: KUBEVIRT_WITH_ETC_CAPACITY
         value: 1G
-      - name: KUBEVIRT_CENTOS_STREAM_VERSION
-        value: "10"
-      - name: KUBEVIRT_CS10_BUILDER_VERSION
-        value: 2606301559-b9f50e380a
       image: quay.io/kubevirtci/bootstrap:v20260830-8316684
       resources:
         requests:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -2310,10 +2310,6 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
           value: 1G
-        - name: KUBEVIRT_CENTOS_STREAM_VERSION
-          value: "10"
-        - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2606301559-b9f50e380a
         image: quay.io/kubevirtci/bootstrap:v20260830-8316684
         resources:
           requests:
@@ -2399,10 +2395,6 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
           value: 1G
-        - name: KUBEVIRT_CENTOS_STREAM_VERSION
-          value: "10"
-        - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2606301559-b9f50e380a
         image: quay.io/kubevirtci/bootstrap:v20260830-8316684
         resources:
           requests:
@@ -2444,10 +2436,6 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
           value: 1G
-        - name: KUBEVIRT_CENTOS_STREAM_VERSION
-          value: "10"
-        - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2606301559-b9f50e380a
         image: quay.io/kubevirtci/bootstrap:v20260830-8316684
         resources:
           requests:
@@ -2490,10 +2478,6 @@ presubmits:
           value: "true"
         - name: KUBEVIRT_WITH_ETC_CAPACITY
           value: 1G
-        - name: KUBEVIRT_CENTOS_STREAM_VERSION
-          value: "10"
-        - name: KUBEVIRT_CS10_BUILDER_VERSION
-          value: 2606301559-b9f50e380a
         image: quay.io/kubevirtci/bootstrap:v20260830-8316684
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the `KUBEVIRT_CS10_BUILDER_VERSION` env var  from all k8s-1.37 Prow jobs (4 presubmits + 4 periodics).

This is a follow-up to kubevirt/kubevirt#18761, which pins the CS10 builder version directly in `hack/dockerized`. With the version pinned the CI jobs no longer need to pass it as an env var.

`KUBEVIRT_CENTOS_STREAM_VERSION`: no longer needed for e2e jobs since kubevirt/kubevirt#18846 auto-detects the CentOS Stream version from the kubevirtci provider in `automation/test.sh`.


**Special notes for your reviewer**:
/cc @dollierp 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated periodic job images to the latest build.
  * Advanced Kubernetes network jobs from version 1.36 to 1.37.
  * Updated S390X testing coverage and authentication configuration.
  * Removed an obsolete S390X external end-to-end job.
  * Removed outdated CentOS Stream 10 and builder-version settings from Kubernetes 1.37 compute, network, operator, and storage jobs.
  * Simplified one periodic job configuration by removing an obsolete clone-depth setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->