### PR TITLE
hpp-operator,presubmits: add unit-test lane for s390x

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner-operator/hostpath-provisioner-operator-presubmits.yaml
@@ -27,3 +27,31 @@ presubmits:
           resources:
             requests:
               memory: "4Gi"
+  - name: pull-hostpath-provisioner-operator-unit-test-s390x
+    skip_branches:
+      - release-v\d+\.\d+
+    cluster: prow-s390x-workloads
+    annotations:
+      fork-per-release: "true"
+    always_run: true
+    skip_report: false
+    optional: true
+    decoration_config:
+      timeout: 1h
+      grace_period: 5m
+    labels:
+      preset-podman-in-container-enabled: "true"
+    spec:
+      containers:
+        - image: quay.io/kubevirtci/golang:v20260830-8316684
+          command:
+            - "/usr/local/bin/runner.sh"
+            - "/bin/sh"
+            - "-c"
+            - "./hack/run-unit-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: "4Gi"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an s390x unit test presubmit for hostpath-provisioner-operator.
The existing x86 job `pull-hostpath-provisioner-operator-unit-test` is unchanged. This PR adds `pull-hostpath-provisioner-operator-unit-test-s390x`, which runs the same `./hack/run-unit-tests.sh` on `prow-s390x-workloads`.
The lane is optional, so a new s390x failure does not block merges until the job is stable. This matches the starting point in kubevirt/hostpath-provisioner-operator#656 (unit tests only; no e2e on the operator repo).


It uses the same `./hack/run-unit-tests.sh` as the existing x86 job, on `prow-s390x-workloads`. The x86 job is unchanged. The new lane is optional until it is stable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubevirt/hostpath-provisioner-operator#656

**Special notes for your reviewer**:
Mirrors CDI/AAQ s390x unit-test jobs: `prow-s390x-workloads`, no `preset-docker-mirror-proxy`, `skip_branches` for `release-v*`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an optional presubmit unit-test job for the hostpath-provisioner-operator on s390x infrastructure.
  * The job skips release branches and runs the existing unit-test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->