### PR TITLE
chore(cri-o): mirror version 1.37 and revamp mirroring script

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -11,25 +11,20 @@ periodics:
     - org: kubevirt
       repo: project-infra
       base_ref: main
+      clone_depth: 1
       workdir: true
   labels:
     preset-gcs-credentials: "true"
-    preset-shared-images: "true"
   cluster: prow-workloads
   spec:
     containers:
+      # GCS authentication is done by KubeVirt CI bootstrap image runner script
       - image: quay.io/kubevirtci/bootstrap:v20260906-22dec7d
-        env:
-          - name: BUCKET_DIR
-            value: kubevirtci-crio-mirror
-          - name: CRIO_VERSIONS
-            value: "1.34,1.35,1.36"
-        command: ["/bin/sh", "-ce"]
+        command: [/usr/local/bin/entrypoint.sh]
         args:
-          - |
-            source /google-cloud-sdk/path.bash.inc
-            gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
-            ./hack/mirror-crio.sh
+          - ./hack/mirror-crio.sh
+          - --bucket=kubevirtci-crio-mirror
+          - --crio-versions=1.34,1.35,1.36,1.37
         resources:
           requests:
             memory: "2Gi"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -559,6 +559,7 @@ periodics:
   - org: kubevirt
     repo: project-infra
     base_ref: main
+    clone_depth: 1
     workdir: true
   - org: kubevirt
     repo: kubevirtci

--- a/hack/bump-crio-mirror-versions.sh
+++ b/hack/bump-crio-mirror-versions.sh
@@ -2,7 +2,7 @@
 
 PROJECT_INFRA_ROOT=$(readlink --canonicalize $(pwd))
 KUBEVIRTCI_PERIODICS="$PROJECT_INFRA_ROOT/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml"
-CURRENT_VERSIONS=$(grep -A 1 "CRIO_VERSIONS" $KUBEVIRTCI_PERIODICS  | grep value | cut -d \" -f 2)
+CURRENT_VERSIONS=$(awk -F = '/--crio-versions=/ { print($2) }' $KUBEVIRTCI_PERIODICS)
 LATEST_VERSION="1.$(curl -s https://api.github.com/repos/cri-o/cri-o/releases/latest | grep tag_name | cut -d : -f 2,3 | cut -d . -f 2)"
 
 if [[ $(echo "$CURRENT_VERSIONS" | grep $LATEST_VERSION) ]]; then

--- a/hack/mirror-crio.sh
+++ b/hack/mirror-crio.sh
@@ -1,53 +1,105 @@
 #!/bin/bash
 
-# Usage:
-# ./mirror-crio.sh
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
 
+set -eu -o pipefail
 
-set -e
+# Process command line arguments
+PROGNAME='mirror-crio'
 
-LOCAL_MIRROR_DIR="crio-mirror"
+# Constants and default values
+BUCKET_NAME='kubevirtci-crio-mirror'
+CRIO_VERSIONS=
 
-dnf install dnf-utils -y
+usage() {
+    cat <<EOF
+Helper script for mirroring CRI-O repositories to a cloud storage bucket.
 
-mirror_crio_repo_for_version () {
-    OLD_CRIO_REPO_VERSIONS="1.22,1.23,1.24,1.25,1.26,1.27"
+Usage:
+  ${PROGNAME} [options]
 
-    if [[ $OLD_CRIO_REPO_VERSIONS == *"$1"* ]]; then
-        BASE_REPOID="devel_kubic_libcontainers_stable"
-        if [ -z "$1" ]; then
-            CRIO_SUBDIR=""
-            REPOID=$BASE_REPOID
-        else
-            CRIO_SUBDIR=":cri-o:$1"
-            REPOID="${BASE_REPOID}_cri-o_$1"
-        fi
-        # cri-o builds > v1.24.1 are broken for Centos_8_Stream
-        # cri-o > v1.24.2 is required to avoid https://github.com/cri-o/cri-o/issues/5889
-        # Use CentOS_8 build for cri-o v1.24
-        if [[ $1 = 1.24 ]]; then
-            OS="CentOS_8"
-        else
-            OS="CentOS_8_Stream"
-        fi
-        curl -L -o $REPOID.repo https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable$CRIO_SUBDIR/$OS/devel:kubic:libcontainers:stable$CRIO_SUBDIR.repo
-        reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR -n --repoid=$REPOID --download-metadata
-    else
-        echo "Mirroring from new pkgs.k8s.io repos"
-        REPOID="isv_cri-o_stable_v$1"
-        curl -L -o $REPOID.repo https://download.opensuse.org/repositories/isv:/cri-o:/stable:/v$1/rpm/isv:cri-o:stable:v$1.repo
-        reposync -c $REPOID.repo -p ./$LOCAL_MIRROR_DIR --repoid=$REPOID --download-metadata
-    fi
+Options:
+  --bucket=<bucket-name>
+    Name of the bucket to which the CRI-O repositories will be mirrored.
+    (Default: ${BUCKET_NAME:-unset})
+
+  --crio-versions=<version1,..,versionN>
+    Comma-separated list of CRI-O versions which must be mirrored.
+    (Default: ${CRIO_VERSIONS:-unset})
+EOF
 }
 
+die(){ usage >&2; exit 64; }  # EX_USAGE
 
-# First mirror the shared stable repository
-mirror_crio_repo_for_version
+# Parse command line arguments
+CMDLINE=$(
+    opts='bucket:,crio-versions:,help'
 
-# Loop over comma-separated list of cri-o versions
-for i in $(echo $CRIO_VERSIONS | sed "s/,/ /g")
-do
-    mirror_crio_repo_for_version $i
+    getopt \
+        --name="${PROGNAME}" \
+        --longoptions="${opts}" \
+        --options='h' \
+        -- "$@"
+) || die
+
+eval set -- "${CMDLINE}"
+
+# Convert command line arguments to local variables
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --bucket) BUCKET_NAME=$2; shift;;
+        # IFS trick converts a comma separated list to a bash array
+        --crio-versions) IFS=',' CRIO_VERSIONS=($2); shift;;
+
+        --help|-H) usage;  exit;;
+        --)        shift; break;;  # End of options
+        *)         die;;           # Should not happen
+    esac
+    shift
 done
 
