### PR TITLE
refactor: consolidate almalinux presubmit jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/containerdisks/containerdisks-presubmits.yaml
@@ -515,7 +515,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-docker-mirror-proxy: "true"
     max_concurrency: 11
-    name: pull-containerdisks-pipeline-almalinux-9
+    name: pull-containerdisks-pipeline-almalinux
     spec:
       containers:
       - command:
@@ -527,7 +527,7 @@ presubmits:
         - name: GO_MOD_PATH
           value: "go.mod"
         - name: FOCUS
-          value: "almalinux:9"
+          value: "almalinux:*"
         image: quay.io/kubevirtci/golang:v20260830-8316684
         resources:
           requests:
@@ -547,7 +547,7 @@ presubmits:
     labels:
       preset-podman-in-container-enabled: "true"
     max_concurrency: 3
-    name: pull-containerdisks-pipeline-almalinux-9-s390x
+    name: pull-containerdisks-pipeline-almalinux-s390x
     spec:
       containers:
       - command:
@@ -559,7 +559,7 @@ presubmits:
         - name: GO_MOD_PATH
           value: "go.mod"
         - name: FOCUS
-          value: "almalinux:9"
+          value: "almalinux:*"
         - name: KUBEVIRT_NESTED_VIRTUALIZATION_REQUIRED
           value: "true"
         image: quay.io/kubevirtci/golang:v20260830-8316684
@@ -568,36 +568,3 @@ presubmits:
             memory: 12Gi
         securityContext:
           privileged: true
-  - always_run: false
-    run_if_changed: "artifacts/almalinux/.*"
-    annotations:
-      testgrid-create-test-group: "false"
-    cluster: prow-workloads
-    decoration_config:
-      grace_period: 5m0s
-      timeout: 1h0m0s
-    labels:
-      preset-podman-in-container-enabled: "true"
-      preset-docker-mirror-proxy: "true"
-    max_concurrency: 11
-    name: pull-containerdisks-pipeline-almalinux-10
-    spec:
-      containers:
-      - command:
-        - /usr/local/bin/entrypoint.sh
-        - /bin/sh
-        - -c
-        - ./pipeline.sh
-        env:
-        - name: GO_MOD_PATH
-          value: "go.mod"
-        - name: FOCUS
-          value: "almalinux:10"
-        image: quay.io/kubevirtci/golang:v20260830-8316684
-        resources:
-          requests:
-            memory: 12Gi
-        securityContext:
-          privileged: true
-      nodeSelector:
-        type: bare-metal-external


### PR DESCRIPTION
Rename pull-containerdisks-pipeline-almalinux-9 and its s390x variant to drop the version suffix, and change the FOCUS env var from "almalnux:9" to "almalinux:*" so a single job covers all AlmaLinux versions.

Remove the separate pull-containerdisks-pipeline-almalinux-10 job, which is now superseeded by the wildcard-based jobs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI**
  * Updated AlmaLinux container disk validation jobs to cover all AlmaLinux versions.
  * Renamed the AlmaLinux presubmit jobs for clearer version-independent labeling.
  * Removed the dedicated AlmaLinux 10 pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->