### PR TITLE
feat(most-flaky-tests): hide optional lanes behind a checkbox

### DIFF
--- a/robots/quarantine/cmd/most-flaky-tests-report.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report.go
@@ -74,6 +74,8 @@ func init() {
 	mostFlakyTestsReportCmd.PersistentFlags().DurationVar(&quarantineOpts.maxFailureAge, "max-failure-age", 72*time.Hour, "maximum age of failures to consider as recent")
 	mostFlakyTestsReportCmd.PersistentFlags().IntVar(&quarantineOpts.minRecentFailures, "min-recent-failures", 2, "minimum number of recent failures required per lane")
 	mostFlakyTestsReportCmd.PersistentFlags().DurationVar(&quarantineOpts.minFailureInterval, "min-failure-interval", 24*time.Hour, "minimum time span between recent failures to confirm a consistent pattern")
+	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.jobConfigPath, "job-config-path", "github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml", "path to the Prow presubmit job config YAML used to determine required vs optional lanes")
+	mostFlakyTestsReportCmd.PersistentFlags().StringVar(&quarantineOpts.jobConfigOrgRepo, "job-config-org-repo", "kubevirt/kubevirt", "org/repo key for looking up presubmits in the job config")
 }
 
 var sigMatcher = regexp.MustCompile(`\[(sig-[^]]+)]`)
@@ -93,6 +95,15 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	requiredJobs, err := loadRequiredJobNames(quarantineOpts.jobConfigPath, quarantineOpts.jobConfigOrgRepo)
+	if err != nil {
+		return fmt.Errorf("could not load required job names: %w", err)
+	}
+	if len(requiredJobs) == 0 {
+		return fmt.Errorf("no required jobs found in %q for %q", quarantineOpts.jobConfigPath, quarantineOpts.jobConfigOrgRepo)
+	}
+	log.Infof("loaded %d required job names from %q", len(requiredJobs), quarantineOpts.jobConfigPath)
+
 	topXTests, err := flakestats.NewFlakeStatsAggregate(reportOpts).AggregateData()
 	if err != nil {
 		return fmt.Errorf("error while aggregating data: %w", err)
@@ -110,7 +121,7 @@ func MostFlakyTestsReport(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("could not create temp file: %w", err)
 	}
-	err = reportTemplate.Execute(outputFile, NewMostFlakyTestsTemplateData(mostFlakyTestsBySig, sigs, testNames))
+	err = reportTemplate.Execute(outputFile, NewMostFlakyTestsTemplateData(mostFlakyTestsBySig, sigs, testNames, requiredJobs))
 	if err != nil {
 		return fmt.Errorf("could not execute template: %w", err)
 	}

--- a/robots/quarantine/cmd/most-flaky-tests-report.gohtml
+++ b/robots/quarantine/cmd/most-flaky-tests-report.gohtml
@@ -354,7 +354,8 @@
     <div class="container">
         <h1>Most Flaky Tests Report</h1>
         <div class="header-controls">
-            <label><input type="checkbox" id="show-release-lanes" onchange="toggleReleaseLanes()"> Show release branch lanes</label>
+            <label><input type="checkbox" id="show-release-lanes" onchange="applyLaneFilters()"> Show release branch lanes</label>
+            <label><input type="checkbox" id="show-optional-lanes" onchange="applyLaneFilters()"> Show optional lanes</label>
             <label><input type="checkbox" id="show-approaching" onchange="toggleApproaching()"> Highlight approaching quarantine</label>
             <input type="text" id="test-filter" placeholder="Filter tests..." oninput="filterTests()">
         </div>
@@ -398,7 +399,7 @@
                                 <div class="test-card-body">
                                     {{ range $mostFlakyTest := $mostFlakyTests }}
                                         {{ range $relevantImpact := $mostFlakyTest.RelevantImpacts -}}
-                                            <div class="impact-entry" data-lane="{{ $relevantImpact.URLToDisplay }}" data-impact="{{ $relevantImpact.Percent }}" data-timerange="{{ $mostFlakyTest.TimeRange }}">
+                                            <div class="impact-entry" data-lane="{{ $relevantImpact.URLToDisplay }}" data-optional="{{ $.IsOptionalLane $relevantImpact.URLToDisplay }}" data-impact="{{ $relevantImpact.Percent }}" data-timerange="{{ $mostFlakyTest.TimeRange }}">
                                                 <div class="impact-row-top">
                                                     <span class="impact-percent" data-percent="{{ $relevantImpact.Percent }}">{{ $relevantImpact.Percent }}%</span>
                                                     <span class="impact-time">{{ $mostFlakyTest.TimeRange }}</span>
@@ -462,15 +463,21 @@
         });
     }
 
