### PR TITLE
Add wg-arch-ppc64le working group label and team

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -96,6 +96,7 @@ larger set of contributors to apply/remove them.
 | <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not or will not be resolved.| anyone | |
 | <a id="wg/aie" href="#wg/aie">`wg/aie`</a> | Denotes an issue or PR that relates to the AIE working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="wg/arch-arm" href="#wg/arch-arm">`wg/arch-arm`</a> | Denotes an issue or PR that relates to the ARM architecture working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
+| <a id="wg/arch-ppc64le" href="#wg/arch-ppc64le">`wg/arch-ppc64le`</a> | Denotes an issue or PR that relates to the ppc64le architecture working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="wg/arch-s390x" href="#wg/arch-s390x">`wg/arch-s390x`</a> | Denotes an issue or PR that relates to the s390x architecture working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 | <a id="wg/code-quality" href="#wg/code-quality">`wg/code-quality`</a> | Denotes an issue or PR that relates to the code-quality working group.| anyone |  [label](https://prow.ci.kubevirt.io/command-help#label) |
 

--- a/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/labels/labels.yaml
@@ -352,6 +352,12 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+    - name: wg/arch-ppc64le
+      color: E3F582
+      description: Denotes an issue or PR that relates to the ppc64le architecture working group.
+      target: both
+      prowPlugin: label
+      addedBy: anyone
     - name: wg/code-quality
       color: E3F582
       description: Denotes an issue or PR that relates to the code-quality working group.

--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -996,6 +996,14 @@ orgs:
           web-ui: write
           web-ui-components: write
           web-ui-operator: write
+      wg-arch-ppc64le:
+        description: >-
+          Working group which takes care of all things related to supporting
+          ppc64le architecture on KubeVirt.
+          Ref: https://github.com/kubevirt/community/blob/main/wg-arch-ppc64le/charter.md
+        members:
+          - pkenchap
+        privacy: closed
       wg-arch-s390x:
         description: >-
           Working group which takes care of all things related to supporting

--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -103,6 +103,7 @@ orgs:
       - ormergi
       - oshoval
       - phoracek
+      - pkenchap
       - qinqon
       - rabin-io
       - RamLavi

--- a/robots/quarantine/cmd/auto-quarantine_test.go
+++ b/robots/quarantine/cmd/auto-quarantine_test.go
@@ -136,9 +136,10 @@ to contain
 				"scale":         true,
 			}
 			validWGs = map[string]bool{
-				"arch-s390x": true,
-				"arch-arm":   true,
-				"aie":        true,
+				"arch-s390x":   true,
+				"arch-arm":     true,
+				"arch-ppc64le": true,
+				"aie":          true,
 			}
 		})
 

--- a/robots/quarantine/cmd/labels.go
+++ b/robots/quarantine/cmd/labels.go
@@ -45,6 +45,7 @@ var ginkgoLabelAliases = map[string]string{
 	"sig-performance": "sig scale",
 	"wg-s390x":        "wg arch-s390x",
 	"wg-arm64":        "wg arch-arm",
+	"wg-ppc64le":      "wg arch-ppc64le",
 }
 
 func loadValidGroupsFromLabelsFile(path string) (sigs, wgs map[string]bool, err error) {

--- a/robots/quarantine/cmd/labels_test.go
+++ b/robots/quarantine/cmd/labels_test.go
@@ -50,6 +50,8 @@ default:
       color: c5def5
     - name: wg/aie
       color: E3F582
+    - name: wg/arch-ppc64le
+      color: E3F582
     - name: wg/arch-s390x
       color: E3F582
     - name: kind/bug
@@ -68,8 +70,9 @@ default:
 				"storage": true,
 			}))
 			Expect(wgs).To(Equal(map[string]bool{
-				"aie":        true,
-				"arch-s390x": true,
+				"aie":          true,
+				"arch-ppc64le": true,
+				"arch-s390x":   true,
 			}))
 		})
 
@@ -106,9 +109,10 @@ default:
 				"scale":         true,
 			}
 			validWGs = map[string]bool{
-				"arch-s390x": true,
-				"arch-arm":   true,
-				"aie":        true,
+				"arch-s390x":  true,
+				"arch-arm":    true,
+				"arch-ppc64le": true,
+				"aie":         true,
 			}
 		})
 
@@ -128,6 +132,7 @@ default:
 			Entry("compound alias for sig-performance-latency", "sig-performance-latency", "sig scale"),
 			Entry("alias for wg-s390x", "wg-s390x", "wg arch-s390x"),
 			Entry("alias for wg-arm64", "wg-arm64", "wg arch-arm"),
+			Entry("alias for wg-ppc64le", "wg-ppc64le", "wg arch-ppc64le"),
 			Entry("compound alias for wg-s390x-ci", "wg-s390x-ci", "wg arch-s390x"),
 			Entry("fallback for sig-operator", "sig-operator", "sig compute"),
 			Entry("direct WG match", "wg-aie", "wg aie"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Registers the wg-arch-ppc64le working group in the KubeVirt project infrastructure. This adds the wg/arch-ppc64le Prow label (used to tag issues and PRs related to ppc64le work), creates the wg-arch-ppc64le GitHub team in orgs.yaml, and wires the wg-ppc64le Ginkgo label alias into the auto-quarantine robot.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
This PR is a companion to [kubevirt/community#441](https://github.com/kubevirt/community/pull/441) which adds the wg-arch-ppc64le working group to sigs.yaml / sig-list.md.
docs/labels.md is a generated file (via hack/labels/update.sh using a podman image); it has been updated manually here to reflect the new label. It will be re-synced properly when the label sync job next runs.
No Prow cluster rerun auth entry (config.yaml) is added yet — that will follow once dedicated ppc64le Prow runner infrastructure is provisioned.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: Not required — infrastructure registration only, no new design
- [x] PR: Description covers all files changed.
- [x] Code: Changes are additive and follow existing patterns exactly
- [ ] Refactor: NA
- [ ] Upgrade: No upgrade impact — label and team additions are purely additive
- [x] Testing: Unit tests in robots/quarantine/cmd/ updated and passing
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Tracked via WG Arch ppc64le

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the ppc64le architecture working group.
  * Added a corresponding label and team configuration.
  * Enabled the working-group label to resolve to the appropriate project command.

* **Documentation**
  * Documented the new ppc64le working-group label and its usage.

* **Tests**
  * Added coverage to verify recognition and command resolution for the new working group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->