### PR TITLE
presubmit/kmp: Add release-0.52 stable branch jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.52.yaml
@@ -1,0 +1,60 @@
+---
+presubmits:
+  k8snetworkplumbingwg/kubemacpool:
+    - name: pull-kubemacpool-unit-test-v0.51
+      context: pull-kubemacpool-unit-test
+      branches:
+        - release-0.51
+      always_run: true
+      optional: false
+      decoration_config:
+        timeout: 1h
+        grace_period: 5m
+      cluster: kubevirt-prow-control-plane
+      max_concurrency: 6
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20260319-c8f1db8
+            securityContext:
+              privileged: true
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.unit-test.sh"
+
+    - name: pull-kubemacpool-e2e-k8s-v0.51
+      context: pull-kubemacpool-e2e-k8s
+      branches:
+        - release-0.51
+      always_run: true
+      optional: false
+      cluster: prow-workloads
+      decoration_config:
+        timeout: 3h
+        grace_period: 5m
+      max_concurrency: 6
+      labels:
+        preset-podman-in-container-enabled: "true"
+        preset-docker-mirror-proxy: "true"
+        preset-shared-images: "true"
+      spec:
+        nodeSelector:
+          type: bare-metal-external
+        containers:
+          - image: quay.io/kubevirtci/bootstrap:v20260319-c8f1db8
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: "52Gi"
+            command:
+              - "/usr/local/bin/runner.sh"
+              - "/bin/sh"
+              - "-c"
+              - "automation/check-patch.e2e-k8s.sh"
+

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.52.yaml
@@ -1,10 +1,10 @@
 ---
 presubmits:
   k8snetworkplumbingwg/kubemacpool:
-    - name: pull-kubemacpool-unit-test-v0.51
+    - name: pull-kubemacpool-unit-test-v0.52
       context: pull-kubemacpool-unit-test
       branches:
-        - release-0.51
+        - release-0.52
       always_run: true
       optional: false
       decoration_config:
@@ -27,10 +27,10 @@ presubmits:
               - "-c"
               - "automation/check-patch.unit-test.sh"
 
-    - name: pull-kubemacpool-e2e-k8s-v0.51
+    - name: pull-kubemacpool-e2e-k8s-v0.52
       context: pull-kubemacpool-e2e-k8s
       branches:
-        - release-0.51
+        - release-0.52
       always_run: true
       optional: false
       cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/k8snetworkplumbingwg/kubemacpool/kubemacpool-presubmits-v0.52.yaml
@@ -18,7 +18,7 @@ presubmits:
         preset-shared-images: "true"
       spec:
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20260319-c8f1db8
+          - image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
             securityContext:
               privileged: true
             command:
@@ -46,7 +46,7 @@ presubmits:
         nodeSelector:
           type: bare-metal-external
         containers:
-          - image: quay.io/kubevirtci/bootstrap:v20260319-c8f1db8
+          - image: quay.io/kubevirtci/bootstrap:v20260715-af3e234
             securityContext:
               privileged: true
             resources:


### PR DESCRIPTION
Copy the release-0.51 presubmit job definitions as a base for the new release-0.52 stable branch, updating job names and branches accordingly. Bootstrap image is aligned with current main.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added required automated presubmit checks for Kubemacpool release 0.52.
  * Added unit-test and Kubernetes end-to-end validation for every pull request.
  * Enabled dedicated bare-metal execution and extended timeout support for end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->