### PR TITLE
feat(docker-mirror-proxy): deploy on the Prow ARM64 cluster

### DIFF
--- a/docs/docker-mirror-proxy.md
+++ b/docs/docker-mirror-proxy.md
@@ -18,6 +18,7 @@ KubeVirt CI project-infra git repository under the Prow deployment folder:
 It is currently provided on the following KubeVirt CI Prow build clusters:
 - kubevirt-prow-control-plane
 - prow-workloads
+- prow-arm64-workloads
 
 ## Usage
 

--- a/github/ci/prow-deploy/defaults/main.yml
+++ b/github/ci/prow-deploy/defaults/main.yml
@@ -1,3 +1,15 @@
 ---
+ansible_python_interpreter: /usr/bin/python3
+
 main_actions:
   - deploy
+
+prowUrl: prow.ci.kubevirt.io
+
+project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
+components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
+testinfra_dir: /tmp/test-infra
+
+bootstrap_full_config: false
+rescale_pushgateway_deployment: false
+rescale_deck_deployment: false

--- a/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/kustomization.yaml
@@ -1,6 +1,20 @@
-# Requires kustomize v3
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources:
+  - resources/bootstrap.yaml
+  - ../../components/docker-mirror-proxy/base
+
+components:
+  - ../../components/docker-mirror-proxy/hostpath
+
+patches:
+  - target:
+      kind: Deployment
+      group: apps
+      name: docker-mirror-proxy
+    path: patches/JsonRFC6902/docker_mirror_deployment.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/patches/JsonRFC6902/docker_mirror_deployment.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/patches/JsonRFC6902/docker_mirror_deployment.yaml
@@ -1,0 +1,15 @@
+---
+# set cpu resources
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: "700m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "700m"
+
+# KubeVirt Prow ARM64 workloads cluster does not provide IPv6 connectivity to Pods
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: DISABLE_IPV6
+    value: "true"

--- a/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/resources/bootstrap.yaml
+++ b/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/resources/bootstrap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-prow
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubevirt-prow-jobs

--- a/github/ci/prow-deploy/vars/kubevirt-prow-control-plane/main.yml
+++ b/github/ci/prow-deploy/vars/kubevirt-prow-control-plane/main.yml
@@ -1,17 +1,11 @@
-prowUrl: prow.ci.kubevirt.io
-
-testinfra_dir: /tmp/test-infra
 bootstrap_full_config: true
 rescale_pushgateway_deployment: true
 rescale_deck_deployment: true
-project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirt-prow-control-plane/secrets/'
-components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
 kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
 
 shell_environment:
   KUBECONFIG: "{{ kubeconfig_path }}"
 
 remote_cluster_prow_jobs_context: kubevirt-prow-control-plane
-ansible_python_interpreter: /usr/bin/python3
 delete_priority_classes: false

--- a/github/ci/prow-deploy/vars/kubevirtci-testing/kubevirtci-testing.yml
+++ b/github/ci/prow-deploy/vars/kubevirtci-testing/kubevirtci-testing.yml
@@ -1,14 +1,9 @@
 # Test provisioning
 prowUrl: prow.prowdeploy.ci
 
-testinfra_dir: /tmp/test-infra
-
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/kubevirtci-testing/secrets/'
-components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
 
 node_name: node01
-
-ansible_python_interpreter: /usr/bin/python3
 
 githubUnprivileged:
   token: "test"

--- a/github/ci/prow-deploy/vars/prow-arm64-workloads/main.yml
+++ b/github/ci/prow-deploy/vars/prow-arm64-workloads/main.yml
@@ -1,0 +1,7 @@
+secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/prow-arm64-workloads/secrets/'
+kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
+
+shell_environment:
+  KUBECONFIG: "{{ kubeconfig_path }}"
+
+remote_cluster_prow_jobs_context: prow-arm64-workloads

--- a/github/ci/prow-deploy/vars/prow-workloads/main.yml
+++ b/github/ci/prow-deploy/vars/prow-workloads/main.yml
@@ -1,17 +1,8 @@
-prowUrl: prow.ci.kubevirt.io
-
-testinfra_dir: /tmp/test-infra
-bootstrap_full_config: false
-rescale_pushgateway_deployment: false
-rescale_deck_deployment: false
-project_infra_root: /home/prow/go/src/github.com/kubevirt/project-infra
 secrets_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/overlays/prow-workloads/secrets/'
-components_dir: '{{ project_infra_root }}/github/ci/prow-deploy/kustom/components'
 kubeconfig_path: '{{ secrets_dir }}/kubeconfig'
 
 shell_environment:
   KUBECONFIG: "{{ kubeconfig_path }}"
 
 remote_cluster_prow_jobs_context: prow-workloads
-ansible_python_interpreter: /usr/bin/python3
 delete_priority_classes: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Add manifests to deploy the `docker-mirror-proxy` on the `prow-arm64-workloads` cluster.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `prow-arm64-workloads` build cluster.
  * Added deployment configuration for ARM64 workload infrastructure, including required namespaces and cluster access settings.
  * Added Docker mirror proxy support for the ARM64 workload environment.

* **Bug Fixes**
  * Improved ARM64 workload deployment reliability by applying resource limits and disabling IPv6 where cluster connectivity is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->