### PR TITLE
kubevirt-aie, kubevirt-aie-webhook: Enable review_acts_as_lgtm

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/plugins/plugins.yaml
@@ -887,6 +887,8 @@ lgtm:
   - kubevirt/kubevirt-migration-controller
   - kubevirt/kubevirt-migration-operator
   - kubevirt/vm-file-restore-operator
+  - kubevirt/kubevirt-aie
+  - kubevirt/kubevirt-aie-webhook
   - kubevirt/ci-health
   - kubevirt/redfish-controller
   - kubevirt/kubevirt-observability-controller


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `review_acts_as_lgtm` for `kubevirt/kubevirt-aie` and `kubevirt/kubevirt-aie-webhook` so that approving a PR via the GitHub UI automatically applies the `lgtm` label.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `kubevirt/kubevirt-aie` and `kubevirt/kubevirt-aie-webhook` to automated LGTM review coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->