### PR TITLE
fix(docker-mirror-proxy): add local cluster registry to no_proxy

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -753,6 +753,8 @@ presets:
     value: http://docker-mirror-proxy.kubevirt-prow.svc:3128
   - name: CONTAINER_HTTPS_PROXY
     value: http://docker-mirror-proxy.kubevirt-prow.svc:3128
+  - name: CONTAINER_NO_PROXY
+    value: localhost,127.0.0.1,registry
   volumes:
   - name: docker-mirror-proxy-ca-cert
     configMap:

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/configs/docker-proxy
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/configs/docker-proxy
@@ -4,3 +4,4 @@ DOCKER_OPTS="${DOCKER_OPTS} --ipv6"
 DOCKER_OPTS="${DOCKER_OPTS} --fixed-cidr-v6 2001:db8:1::/64"
 export http_proxy=http://docker-mirror-proxy.kubevirt-prow.svc:3128
 export https_proxy=http://docker-mirror-proxy.kubevirt-prow.svc:3128
+export no_proxy=localhost,127.0.0.1,registry

--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -75,10 +75,11 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
     (
         export HTTP_PROXY=${CONTAINER_HTTP_PROXY}
         export HTTPS_PROXY=${CONTAINER_HTTPS_PROXY}
+        export NO_PROXY=${CONTAINER_NO_PROXY}
         export KIND_EXPERIMENTAL_PROVIDER="podman"
 
         mkdir -p ${PODMAN_SOCKET_PATH}
-      
+
         podman system service \
                 -t 0 \
                 unix://${PODMAN_SOCKET} \
@@ -99,7 +100,7 @@ if [[ "${PODMAN_IN_CONTAINER_ENABLED}" == "true" ]]; then
             sleep ${WAIT_N}
         else
             echo "Reached maximum attempts, not waiting any longer..."
-	    echo "Podman daemon failed to start successfully"
+            echo "Podman daemon failed to start successfully"
             cat /var/log/podman.log
             exit 1
         fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Newer versions of the docker-mirror-proxy generate a large number of errors in the logs:

```
2026/08/25 10:14:44 [error] 131#131: *52104 proxy_connect: registry could not be resolved (3: Host not found), client: 100.66.18.33, server: proxy_director_, request: "CONNECT registry:5000 HTTP/1.1", host: "registry:5000"
```

Exclude the cluster local registry from being proxied like it is done for kubevirtci k8s providers.

**Special notes for your reviewer**:

/cc @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container networking by excluding local hosts and the internal registry from proxy routing.
  * Applied consistent no-proxy settings across container builds and runtime environments.
* **Style**
  * Improved alignment of a container startup failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->