### PR TITLE
HCO: new release branch for v1.19

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.19.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-1.19.yaml
@@ -1,0 +1,99 @@
+presubmits:
+  kubevirt/hyperconverged-cluster-operator:
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.35
+      branches:
+        - release-1.19
+      always_run: true
+      optional: false
+      decoration_config:
+        timeout: 7h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-podman-shared-images: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260715-af3e234
+            command:
+              - "/usr/local/bin/entrypoint.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.35 && automation/test.sh"
+            env:
+              - name: GO_MOD_PATH
+                value: "go.mod"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY'
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-e2e-k8s-1.36
+      branches:
+        - release-1.19
+      always_run: true
+      optional: false
+      decoration_config:
+        timeout: 7h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-podman-shared-images: "true"
+      cluster: prow-workloads
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260715-af3e234
+            command:
+              - "/usr/local/bin/entrypoint.sh"
+              - "/bin/sh"
+              - "-c"
+              - "export TARGET=k8s-1.36 && automation/test.sh"
+            env:
+              - name: GO_MOD_PATH
+                value: "go.mod"
+              - name: GINKGO_LABELS
+                value: '!OpenShift && !SINGLE_NODE_ONLY'
+            # docker-in-docker needs privileged mode
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "50Gi"
+    - name: pull-hyperconverged-cluster-operator-unit-test-s390x
+      branches:
+        - release-1.19
+      always_run: true
+      optional: false
+      decoration_config:
+        timeout: 2h
+        grace_period: 5m
+      cluster: prow-s390x-workloads
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/golang:v20260715-af3e234
+            env:
+              - name: GO_MOD_PATH
+                value: "go.mod"
+            command:
+              - "/usr/local/bin/entrypoint.sh"
+              - "/bin/sh"
+              - "-c"
+              - |
+                go build -o $(go env GOROOT)/pkg/tool/$(go env GOOS)_$(go env GOARCH)/covdata cmd/covdata && \
+                make test
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "2Gi"


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added always-running presubmit validation for release 1.19.
  * Added Kubernetes 1.35 and 1.36 end-to-end testing on bare-metal environments.
  * Added s390x unit test coverage.
  * Configured required test execution settings, including timeouts and resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->