### PR TITLE
ci: add presubmit job for AlmaLinux 10 containerdisks pipeline

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -568,3 +568,36 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
+  - always_run: false
+    run_if_changed: "artifacts/almalinux/.*"
+    annotations:
+      testgrid-create-test-group: "false"
+    cluster: prow-workloads
+    decoration_config:
+      grace_period: 5m0s
+      timeout: 1h0m0s
+    labels:
+      preset-podman-in-container-enabled: "true"
+      preset-docker-mirror-proxy: "true"
+    max_concurrency: 11
+    name: pull-containerdisks-pipeline-almalinux-10
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint.sh
+        - /bin/sh
+        - -c
+        - ./pipeline.sh
+        env:
+        - name: GO_MOD_PATH
+          value: "go.mod"
+        - name: FOCUS
+          value: "almalinux:10"
+        image: quay.io/kubevirtci/golang:v20260715-af3e234
+        resources:
+          requests:
+            memory: 12Gi
+        securityContext:
+          privileged: true
+      nodeSelector:
+        type: bare-metal-external


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added optional, change-triggered validation for AlmaLinux 10 container disk builds.
  - The new checks run on external bare-metal workloads through the container-disk pipeline.
  - Relevant changes can now be automatically built and tested before integration, improving release confidence and helping identify issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->