### PR TITLE
fix(golang): entrypoint.sh reads toolchain directive for Go compiler version

### DIFF
--- a/images/golang/entrypoint.sh
+++ b/images/golang/entrypoint.sh
@@ -21,7 +21,13 @@ set -o pipefail
 GO_MOD_PATH=${GO_MOD_PATH:-}
 
 if [[ -n ${GO_MOD_PATH} && -f ${GO_MOD_PATH} ]]; then
-  export GIMME_GO_VERSION="$(grep -E '^go' "${GO_MOD_PATH}" | cut -d' ' -f 2)"
+  toolchain_version="$(grep -E '^toolchain go' "${GO_MOD_PATH}" | cut -d' ' -f2 | sed 's/^go//')"
+  if [[ -n ${toolchain_version} ]]; then
+    export GIMME_GO_VERSION="${toolchain_version}"
+  else
+    # Fallback to go directive for repos without toolchain line
+    export GIMME_GO_VERSION="$(grep -E '^go ' "${GO_MOD_PATH}" | cut -d' ' -f2)"
+  fi
 fi
 
 # actually start bootstrap and the job, under the runner (which handles dind etc.)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `entrypoint.sh` script reads `GO_MOD_PATH` to auto-detect the Go version from `go.mod`.
**Current behavior:**
- Reads `go 1.26.0` 
- Tries to install Go 1.26.0 via gimme
- Fails because 1.26.0 isn't cached in the image or downloadable

**Example failure:** [rehearsal-pull-project-infra-test-releng](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/5423/rehearsal-pull-project-infra-test-releng/2095488938968879104)

After this PR it reads the `toolchain` directive instead of the `go` directive by:
- First checks for `toolchain go1.x.y` 
- Falls back to `go 1.x.y` for older repos without toolchain
- Strips the `go` prefix from toolchain 

**Special notes for your reviewer**:
/cc @dhiller @dollierp 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Go version selection now prioritizes the toolchain version specified in the project configuration.
  * Added fallback behavior to use the configured Go version when no toolchain version is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->