### PR TITLE
virt-template: Add release-1.9 periodic update job

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
@@ -76,6 +76,52 @@ periodics:
           memory: 2Gi
       securityContext:
         privileged: true
+- name: periodic-update-virt-template-kubevirt-release-1.9
+  cron: 0 2 * * *
+  cluster: kubevirt-prow-control-plane
+  max_concurrency: 1
+  annotations:
+    testgrid-create-test-group: "false"
+  labels:
+    preset-github-credentials: "true"
+    preset-podman-in-container-enabled: "true"
+  decoration_config:
+    grace_period: 5m0s
+    timeout: 1h0m0s
+  extra_refs:
+  - org: kubevirt
+    repo: kubevirt
+    base_ref: release-1.9
+  spec:
+    containers:
+    - image: quay.io/kubevirtci/pr-creator:v20260809-12a13ee
+      env:
+      - name: VIRT_TEMPLATE_BRANCH
+        value: release-0.2
+      - name: KUBEVIRT_BRANCH
+        value: release-1.9
+      command:
+      - /usr/local/bin/runner.sh
+      - /bin/bash
+      - -c
+      - |
+        export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
+        latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
+        description="[release-1.9] Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+
+        git-pr.sh \
+          --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \
+          --repo-path ../kubevirt \
+          --description-command "echo -e \"${description}\"" \
+          --repo kubevirt \
+          --branch update-virt-template-release-1.9 \
+          --target "${KUBEVIRT_BRANCH}" \
+          --missing-labels lgtm,approved,do-not-merge/hold
+      resources:
+        requests:
+          memory: 2Gi
+      securityContext:
+        privileged: true
 - name: periodic-update-virt-template-kubevirt-release-1.8
   cron: 0 2 * * *
   cluster: kubevirt-prow-control-plane
@@ -107,7 +153,7 @@ periodics:
       - |
         export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
         latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
-        description="Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+        description="[release-1.8] Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
 
         git-pr.sh \
           --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a periodic job `periodic-update-virt-template-kubevirt-release-1.9` to
bump virt-template on the `release-1.9` branch of kubevirt/kubevirt, using
`VIRT_TEMPLATE_BRANCH=release-0.2`.

Also prefixes release branch PR titles with `[release-X.Y]` for both
release-1.8 and release-1.9 jobs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a nightly automated update for the `kubevirt` release-1.9 branch using the latest `virt-template` release.

- **Chores**
  - Improved release-1.8 update pull-request descriptions with a clear branch prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->