-    function toggleReleaseLanes() {
-        var show = document.getElementById('show-release-lanes').checked;
+    function applyLaneFilters() {
+        var showRelease = document.getElementById('show-release-lanes').checked;
+        var showOptional = document.getElementById('show-optional-lanes').checked;
         document.querySelectorAll('.impact-entry').forEach(function(el) {
-            var lane = el.getAttribute('data-lane');
-            if (releaseLanePattern.test(lane)) {
-                el.style.display = show ? '' : 'none';
-            }
+            var lane = el.getAttribute('data-lane') || '';
+            var optional = el.getAttribute('data-optional') === 'true';
+            var isReleaseLane = releaseLanePattern.test(lane);
+            var hide = (!showRelease && isReleaseLane) || (!showOptional && optional && !isReleaseLane);
+            el.style.display = hide ? 'none' : '';
         });
         document.querySelectorAll('.test-card').forEach(function(card) {
+            if (card.getAttribute('data-filtered') === '1') {
+                card.style.display = 'none';
+                return;
+            }
             var entries = card.querySelectorAll('.impact-entry');
             var anyVisible = false;
             entries.forEach(function(el) {
@@ -479,6 +486,7 @@
             card.style.display = (entries.length > 0 && !anyVisible) ? 'none' : '';
         });
         updateSIGCounts();
+        toggleApproaching();
     }
 
     function filterTests() {
@@ -491,10 +499,7 @@
                 card.setAttribute('data-filtered', '1');
             }
         });
-        toggleReleaseLanes();
-        document.querySelectorAll('.test-card[data-filtered="1"]').forEach(function(card) {
-            card.style.display = 'none';
-        });
+        applyLaneFilters();
     }
 
     function updateSIGCounts() {
@@ -540,7 +545,7 @@
     }
 
     applyImpactColors();
-    toggleReleaseLanes();
+    applyLaneFilters();
     updateSIGCounts();
 </script>
 </body>

--- a/robots/quarantine/cmd/most-flaky-tests-report_test.go
+++ b/robots/quarantine/cmd/most-flaky-tests-report_test.go
@@ -20,6 +20,8 @@
 package cmd
 
 import (
+	"bytes"
+	"html/template"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -139,6 +141,103 @@ var _ = Describe("most-flaky-tests", func() {
 			tests := result["sig-compute"]["[sig-compute] my stale flaky test"]
 			Expect(tests).ToNot(BeEmpty())
 			Expect(tests[0].HasRecentFailures).To(BeFalse())
+		})
+	})
+
+	When("classifying optional lanes from required job names", func() {
+		var data MostFlakyTestsTemplateData
+
+		BeforeEach(func() {
+			data = NewMostFlakyTestsTemplateData(nil, nil, nil, map[string]struct{}{
+				"pull-kubevirt-e2e-k8s-1.36-sig-compute": {},
+				"pull-kubevirt-e2e-k8s-1.36-sig-storage": {},
+			})
+		})
+
+		It("treats required presubmits as not optional", func() {
+			Expect(data.IsOptionalLane("pull-kubevirt-e2e-k8s-1.36-sig-compute")).To(BeFalse())
+			Expect(data.IsOptionalLane("pull-kubevirt-e2e-k8s-1.36-sig-storage")).To(BeFalse())
+		})
+
+		It("treats optional presubmits as optional", func() {
+			Expect(data.IsOptionalLane("pull-kubevirt-e2e-k8s-1.37-sig-compute")).To(BeTrue())
+		})
+
+		It("tags release-branch lanes as optional because they are absent from main presubmits", func() {
+			Expect(data.IsOptionalLane("pull-kubevirt-e2e-k8s-1.36-sig-compute-1.6")).To(BeTrue())
+		})
+
+		DescribeTable("keeps release and optional checkboxes independent",
+			func(showRelease, showOptional, isRelease, optional, expectedHidden bool) {
+				hide := (!showRelease && isRelease) || (!showOptional && optional && !isRelease)
+				Expect(hide).To(Equal(expectedHidden))
+			},
+			Entry("default hides release lanes", false, false, true, true, true),
+			Entry("default hides optional main lanes", false, false, false, true, true),
+			Entry("default keeps required main lanes", false, false, false, false, false),
+			Entry("show release only still shows release lanes tagged optional", true, false, true, true, false),
+			Entry("show release only still hides optional main lanes", true, false, false, true, true),
+			Entry("show optional only still hides release lanes", false, true, true, true, true),
+			Entry("show optional only shows optional main lanes", false, true, false, true, false),
+			Entry("both checked shows release lanes", true, true, true, true, false),
+			Entry("both checked shows optional main lanes", true, true, false, true, false),
+		)
+
+		It("treats empty job names as optional", func() {
+			Expect(data.IsOptionalLane("")).To(BeTrue())
+		})
+	})
+
+	When("rendering the report template", func() {
+		It("emits optional-lane checkbox and data-optional attributes", func() {
+			testName := "[sig-compute] flake"
+			data := NewMostFlakyTestsTemplateData(
+				map[string]TestsPerSIG{
+					"sig-compute": {
+						testName: []*TestToQuarantine{
+							{
+								Test:      flakestats.NewTopXTest(testName),
+								TimeRange: searchci.ThreeDays,
+								RelevantImpacts: []searchci.Impact{
+									{
+										URL:          "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.36-sig-compute",
+										URLToDisplay: "pull-kubevirt-e2e-k8s-1.36-sig-compute",
+										Percent:      2,
+									},
+									{
+										URL:          "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.37-sig-compute",
+										URLToDisplay: "pull-kubevirt-e2e-k8s-1.37-sig-compute",
+										Percent:      20,
+									},
+									{
+										URL:          "https://prow.ci.kubevirt.io/job-history/kubevirt-prow/pr-logs/directory/pull-kubevirt-e2e-k8s-1.36-sig-compute-1.6",
+										URLToDisplay: "pull-kubevirt-e2e-k8s-1.36-sig-compute-1.6",
+										Percent:      8,
+									},
+								},
+							},
+						},
+					},
+				},
+				[]string{"sig-compute"},
+				[]string{testName},
+				map[string]struct{}{
+					"pull-kubevirt-e2e-k8s-1.36-sig-compute": {},
+				},
+			)
+
+			tmpl, err := template.New("mostFlakyTests").Parse(mostFlakyTestsReportTemplate)
+			Expect(err).ToNot(HaveOccurred())
+			var buf bytes.Buffer
+			Expect(tmpl.Execute(&buf, data)).To(Succeed())
+			html := buf.String()
+			Expect(html).To(ContainSubstring(`id="show-optional-lanes"`))
+			Expect(html).To(ContainSubstring(`data-lane="pull-kubevirt-e2e-k8s-1.36-sig-compute"`))
+			Expect(html).To(ContainSubstring(`data-optional="false"`))
+			Expect(html).To(ContainSubstring(`data-lane="pull-kubevirt-e2e-k8s-1.37-sig-compute"`))
+			Expect(html).To(ContainSubstring(`data-optional="true"`))
+			Expect(html).To(ContainSubstring(`data-lane="pull-kubevirt-e2e-k8s-1.36-sig-compute-1.6"`))
+			Expect(html).To(ContainSubstring(`(!showOptional && optional && !isReleaseLane)`))
 		})
 	})
 })

