### PR TITLE
chore(images): golang's entrypoint.sh already selects Go from GO_MOD_PATH.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
     containers:
     - image: quay.io/kubevirtci/golang:v20260830-8316684
       command:
-      - "/usr/local/bin/runner.sh"
+      - "/usr/local/bin/entrypoint.sh"
       - "/bin/sh"
       - "-ce"
       - >
@@ -21,8 +21,8 @@ periodics:
         --ceiling=1
         --confirm
       env:
-      - name: GIMME_GO_VERSION
-        value: "1.25.1"
+      - name: GO_MOD_PATH
+        value: go.mod
       volumeMounts:
       - name: token
         mountPath: /etc/github
@@ -1144,7 +1144,7 @@ periodics:
     containers:
     - image: quay.io/kubevirtci/golang:v20260830-8316684
       command:
-      - "/usr/local/bin/runner.sh"
+      - "/usr/local/bin/entrypoint.sh"
       - "/bin/sh"
       - "-ce"
       - |
@@ -1156,6 +1156,9 @@ periodics:
         cleanup_secrets
 
         ./robots/job-config-validator/job-config-validator
+      env:
+      - name: GO_MOD_PATH
+        value: go.mod
       resources:
         requests:
           memory: "1Gi"
@@ -1182,8 +1185,8 @@ periodics:
       env:
         - name: KUBEVIRT_PROVIDER
           value: k8s-1.36
-        - name: GIMME_GO_VERSION
-          value: "1.25.1"
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: GIT_AUTHOR_NAME
           value: kubevirt-bot
         - name: GIT_AUTHOR_EMAIL
@@ -1191,7 +1194,7 @@ periodics:
         - name: TARGET_GITHUB_REPO
           value: kubevirt/ci-performance-benchmarks
       command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-postsubmits.yaml
@@ -637,7 +637,7 @@ postsubmits:
           runAsUser: 0
         containers:
         - command:
-            - "/usr/local/bin/runner.sh"
+            - "/usr/local/bin/entrypoint.sh"
             - "/bin/bash"
             - "-ce"
             - |
@@ -656,8 +656,8 @@ postsubmits:
 
               ./github/ci/services/grafana/hack/deploy.sh "${environment}"
           env:
-          - name: GIMME_GO_VERSION
-            value: "1.25.1"
+          - name: GO_MOD_PATH
+            value: go.mod
           image: quay.io/kubevirtci/golang:v20260830-8316684
           resources:
             requests:
@@ -799,10 +799,10 @@ postsubmits:
         containers:
         - image: quay.io/kubevirtci/golang:v20260830-8316684
           env:
-          - name: GIMME_GO_VERSION
-            value: "1.25.1"
+          - name: GO_MOD_PATH
+            value: go.mod
           command:
-          - /usr/local/bin/runner.sh
+          - /usr/local/bin/entrypoint.sh
           - /bin/sh
           - -ce
           args:
@@ -848,8 +848,10 @@ postsubmits:
             value: kubevirt/ci-performance-benchmarks
           - name: GITHUB_TOKEN_PATH
             value: /etc/github/token
+          - name: GO_MOD_PATH
+            value: go.mod
           command:
-          - /usr/local/bin/runner.sh
+          - /usr/local/bin/entrypoint.sh
           - /bin/sh
           - -c
           args:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-presubmits.yaml
@@ -37,14 +37,14 @@ presubmits:
       containers:
       - image: quay.io/kubevirtci/golang:v20260830-8316684
         command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |
           go test ./robots/... ./pkg/...
         env:
-        - name: GIMME_GO_VERSION
-          value: "1.25.1"
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: GOFLAGS
           value: "-mod=vendor"
         resources:
@@ -59,7 +59,7 @@ presubmits:
       containers:
       - image: quay.io/kubevirtci/golang:v20260830-8316684
         command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |
@@ -68,8 +68,8 @@ presubmits:
            --github-token-path='' \
            --dry-run=false
         env:
-        - name: GIMME_GO_VERSION
-          value: "1.26.4"
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: GOFLAGS
           value: "-mod=vendor"
         resources:
@@ -85,14 +85,14 @@ presubmits:
       containers:
       - image: quay.io/kubevirtci/golang:v20260830-8316684
         command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |
           go test ./releng/...
         env:
-        - name: GIMME_GO_VERSION
-          value: "1.25.1"
+        - name: GO_MOD_PATH
+          value: go.mod
         resources:
           requests:
             memory: "4Gi"
@@ -106,11 +106,14 @@ presubmits:
       containers:
       - image: quay.io/kubevirtci/golang:v20260830-8316684
         command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |
           go build ./github/ci/services/...
+        env:
+        - name: GO_MOD_PATH
+          value: go.mod
         resources:
           requests:
             memory: "4Gi"
@@ -124,15 +127,15 @@ presubmits:
     spec:
       containers:
       - command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |
           curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b ${GOPATH}/bin ${GOLANGCI_LINT_VERSION}
           make lint
         env:
