### PR TITLE
chore(jobs): remove docker-mirror leftovers

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.27.yaml
@@ -42,7 +42,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -100,7 +99,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.39.yaml
@@ -42,7 +42,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -100,7 +99,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.44.yaml
@@ -196,7 +196,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.53.yaml
@@ -196,7 +196,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.58.yaml
@@ -190,7 +190,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.65.yaml
@@ -42,7 +42,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -71,7 +70,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -100,7 +98,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -220,7 +217,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/cluster-network-addons-operator/cluster-network-addons-operator-presubmits-0.76.yaml
@@ -42,7 +42,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -71,7 +70,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:
@@ -100,7 +98,6 @@ presubmits:
       cluster: prow-workloads
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       spec:
         nodeSelector:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.1.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.3.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-0.4.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.0.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.0.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -285,7 +283,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.1.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -357,7 +355,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.2.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -357,7 +355,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.3.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -489,7 +487,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.4.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -525,7 +523,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.5.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -530,7 +528,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.6.yaml
@@ -7,8 +7,6 @@ presubmits:
       decoration_config:
         timeout: 3h
       max_concurrency: 5
-      labels:
-        preset-docker-mirror: "true"
       cluster: kubevirt-prow-control-plane
       spec:
         containers:
@@ -528,7 +526,6 @@ presubmits:
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
-        preset-docker-mirror: "true"
       annotations:
         testgrid-create-test-group: "false"
       cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-1.7.yaml
@@ -7,8 +7,6 @@ presubmits:
     decoration_config:
       timeout: 3h
     max_concurrency: 5
-    labels:
-      preset-docker-mirror: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -677,7 +675,6 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-postsubmits.yaml
@@ -10,7 +10,7 @@ postsubmits:
       max_concurrency: 1
       labels:
         preset-podman-in-container-enabled: "true"
-        preset-docker-mirror: "true"
+        preset-docker-mirror-proxy: "true"
         preset-kubevirtci-quay-credential: "true"
       annotations:
         testgrid-create-test-group: "false"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       timeout: 3h
     max_concurrency: 5
     labels:
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -753,7 +753,7 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
     annotations:
       testgrid-create-test-group: "false"
     cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/csi-driver/csi-driver-presubmits.yaml
@@ -230,7 +230,7 @@ presubmits:
         grace_period: 10m
       labels:
         preset-podman-in-container-enabled: "true"
-        preset-docker-mirror: "true"
+        preset-docker-mirror-proxy: "true"
       spec:
         containers:
           - image: quay.io/kubevirtci/bootstrap:v20260906-22dec7d

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hostpath-provisioner/hostpath-provisioner-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:
@@ -45,7 +45,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:
@@ -77,7 +77,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:
@@ -109,7 +109,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:
@@ -141,7 +141,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:
@@ -170,7 +170,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/hyperconverged-cluster-operator/hyperconverged-cluster-operator-presubmits-2.3.yaml
@@ -36,7 +36,6 @@ presubmits:
       timeout: 7h0m0s
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-kubevirtci-quay-credential: "true"
       preset-shared-images: "true"
     max_concurrency: 6

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-controller/kubevirt-migration-controller-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-migration-operator/kubevirt-migration-operator-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -522,7 +522,7 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
     preset-podman-in-container-enabled: "true"
@@ -568,7 +568,7 @@ periodics:
     repo: kubevirt
   labels:
     preset-bazel-cache: "true"
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
     preset-podman-in-container-enabled: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-postsubmits.yaml
@@ -214,7 +214,7 @@ postsubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"
@@ -249,7 +249,7 @@ postsubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-github-credentials: "true"
       preset-kubevirtci-quay-credential: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirtci/kubevirtci-periodics.yaml
@@ -49,7 +49,7 @@ periodics:
     base_ref: main
   labels:
     preset-podman-in-container-enabled: "true"
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   cluster: kubevirt-prow-control-plane
@@ -85,7 +85,7 @@ periodics:
     base_ref: main
     workdir: true
   labels:
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-github-credentials: "true"
   cluster: prow-workloads
   spec:
@@ -350,7 +350,7 @@ periodics:
       base_ref: main
   labels:
     preset-podman-in-container-enabled: "true"
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
     rehearsal.allowed: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-periodics.yaml
@@ -12,7 +12,7 @@ periodics:
   max_concurrency: 1
   labels:
     preset-podman-in-container-enabled: "true"
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-gcs-credentials: "true"
   extra_refs:
    - org: kubevirt

--- a/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/libguestfs-appliance/libguestfs-appliance-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/node-maintenance-operator/node-maintenance-operator-presubmits-release-0.8.yaml
@@ -13,7 +13,6 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/project-infra/project-infra-periodics.yaml
@@ -1134,7 +1134,7 @@ periodics:
     workdir: true
   interval: 1h
   labels:
-    preset-docker-mirror: "true"
+    preset-docker-mirror-proxy: "true"
     preset-shared-images: "true"
     preset-github-credentials: "true"
     preset-pgp-bot-key: "true"

