### PR TITLE
ci: add presubmit job for AlmaLinux 9 containerdisk on s390x

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -536,3 +536,35 @@ presubmits:
           privileged: true
       nodeSelector:
         type: bare-metal-external
+  - always_run: false
+    run_if_changed: "artifacts/almalinux/.*"
+    annotations:
+      testgrid-create-test-group: "false"
+    cluster: prow-s390x-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+    max_concurrency: 3
+    name: pull-containerdisks-pipeline-almalinux-9-s390x
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint.sh
+        - /bin/sh
+        - -c
+        - ./pipeline.sh
+        env:
+        - name: GO_MOD_PATH
+          value: "go.mod"
+        - name: FOCUS
+          value: "almalinux:9"
+        - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
+          value: "true"
+        image: quay.io/kubevirtci/golang:v20260715-af3e234
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added presubmit validation for AlmaLinux 9 container disk builds on the s390x architecture.
  - The validation runs automatically when relevant AlmaLinux artifact files change.
  - Added support for nested virtualization requirements in the s390x build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->