### PR TITLE
chore(jobs): remove unused preset-bazel-cache labels

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.1.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.2.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.3.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.4.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.5.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.6.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.7.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits-1.8.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20240911-16816d3

--- a/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/application-aware-quota/application-aware-quota-presubmits.yaml
@@ -42,7 +42,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20260715-af3e234

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
@@ -30,7 +30,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
@@ -30,7 +30,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.0.yaml
@@ -30,7 +30,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -67,7 +66,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -104,7 +102,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -141,7 +138,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -178,7 +174,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -215,7 +210,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -252,7 +246,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -324,7 +317,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -361,7 +353,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -398,7 +389,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -435,7 +425,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -475,7 +464,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
@@ -30,7 +30,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -67,7 +66,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -104,7 +102,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -141,7 +138,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -178,7 +174,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -215,7 +210,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -252,7 +246,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -289,7 +282,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -326,7 +318,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -398,7 +389,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -435,7 +425,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -472,7 +461,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -509,7 +497,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -549,7 +536,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
@@ -30,7 +30,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -67,7 +66,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -104,7 +102,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -141,7 +138,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -178,7 +174,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -215,7 +210,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -252,7 +246,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -289,7 +282,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -326,7 +318,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -398,7 +389,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -435,7 +425,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -472,7 +461,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -509,7 +497,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -549,7 +536,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
@@ -30,7 +30,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -69,7 +68,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -108,7 +106,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -147,7 +144,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -186,7 +182,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -225,7 +220,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -264,7 +258,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -303,7 +296,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -342,7 +334,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -384,7 +375,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -423,7 +413,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -462,7 +451,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -533,7 +521,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -575,7 +562,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -31,7 +31,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -70,7 +69,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -144,7 +142,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -183,7 +180,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -222,7 +218,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -261,7 +256,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -300,7 +294,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -339,7 +332,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -378,7 +370,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -420,7 +411,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -459,7 +449,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -498,7 +487,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -569,7 +557,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -611,7 +598,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -31,7 +31,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -70,7 +69,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -149,7 +147,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -188,7 +185,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -227,7 +223,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -266,7 +261,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -305,7 +299,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -344,7 +337,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -383,7 +375,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -425,7 +416,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -464,7 +454,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -503,7 +492,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -574,7 +562,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -616,7 +603,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -31,7 +31,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -70,7 +69,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -147,7 +145,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -186,7 +183,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -225,7 +221,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -264,7 +259,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -303,7 +297,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -342,7 +335,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -381,7 +373,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -423,7 +414,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -462,7 +452,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -501,7 +490,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -572,7 +560,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"
@@ -614,7 +601,6 @@ presubmits:
         grace_period: 5m0s
         timeout: 1h0m0s
       labels:
-        preset-bazel-cache: "true"
         preset-bazel-unnested: "true"
         preset-docker-mirror-proxy: "true"
         preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -31,7 +31,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -70,7 +69,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -190,7 +188,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -265,7 +262,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -340,7 +336,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -415,7 +410,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -490,7 +484,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -529,7 +522,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -571,7 +563,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -610,7 +601,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -649,7 +639,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -720,7 +709,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -762,7 +750,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -31,7 +31,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -70,7 +69,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -109,7 +107,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -148,7 +145,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -268,7 +264,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -343,7 +338,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -418,7 +412,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -493,7 +486,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -568,7 +560,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -607,7 +598,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -649,7 +639,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -688,7 +677,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -727,7 +715,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -798,7 +785,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
@@ -840,7 +826,6 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
-      preset-bazel-cache: "true"
       preset-bazel-unnested: "true"
       preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.38.yaml
@@ -100,7 +100,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -128,7 +127,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -156,7 +154,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.43.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -68,7 +67,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -96,7 +94,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63

--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerized-data-importer/containerized-data-importer-presubmits-1.49.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -68,7 +67,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63
@@ -96,7 +94,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20220728-1410a63

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -231,7 +231,6 @@ presubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-docker-mirror: "true"
-        preset-bazel-cache: "true"
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
@@ -242,7 +241,7 @@ presubmits:
               - "/usr/local/bin/runner.sh"
               - "/bin/sh"
               - "-c"
-              - "cp /etc/bazel.bazelrc ./ci.bazelrc && if [ ${JOB_TYPE} != 'batch' ]; then make goveralls; fi"
+              - "if [ ${JOB_TYPE} != 'batch' ]; then make goveralls; fi"
             # docker-in-docker needs privileged mode
             securityContext:
               privileged: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.1.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20230626-e1b7af2

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits-1.2.yaml
@@ -40,7 +40,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20231219-bf5e580