--- a/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/test-benchmarks/test-benchmarks-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       timeout: 3h
     max_concurrency: 1
     labels:
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
     cluster: kubevirt-prow-control-plane
     spec:
       containers:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.1.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.1.yaml
@@ -60,7 +60,6 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.2.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-0.2.yaml
@@ -35,7 +35,6 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/virt-template/virt-template-presubmits.yaml
@@ -35,7 +35,7 @@ presubmits:
       testgrid-create-test-group: "false"
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
     decoration_config:
       grace_period: 5m0s
       timeout: 1h0m0s

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-file-restore-operator/vm-file-restore-operator-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-podman-in-container-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:

--- a/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/vm-import-operator/vm-import-operator-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     max_concurrency: 6
     labels:
       preset-dind-enabled: "true"
-      preset-docker-mirror: "true"
+      preset-docker-mirror-proxy: "true"
       preset-shared-images: "true"
     cluster: prow-workloads
     spec:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.15.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       cluster: kubevirt-prow-control-plane
       spec:
@@ -37,7 +36,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:
@@ -67,7 +65,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:
@@ -97,7 +94,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
         preset-kubevirtci-quay-credential: "true"
       cluster: prow-workloads

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.31.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: kubevirt-prow-control-plane
       spec:
@@ -37,7 +36,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:
@@ -67,7 +65,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.35.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: kubevirt-prow-control-plane
       spec:
@@ -67,7 +66,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "true"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.37.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: kubevirt-prow-control-plane
       spec:
@@ -97,7 +96,6 @@ presubmits:
         grace_period: 5m
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       spec:
         containers:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.43.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.43.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.47.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.47.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: prow-workloads
       spec:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.52.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: kubevirt-prow-control-plane
       spec:

--- a/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
+++ b/github/ci/prow-deploy/files/jobs/nmstate/kubernetes-nmstate/kubernetes-nmstate-presubmits-0.64.yaml
@@ -12,7 +12,6 @@ presubmits:
       max_concurrency: 6
       labels:
         preset-dind-enabled: "true"
-        preset-docker-mirror: "false"
         preset-shared-images: "true"
       cluster: kubevirt-prow-control-plane
       spec:

--- a/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
+++ b/github/ci/prow-deploy/kustom/base/configs/current/config/config.yaml
@@ -735,16 +735,6 @@ presets:
     mountPath: /var/lib/shared-images
     readOnly: true
 - labels:
-    preset-docker-mirror: "true"
-  volumes:
-  - name: docker-config
-    configMap:
-      name: docker-daemon-mirror-config
-  volumeMounts:
-  - name: docker-config
-    mountPath: /etc/default
-    readOnly: true
-- labels:
     preset-docker-mirror-proxy: "true"
   env:
   - name: CA_CERT_FILE

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/configs/docker
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/configs/docker
@@ -1,5 +1,0 @@
-DOCKER_OPTS="${DOCKER_OPTS} --data-root=/docker-graph"
-DOCKER_OPTS="${DOCKER_OPTS} --registry-mirror=http://docker-mirror.kubevirt-prow.svc:5000 --insecure-registry=http://docker-mirror.kubevirt-prow.svc:5000"
-DOCKER_OPTS="${DOCKER_OPTS} --mtu=1450"
-DOCKER_OPTS="${DOCKER_OPTS} --ipv6"
-DOCKER_OPTS="${DOCKER_OPTS} --fixed-cidr-v6 2001:db8:1::/64"

--- a/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/kustomization.yaml
+++ b/github/ci/prow-deploy/kustom/components/docker-mirror-proxy/base/kustomization.yaml
@@ -14,7 +14,6 @@ configMapGenerator:
   - name: docker-daemon-mirror-config
     namespace: kubevirt-prow-jobs
     files:
-      - configs/docker
       - configs/docker-proxy
 
 secretGenerator:

--- a/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_modify/kubevirt-periodics.yaml
@@ -936,7 +936,6 @@ periodics:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
-    preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   max_concurrency: 1

--- a/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
+++ b/pkg/kubevirt/cmd/remove/testdata/should_not_modify/kubevirt-periodics.yaml
@@ -935,7 +935,6 @@ periodics:
     preset-bazel-cache: "true"
     preset-bazel-unnested: "true"
     preset-dind-enabled: "true"
-    preset-docker-mirror: "true"
     preset-gcs-credentials: "true"
     preset-github-credentials: "true"
   max_concurrency: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

`docker-mirror` (backed by docker/distributon) has been replaced by `docker-mirror-proxy` (backed by rpardini/docker-registry-proxy) several years ago:

=> https://github.com/kubevirt/project-infra/pull/1249

This change removes the preset `docker-mirror` from jobs targeting release branches and replace it by the preset `docker-mirror-proxy` for jobs targeting main branches.

**Special notes for your reviewer**:

/cc @dhiller @Whitedyl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI job configurations across KubeVirt and NMState projects to use the Docker mirror proxy where applicable.
  - Removed direct Docker mirror settings from affected presubmit and periodic jobs.
  - Retired the legacy direct-mirror configuration while retaining proxy-based image access.
  - Updated job presets consistently across multiple supported release branches and build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->