-        - name: GIMME_GO_VERSION
-          value: "1.26.4"
+        - name: GO_MOD_PATH
+          value: go.mod
         - name: GOLANGCI_LINT_VERSION
           value: "v2.12.2"
         image: quay.io/kubevirtci/golang:v20260830-8316684
@@ -727,7 +730,7 @@ presubmits:
       containers:
         - image: quay.io/kubevirtci/golang:v20260830-8316684
           command:
-            - "/usr/local/bin/runner.sh"
+            - "/usr/local/bin/entrypoint.sh"
             - "/bin/sh"
             - "-ce"
             - |
@@ -742,8 +745,8 @@ presubmits:
 
               go test ./github/ci/services/ci-search/e2e/...
           env:
-          - name: GIMME_GO_VERSION
-            value: "1.25.1"
+          - name: GO_MOD_PATH
+            value: go.mod
           resources:
             requests:
               memory: "16Gi"
@@ -768,7 +771,7 @@ presubmits:
     spec:
       containers:
         - command:
-            - "/usr/local/bin/runner.sh"
+            - "/usr/local/bin/entrypoint.sh"
             - "/bin/bash"
             - "-ce"
             - |
@@ -782,8 +785,8 @@ presubmits:
 
               ./github/ci/services/grafana/hack/test.sh
           env:
-          - name: GIMME_GO_VERSION
-            value: "1.25.1"
+          - name: GO_MOD_PATH
+            value: go.mod
           image: quay.io/kubevirtci/golang:v20260830-8316684
           resources:
             requests:
@@ -906,10 +909,10 @@ presubmits:
       containers:
       - image: quay.io/kubevirtci/golang:v20260830-8316684
         env:
-        - name: GIMME_GO_VERSION
-          value: "1.25.1"
+        - name: GO_MOD_PATH
+          value: go.mod
         command:
-        - "/usr/local/bin/runner.sh"
+        - "/usr/local/bin/entrypoint.sh"
         - "/bin/sh"
         - "-ce"
         - |

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -937,8 +937,8 @@ presets:
 - labels:
     preset-project-infra-image-build-linux: "true"
   env:
-    - name: GIMME_GO_VERSION
-      value: "1.25.1"
+    - name: GO_MOD_PATH
+      value: "/project-infra/go.mod"
     - name: GOFLAGS
       value: "-mod=vendor -ldflags=-extldflags=\"-static\""
     - name: CGO_ENABLED

--- a/images/flake-report-creator/Containerfile
+++ b/images/flake-report-creator/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra/ && \
-    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/flake-report-creator ./robots/flake-report-creator"
+    /usr/local/bin/entrypoint.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/flake-report-creator ./robots/flake-report-creator"
 
 FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
 COPY --from=builder /go/bin/flake-report-creator /usr/bin/flake-report-creator

--- a/images/flakefinder/Containerfile
+++ b/images/flakefinder/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra/ && \
-    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/flakefinder ./robots/flakefinder"
+    /usr/local/bin/entrypoint.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/flakefinder ./robots/flakefinder"
 
 FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
 COPY --from=builder /go/bin/flakefinder /usr/bin/flakefinder

--- a/images/ginkgo-tests/Containerfile
+++ b/images/ginkgo-tests/Containerfile
@@ -1,6 +1,7 @@
 # Not using a staged build here as ginkgo-tests internally calls ginkgo which in
 # turn compiles the test suite. This requires the full Go toolchain
 FROM quay.io/kubevirtci/golang:v20260830-8316684
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra && \
-    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/ginkgo-tests ./robots/ginkgo-tests"
+    /usr/local/bin/entrypoint.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/ginkgo-tests ./robots/ginkgo-tests"
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "/go/bin/ginkgo-tests"]

--- a/images/indexpagecreator/Containerfile
+++ b/images/indexpagecreator/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra/ && \
-    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/indexpagecreator ./robots/indexpagecreator"
+    /usr/local/bin/entrypoint.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/indexpagecreator ./robots/indexpagecreator"
 
 FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
 COPY --from=builder /go/bin/indexpagecreator /usr/bin/indexpagecreator

--- a/images/pr-creator/Containerfile
+++ b/images/pr-creator/Containerfile
@@ -15,17 +15,16 @@ ENV GOPROXY=https://proxy.golang.org|direct \
 # - https://gitlab.com/qemu-project/qemu/-/issues/2738
 # - https://github.com/openshift/dpu-operator/pull/308
 ENV GOMAXPROCS=3
-ENV GIMME_GO_VERSION=1.25.1
 
 RUN set -x && \
     git clone --depth 1 --revision 03e5768a447b55381f7517a9d27bb51831893d31 https://github.com/kubernetes/test-infra.git && \
     cd ./test-infra && \
