### PR TITLE
orgs: add ema-aka-young to vm-file-restore-maintainers

### DIFF
--- a/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/orgs/orgs.yaml
@@ -1121,6 +1121,7 @@ orgs:
         description: Maintainers of vm file restore operator project
         members:
           - arnongilboa
+          - ema-aka-young
           - noamasu
         repos:
           vm-file-restore-operator: admin


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the VM file restore maintainers roster to include an additional maintainer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->