### PR TITLE
kubevirtci,presubmit: add optional test lane for new kind-1.37-vgpu provider

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-presubmits.yaml
@@ -292,6 +292,72 @@ presubmits:
           path: /sys/fs/cgroup
           type: Directory
         name: cgroup
+  - always_run: false
+    cluster: prow-workloads
+    decoration_config:
+      timeout: 3h0m0s
+    labels:
+      preset-docker-mirror-proxy: "true"
+      preset-podman-in-container-enabled: "true"
+      vgpu: "true"
+    max_concurrency: 3
+    name: check-up-kind-1.37-vgpu
+    optional: true
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: vgpu
+                operator: In
+                values:
+                - "true"
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - /usr/local/bin/runner.sh
+        - /bin/bash
+        - -ce
+        - |
+          trap "echo teardown && make cluster-down" EXIT ERR SIGINT SIGTERM
+          make cluster-up
+          ./cluster-up/cluster/kind/check-cluster-up.sh
+        env:
+        - name: KUBEVIRT_PROVIDER
+          value: kind-1.37-vgpu
+        - name: KUBEVIRT_NUM_NODES
+          value: "1"
+        - name: RUN_KUBEVIRT_CONFORMANCE
+          value: "true"
+        - name: KUBEVIRT_MEMORY_SIZE
+          value: 11264M
+        - name: SONOBUOY_EXTRA_ARGS
+          value: --plugin-env kubevirt-conformance.E2E_FOCUS=MediatedDevices --plugin-env
+            kubevirt-conformance.E2E_SKIP=QUARANTINE
+        image: quay.io/kubevirtci/golang:v20260830-8316684
+        resources:
+          requests:
+            memory: 52Gi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /dev/vfio/
+          name: vfio
+      nodeSelector:
+        hardwareSupport: gpu
+      priorityClassName: vgpu
+      volumes:
+      - hostPath:
+          path: /sys/fs/cgroup
+          type: Directory
+        name: cgroup
+      - hostPath:
+          path: /dev/vfio/
+          type: Directory
+        name: vfio
   - always_run: true
     cluster: prow-workloads
     decoration_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

This will help to verify the new provider being added here - https://github.com/kubevirt/kubevirtci/pull/1832

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

@dollierp @Whitedyl 

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional presubmit validation job for Kubernetes 1.37 environments with virtual GPU support.
  * The check validates KubeVirt mediated-device conformance and GPU-related scheduling, affinity, node selection, and device access configurations.
  * Includes automatic cluster setup and teardown during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->