### PR TITLE
chore(ci): skip s390x CDI node-pull e2e and add shared-cluster hygiene

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits.yaml
@@ -496,7 +496,7 @@ presubmits:
           - name: CDI_NAMESPACE
             value: cdi
           - name: CDI_E2E_SKIP
-            value: "Destructive|Cert rotation|cdi-apiserver tests|Importer Test Suite-prometheus|test_id:3996|test_id:8266"
+            value: "Destructive|Cert rotation|cdi-apiserver tests|Importer Test Suite-prometheus|test_id:3996|test_id:8266|Registry node pull|ImageStream-wannabe node pull|node pull import|pullMethod node|pull method = node|pull method Node|test_id:11004|test_id:11005|import Block PVC with Registry image"
           - name: SNAPSHOT_SC
             value: ocs-storagecluster-ceph-rbd
           - name: BLOCK_SC
@@ -519,6 +519,14 @@ presubmits:
 
               cat "$QUAY_PASSWORD" | docker login --username $(cat "$QUAY_USER") --password-stdin=true quay.io
               echo "195.212.74.206 api.odf.cdi.ci oauth-openshift.apps.odf.cdi.ci cdi-uploadproxy-cdi.apps.odf.cdi.ci" >> /etc/hosts
+
+              # aborted runs leak cdi-e2e namespaces and cdi.kubevirt.io/testing StorageClasses
+              for ns in $(kubectl get ns -l cdi-e2e -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+                kubectl delete pods --all -n "$ns" --force --grace-period=0 --ignore-not-found=true || true
+              done
+              kubectl delete ns -l cdi-e2e --wait=false --ignore-not-found=true || true
+              kubectl delete sc -l cdi.kubevirt.io/testing --wait=false --ignore-not-found=true || true
+              kubectl annotate sc ocs-storagecluster-ceph-rbd storageclass.kubernetes.io/is-default-class=true --overwrite || true
 
               kubectl delete cdi cdi --ignore-not-found --timeout=120s
               kubectl delete ns cdi --ignore-not-found --timeout=120s


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Follow-up to https://github.com/kubevirt/project-infra/pull/5376, because `pull-containerized-data-importer-e2e-s390x` was consistently failing

- Skip the 11 registry **node-pull** specs that failed every recent full run
- Before `automation/test.sh`, drop leftover `cdi-e2e` test namespaces and `cdi.kubevirt.io/testing` StorageClasses, and restore `ocs-storagecluster-ceph-rbd` as the default SC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated s390x CDI end-to-end presubmit coverage to exclude unsupported node-pull, registry, ImageStream, and block-PVC scenarios.
  * Improved test-environment cleanup by removing leftover namespaces, pods, and test-created StorageClasses.
  * Restored the default StorageClass configuration before CDI resources are removed and tests begin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->