### PR TITLE
Include common-instancetypes release notes in bump PRs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-periodics.yaml
@@ -25,12 +25,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/common-instancetypes/bump.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"${description}\"" \
+                --description-command "cat /tmp/pr-description" \
                 --repo kubevirt \
                 --branch update-common-instancetypes-main \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -64,12 +75,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/common-instancetypes/bump.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -103,12 +125,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/common-instancetypes/bump.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -142,12 +175,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/common-instancetypes/bump.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -181,12 +225,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/common-instancetypes/bump.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -220,12 +275,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -259,12 +325,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
@@ -303,20 +380,31 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
               missing_labels="lgtm,approved,do-not-merge/hold"
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
                 --missing-labels "${missing_labels}"
               git-pr.sh \
                 --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${SSP_BRANCH}] /' /tmp/pr-description" \
                 --repo ssp-operator \
                 --branch "update-common-instancetypes-${SSP_BRANCH}" \
                 --target "${SSP_BRANCH}" \
@@ -350,12 +438,23 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
 
               git-pr.sh \
                 --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${SSP_BRANCH}] /' /tmp/pr-description" \
                 --repo ssp-operator \
                 --branch "update-common-instancetypes-${SSP_BRANCH}" \
                 --target "${SSP_BRANCH}"
@@ -393,20 +492,31 @@ periodics:
           args:
             - |
               export GIT_ASKPASS=/usr/local/bin/git-askpass.sh
-              latest_version=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -r '.[] | select(.target_commitish == '\""${COMMON_INSTANCETYPES_BRANCH}"\"') | .tag_name' | head -n1)
-              description="Automated update of common-instancetypes bundles to ${latest_version}\n\n\\\`\\\`\\\`release-note\nUpdated common-instancetypes bundles to ${latest_version}\n\\\`\\\`\\\`"
+              release=$(curl --fail -s https://api.github.com/repos/kubevirt/common-instancetypes/releases | jq -c --arg branch "${COMMON_INSTANCETYPES_BRANCH}" 'map(select(.target_commitish == $branch)) | first')
+              latest_version=$(echo "${release}" | jq -r '.tag_name')
+              release_notes=$(echo "${release}" | jq -r '.body // ""' | tr -d '\r' | sed 's/@//g')
+
+              cat >/tmp/pr-description <<EOF
+              Automated update of common-instancetypes bundles to ${latest_version}
+
+              ${release_notes}
+
+              \`\`\`release-note
+              Updated common-instancetypes bundles to ${latest_version}
+              \`\`\`
+              EOF
               missing_labels="lgtm,approved,do-not-merge/hold"
 
               git-pr.sh \
                 --command "cd ../kubevirt && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${KUBEVIRT_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${KUBEVIRT_BRANCH}] /' /tmp/pr-description" \
                 --repo kubevirt \
                 --branch "update-common-instancetypes-${KUBEVIRT_BRANCH}" \
                 --target "${KUBEVIRT_BRANCH}" \
                 --missing-labels "${missing_labels}"
               git-pr.sh \
                 --command "cd ../ssp-operator && hack/bump-common-instancetypes.sh ${COMMON_INSTANCETYPES_BRANCH}" \
-                --description-command "echo -e \"[${SSP_BRANCH}] ${description}\"" \
+                --description-command "sed '1s/^/[${SSP_BRANCH}] /' /tmp/pr-description" \
                 --repo ssp-operator \
                 --branch "update-common-instancetypes-${SSP_BRANCH}" \
                 --target "${SSP_BRANCH}" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Same as #5413, for common-instancetypes: the periodic bump jobs now add the
release notes of the version they bump to into the commit message and PR
description.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

The description is written to a file instead of an escaped `echo -e` string,
since `git-pr.sh` evals the `--description-command` and release notes may
contain quotes, backticks or dollar signs. Jobs creating PRs for two repos
prefix the title with `sed` at the use site. Mentions are stripped so the
nightly PR does not ping every contributor in the changelog.

**Release note**:
```release-note
NONE
```
