### PR TITLE
fix(golang,entrypoint): don't fail in no toolchain is set in go.mod

### DIFF
--- a/images/golang/entrypoint.sh
+++ b/images/golang/entrypoint.sh
@@ -20,13 +20,13 @@ set -o pipefail
 
 GO_MOD_PATH=${GO_MOD_PATH:-}
 
-if [[ -n ${GO_MOD_PATH} && -f ${GO_MOD_PATH} ]]; then
-  toolchain_version="$(grep -E '^toolchain go' "${GO_MOD_PATH}" | cut -d' ' -f2 | sed 's/^go//')"
-  if [[ -n ${toolchain_version} ]]; then
+if [[ -n "${GO_MOD_PATH}" && -f "${GO_MOD_PATH}" ]]; then
+  toolchain_version="$(awk '/^toolchain go[0-9]+(.[0-9]+){1,2}/ { sub("^go", "", $2); print($2) }' "${GO_MOD_PATH}")"
+  if [[ -n "${toolchain_version}" ]]; then
     export GIMME_GO_VERSION="${toolchain_version}"
   else
     # Fallback to go directive for repos without toolchain line
-    export GIMME_GO_VERSION="$(grep -E '^go ' "${GO_MOD_PATH}" | cut -d' ' -f2)"
+    export GIMME_GO_VERSION="$(awk '/^go [0-9]+(.[0-9]+){1,2}/ { print($2) }' "${GO_MOD_PATH}")"
   fi
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `entrypoint.sh` script of the golang image sets `errexit` and `pipefail` options. Since the `grep` command exits with an error when there are no matches, the script fails if no `toolchain` directive is present in the `go.mod` file.

This change replaces `grep` commands by `awk` equivalent commands that do not fail if there is no match.

**Which issue(s) this PR fixes**:

Fixes regression from https://github.com/kubevirt/project-infra/pull/5432.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go version detection from project configuration files.
  * Ensured toolchain versions are parsed consistently and validated against the expected format.
  * Improved handling of configured project paths and version values, reducing potential setup or build issues when Go versions are specified in different supported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->