-gcloud storage rsync --delete-unmatched-destination-objects -r "$LOCAL_MIRROR_DIR" "gs://$BUCKET_DIR"
+mirror_crio_repo_for_version()
+{
+    local channel repo_id repo_url version
+
+    # https://cri-o.io/#distribution-packaging
+    version="$1"
+    channel="stable"
+    repo_id="isv_cri-o_${channel}_v${version}"
+    repo_url="https://download.opensuse.org/repositories/isv:/cri-o:/${channel}:/v${version}/rpm/isv:cri-o:${channel}:v${version}.repo"
+
+    echo "[INFO] Mirroring CRI-O v${version} repository" >&2
+    curl -sSLR --fail-with-body --retry 2 "${repo_url}" -o "${repo_id}".repo
+    dnf reposync --config="${repo_id}.repo" --repo="${repo_id}" \
+        --destdir="./crio-mirror" --download-metadata \
+        --newest-only --remote-time
+}
+
+workdir=$(mktemp -d)
+trap 'rm -rf "${workdir}"' EXIT
+
+cd "${workdir}"
+
+for version in "${CRIO_VERSIONS[@]}"; do
+    mirror_crio_repo_for_version "${version}"
+done
+
+gcloud storage rsync ./crio-mirror gs://"${BUCKET_NAME}" \
+    --recursive \
+    --delete-unmatched-destination-objects
+
+cd - >/dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:

This change adds the version 1.37 to the list of CRI-O versions for which the RPMs should be mirrored in KubeVirt CI dedicated GCS bucket.

It also refactors the CRI-O mirroring script to use command line parameters instead of environment variable and remove obsolete code.

**Special notes for your reviewer**:

/cc @dhiller, @Whitedyl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the weekly CRI-O mirror process to support versions 1.34–1.37.
  - Improved mirror execution with configurable cloud storage settings, command-line options, usage guidance, and safer cleanup.
  - Streamlined repository retrieval through shallow clones, reducing unnecessary download time and storage.
  - Automated version tracking now reads the configured versions directly from the scheduled job definition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->