--- a/robots/quarantine/cmd/types.go
+++ b/robots/quarantine/cmd/types.go
@@ -85,13 +85,14 @@ func (t TestToQuarantine) String() string {
 	return fmt.Sprintf("TestToQuarantine{Test: %+v, SearchCIURL: %q, RelevantImpacts: %+v}", t.Test, t.SearchCIURL, t.RelevantImpacts)
 }
 
-func NewMostFlakyTestsTemplateData(mostFlakyTestsBySig map[string]TestsPerSIG, sigs []string, testNames []string) MostFlakyTestsTemplateData {
+func NewMostFlakyTestsTemplateData(mostFlakyTestsBySig map[string]TestsPerSIG, sigs []string, testNames []string, requiredJobs map[string]struct{}) MostFlakyTestsTemplateData {
 	return MostFlakyTestsTemplateData{
 		ReportCreation:      time.Now(),
 		MostFlakyTestsBySig: mostFlakyTestsBySig,
 		SIGs:                sigs,
 		TestNames:           testNames,
 		TimeRanges:          mostFlakyTestsTimeRanges,
+		RequiredJobs:        requiredJobs,
 	}
 }
 
@@ -101,4 +102,16 @@ type MostFlakyTestsTemplateData struct {
 	MostFlakyTestsBySig map[string]TestsPerSIG
 	SIGs                []string
 	TestNames           []string
+	RequiredJobs        map[string]struct{}
+}
+
+// IsOptionalLane reports whether a search.ci job name is not a required presubmit.
+// Jobs missing from the required set (optional, skip_report, release-branch suffixes,
+// or otherwise unknown) are tagged optional.
+func (d MostFlakyTestsTemplateData) IsOptionalLane(laneName string) bool {
+	if laneName == "" {
+		return true
+	}
+	_, required := d.RequiredJobs[laneName]
+	return !required
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With the addition of 1.37 lanes the most flaky report has been cluttered with these tests and this PR adds:

- A "Show optional lanes" checkbox to the most-flaky-tests report, default off, same UX as release branch lanes.
- Classify lanes from kubevirt-presubmits.yaml via the existing auto-quarantine required-job lookup (`ContextRequired()`), so optional jobs such as k8s-1.37 are tagged in the HTML and filtered in the browser.

**Special notes for your reviewer**:
/cc @dollierp 

**Checklist**
Ran the report locally with the results below:
<img width="1610" height="965" alt="Most-flaky-report-1" src="https://github.com/user-attachments/assets/11403f03-6984-42db-bca0-78e8180c2878" />

<img width="1610" height="965" alt="most-flaky-report-2" src="https://github.com/user-attachments/assets/8e21fe03-90be-4e43-a672-8275981c0ed5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional-lane visibility controls to the flaky tests report.
  - Reports now distinguish required and optional lanes, including empty or unlisted job names.
  - Added configuration options for loading required presubmit jobs.
  - Added filtering for release and optional lanes while preserving test-name filtering.

- **Bug Fixes**
  - Reports now fail clearly when required job configuration cannot be loaded or contains no applicable jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->