-    /usr/local/bin/runner.sh /bin/sh -cex 'go mod vendor && time go build -tags netgo -o /usr/local/bin/pr-creator ./robots/pr-creator' && \
+    /usr/local/bin/entrypoint.sh /bin/sh -cex 'go mod vendor && time go build -tags netgo -o /usr/local/bin/pr-creator ./robots/pr-creator' && \
     chmod +x /usr/local/bin/pr-creator
 
 RUN set -x && \
     cd /project-infra && \
-    /usr/local/bin/runner.sh /bin/sh -cex 'time go build -tags netgo -o /usr/local/bin/labels-checker ./robots/labels-checker' && \
+    /usr/local/bin/entrypoint.sh /bin/sh -cex 'time go build -tags netgo -o /usr/local/bin/labels-checker ./robots/labels-checker' && \
     chmod +x /usr/local/bin/labels-checker
 
 FROM quay.io/kubevirtci/golang:v20260830-8316684 AS final

--- a/images/publish_image.sh
+++ b/images/publish_image.sh
@@ -25,7 +25,7 @@ main() {
                     "--env=CGO_ENABLED=${CGO_ENABLED}"
                     "--env=GOOS=${GOOS}"
                     "--env=GOARCH=${GOARCH}"
-                    "--env=GIMME_GO_VERSION=${GIMME_GO_VERSION}"
+                    "--env=GO_MOD_PATH=${GO_MOD_PATH:-/project-infra/go.mod}"
                 )
                 ;;
             h)

--- a/images/release-tool/Containerfile
+++ b/images/release-tool/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra/ && \
-    /usr/local/bin/runner.sh /bin/sh -c "env GOPROXY=off go build -tags netgo -o /go/bin/release-tool ./releng/release-tool"
+    /usr/local/bin/entrypoint.sh /bin/sh -c "env GOPROXY=off go build -tags netgo -o /go/bin/release-tool ./releng/release-tool"
 
 FROM quay.io/kubevirtci/release-tool-base:v20250214-0d9df61
 COPY ./entrypoint.sh /usr/sbin/entrypoint.sh

--- a/images/shared-images-controller/Containerfile
+++ b/images/shared-images-controller/Containerfile
@@ -1,7 +1,5 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
 
-ENV GIMME_GO_VERSION=1.25.1
-
 WORKDIR /workspace
 
 RUN dnf install -y gpgme-devel device-mapper-devel btrfs-progs-devel
@@ -12,11 +10,11 @@ COPY go.mod go.mod
 
 COPY go.sum go.sum
 
-RUN /usr/local/bin/runner.sh /bin/sh -c "go mod download"
+RUN /usr/local/bin/entrypoint.sh /bin/sh -c "go mod download"
 
 COPY ./ ./
 
-RUN /usr/local/bin/runner.sh /bin/sh -c "go build ."
+RUN /usr/local/bin/entrypoint.sh /bin/sh -c "go build ."
 
 FROM quay.io/kubevirtci/bootstrap:v20260830-8316684
 

--- a/images/test-label-analyzer/Containerfile
+++ b/images/test-label-analyzer/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra/ && \
-    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/test-label-analyzer ./robots/test-label-analyzer"
+    /usr/local/bin/entrypoint.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/test-label-analyzer ./robots/test-label-analyzer"
 
 FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
 COPY --from=builder /go/bin/test-label-analyzer /usr/bin/test-label-analyzer

--- a/images/test-report/Containerfile
+++ b/images/test-report/Containerfile
@@ -1,6 +1,7 @@
 FROM quay.io/kubevirtci/golang:v20260830-8316684 as builder
+ENV GO_MOD_PATH=/project-infra/go.mod
 RUN cd /project-infra/ && \
-    /usr/local/bin/runner.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/test-report ./robots/test-report"
+    /usr/local/bin/entrypoint.sh /bin/sh -ce "env GOPROXY=off go build -tags netgo -o /go/bin/test-report ./robots/test-report"
 
 FROM gcr.io/k8s-prow/git:v20240729-4f255edb07
 COPY --from=builder /go/bin/test-report /usr/bin/test-report


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed [build-pr-creator-image](https://prow.ci.kubevirt.io/job-history/gs/kubevirt-prow/pr-logs/directory/build-pr-creator-image) failing due to `I don't have any idea what to do with '1.25.1'`. this is caused by:
The golang image caches **1.26.4**. Consumer Containerfiles and some project-infra jobs still set `GIMME_GO_VERSION=1.25.1` and call `runner.sh`, which does not read `go.mod`. gimme then tries to download 1.25.1, causing the job to fail. 
This follows the `covreport` Containerfile and #5254 (`entrypoint.sh` + `GO_MOD_PATH`):
- project-infra golang jobs: `runner.sh` -> `entrypoint.sh`, `GIMME_GO_VERSION` -> `GO_MOD_PATH: go.mod`
- project-infra image Containerfiles that compile this repo: `entrypoint.sh`, drop the 1.25.1 pin



**Special notes for your reviewer**:

