### PR TITLE
fix(gcp,deprovision): prune CSI driver leftover images

### DIFF
--- a/hack/gcp-cluster-deprovision.sh
+++ b/hack/gcp-cluster-deprovision.sh
@@ -71,6 +71,10 @@ DISK_FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff
 gcloud --project="${GCP_PROJECT}" compute disks list --filter "${DISK_FILTER}" --uri \
   | xargs -r --max-procs='10' gcloud --project="${GCP_PROJECT}" compute disks delete --quiet
 
+IMAGE_FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND description:'Image created by GCE-PD CSI Driver' AND sourceDisk.basename():pvc-"
+gcloud --project="${GCP_PROJECT}" compute images list --no-standard-images --filter "${IMAGE_FILTER}" --uri \
+  | xargs -r --max-procs='10' gcloud --project="${GCP_PROJECT}" compute images delete --quiet
+
 SNAPSHOT_FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND description:'Snapshot created by GCE-PD CSI Driver' AND sourceDisk.basename():pvc-"
 gcloud --project="${GCP_PROJECT}" compute snapshots list --filter "${SNAPSHOT_FILTER}" --uri \
   | xargs -r --max-procs='10' gcloud --project="${GCP_PROJECT}" compute snapshots delete --quiet


### PR DESCRIPTION
**What this PR does / why we need it**:

This change improves the GCP cleanup script so that it identifies and deletes orphaned images created by the GCE-PD CSI driver, in addition to disks and snapshots.

The KubeVirt project on GCP currently lists more than 2,400 of these images.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP cluster cleanup by removing leftover persistent-disk driver images associated with deprovisioned clusters.
  * Cleanup operations now run in parallel to reduce deprovisioning time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->