--- a/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/managed-tenant-quota/managed-tenant-quota-presubmits.yaml
@@ -42,7 +42,6 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
-      preset-bazel-cache: "true"
     spec:
       containers:
         - image: quay.io/kubevirtci/bootstrap:v20260715-af3e234

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1172,7 +1172,6 @@ periodics:
     workdir: true
   interval: 168h
   labels:
-    preset-bazel-cache: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -92,7 +92,6 @@ postsubmits:
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
-        preset-bazel-cache: "true"
         preset-kubevirtci-quay-credential: "true"
         preset-project-infra-image-build-linux: "true"
       spec:
@@ -122,7 +121,6 @@ postsubmits:
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
-        preset-bazel-cache: "true"
         preset-kubevirtci-quay-credential: "true"
         preset-podman-in-container-enabled: "true"
         preset-project-infra-image-build-linux: "true"
@@ -154,7 +152,6 @@ postsubmits:
       cluster: kubevirt-prow-control-plane
       max_concurrency: 1
       labels:
-        preset-bazel-cache: "true"
         preset-kubevirtci-quay-credential: "true"
         preset-podman-in-container-enabled: "true"
         preset-project-infra-image-build-linux: "true"
@@ -704,7 +701,6 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-        preset-bazel-cache: "true"
         preset-project-infra-image-build-linux: "true"
       spec:
         containers:
@@ -735,7 +731,6 @@ postsubmits:
       labels:
         preset-podman-in-container-enabled: "true"
         preset-kubevirtci-quay-credential: "true"
-        preset-bazel-cache: "true"
         preset-project-infra-image-build-linux: "true"
       spec:
         containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -102,8 +102,6 @@ presubmits:
     run_if_changed: "github/ci/services/.*|go.mod"
     optional: false
     cluster: kubevirt-prow-control-plane
-    labels:
-      preset-bazel-cache: "true"
     spec:
       containers:
       - image: quay.io/kubevirtci/golang:v20260715-af3e234
@@ -476,7 +474,6 @@ presubmits:
     cluster: kubevirt-prow-control-plane
     max_concurrency: 1
     labels:
-      preset-bazel-cache: "true"
       preset-kubevirtci-quay-credential: "true"
       preset-podman-in-container-enabled: "true"
       preset-project-infra-image-build-linux: "true"
@@ -798,8 +795,6 @@ presubmits:
             runAsUser: 0
   - name: pull-project-infra-check-testgrid-config
     run_if_changed: '^github/ci/prow-deploy/files/jobs/.*$|^github/ci/testgrid/gen-config\.yaml$|^github/ci/testgrid/default\.yaml$'
-    labels:
-      preset-bazel-cache: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: kubevirt-prow-control-plane


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes leftover `preset-bazel-cache` labels from jobs that do not run bazel.

These jobs never copy `ci.bazelrc` and do not run bazel, so dropping the label is a no-op for them today and avoids pointing them at GCS later.

**Removed from**
- kubevirt/application-aware-quota (main + release-v1.1–1.8 generate-verify)
- kubevirt/common-instancetypes (main + 0.1, 0.3, 1.0–1.7)
- kubevirt/containerized-data-importer (release-v1.38 / 1.43 / 1.49)
- kubevirt/csi-driver (goveralls; also dropped the unused `cp /etc/bazel.bazelrc`)
- kubevirt/managed-tenant-quota (main + 1.1 + 1.2)
- kubevirt/project-infra (leftover image/config jobs)
- 
**Left in place** (still use bazel)
- kubevirt/kubevirt (main)
- kubevirt/kubevirt-aie (release-1.8-aie-nv and release-1.9-aie-nv)
- kubevirt/containerized-data-importer (main, including goveralls)

**Special notes for your reviewer**:
/cc @dollierp 
This is the last step before re-enabling gcs caching. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated validation, functional-test, generation, linting, documentation, and reporting jobs to run without the Bazel cache preset.
  - Applied the configuration consistently across Application-Aware Quota, Common InstanceTypes, Containerized Data Importer, Managed Tenant Quota, CSI Driver, and project infrastructure workflows.
  - Simplified the CSI Driver coverage job by removing obsolete cache setup.
  - Updated image publishing and post-submit automation settings without changing their core commands or triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->