### PR TITLE
Adds kubevirtci cluster-up path to run_if_changed for the sig-monitoring presubmit job.

### DIFF
--- a/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
+++ b/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml
@@ -1370,7 +1370,7 @@ presubmits:
       preset-podman-in-container-enabled: "true"
       preset-podman-shared-images: "true"
     name: pull-kubevirt-e2e-k8s-1.36-sig-monitoring
-    run_if_changed: ^pkg/monitoring/.*|^tests/monitoring/.*|^tests/libmonitoring/.*|^vendor/github.com/machadovilaca/operator-observability/.*
+    run_if_changed: ^pkg/monitoring/.*|^tests/monitoring/.*|^tests/libmonitoring/.*|^vendor/github.com/machadovilaca/operator-observability/.*|^kubevirtci/cluster-up/.*
     skip_branches:
     - release-\d+\.\d+
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an additional trigger condition for the `pull-kubevirt-e2e-k8s-1.36-sig-monitoring` presubmit job to run when `kubevirtci/cluster-up/` files change.

A kubevirtci bump in  kubevirt/kubevirt#19022 caused the sig-monitoring lane to start failing, but the monitoring job did not run during that PR because it only triggers on direct monitoring code changes.

Since kubevirtci bumps can include changes that affect monitoring infrastructure the sig-monitoring lane should run on all kubevirtci bumps to catch these issues before they merge.

**Special notes for your reviewer**:
/cc @dollierp @machadovilaca 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - The Kubernetes 1.36 monitoring end-to-end validation now runs when cluster setup scripts are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->