### PR TITLE
fix(searchci): round "N days ago" up so 3-day failures leave the 72h recency window

### DIFF
--- a/pkg/searchci/searchci.go
+++ b/pkg/searchci/searchci.go
@@ -119,23 +119,29 @@ func ScrapeImpact(body string) []Impact {
 				log.Fatalf("unparseable amount %q", timeAmountStr)
 			}
 			unitWord := submatch[8]
-			var duration time.Duration
-			switch {
-			case unitWord == "minutes":
-				duration = time.Minute * time.Duration(timeAmount)
-			case unitWord == "hours":
-				duration = time.Hour * time.Duration(timeAmount)
-			case unitWord == "days":
-				duration = time.Hour * 24 * time.Duration(timeAmount)
-			}
 			jobBuild := JobBuildURL{
 				URL:      viewJobBuildURL,
-				Interval: duration,
+				Interval: parseSearchCIAge(timeAmount, unitWord),
 			}
 			result[len(result)-1].BuildURLs = append(result[len(result)-1].BuildURLs, jobBuild)
 		}
 	}
 	return result
+}
+
+// parseSearchCIAge converts a search.ci relative timestamp into a duration.
+func parseSearchCIAge(amount int, unit string) time.Duration {
+	switch unit {
+	case "minutes":
+		return time.Minute * time.Duration(amount)
+	case "hours":
+		return time.Hour * time.Duration(amount)
+	case "days":
+		return time.Hour * 24 * time.Duration(amount+1)
+	default:
+		log.Fatalf("unparseable search.ci age unit %q", unit)
+		return 0
+	}
 }
 
 type FilterOpt func(i Impact) bool

--- a/pkg/searchci/searchci_test.go
+++ b/pkg/searchci/searchci_test.go
@@ -82,7 +82,7 @@ tests/compute/vm_lifecycle.go:51
 						},
 						{
 							URL:      "https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/14802/pull-kubevirt-e2e-k8s-1.30-sig-compute/1930397210671845376",
-							Interval: time.Hour * 24 * 6,
+							Interval: time.Hour * 24 * 7,
 						},
 					},
 				},
@@ -335,6 +335,37 @@ tests/migration/namespace.go:236
 			72*time.Hour, 2, time.Duration(0),
 			true,
 		),
+		Entry("filters impact when oldest failure is a 3-day search.ci bucket (upper bound 96h)",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 47 * time.Hour},
+					{Interval: parseSearchCIAge(3, "days")},
+				},
+			},
+			72*time.Hour, 2, 24*time.Hour,
+			false,
+		),
+		Entry("keeps impact when oldest failure is a 2-day search.ci bucket (upper bound 72h)",
+			Impact{
+				BuildURLs: []JobBuildURL{
+					{Interval: 4 * time.Hour},
+					{Interval: parseSearchCIAge(2, "days")},
+				},
+			},
+			72*time.Hour, 2, 24*time.Hour,
+			true,
+		),
+	)
+
+	DescribeTable("parseSearchCIAge",
+		func(amount int, unit string, expected time.Duration) {
+			Expect(parseSearchCIAge(amount, unit)).To(Equal(expected))
+		},
+		Entry("minutes stay exact", 34, "minutes", 34*time.Minute),
+		Entry("hours stay exact", 47, "hours", 47*time.Hour),
+		Entry("2 days ago rounds up to 72h", 2, "days", 72*time.Hour),
+		Entry("3 days ago rounds up to 96h", 3, "days", 96*time.Hour),
+		Entry("4 days ago rounds up to 120h", 4, "days", 120*time.Hour),
 	)
 
 	Context("ScrapeImpacts", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
search.ci labels jobs older than ~48h as `N days ago` (a floor bucket). Our scraper stored as `N*24h`, so `"3 days ago"` became **72h** and still counted as recent for auto-quarantine (`Interval <= 72h`). This is how kubevirt/kubevirt#18944 quarantined a Prometheus test whose newest “72h” failure was actually ~90h old.

Parse day labels as the **bucket ceiling** `(N+1)*24h`: `2 days ago` -> 72h, `3 days ago` -> 96h (out of the 72h window). Hours/minutes unchanged. Auto-quarantine and the most-flaky report already consume `JobBuildURL.Interval`.

**Special notes for your reviewer**:
/cc @dollierp 
**Checklist**

To visualize the change I generated the most flaky report locally and compared a test (failed 75 hours ago) this change affects:
Old:
<img width="706" height="214" alt="image" src="https://github.com/user-attachments/assets/f6ebfae4-bd87-4c97-92c2-1a813934cd1c" />

With PR chnages:
<img width="783" height="235" alt="image" src="https://github.com/user-attachments/assets/ec38c1ea-add2-4419-b52a-cdd8eec53dbe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of search.ci age values, including day-based durations and unrecognized units.
  * Corrected recent-failure detection for seven-day build intervals.
  * Improved accuracy when processing two- and three-day age ranges.

* **Tests**
  * Added coverage for minute-, hour-, and rounded-day duration conversions.
  * Expanded validation for recent-failure detection across multiple age ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->