### PR TITLE
chore(jobs): add preset-docker-mirror-proxy to ARM64 jobs

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/common-instancetypes/common-instancetypes-presubmits.yaml
@@ -219,6 +219,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 1h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 1
     optional: true

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.8-aie-nv-presubmits.yaml
@@ -123,6 +123,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-aie-unit-test-arm64-1.8-aie-nv
     branches:
@@ -149,6 +150,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.8-aie-nv
@@ -194,6 +196,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 2
     name: pull-kubevirt-aie-kind-1.35-conformance-arm64-1.8-aie-nv

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt-aie/kubevirt-release-1.9-aie-nv-presubmits.yaml
@@ -132,6 +132,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     name: pull-kubevirt-aie-unit-test-arm64-1.9-aie-nv
     branches:
@@ -160,6 +161,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
     name: pull-kubevirt-aie-kind-1.35-sig-compute-arm64-1.9-aie-nv

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-periodics.yaml
@@ -612,6 +612,7 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
+    preset-docker-mirror-proxy: "true"
     preset-gomaxprocs-16: "true"
     preset-podman-in-container-enabled: "true"
   max_concurrency: 5
@@ -655,6 +656,7 @@ periodics:
     org: kubevirt
     repo: kubevirt
   labels:
+    preset-docker-mirror-proxy: "true"
     preset-gomaxprocs-16: "true"
     preset-podman-in-container-enabled: "true"
   max_concurrency: 1

--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -493,6 +493,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 2h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-gcs-credentials: "true"
       preset-go-test-cache-bucket: "true"
       preset-gomaxprocs-4: "true"
@@ -1106,6 +1107,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-gomaxprocs-16: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 4
@@ -1148,6 +1150,7 @@ presubmits:
       grace_period: 5m0s
       timeout: 4h0m0s
     labels:
+      preset-docker-mirror-proxy: "true"
       preset-gomaxprocs-16: "true"
       preset-podman-in-container-enabled: "true"
     max_concurrency: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

A docker-mirror-proxy instance is now deployed on the `prow-arm64-workloads` cluster.

This change adds the `preset-docker-mirror-proxy` preset to ARM64 jobs in order to take advantage of this service.

**Special notes for your reviewer**:

/cc @lyarwood @Whitedyl 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Enabled the Docker mirror proxy for additional ARM64 presubmit and periodic test jobs.
  * Expanded coverage across unit, end-to-end, conformance, and functional test workflows.
  * Updated ARM64 testing for multiple supported release and Kubernetes configurations to use the mirror proxy when retrieving container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->