### PR TITLE
Include virt-template release notes in bump PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-periodics.yaml
@@ -60,13 +60,24 @@ periodics:
       - -c
       - |
         export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-        latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
-        description="Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+        release=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -c --arg branch "${VIRT_TEMPLATE_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+        latest_version=$(echo "${release}" | jq -r '.tag_name')
+        release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+        cat >/tmp/pr-description <<EOF
+        Automated update of virt-template to ${latest_version}
+
+        ${release_notes}
+
+        \`\`\`release-note
+        Updated virt-template to ${latest_version}
+        \`\`\`
+        EOF
 
         git-pr.sh \
           --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \
           --repo-path ../kubevirt \
-          --description-command "echo -e \"${description}\"" \
+          --description-command "cat /tmp/pr-description" \
           --repo kubevirt \
           --branch update-virt-template-main \
           --target "${KUBEVIRT_BRANCH}" \
@@ -106,13 +117,24 @@ periodics:
       - -c
       - |
         export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-        latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
-        description="[release-1.9] Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+        release=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -c --arg branch "${VIRT_TEMPLATE_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+        latest_version=$(echo "${release}" | jq -r '.tag_name')
+        release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+        cat >/tmp/pr-description <<EOF
+        [release-1.9] Automated update of virt-template to ${latest_version}
+
+        ${release_notes}
+
+        \`\`\`release-note
+        Updated virt-template to ${latest_version}
+        \`\`\`
+        EOF
 
         git-pr.sh \
           --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \
           --repo-path ../kubevirt \
-          --description-command "echo -e \"${description}\"" \
+          --description-command "cat /tmp/pr-description" \
           --repo kubevirt \
           --branch update-virt-template-release-1.9 \
           --target "${KUBEVIRT_BRANCH}" \
@@ -152,13 +174,24 @@ periodics:
       - -c
       - |
         export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-        latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -r '.[] | select(.target_commitish == '\""${VIRT_TEMPLATE_BRANCH}"\"') | .tag_name' | head -n1)
-        description="[release-1.8] Automated update of virt-template to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated virt-template to ${latest_version}\n\\\`\\\`\\\`"
+        release=$(curl --fail -s https://api.github.com/repos/kubevirt/virt-template/releases | jq -c --arg branch "${VIRT_TEMPLATE_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+        latest_version=$(echo "${release}" | jq -r '.tag_name')
+        release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+        cat >/tmp/pr-description <<EOF
+        [release-1.8] Automated update of virt-template to ${latest_version}
+
+        ${release_notes}
+
+        \`\`\`release-note
+        Updated virt-template to ${latest_version}
+        \`\`\`
+        EOF
 
         git-pr.sh \
           --command "cd ../kubevirt && hack/virt-template/bump.sh ${VIRT_TEMPLATE_BRANCH} && make generate" \
           --repo-path ../kubevirt \
-          --description-command "echo -e \"${description}\"" \
+          --description-command "cat /tmp/pr-description" \
           --repo kubevirt \
           --branch update-virt-template-release-1.8 \
           --target "${KUBEVIRT_BRANCH}" \


### PR DESCRIPTION
**What this PR does / why we need it**:

The periodic virt-template bump jobs now add the release notes of the version
they bump to into the commit message and PR description, so reviewers see what
is pulled in without opening the release page.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

The description is written to a file instead of an escaped `echo -e` string,
since `git-pr.sh` evals the `--description-command` and release notes may
contain quotes, backticks or dollar signs. Mentions are stripped so the nightly
PR does not ping every contributor in the changelog.

**Release note**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Periodic virt-template update pull requests now include the matching release version and release notes.
  * Release notes are formatted more reliably, with improved handling of special characters and line breaks.
  * Pull request descriptions now consistently include the required release-note information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->