### PR TITLE
Add kubevirt-no-bazel repo and maintainers team

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -629,6 +629,12 @@ orgs:
         has_projects: true
         has_wiki: true
         has_issues: true
+      kubevirt-no-bazel:
+        description: Fork of Kubevirt for development and testing of bazel removal changes.
+        default_branch: main
+        has_projects: true
+        has_wiki: true
+        has_issues: true
     teams:
       QE:
         description: ""
@@ -1190,3 +1196,16 @@ orgs:
           - MarSik
         repos:
           redfish-controller: admin
+      kubevirt-no-bazel-maintainers:
+        description: "Maintainers of kubevirt-no-bazel"
+        members:
+          - dhiller
+          - dollierp
+          - enp0s3
+          - jschintag
+          - lyarwood
+          - nekkunti
+          - vamsikrishna-siddu
+          - Whitedyl
+        repos:
+          kubevirt-no-bazel: admin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This PR adds the `kubevirt-no-bazel` repository and its maintainers team to the KubeVirt GitHub organization. This fork of kubevirt/kubevirt will be used for development and testing of Bazel removal changes during the v1.10.0 cycle, as discussed in the [VEP-392 enhancements PR](https://github.com/kubevirt/enhancements/pull/393#pullrequestreview-4855609922). The fork-based approach was recommended to:
1. Avoid the risk of breaking the existing Bazel-based build in kubevirt/kubevirt while the non-Bazel path is being developed and stabilized
2. Allow bespoke prow jobs in project-infra targeting the fork, giving full CI signal on the new build path without flooding kubevirt/kubevirt presubmits or breaking existing jobs
Once the fork demonstrates a stable, passing CI signal with the non-Bazel build, the changes will be brought back into kubevirt/kubevirt for the v1.11.0 milestone.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related: https://github.com/kubevirt/enhancements/pull/393

**Special notes for your reviewer**:
This only adds the repo and team entries to `orgs.yaml`. Prow job configuration for the fork will follow in a separate PR.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `kubevirt-no-bazel` repository to the KubeVirt organization configuration.
  * Enabled the repository’s projects, wiki, and issue tracking.
  * Added a dedicated maintainer team with administrative access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->